### PR TITLE
fix: tighten README description and add scanned-by badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Each skill is a standalone Python script with its own checks, tests, examples, a
 ```mermaid
 flowchart LR
     HR["HR Sources\nWorkday · Snowflake\nDatabricks · ClickHouse"]
-    REC["Reconciler\nSHA-256 diff"]
-    SFN["Step Function\nParser → Worker"]
-    TGT["IAM Cleanup\n13 steps · 5 clouds"]
-    AUDIT["Audit\nDDB + S3"]
+    REC["Reconciler\nSHA-256 row diff\nchange detect → S3 manifest\nKMS encrypted"]
+    SFN["Step Function\nParser: validate · grace period · rehire\nWorker: 13-step IAM cleanup"]
+    TGT["5 Cloud Targets\nAWS IAM · Azure Entra\nGCP IAM · Snowflake · Databricks"]
+    AUDIT["Audit Trail\nDynamoDB + S3\nwarehouse ingest-back"]
 
     HR --> REC --> SFN --> TGT --> AUDIT
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 [![CI](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml/badge.svg)](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-Production-grade cloud security benchmarks and automation — CIS checks for AWS/GCP/Azure, Kubernetes and container hardening, model serving security, GPU cluster security, IAM remediation, and vulnerability response pipelines. Each skill is compliance-mapped, tested, and ready to deploy.
+[![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
+
+Production-grade cloud security benchmarks and automation — 10 skills, 159 tests, compliance-mapped to MITRE ATT&CK, NIST CSF, CIS, ISO 27001, and SOC 2.
+
+Each skill is a standalone Python script with its own checks, tests, examples, and SKILL.md definition following [Anthropic's skill spec](https://docs.anthropic.com). Skills can be used directly from the CLI, integrated into CI/CD pipelines, or referenced by AI agents that read SKILL.md files (Claude Desktop, Cortex Code, etc.).
 
 ## Skills
 


### PR DESCRIPTION
Shorter accurate description. Badge links to agent-bom. Clarifies skills are standalone CLI scripts + readable by AI agents via SKILL.md.