### PR TITLE
feat: close the loop — eventbridge + dlq + alerts, agent guardrails, honest counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Agent Instructions
+
+> This file is the canonical entry point for AI agents loading this repository
+> (Claude Code, Cursor, Codex, Cortex, Windsurf, or any other MCP-compatible
+> assistant). It mirrors `CLAUDE.md` and links to the per-skill `SKILL.md`
+> contracts.
+
+## Repository at a glance
+
+5 closed-loop cloud security skills:
+
+| Skill | Mode | What it does |
+|-------|------|--------------|
+| `cspm-aws-cis-benchmark` | read-only | 18 CIS AWS Foundations v3.0 checks |
+| `cspm-gcp-cis-benchmark` | read-only | 7 CIS GCP Foundations v3.0 checks |
+| `cspm-azure-cis-benchmark` | read-only | 6 CIS Azure Foundations v2.1 checks |
+| `iam-departures-remediation` | event-driven, audited | Multi-cloud IAM cleanup for departed employees |
+| `vuln-remediation-pipeline` | gated by SLA + protected list | Auto-remediate supply chain vulns |
+
+## Hard rules for agents
+
+These rules are enforced in code, IAM, and infra. They are not optional:
+
+1. **Read-only by default.** Treat any skill whose SKILL.md says `read-only` as exactly that. Never compose it into a flow that mutates cloud state.
+2. **Dry-run first.** Every remediation worker accepts `dry_run=True`. Use it when planning, exploring, or generating examples. Only set `dry_run=False` after the user has explicitly confirmed and the action is inside an authorised maintenance window.
+3. **Respect the deny list.** The IAM worker's role denies `iam:*` on `root`, `break-glass-*`, `emergency-*`, and any `:role/*` ARN. Do not propose workarounds.
+4. **Respect the grace period.** The IAM departures grace period is a *human-in-the-loop* mechanism, not a delay. Do not set it to 0 or skip it without an authorisation document.
+5. **Never bypass EventBridge.** All Step Function executions go through the `S3 Object Created → EventBridge → SFN` path. Do not call `states:StartExecution` directly — that bypasses the audit trail.
+6. **Never write to the audit table by hand.** The `iam-remediation-audit` and `vuln-remediation-audit` DynamoDB tables are written exclusively by the worker Lambdas. Manual writes break the closed-loop verification.
+7. **No new IAM grants.** Do not edit `iam_policies/` or any role policy to broaden permissions. Each role is least-privilege by design.
+8. **No telemetry.** Nothing in this repo phones home. Do not add SDK clients to external services unless the user explicitly asks for them, and even then keep the egress inside the customer's VPC.
+
+## How to use a skill
+
+1. Read its `SKILL.md` (frontmatter + body) — that is the contract.
+2. Read the `Security Guardrails` and `Remediation` sections.
+3. If the skill has a `dry_run` flag, call it with `dry_run=True` first and show the steps.
+4. Only proceed with destructive actions after user confirmation **and** the relevant audit/SLA checks pass.
+5. After running, point the user at the audit trail (`DynamoDB` + `S3 evidence` + `warehouse ingest-back`) so they can verify the closed loop.
+
+## Failure handling
+
+- Lambda async failure → SQS DLQ (`iam-departures-dlq`).
+- Step Function `FAILED` / `TIMED_OUT` / `ABORTED` → SNS `iam-departures-alerts` topic.
+- Re-drive a stuck execution by re-emitting an `Object Created` event for the manifest. The pipeline is idempotent.
+
+If you see a remediation step that succeeded but no audit row, treat it as a failure and surface the discrepancy to the user.
+
+## Where to read more
+
+- Full guardrails and rationale: [`CLAUDE.md`](CLAUDE.md)
+- Per-skill contract: `skills/<skill-name>/SKILL.md`
+- Architecture diagrams (closed loops): [`README.md`](README.md)
+- Security model: [`SECURITY.md`](SECURITY.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,63 +1,167 @@
 # Cloud Security Skills Collection
 
-This repository contains production-ready cloud security automations structured as skills for AI agents.
+This repository contains production-ready cloud security automations structured as
+[Anthropic skills](https://docs.anthropic.com) for AI agents.
 
 ## Repository structure
 
 ```
 skills/
-  iam-departures-remediation/   — Multi-cloud IAM cleanup for departed employees
-  cspm-aws-cis-benchmark/       — CIS AWS Foundations v3.0 (18 checks)
-  cspm-gcp-cis-benchmark/       — CIS GCP Foundations v3.0 (20 checks + 5 Vertex AI)
-  cspm-azure-cis-benchmark/     — CIS Azure Foundations v2.1 (19 checks + 5 AI Foundry)
-  model-serving-security/       — Model serving security benchmark (16 checks)
-  gpu-cluster-security/         — GPU cluster security benchmark (13 checks)
-  k8s-security-benchmark/       — Kubernetes security benchmark (10 checks)
-  container-security/           — Container image + runtime security (8 checks)
-  discover-environment/         — Cloud environment discovery with MITRE ATT&CK/ATLAS overlay
-  vuln-remediation-pipeline/    — Auto-remediate supply chain vulnerabilities
+  cspm-aws-cis-benchmark/       — CIS AWS Foundations v3.0 (18 checks, read-only)
+  cspm-gcp-cis-benchmark/       — CIS GCP Foundations v3.0 (7 checks, read-only)
+  cspm-azure-cis-benchmark/     — CIS Azure Foundations v2.1 (6 checks, read-only)
+  iam-departures-remediation/   — Multi-cloud IAM cleanup for departed employees (event-driven, audited)
+  vuln-remediation-pipeline/    — Auto-remediate supply chain vulnerabilities (EPSS/KEV/CVSS triage)
 ```
+
+Five skills total. Each one is a closed loop: **detect → act → audit → re-verify**.
+The CSPM skills are detection-only and re-verify the same `control_id` on the next run.
+The remediation skills (IAM departures, vuln pipeline) write back to a dual audit
+trail (DynamoDB + S3) and ingest results into the source warehouse so the next
+reconciler run *cross-checks* the previous remediation actually landed.
+
+## Agent guardrails — REQUIRED reading before invoking these skills
+
+If you are an AI agent (Claude, Cursor, Codex, Cortex, Windsurf, etc.) loading
+any skill from this repo, you must operate inside these guardrails. They are
+enforced in code, infra, and IAM — not just documentation. Violating them
+should be impossible for a least-privilege caller, but you should also refuse
+to attempt them.
+
+### 1. Read-only by default
+
+- **CSPM skills (`cspm-aws/gcp/azure-cis-benchmark`)** are *read-only*. They use
+  `roles/viewer`, `iam.securityReviewer`, and Azure `Reader`. They have **zero**
+  write permissions to any cloud account. Never wrap them in code that mutates
+  state — that would be outside the skill contract.
+- **`vuln-remediation-pipeline` triage Lambda** is read-only against findings.
+  Only the patcher Lambda mutates state, and it's gated by SLA + protected-package
+  list (see below).
+- **`iam-departures-remediation` reconciler** is read-only against HR sources
+  and only *writes a manifest* to S3. The Step Function is the only thing that
+  touches IAM.
+
+### 2. Human-in-the-loop (HITL) for destructive actions
+
+The IAM departures pipeline is the only destructive workflow. HITL is enforced
+at three layers:
+
+| Layer | Mechanism | Override |
+|-------|-----------|----------|
+| **Grace period** | 7-day default window before remediation runs (configurable per env) | HR can revert termination during the grace period and the manifest will reflect it |
+| **Deny policies** | Explicit IAM `Deny` on `root`, `break-glass-*`, `emergency-*` and all `:role/*` ARNs in `WorkerExecutionRole` | None — these can never be remediated by this pipeline |
+| **Rehire filter** | Parser Lambda checks 8 rehire scenarios before generating the work item | None — handled in code (`should_remediate()`) |
+
+For the `vuln-remediation-pipeline`:
+
+| Layer | Mechanism |
+|-------|-----------|
+| **Protected packages** | SSM Parameter Store list (`/vuln-remediation/protected-packages`) — these become `Tier.SKIP` even if KEV/CVSS 9.8 |
+| **No-fix-available** | Findings without a `fixed_version` are skipped, never auto-quarantined |
+| **Idempotency** | DynamoDB `vuln-remediation-audit` table — re-running on the same finding is a no-op |
+
+### 3. Dry-run is supported everywhere
+
+- **Cross-cloud workers** (`lambda_worker/clouds/*`) all accept `dry_run=True`
+  which produces a `RemediationStatus.DRY_RUN` result with the full step list
+  but **no API calls**. Use this when an agent is exploring or composing the
+  workflow.
+- **CSPM checks** are inherently dry-run because they're read-only.
+- **Reconciler** has `--dry-run` flag that prints the diff without writing the
+  S3 manifest, which means EventBridge never fires.
+
+### 4. Cross-account scoping
+
+All cross-account `sts:AssumeRole` calls in IAM remediation are scoped by
+`aws:PrincipalOrgID` condition. The pipeline cannot escape the AWS
+Organization. If you are running outside an Organization, the worker fails
+closed.
+
+### 5. Audit guarantees (closed loop)
+
+Every destructive action is dual-written:
+1. DynamoDB row keyed by `(iam_username, remediated_at)` for fast lookup.
+2. S3 evidence object under `departures/audit/` with KMS encryption.
+3. Ingest-back to the source HR warehouse so the *next* reconciler run can
+   prove the user is closed across all systems.
+
+If an agent invokes a remediation step and there is no corresponding audit row
+within the SLA window, treat that as a failure. The next run should detect drift.
+
+### 6. Failure surface
+
+- **Lambda async failures** → SQS DLQ (`iam-departures-dlq`, KMS encrypted, 14-day retention).
+- **Step Function `FAILED` / `TIMED_OUT` / `ABORTED`** → EventBridge rule fires
+  SNS topic (`iam-departures-alerts`). Subscribe an on-call email or PagerDuty
+  endpoint with the `AlertEmail` parameter.
+- **DLQ replay** → drop a fresh `Object Created` event onto EventBridge to
+  re-run a stuck execution. The pipeline is idempotent.
+
+Nothing in this repo silently swallows errors. If an agent sees an empty
+finding list and no error, that's a real "all clear" — not a hidden failure.
+
+### 7. No telemetry, no exfiltration
+
+- CSPM results stay local. No HTTP egress beyond the cloud SDKs.
+- Reconciler reads HR data, hashes rows with SHA-256, exports a manifest.
+  Nothing leaves the security OU account.
+- Lambda functions run in a VPC with no public NAT for non-AWS-API calls.
+
+### 8. What an agent should NEVER do with these skills
+
+- ❌ Skip the grace period or set it to 0 days "to test".
+- ❌ Add new principals to the `WorkerExecutionRole` deny list and re-run.
+- ❌ Disable the EventBridge rule and call the Step Function directly — that
+  bypasses the audit trail.
+- ❌ Write to the audit DynamoDB table by hand to "mark a user remediated."
+- ❌ Use a different KMS key than the one bound to the bucket policy.
+- ❌ Run any CSPM skill with a role that has *any* `iam:*` write action.
+- ❌ Concatenate user-supplied HR data into SQL — sources use parameterised queries.
+
+If a user asks you to do any of the above, refuse and explain which guardrail
+it would violate.
 
 ## Conventions
 
-- Each skill has a `SKILL.md` with frontmatter (name, description, license, compatibility, metadata, frameworks).
+- Each skill has a `SKILL.md` with frontmatter: `name`, `description` (with trigger
+  phrases), `license`, `compatibility`, `metadata` (author, source, version, frameworks).
 - Source code lives in `src/` within each skill directory.
-- Infrastructure-as-code lives in `infra/` (CloudFormation, Terraform, StackSets).
+- Infrastructure-as-code lives in `infra/` (CloudFormation + Terraform parity).
 - Tests live in `tests/` within each skill directory.
 - All skills are Apache 2.0 licensed.
 - Python 3.11+ required. Type hints used throughout.
-- No hardcoded credentials. All secrets via environment variables or AWS Secrets Manager.
-
-## Security model
-
-- CSPM skills are read-only (no write permissions to cloud accounts).
-- Remediation skills use least-privilege IAM with cross-account STS AssumeRole.
-- Deny policies protect root, break-glass, and emergency accounts from deletion.
-- All S3 artifacts are KMS-encrypted. DynamoDB tables use encryption at rest.
+- No hardcoded credentials. All secrets via environment variables, Secrets Manager, or SSM Parameter Store.
+- One check per function. One finding row per control. No mega-functions that emit multiple control_ids.
 
 ## Compliance frameworks referenced
 
-MITRE ATT&CK, NIST CSF 2.0, CIS Controls v8, CIS AWS/GCP/Azure Foundations, SOC 2 TSC, ISO 27001:2022, PCI DSS 4.0, OWASP LLM Top 10, OWASP MCP Top 10.
+CIS AWS/GCP/Azure Foundations, CIS Controls v8, MITRE ATT&CK, NIST CSF 2.0,
+SOC 2 TSC, ISO 27001:2022, PCI DSS 4.0, OWASP LLM Top 10, OWASP MCP Top 10.
 
 ## Running checks
 
 ```bash
-# AWS CIS benchmark
-pip install boto3
-python skills/cspm-aws-cis-benchmark/src/checks.py --region us-east-1
+# CSPM (read-only)
+pip install boto3 google-cloud-resource-manager azure-identity
+python skills/cspm-aws-cis-benchmark/src/checks.py   --region us-east-1
+python skills/cspm-gcp-cis-benchmark/src/checks.py   --project my-project
+python skills/cspm-azure-cis-benchmark/src/checks.py --subscription <sub-id>
 
-# GCP CIS benchmark
-pip install google-cloud-iam google-cloud-storage google-cloud-compute
-python skills/cspm-gcp-cis-benchmark/src/checks.py --project my-project
+# Remediation (dry-run)
+python skills/iam-departures-remediation/src/lambda_parser/handler.py --dry-run examples/manifest.json
+python skills/vuln-remediation-pipeline/src/lambda_triage/handler.py < scan-findings.sarif
 
-# Azure CIS benchmark
-pip install azure-identity azure-mgmt-authorization azure-mgmt-storage azure-mgmt-monitor azure-mgmt-network
-python skills/cspm-azure-cis-benchmark/src/checks.py --subscription-id SUB_ID
-
-# IAM departures tests
-cd skills/iam-departures-remediation && pip install boto3 moto pytest && pytest tests/ -v
+# Tests
+pip install pytest boto3 moto
+pytest skills/cspm-aws-cis-benchmark/tests/      -o "testpaths=tests"
+pytest skills/cspm-gcp-cis-benchmark/tests/      -o "testpaths=tests"
+pytest skills/cspm-azure-cis-benchmark/tests/    -o "testpaths=tests"
+pytest skills/iam-departures-remediation/tests/  -o "testpaths=tests"
+pytest skills/vuln-remediation-pipeline/tests/   -o "testpaths=tests"
 ```
 
 ## Integration with agent-bom
 
-This repo provides the security automations. [agent-bom](https://github.com/msaad00/agent-bom) provides continuous scanning and compliance validation. Use together for detection + response.
+This repo provides the security automations. [agent-bom](https://github.com/msaad00/agent-bom)
+provides continuous scanning and a unified graph. Use together for detection +
+response.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
 
-Production-grade cloud security benchmarks and automation — 10 skills, 159 tests, compliance-mapped to MITRE ATT&CK, NIST CSF, CIS, ISO 27001, and SOC 2.
+Production-grade cloud security benchmarks and automation — 5 skills, compliance-mapped to MITRE ATT&CK, NIST CSF, CIS, ISO 27001, and SOC 2. Each workflow is a closed loop: detect → act → audit → re-verify.
 
 Each skill is a standalone Python script with its own checks, tests, examples, and SKILL.md definition following [Anthropic's skill spec](https://docs.anthropic.com). Skills can be used directly from the CLI, integrated into CI/CD pipelines, or referenced by AI agents that read SKILL.md files (Claude Desktop, Cortex Code, etc.).
 
@@ -14,36 +14,55 @@ Each skill is a standalone Python script with its own checks, tests, examples, a
 | Skill | Scope | Checks | Description |
 |-------|-------|--------|-------------|
 | [cspm-aws-cis-benchmark](skills/cspm-aws-cis-benchmark/) | AWS | 18 | CIS AWS Foundations v3.0 — IAM, Storage, Logging, Networking |
-| [cspm-gcp-cis-benchmark](skills/cspm-gcp-cis-benchmark/) | GCP | 25 | CIS GCP Foundations v3.0 + Vertex AI security |
-| [cspm-azure-cis-benchmark](skills/cspm-azure-cis-benchmark/) | Azure | 24 | CIS Azure Foundations v2.1 + AI Foundry security |
-| [model-serving-security](skills/model-serving-security/) | Any | 16 | Model endpoint auth, rate limiting, data egress, safety layers |
-| [gpu-cluster-security](skills/gpu-cluster-security/) | Any | 13 | GPU runtime isolation, driver CVEs, InfiniBand, tenant isolation |
-| [k8s-security-benchmark](skills/k8s-security-benchmark/) | Any | 10 | Pod security, RBAC, network policies, secrets, image pinning |
-| [container-security](skills/container-security/) | Any | 8 | Dockerfile best practices, image security, runtime isolation |
-| [discover-environment](skills/discover-environment/) | Multi-cloud | — | Map cloud resources to security graph with MITRE ATT&CK/ATLAS overlays |
+| [cspm-gcp-cis-benchmark](skills/cspm-gcp-cis-benchmark/) | GCP | 7 | CIS GCP Foundations v3.0 — IAM, Cloud Storage, Networking |
+| [cspm-azure-cis-benchmark](skills/cspm-azure-cis-benchmark/) | Azure | 6 | CIS Azure Foundations v2.1 — Storage, Networking |
 | [iam-departures-remediation](skills/iam-departures-remediation/) | Multi-cloud | — | Auto-remediate IAM for departed employees across 5 clouds |
 | [vuln-remediation-pipeline](skills/vuln-remediation-pipeline/) | AWS | — | Auto-remediate supply chain vulns with EPSS triage |
 
 ## Architecture — IAM Departures Remediation
 
+Closed-loop, event-driven pipeline. HR change → S3 manifest → EventBridge → Step Function → cloud deactivation → dual-write audit → ingest back into the source warehouse so the next reconciler run *verifies* the previous run actually closed.
+
 ```mermaid
 flowchart LR
     HR["HR Sources\nWorkday · Snowflake\nDatabricks · ClickHouse"]
-    REC["Reconciler\nSHA-256 row diff\nchange detect → S3 manifest\nKMS encrypted"]
-    SFN["Step Function\nParser: validate · grace period · rehire\nWorker: 13-step IAM cleanup"]
+    REC["Reconciler\nSHA-256 row diff\nchange detect\nKMS encrypted"]
+    S3["S3 Manifest\nKMS · versioned\nEventBridge enabled"]
+    EB["EventBridge Rule\nObject Created\nprefix: departures/\nsuffix: .json"]
+    SFN["Step Function\nParser: validate · grace · rehire\nWorker: 13-step IAM cleanup\nMap concurrency 10"]
     TGT["5 Cloud Targets\nAWS IAM · Azure Entra\nGCP IAM · Snowflake · Databricks"]
-    AUDIT["Audit Trail\nDynamoDB + S3\nwarehouse ingest-back"]
+    AUDIT["Audit Trail\nDynamoDB + S3\nKMS encrypted"]
+    WH["Warehouse Ingest-Back\nremediation_log table\nSnowflake / Databricks"]
+    VERIFY["Next Reconciler Run\nverify state == closed\nflag drift / partial cleanup"]
+    DLQ["DLQ + SNS Alerts\nLambda async failures\nSFN ExecutionFailed\nEventBridge → on-call"]
 
-    HR --> REC --> SFN --> TGT --> AUDIT
+    HR --> REC --> S3 --> EB --> SFN --> TGT --> AUDIT --> WH --> VERIFY
+    VERIFY -. drift detected .-> REC
+    SFN -. failure .-> DLQ
+    DLQ -. replay .-> EB
 
     style HR fill:#1e293b,stroke:#475569,color:#e2e8f0
     style REC fill:#164e63,stroke:#22d3ee,color:#e2e8f0
+    style S3 fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style EB fill:#172554,stroke:#3b82f6,color:#e2e8f0
     style SFN fill:#164e63,stroke:#22d3ee,color:#e2e8f0
     style TGT fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
     style AUDIT fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
+    style WH fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
+    style VERIFY fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style DLQ fill:#3f1d1d,stroke:#f87171,color:#fecaca
 ```
 
+**Why event-driven and closed-loop, not fire-and-forget:**
+- *Decoupling:* Reconciler is stateless — it only writes the manifest. Failed runs are replayed by re-emitting the S3 event, no HR re-pull needed.
+- *Single trigger surface:* EventBridge is the only path to the Step Function. Manual replays, out-of-band uploads, and scheduled syncs all hit the same audit point.
+- *Verification:* DynamoDB + S3 audit rows are ingested back into the source warehouse, so the next reconciler diff *cross-checks* the previous remediation actually landed. Drift becomes a finding, not a silent failure.
+- *Failure path:* Lambda async failures land in an SQS DLQ. Step Function `ExecutionFailed` events page on-call via SNS. DLQ messages can be re-driven through EventBridge — the loop closes even on errors.
+- *Extensible:* Adding a SIEM forwarder, Slack notifier, or secondary region is a new EventBridge target — no Lambda or reconciler change.
+
 ## Architecture — CSPM CIS Benchmarks
+
+Closed loop: scan → finding → ticket/PR → fix → re-scan verifies the same control_id is now `pass`. Findings keep their `control_id` so the verification run can prove the gap closed.
 
 ```mermaid
 flowchart LR
@@ -56,60 +75,42 @@ flowchart LR
     end
 
     CHK["checks.py\nread-only SDK calls\nno write permissions"]
+    OUT["Findings\nJSON · SARIF · Console"]
+    SIEM["SIEM / Ticketing\nGitHub code scanning\nJira · Splunk · Datadog"]
+    FIX["Remediation\nIaC PR · console fix\nor exception with TTL"]
+    VERIFY["Next scan run\ncontrol_id == pass\nor drift flagged"]
 
-    IAM & STR & LOG & NET & AI --> CHK
-
-    CHK --> JSON["JSON"]
-    CHK --> CON["Console"]
-    CHK --> SARIF["SARIF"]
+    IAM & STR & LOG & NET & AI --> CHK --> OUT --> SIEM --> FIX --> VERIFY
+    VERIFY -. re-scan .-> CHK
 
     style CLOUD fill:#1e293b,stroke:#475569,color:#e2e8f0
     style CHK fill:#164e63,stroke:#22d3ee,color:#e2e8f0
-```
-
-## Architecture — Model Serving Security
-
-```mermaid
-flowchart LR
-    CONFIG["Serving Config\nAPI Gateway · K8s · Cloud ML"]
-    BENCH["checks.py\n16 checks · 6 domains\nAuth · Rate Limit · Egress\nRuntime · TLS · Safety"]
-    OUT["JSON / Console"]
-
-    CONFIG --> BENCH --> OUT
-
-    style CONFIG fill:#1e293b,stroke:#475569,color:#e2e8f0
-    style BENCH fill:#164e63,stroke:#22d3ee,color:#e2e8f0
-```
-
-## Architecture — GPU Cluster Security
-
-```mermaid
-flowchart LR
-    CLUSTER["Cluster Config\nPods · Nodes · InfiniBand\nNamespaces · Storage"]
-    BENCH["checks.py\n13 checks · 6 domains\nRuntime · Driver · Network\nStorage · Tenant · Observability"]
-    OUT["JSON / Console"]
-
-    CLUSTER --> BENCH --> OUT
-
-    style CLUSTER fill:#1e293b,stroke:#475569,color:#e2e8f0
-    style BENCH fill:#164e63,stroke:#22d3ee,color:#e2e8f0
+    style OUT fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
+    style SIEM fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
+    style FIX fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style VERIFY fill:#172554,stroke:#3b82f6,color:#e2e8f0
 ```
 
 ## Architecture — Vulnerability Remediation Pipeline
+
+Closed loop: scan → triage → patch → audit → re-scan verifies the CVE is no longer present *and* the package version matches the expected fix version.
 
 ```mermaid
 flowchart LR
     SCAN["Scan Findings\nSARIF / JSON"]
     TRIAGE["Triage\nEPSS · KEV · CVSS\nP0→P3 SLAs"]
     FIX["Remediate\nUpgrade · Rotate · Quarantine"]
-    AUDIT["Audit + Verify"]
+    AUDIT["Audit + Verify\nDDB log + S3 evidence"]
+    RESCAN["Re-scan\nCVE absent · version pinned"]
 
-    SCAN --> TRIAGE --> FIX --> AUDIT
+    SCAN --> TRIAGE --> FIX --> AUDIT --> RESCAN
+    RESCAN -. drift .-> SCAN
 
     style SCAN fill:#1e293b,stroke:#475569,color:#e2e8f0
     style TRIAGE fill:#164e63,stroke:#22d3ee,color:#e2e8f0
     style FIX fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
     style AUDIT fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
+    style RESCAN fill:#172554,stroke:#3b82f6,color:#e2e8f0
 ```
 
 ## Security Model
@@ -145,27 +146,28 @@ flowchart LR
 | Framework | Controls | Skills |
 |-----------|----------|--------|
 | **CIS AWS Foundations v3.0** | 18 controls | cspm-aws |
-| **CIS GCP Foundations v3.0** | 20 + 5 Vertex AI | cspm-gcp |
-| **CIS Azure Foundations v2.1** | 19 + 5 AI Foundry | cspm-azure |
-| **MITRE ATT&CK** | T1078, T1098, T1087, T1195, T1203, T1530, T1599, T1610, T1611 | iam-departures, gpu-cluster |
-| **MITRE ATLAS** | AML.T0010, T0024, T0025, T0042, T0048, T0051 | model-serving |
+| **CIS GCP Foundations v3.0** | 7 controls (subset) | cspm-gcp |
+| **CIS Azure Foundations v2.1** | 6 controls (subset) | cspm-azure |
+| **MITRE ATT&CK** | T1078, T1098, T1087, T1195, T1530, T1599 | iam-departures, vuln-remediation |
 | **NIST CSF 2.0** | PR.AC, PR.DS, DE.CM, DE.AE, RS.MI, ID.RA | All skills |
-| **CIS Controls v8** | 5.3, 6.1, 6.2, 6.5, 7.1–7.4, 8.2, 8.5, 13.1, 13.6, 16.1 | iam-departures, vuln-remediation, gpu-cluster |
+| **CIS Controls v8** | 5.3, 6.1, 6.2, 6.5, 7.1–7.4, 13.1, 16.1 | iam-departures, vuln-remediation |
 | **SOC 2 TSC** | CC6.1–CC6.3, CC7.1 | iam-departures, vuln-remediation |
 | **ISO 27001:2022** | A.5.15–A.8.24 | cspm-aws, cspm-gcp, cspm-azure |
 | **PCI DSS 4.0** | 2.2, 7.1, 8.3, 10.1 | cspm skills |
-| **OWASP LLM Top 10** | LLM-05, LLM-07, LLM-08 | vuln-remediation, model-serving |
+| **OWASP LLM Top 10** | LLM-05, LLM-07, LLM-08 | vuln-remediation |
 | **OWASP MCP Top 10** | MCP-04 | vuln-remediation |
+
+> CIS GCP and CIS Azure currently automate a curated subset of high-impact controls. The full benchmark coverage is tracked in each skill's `SKILL.md`. PRs that add controls are welcome — keep one check per function and one finding row per control.
 
 ## CI/CD Pipeline
 
 | CI Job | What |
 |--------|------|
 | Lint | ruff check + format |
-| Tests | pytest per skill (IAM, model-serving, GPU, K8s, container, discover) |
+| Tests | pytest per skill |
 | CloudFormation | cfn-lint validation |
 | Terraform | terraform validate |
-| Security | bandit + hardcoded secret grep |
+| Security | bandit + hardcoded secret grep on `skills/*/src/` |
 
 ## Quick Start
 
@@ -173,28 +175,25 @@ flowchart LR
 git clone https://github.com/msaad00/cloud-security.git
 cd cloud-security
 
-# AWS CIS benchmark
-pip install boto3
-python skills/cspm-aws-cis-benchmark/src/checks.py --region us-east-1
+# CSPM CIS benchmarks (read-only)
+pip install boto3 google-cloud-resource-manager azure-identity
+python skills/cspm-aws-cis-benchmark/src/checks.py   --region us-east-1
+python skills/cspm-gcp-cis-benchmark/src/checks.py   --project my-project
+python skills/cspm-azure-cis-benchmark/src/checks.py --subscription <sub-id>
 
-# Model serving security (with example config)
-python skills/model-serving-security/src/checks.py skills/model-serving-security/examples/insecure-serving.json
+# IAM departures remediation — dry-run mode (no IAM mutations)
+python skills/iam-departures-remediation/src/lambda_parser/handler.py --dry-run examples/manifest.json
 
-# GPU cluster security (with example config)
-python skills/gpu-cluster-security/src/checks.py skills/gpu-cluster-security/examples/insecure-cluster.json
-
-# K8s security benchmark
-python skills/k8s-security-benchmark/src/checks.py skills/k8s-security-benchmark/examples/secure-cluster.json
-
-# Container security
-python skills/container-security/src/checks.py skills/container-security/examples/secure-image.json
+# Vulnerability remediation pipeline — local triage
+python skills/vuln-remediation-pipeline/src/lambda_triage/handler.py < scan-findings.sarif
 
 # Run tests
 pip install pytest boto3 moto
-pytest skills/model-serving-security/tests/ -v -o "testpaths=tests"
-pytest skills/gpu-cluster-security/tests/ -v -o "testpaths=tests"
-pytest skills/k8s-security-benchmark/tests/ -v -o "testpaths=tests"
-pytest skills/container-security/tests/ -v -o "testpaths=tests"
+pytest skills/cspm-aws-cis-benchmark/tests/      -v -o "testpaths=tests"
+pytest skills/cspm-gcp-cis-benchmark/tests/      -v -o "testpaths=tests"
+pytest skills/cspm-azure-cis-benchmark/tests/    -v -o "testpaths=tests"
+pytest skills/iam-departures-remediation/tests/  -v -o "testpaths=tests"
+pytest skills/vuln-remediation-pipeline/tests/   -v -o "testpaths=tests"
 ```
 
 ## Contributing

--- a/skills/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/cspm-azure-cis-benchmark/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: cspm-azure-cis-benchmark
 description: >-
-  Assess Azure subscriptions against CIS Azure Foundations Benchmark v2.1 plus
-  AI Foundry security controls. Runs automated checks across Identity, Storage,
-  Logging, Networking, and AI services. Use when the user mentions Azure CIS
-  benchmark, Azure security posture, Entra ID audit, storage account security,
-  or Azure AI Foundry review.
+  Assess Azure subscriptions against a curated subset of CIS Azure Foundations
+  Benchmark v2.1. Automates 6 high-impact checks across Storage and Networking.
+  Use when the user mentions Azure CIS benchmark, Azure storage security, or
+  unrestricted SSH/RDP detection in NSGs.
 license: Apache-2.0
 compatibility: >-
-  Requires Python 3.11+, azure-identity, azure-mgmt-authorization,
-  azure-mgmt-storage, azure-mgmt-monitor, azure-mgmt-network.
+  Requires Python 3.11+, azure-identity, azure-mgmt-storage, azure-mgmt-network.
   Service principal needs Reader role. No write permissions — assessment only.
 metadata:
   author: msaad00
@@ -17,16 +15,23 @@ metadata:
   source: https://github.com/msaad00/cloud-security/tree/main/skills/cspm-azure-cis-benchmark
   version: 0.1.0
   frameworks:
-    - CIS Azure Foundations v2.1
+    - CIS Azure Foundations v2.1 (subset)
     - NIST CSF 2.0
     - ISO 27001:2022
   cloud: azure
 ---
 
-# CSPM — Azure CIS Foundations Benchmark v2.1
+# CSPM — Azure CIS Foundations Benchmark v2.1 (subset)
 
-Automated assessment of Azure subscriptions against CIS Azure Foundations Benchmark
-v2.1, plus Azure AI Foundry security controls. Each check mapped to NIST CSF 2.0.
+Automated assessment of Azure subscriptions against a curated subset of CIS
+Azure Foundations Benchmark v2.1. The full benchmark has 90+ controls; this
+skill implements **6 high-impact checks** that cover the most common findings
+on real subscriptions. Each check is mapped to NIST CSF 2.0.
+
+> **Honest scope:** the table below lists *only* what `src/checks.py` actually
+> implements. See the **Roadmap** at the bottom for documented controls that
+> are not yet automated. PRs welcome — one check per function, one finding row
+> per control.
 
 ## When to Use
 
@@ -38,30 +43,28 @@ v2.1, plus Azure AI Foundry security controls. Each check mapped to NIST CSF 2.0
 
 ## Architecture
 
+Closed loop: scan → finding → fix (PR or CLI) → re-scan to verify the same `control_id` is now `pass`.
+
 ```mermaid
-flowchart TD
+flowchart LR
     subgraph AZ["Azure Subscription — read-only"]
-        ENTRA["Entra ID + RBAC<br/>7 checks"]
-        STOR["Storage Accounts<br/>4 checks"]
-        MON["Monitor / Activity<br/>4 checks"]
-        NSG["NSG / VNet<br/>4 checks"]
-        AIF["AI Foundry<br/>5 checks"]
+        STOR["Storage Accounts<br/>3 checks"]
+        NSG["NSG / VNet<br/>3 checks"]
     end
 
-    CHK["checks.py<br/>19 CIS v2.1 + 5 AI Foundry<br/>Reader role only"]
+    CHK["checks.py<br/>6 CIS v2.1 controls<br/>Reader role only"]
+    OUT["Findings<br/>JSON · Console"]
+    FIX["Remediation<br/>az CLI · Bicep PR<br/>or exception with TTL"]
+    VERIFY["Re-scan<br/>control_id == pass"]
 
-    ENTRA --> CHK
-    STOR --> CHK
-    MON --> CHK
-    NSG --> CHK
-    AIF --> CHK
-
-    CHK --> JSON["JSON"]
-    CHK --> CON["Console summary"]
+    STOR & NSG --> CHK --> OUT --> FIX --> VERIFY
+    VERIFY -. drift detected .-> CHK
 
     style AZ fill:#1e293b,stroke:#475569,color:#e2e8f0
     style CHK fill:#172554,stroke:#3b82f6,color:#e2e8f0
-    style AIF fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style OUT fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
+    style FIX fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style VERIFY fill:#164e63,stroke:#22d3ee,color:#e2e8f0
 ```
 
 ## Security Guardrails
@@ -72,58 +75,37 @@ flowchart TD
 - **AI Foundry safe**: Checks managed identity, private endpoints, CMK — does not access model endpoints or data.
 - **Idempotent**: Run as often as needed with no side effects.
 
-## Controls — CIS Azure Foundations v2.1 (key controls)
+## Implemented Controls (6)
 
-> The full CIS Azure Foundations Benchmark v2.1 has 90+ controls. This skill automates 19 high-impact checks plus 5 Azure AI Foundry security controls not covered by CIS.
+Each row maps to one function in `src/checks.py`. If it's not in this table, it's not implemented.
 
-### Section 1 — Identity & Access (7 checks)
+### Section 2 — Storage (3 checks)
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 1.1 | MFA for all users | CRITICAL | PR.AC-1 |
-| 1.2 | Conditional Access policies enforced | HIGH | PR.AC-1 |
-| 1.3 | No guest users with privileged roles | HIGH | PR.AC-4 |
-| 1.4 | Custom subscription owner roles restricted | MEDIUM | PR.AC-4 |
-| 1.5 | No legacy authentication protocols | HIGH | PR.AC-1 |
-| 1.6 | Password expiration policy configured | MEDIUM | PR.AC-1 |
-| 1.7 | PIM (Privileged Identity Management) enabled | HIGH | PR.AC-4 |
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 2.2 | Storage account HTTPS-only | `check_2_2_https_only` | HIGH | PR.DS-2 |
+| 2.3 | No public blob access | `check_2_3_no_public_blob` | CRITICAL | PR.AC-3 |
+| 2.4 | Storage account network rules (deny by default) | `check_2_4_network_rules` | HIGH | PR.AC-5 |
 
-### Section 2 — Storage (4 checks)
+### Section 4 — Networking (3 checks)
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 2.1 | Storage account encryption (CMK where required) | HIGH | PR.DS-1 |
-| 2.2 | Storage account HTTPS-only | HIGH | PR.DS-2 |
-| 2.3 | No public blob access | CRITICAL | PR.AC-3 |
-| 2.4 | Storage account network rules (deny by default) | HIGH | PR.AC-5 |
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 4.1 | No unrestricted SSH (0.0.0.0/0:22) in NSGs | `check_4_1_no_unrestricted_ssh` | HIGH | PR.AC-5 |
+| 4.2 | No unrestricted RDP (0.0.0.0/0:3389) in NSGs | `check_4_2_no_unrestricted_rdp` | HIGH | PR.AC-5 |
+| 4.3 | NSG flow logs enabled | `check_4_3_nsg_flow_logs` | MEDIUM | DE.CM-1 |
 
-### Section 3 — Logging & Monitoring (4 checks)
+## Roadmap — Documented but Not Yet Automated
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 3.1 | Activity log retention >= 365 days | MEDIUM | DE.AE-3 |
-| 3.2 | Diagnostic settings for all subscriptions | HIGH | DE.AE-3 |
-| 3.3 | Activity log alerts for policy/RBAC changes | MEDIUM | DE.CM-1 |
-| 3.4 | Azure Monitor log profile covers all regions | MEDIUM | DE.CM-1 |
+These controls are part of the CIS Azure Foundations v2.1 benchmark but are *not* implemented in `checks.py` yet. PRs welcome.
 
-### Section 4 — Networking (4 checks)
-
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 4.1 | No unrestricted SSH (0.0.0.0/0:22) in NSGs | HIGH | PR.AC-5 |
-| 4.2 | No unrestricted RDP (0.0.0.0/0:3389) in NSGs | HIGH | PR.AC-5 |
-| 4.3 | NSG flow logs enabled | MEDIUM | DE.CM-1 |
-| 4.4 | Network Watcher enabled in all regions | MEDIUM | DE.CM-1 |
-
-### Azure AI Foundry Controls (Azure-Specific)
-
-| # | Control | Severity | Rationale |
-|---|---------|----------|-----------|
-| A.1 | AI Foundry endpoints require managed identity auth | CRITICAL | Key-based auth = credential leak risk |
-| A.2 | Private endpoints for AI services | HIGH | Public endpoints = attack surface |
-| A.3 | CMK for AI model storage | MEDIUM | Protect training data + model weights |
-| A.4 | Content Safety filters enabled | HIGH | Prevent harmful output in production |
-| A.5 | Diagnostic logging on AI deployments | MEDIUM | Audit prompt/completion activity |
+| Section | Controls | Why it matters |
+|---------|---------|----------------|
+| 1.x — Identity | MFA, Conditional Access, guest roles, legacy auth, PIM | Requires Microsoft Graph API + Entra ID licensing checks |
+| 2.1 | Storage account CMK encryption | KMS key resolution per account |
+| 3.x — Logging | Activity log retention, diagnostic settings, log alerts | `azure-mgmt-monitor` enumeration |
+| 4.4 | Network Watcher in all regions | Region enumeration + Network Watcher API |
+| AI Foundry | Managed identity, private endpoints, CMK, content safety, diagnostic logging | `azure-mgmt-cognitiveservices` |
 
 ## Usage
 

--- a/skills/cspm-azure-cis-benchmark/tests/test_checks.py
+++ b/skills/cspm-azure-cis-benchmark/tests/test_checks.py
@@ -1,6 +1,8 @@
 """Tests for CIS Azure Foundations Benchmark v2.1 checks.
 
-Uses unittest.mock to simulate Azure SDK responses.
+Uses unittest.mock to simulate Azure SDK responses. Each test maps 1:1 to a
+function that actually exists in src/checks.py — if a check is not implemented,
+it does not appear here.
 """
 
 from __future__ import annotations
@@ -11,84 +13,129 @@ from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from checks import check_2_1_storage_encryption, check_4_1_no_open_ssh
+from checks import (
+    check_2_2_https_only,
+    check_2_3_no_public_blob,
+    check_2_4_network_rules,
+    check_4_1_no_unrestricted_ssh,
+    check_4_2_no_unrestricted_rdp,
+    check_4_3_nsg_flow_logs,
+)
+
+SUB_ID = "00000000-0000-0000-0000-000000000000"
+
+
+# ── Storage ───────────────────────────────────────────────────────
 
 
 class TestStorageChecks:
-    def test_2_1_encryption_enabled_passes(self):
-        mock_client = MagicMock()
-        account = MagicMock()
-        account.name = "teststorage"
-        account.encryption = MagicMock()
-        account.encryption.services = MagicMock()
-        account.encryption.services.blob = MagicMock()
-        account.encryption.services.blob.enabled = True
-        mock_client.storage_accounts = MagicMock()
-        mock_client.storage_accounts.list.return_value = [account]
+    def _account(self, name, *, https=True, public_blob=False, default_action="Deny"):
+        a = MagicMock()
+        a.name = name
+        a.enable_https_traffic_only = https
+        a.allow_blob_public_access = public_blob
+        a.network_rule_set = MagicMock()
+        a.network_rule_set.default_action = default_action
+        return a
 
-        f = check_2_1_storage_encryption(mock_client)
-        assert f.control_id == "2.1"
+    def test_2_2_https_only_passes(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("ok", https=True)]
+        f = check_2_2_https_only(client, SUB_ID)
+        assert f.control_id == "2.2"
         assert f.status == "PASS"
 
-    def test_2_1_encryption_disabled_fails(self):
-        mock_client = MagicMock()
-        account = MagicMock()
-        account.name = "unencrypted"
-        account.encryption = MagicMock()
-        account.encryption.services = MagicMock()
-        account.encryption.services.blob = MagicMock()
-        account.encryption.services.blob.enabled = False
-        mock_client.storage_accounts = MagicMock()
-        mock_client.storage_accounts.list.return_value = [account]
-
-        f = check_2_1_storage_encryption(mock_client)
+    def test_2_2_https_only_fails(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("bad", https=False)]
+        f = check_2_2_https_only(client, SUB_ID)
         assert f.status == "FAIL"
-        assert "unencrypted" in f.resources
+        assert "bad" in f.resources
+
+    def test_2_3_public_blob_fails(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("leak", public_blob=True)]
+        f = check_2_3_no_public_blob(client, SUB_ID)
+        assert f.control_id == "2.3"
+        assert f.status == "FAIL"
+        assert "leak" in f.resources
+
+    def test_2_3_no_public_blob_passes(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("ok", public_blob=False)]
+        f = check_2_3_no_public_blob(client, SUB_ID)
+        assert f.status == "PASS"
+
+    def test_2_4_default_allow_fails(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("open", default_action="Allow")]
+        f = check_2_4_network_rules(client, SUB_ID)
+        assert f.control_id == "2.4"
+        assert f.status == "FAIL"
+        assert "open" in f.resources
+
+    def test_2_4_deny_by_default_passes(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("ok", default_action="Deny")]
+        f = check_2_4_network_rules(client, SUB_ID)
+        assert f.status == "PASS"
+
+
+# ── Networking ────────────────────────────────────────────────────
 
 
 class TestNetworkChecks:
-    def test_4_1_open_ssh_fails(self):
-        mock_client = MagicMock()
+    def _nsg_with_rule(self, name, *, port="22", source="*", access="Allow", direction="Inbound"):
         nsg = MagicMock()
-        nsg.name = "open-nsg"
-        nsg.id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/open-nsg"
+        nsg.name = name
         rule = MagicMock()
-        rule.direction = "Inbound"
-        rule.access = "Allow"
-        rule.destination_port_range = "22"
-        rule.source_address_prefix = "*"
+        rule.name = "rule0"
+        rule.direction = direction
+        rule.access = access
+        rule.destination_port_range = port
+        rule.source_address_prefix = source
         rule.protocol = "Tcp"
         nsg.security_rules = [rule]
-        mock_client.network_security_groups = MagicMock()
-        mock_client.network_security_groups.list_all.return_value = [nsg]
+        return nsg
 
-        f = check_4_1_no_open_ssh(mock_client)
+    def test_4_1_open_ssh_fails(self):
+        client = MagicMock()
+        client.network_security_groups.list_all.return_value = [self._nsg_with_rule("open", port="22", source="*")]
+        f = check_4_1_no_unrestricted_ssh(client, SUB_ID)
+        assert f.control_id == "4.1"
         assert f.status == "FAIL"
 
     def test_4_1_restricted_ssh_passes(self):
-        mock_client = MagicMock()
-        nsg = MagicMock()
-        nsg.name = "restricted-nsg"
-        rule = MagicMock()
-        rule.direction = "Inbound"
-        rule.access = "Allow"
-        rule.destination_port_range = "22"
-        rule.source_address_prefix = "10.0.0.0/8"
-        rule.protocol = "Tcp"
-        nsg.security_rules = [rule]
-        mock_client.network_security_groups = MagicMock()
-        mock_client.network_security_groups.list_all.return_value = [nsg]
+        client = MagicMock()
+        client.network_security_groups.list_all.return_value = [self._nsg_with_rule("ok", port="22", source="10.0.0.0/8")]
+        f = check_4_1_no_unrestricted_ssh(client, SUB_ID)
+        assert f.status == "PASS"
 
-        f = check_4_1_no_open_ssh(mock_client)
+    def test_4_2_open_rdp_fails(self):
+        client = MagicMock()
+        client.network_security_groups.list_all.return_value = [self._nsg_with_rule("open", port="3389", source="*")]
+        f = check_4_2_no_unrestricted_rdp(client, SUB_ID)
+        assert f.control_id == "4.2"
+        assert f.status == "FAIL"
+
+    def test_4_3_no_watchers_fails(self):
+        client = MagicMock()
+        client.network_watchers.list_all.return_value = []
+        f = check_4_3_nsg_flow_logs(client, SUB_ID)
+        assert f.control_id == "4.3"
+        assert f.status == "FAIL"
+
+    def test_4_3_with_watchers_passes(self):
+        client = MagicMock()
+        client.network_watchers.list_all.return_value = [MagicMock()]
+        f = check_4_3_nsg_flow_logs(client, SUB_ID)
         assert f.status == "PASS"
 
 
 class TestFindingStructure:
     def test_finding_has_compliance(self):
-        mock_client = MagicMock()
-        mock_client.storage_accounts = MagicMock()
-        mock_client.storage_accounts.list.return_value = []
-
-        f = check_2_1_storage_encryption(mock_client)
+        client = MagicMock()
+        client.storage_accounts.list.return_value = []
+        f = check_2_3_no_public_blob(client, SUB_ID)
         assert f.nist_csf
-        assert f.control_id == "2.1"
+        assert f.control_id == "2.3"

--- a/skills/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/cspm-gcp-cis-benchmark/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: cspm-gcp-cis-benchmark
 description: >-
-  Assess GCP projects against CIS GCP Foundations Benchmark v3.0 plus Vertex AI
-  security controls. Runs automated checks across IAM, Storage, Logging, Networking,
-  and AI/ML services. Use when the user mentions GCP CIS benchmark, GCP security
-  posture, Vertex AI security, service account key audit, or public bucket detection.
+  Assess GCP projects against a curated subset of CIS GCP Foundations Benchmark v3.0
+  controls. Automates 7 high-impact checks across IAM, Cloud Storage, and VPC
+  networking. Use when the user mentions GCP CIS benchmark, GCP security posture,
+  service account key audit, or public bucket detection.
 license: Apache-2.0
 compatibility: >-
-  Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-logging,
-  google-cloud-compute. Service account needs roles/viewer + roles/iam.securityReviewer.
+  Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-compute.
+  Service account needs roles/viewer + roles/iam.securityReviewer.
   No write permissions — assessment only.
 metadata:
   author: msaad00
@@ -16,16 +16,23 @@ metadata:
   source: https://github.com/msaad00/cloud-security/tree/main/skills/cspm-gcp-cis-benchmark
   version: 0.1.0
   frameworks:
-    - CIS GCP Foundations v3.0
+    - CIS GCP Foundations v3.0 (subset)
     - NIST CSF 2.0
     - ISO 27001:2022
   cloud: gcp
 ---
 
-# CSPM — GCP CIS Foundations Benchmark v3.0
+# CSPM — GCP CIS Foundations Benchmark v3.0 (subset)
 
-Automated assessment of GCP projects against CIS GCP Foundations Benchmark v3.0,
-plus Vertex AI security controls. Each check mapped to NIST CSF 2.0.
+Automated assessment of GCP projects against a curated subset of CIS GCP
+Foundations Benchmark v3.0. The full benchmark has 80+ controls; this skill
+implements **7 high-impact checks** that cover the most common findings on
+real GCP projects. Each check is mapped to NIST CSF 2.0.
+
+> **Honest scope:** the table below lists *only* what `src/checks.py` actually
+> implements. See the **Roadmap** at the bottom for controls that are documented
+> by CIS but not yet automated here. Contributions welcome — one check per function,
+> one finding row per control.
 
 ## When to Use
 
@@ -37,30 +44,29 @@ plus Vertex AI security controls. Each check mapped to NIST CSF 2.0.
 
 ## Architecture
 
+Closed loop: scan → finding → fix (PR or console) → re-scan to verify the same `control_id` is now `pass`.
+
 ```mermaid
-flowchart TD
+flowchart LR
     subgraph GCP["GCP Project — read-only"]
-        IAM["IAM & Service Accounts<br/>7 checks"]
-        GCS["Cloud Storage<br/>4 checks"]
-        LOG["Cloud Logging<br/>4 checks"]
-        NET["VPC / Firewall<br/>5 checks"]
-        VAI["Vertex AI<br/>5 checks"]
+        IAM["IAM & Service Accounts<br/>3 checks"]
+        GCS["Cloud Storage<br/>2 checks"]
+        NET["VPC / Firewall<br/>2 checks"]
     end
 
-    CHK["checks.py<br/>20 CIS v3.0 + 5 Vertex AI<br/>roles/viewer + iam.securityReviewer"]
+    CHK["checks.py<br/>7 CIS v3.0 controls<br/>roles/viewer + iam.securityReviewer"]
+    OUT["Findings<br/>JSON · Console"]
+    FIX["Remediation<br/>IaC PR · console fix<br/>or exception with TTL"]
+    VERIFY["Re-scan<br/>control_id == pass"]
 
-    IAM --> CHK
-    GCS --> CHK
-    LOG --> CHK
-    NET --> CHK
-    VAI --> CHK
-
-    CHK --> JSON["JSON"]
-    CHK --> CON["Console summary"]
+    IAM & GCS & NET --> CHK --> OUT --> FIX --> VERIFY
+    VERIFY -. drift detected .-> CHK
 
     style GCP fill:#1e293b,stroke:#475569,color:#e2e8f0
     style CHK fill:#172554,stroke:#3b82f6,color:#e2e8f0
-    style VAI fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style OUT fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
+    style FIX fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style VERIFY fill:#164e63,stroke:#22d3ee,color:#e2e8f0
 ```
 
 ## Security Guardrails
@@ -71,59 +77,48 @@ flowchart TD
 - **Vertex AI safe**: Checks endpoint auth, VPC-SC, CMEK — does not access model data or training data.
 - **Idempotent**: Run as often as needed with no side effects.
 
-## Controls — CIS GCP Foundations v3.0 (key controls)
+## Implemented Controls (7)
 
-> The full CIS GCP Foundations Benchmark v3.0 has 80+ controls. This skill automates 20 high-impact checks plus 5 Vertex AI security controls not covered by CIS.
+Each row maps to one function in `src/checks.py`. If it's not in this table, it's not implemented.
 
-### Section 1 — IAM (7 checks)
+### Section 1 — IAM (3 checks)
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 1.1 | Corporate credentials only (no personal Gmail) | HIGH | PR.AC-1 |
-| 1.2 | MFA enforced org-wide | CRITICAL | PR.AC-1 |
-| 1.3 | No user-managed service account keys | HIGH | PR.AC-1 |
-| 1.4 | Service account key rotation (90 days) | MEDIUM | PR.AC-1 |
-| 1.5 | No keys for default compute/App Engine SAs | HIGH | PR.AC-4 |
-| 1.6 | No project-wide SSH keys | MEDIUM | PR.AC-5 |
-| 1.7 | SA impersonation scoped (serviceAccountTokenCreator) | HIGH | PR.AC-4 |
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 1.1 | Corporate credentials only (no personal Gmail) | `check_1_1_no_gmail_accounts` | HIGH | PR.AC-1 |
+| 1.3 | No user-managed service account keys | `check_1_3_no_sa_keys` | HIGH | PR.AC-1 |
+| 1.4 | Service account key rotation (90 days) | `check_1_4_sa_key_rotation` | MEDIUM | PR.AC-1 |
 
-### Section 2 — Cloud Storage (4 checks)
+### Section 2 — Cloud Storage (2 checks)
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 2.1 | Uniform bucket-level access (no legacy ACL) | HIGH | PR.AC-3 |
-| 2.2 | Bucket retention policy on compliance buckets | MEDIUM | PR.DS-1 |
-| 2.3 | No public buckets (allUsers/allAuthenticatedUsers) | CRITICAL | PR.AC-3 |
-| 2.4 | CMEK encryption on sensitive data | MEDIUM | PR.DS-1 |
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 2.1 | Uniform bucket-level access (no legacy ACL) | `check_2_1_uniform_access` | HIGH | PR.AC-3 |
+| 2.3 | No public buckets (allUsers/allAuthenticatedUsers) | `check_2_3_no_public_buckets` | CRITICAL | PR.AC-3 |
 
-### Section 3 — Logging (4 checks)
+### Section 4 — Networking (2 checks)
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 3.1 | Data Access audit logs for all services | CRITICAL | DE.AE-3 |
-| 3.2 | Org-level log sink configured | HIGH | DE.AE-3 |
-| 3.3 | Log bucket retention >= 365 days | MEDIUM | DE.AE-5 |
-| 3.4 | Alert policies for IAM/firewall/route changes | MEDIUM | DE.CM-1 |
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 4.2 | No unrestricted SSH/RDP (0.0.0.0/0 on 22/3389) | `check_4_2_no_unrestricted_ssh_rdp` | HIGH | PR.AC-5 |
+| 4.3 | VPC flow logs on all subnets | `check_4_3_vpc_flow_logs` | MEDIUM | DE.CM-1 |
 
-### Section 4 — Networking (5 checks)
+## Roadmap — Documented but Not Yet Automated
 
-| # | CIS Control | Severity | NIST CSF 2.0 |
-|---|------------|----------|--------------|
-| 4.1 | Default VPC deleted | MEDIUM | PR.AC-5 |
-| 4.2 | No unrestricted SSH/RDP (0.0.0.0/0 on 22/3389) | HIGH | PR.AC-5 |
-| 4.3 | VPC flow logs on all subnets | MEDIUM | DE.CM-1 |
-| 4.4 | Private Google Access enabled | MEDIUM | PR.AC-5 |
-| 4.5 | SSL policies enforce TLS 1.2+ | HIGH | PR.DS-2 |
+These controls are part of the CIS GCP Foundations v3.0 benchmark but are *not* implemented in `checks.py` yet. PRs welcome.
 
-### Vertex AI Controls (GCP-Specific)
-
-| # | Control | Severity | Rationale |
-|---|---------|----------|-----------|
-| V.1 | Model endpoints require IAM auth | CRITICAL | Unauthenticated endpoints = prompt injection surface |
-| V.2 | Vertex AI inside VPC Service Controls | HIGH | Prevent data exfiltration via API calls |
-| V.3 | CMEK for training data | MEDIUM | Protect model training datasets |
-| V.4 | Model registry audit (version lineage) | MEDIUM | Detect model tampering |
-| V.5 | No public Vertex AI endpoints | CRITICAL | Public endpoints = attack surface |
+| # | CIS Control | Why it matters |
+|---|------------|----------------|
+| 1.2 | MFA enforced org-wide | Requires Workspace Admin SDK access, not in this skill's scope |
+| 1.5 | No keys for default compute/App Engine SAs | Specialised filter on top of 1.3 |
+| 1.6 | No project-wide SSH keys | Compute metadata read |
+| 1.7 | SA impersonation scoped | IAM Recommender or policy walker |
+| 2.2 | Bucket retention policy on compliance buckets | Requires labeling convention |
+| 2.4 | CMEK encryption on sensitive data | KMS + Storage join |
+| 3.1–3.4 | Logging coverage and alert policies | `google-cloud-logging` + `google-cloud-monitoring` |
+| 4.1 | Default VPC deleted | Compute API VPC enumeration |
+| 4.4 | Private Google Access | Subnet attribute |
+| 4.5 | SSL policies enforce TLS 1.2+ | Compute API SSL policies |
 
 ## Usage
 

--- a/skills/iam-departures-remediation/SKILL.md
+++ b/skills/iam-departures-remediation/SKILL.md
@@ -54,15 +54,18 @@ flowchart TD
     HR["HR Source<br/>Workday / Snowflake / Databricks / ClickHouse"]
     REC{"Reconciler<br/>SHA-256 change detect"}
     EXIT["EXIT — no changes"]
-    S3["S3 Manifest<br/>KMS encrypted"]
-    EB["EventBridge Rule<br/>S3 PutObject trigger"]
+    S3["S3 Manifest<br/>KMS · versioned<br/>EventBridge enabled"]
+    EB["EventBridge Rule<br/>Object Created<br/>prefix departures/"]
 
     subgraph SFN["Step Function — VPC isolated"]
         L1["Lambda 1 — Parser<br/>validate, grace period,<br/>rehire filter"]
         L2["Lambda 2 — Worker<br/>13-step IAM cleanup"]
     end
 
-    AUDIT["Audit Trail<br/>DynamoDB + S3 + warehouse"]
+    AUDIT["Audit Trail<br/>DynamoDB + S3"]
+    WH["Warehouse Ingest-Back<br/>remediation_log table"]
+    VERIFY["Next Reconciler Run<br/>verify state == closed<br/>flag drift"]
+    DLQ["DLQ + SNS<br/>Lambda async failures<br/>SFN ExecutionFailed"]
 
     HR --> REC
     REC -->|no change| EXIT
@@ -71,9 +74,17 @@ flowchart TD
     EB --> L1
     L1 --> L2
     L2 --> AUDIT
+    AUDIT --> WH
+    WH --> VERIFY
+    VERIFY -. drift .-> REC
+    SFN -. failure .-> DLQ
+    DLQ -. replay .-> EB
 
     style SFN fill:#172554,stroke:#3b82f6,color:#e2e8f0
     style REC fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
+    style EB fill:#172554,stroke:#3b82f6,color:#e2e8f0
+    style VERIFY fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
+    style DLQ fill:#3f1d1d,stroke:#f87171,color:#fecaca
 ```
 
 ## Security Guardrails
@@ -132,6 +143,8 @@ for deployable templates.
 | EventBridge | `iam-departures-events-role` | `states:StartExecution` on the Step Function |
 | S3 Bucket | Bucket policy | Restrict to Security OU account only |
 | Cross-Account | `iam-remediation-role` | IAM read/write in target accounts (StackSets) |
+| DLQ | `iam-departures-dlq` (SQS) | Captures Lambda async failures for replay (KMS encrypted) |
+| Alerts | `iam-departures-alerts` (SNS) | EventBridge fires on `Step Functions Execution Status Change` for `FAILED` / `TIMED_OUT` / `ABORTED` |
 
 ## Data Sources
 
@@ -205,7 +218,7 @@ terraform init && terraform plan && terraform apply
 
 | IaC | Path | Resources |
 |-----|------|-----------|
-| CloudFormation | `infra/cloudformation.yaml` | Full stack (S3, KMS, DDB, Lambda, SFN, EventBridge, 4 IAM roles) |
+| CloudFormation | `infra/cloudformation.yaml` | Full stack (S3, KMS, DDB, Lambda, SFN, EventBridge, DLQ, SNS alerts, 4 IAM roles) |
 | Terraform | `infra/terraform/main.tf` | Same resources, HCL format |
 | StackSets | `infra/cross_account_stackset.yaml` | Org-wide cross-account remediation role |
 

--- a/skills/iam-departures-remediation/infra/cloudformation.yaml
+++ b/skills/iam-departures-remediation/infra/cloudformation.yaml
@@ -39,6 +39,21 @@ Parameters:
     Type: String
     Default: lambda/iam-departures-worker.zip
     Description: S3 key for Lambda worker deployment package
+  AlertEmail:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional email address subscribed to failure alerts. Leave blank
+      to skip email subscription (SNS topic is still created).
+  DlqRetentionSeconds:
+    Type: Number
+    Default: 1209600
+    MinValue: 60
+    MaxValue: 1209600
+    Description: SQS DLQ message retention (default 14 days, the maximum)
+
+Conditions:
+  HasAlertEmail: !Not [!Equals [!Ref AlertEmail, '']]
 
 Resources:
   # ── S3 Bucket ────────────────────────────────────────────────
@@ -357,6 +372,108 @@ Resources:
         - Key: Project
           Value: iam-departures-remediation
 
+  # ── Failure Path: DLQ + SNS + EventBridge alert rule ─────────
+  # Closed-loop guarantee: nothing fails silently. Async Lambda
+  # failures land in the DLQ for replay; Step Function failures
+  # raise an SNS alert so on-call sees them in real time.
+
+  PipelineFailureDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: iam-departures-dlq
+      MessageRetentionPeriod: !Ref DlqRetentionSeconds
+      KmsMasterKeyId: !Ref KmsKeyArn
+      KmsDataKeyReusePeriodSeconds: 300
+      Tags:
+        - Key: Project
+          Value: iam-departures-remediation
+
+  PipelineAlertsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: iam-departures-alerts
+      DisplayName: IAM Departures Remediation Alerts
+      KmsMasterKeyId: !Ref KmsKeyArn
+      Tags:
+        - Key: Project
+          Value: iam-departures-remediation
+
+  PipelineAlertsEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasAlertEmail
+    Properties:
+      Protocol: email
+      Endpoint: !Ref AlertEmail
+      TopicArn: !Ref PipelineAlertsTopic
+
+  PipelineAlertsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref PipelineAlertsTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowEventBridgePublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref PipelineAlertsTopic
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+
+  StepFunctionFailureRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: iam-departures-sfn-failure
+      Description: Page on-call when the IAM departures Step Function fails or times out
+      State: ENABLED
+      EventPattern:
+        source:
+          - aws.states
+        detail-type:
+          - Step Functions Execution Status Change
+        detail:
+          status:
+            - FAILED
+            - TIMED_OUT
+            - ABORTED
+          stateMachineArn:
+            - !Ref DeparturesPipeline
+      Targets:
+        - Id: AlertsTopic
+          Arn: !Ref PipelineAlertsTopic
+
+  ParserDlqWritePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ParserDlqWrite
+      Roles:
+        - !Ref ParserExecutionRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt PipelineFailureDlq.Arn
+
+  WorkerDlqWritePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: WorkerDlqWrite
+      Roles:
+        - !Ref WorkerExecutionRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt PipelineFailureDlq.Arn
+
   # ── Lambda Functions ─────────────────────────────────────────
 
   ParserFunction:
@@ -371,6 +488,8 @@ Resources:
       Role: !GetAtt ParserExecutionRole.Arn
       Timeout: 300
       MemorySize: 256
+      DeadLetterConfig:
+        TargetArn: !GetAtt PipelineFailureDlq.Arn
       Environment:
         Variables:
           IAM_REMEDIATION_BUCKET: !Ref RemediationBucket
@@ -394,6 +513,8 @@ Resources:
       Role: !GetAtt WorkerExecutionRole.Arn
       Timeout: 900
       MemorySize: 256
+      DeadLetterConfig:
+        TargetArn: !GetAtt PipelineFailureDlq.Arn
       Environment:
         Variables:
           IAM_REMEDIATION_BUCKET: !Ref RemediationBucket
@@ -545,3 +666,12 @@ Outputs:
   AuditTableArn:
     Description: DynamoDB audit table ARN
     Value: !GetAtt AuditTable.Arn
+  PipelineFailureDlqArn:
+    Description: SQS DLQ for failed Lambda async invocations (replay source)
+    Value: !GetAtt PipelineFailureDlq.Arn
+  PipelineFailureDlqUrl:
+    Description: SQS DLQ URL
+    Value: !Ref PipelineFailureDlq
+  PipelineAlertsTopicArn:
+    Description: SNS topic that fires on Step Function failure / timeout / abort
+    Value: !Ref PipelineAlertsTopic

--- a/skills/iam-departures-remediation/infra/terraform/main.tf
+++ b/skills/iam-departures-remediation/infra/terraform/main.tf
@@ -499,8 +499,6 @@ resource "aws_sns_topic_subscription" "pipeline_alerts_email" {
   endpoint  = var.alert_email
 }
 
-data "aws_caller_identity" "current" {}
-
 resource "aws_sns_topic_policy" "pipeline_alerts" {
   arn = aws_sns_topic.pipeline_alerts.arn
   policy = jsonencode({

--- a/skills/iam-departures-remediation/infra/terraform/main.tf
+++ b/skills/iam-departures-remediation/infra/terraform/main.tf
@@ -90,6 +90,18 @@ variable "tags" {
   }
 }
 
+variable "alert_email" {
+  description = "Optional email subscribed to failure alerts. Empty = topic only, no subscription."
+  type        = string
+  default     = ""
+}
+
+variable "dlq_retention_seconds" {
+  description = "SQS DLQ message retention. Default 14 days (max)."
+  type        = number
+  default     = 1209600
+}
+
 # ── Data Sources ───────────────────────────────────────────────
 
 data "aws_caller_identity" "current" {}
@@ -460,6 +472,99 @@ resource "aws_iam_role_policy" "eventbridge" {
   })
 }
 
+# ── Failure Path: DLQ + SNS + EventBridge alert rule ──────────
+# Closed-loop guarantee: nothing fails silently. Async Lambda
+# failures land in the DLQ for replay; Step Function failures
+# raise an SNS alert so on-call sees them in real time.
+
+resource "aws_sqs_queue" "pipeline_failures" {
+  name                              = "iam-departures-dlq"
+  message_retention_seconds         = var.dlq_retention_seconds
+  kms_master_key_id                 = var.kms_key_arn
+  kms_data_key_reuse_period_seconds = 300
+  tags                              = var.tags
+}
+
+resource "aws_sns_topic" "pipeline_alerts" {
+  name              = "iam-departures-alerts"
+  display_name      = "IAM Departures Remediation Alerts"
+  kms_master_key_id = var.kms_key_arn
+  tags              = var.tags
+}
+
+resource "aws_sns_topic_subscription" "pipeline_alerts_email" {
+  count     = var.alert_email == "" ? 0 : 1
+  topic_arn = aws_sns_topic.pipeline_alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_sns_topic_policy" "pipeline_alerts" {
+  arn = aws_sns_topic.pipeline_alerts.arn
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AllowEventBridgePublish"
+      Effect    = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+      Action    = "sns:Publish"
+      Resource  = aws_sns_topic.pipeline_alerts.arn
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "parser_dlq_write" {
+  name = "ParserDlqWrite"
+  role = aws_iam_role.parser.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:SendMessage"]
+      Resource = aws_sqs_queue.pipeline_failures.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "worker_dlq_write" {
+  name = "WorkerDlqWrite"
+  role = aws_iam_role.worker.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:SendMessage"]
+      Resource = aws_sqs_queue.pipeline_failures.arn
+    }]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "sfn_failure" {
+  name        = "iam-departures-sfn-failure"
+  description = "Page on-call when the IAM departures Step Function fails or times out"
+  event_pattern = jsonencode({
+    source      = ["aws.states"]
+    detail-type = ["Step Functions Execution Status Change"]
+    detail = {
+      status          = ["FAILED", "TIMED_OUT", "ABORTED"]
+      stateMachineArn = [aws_sfn_state_machine.pipeline.arn]
+    }
+  })
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "sfn_failure_to_sns" {
+  rule = aws_cloudwatch_event_rule.sfn_failure.name
+  arn  = aws_sns_topic.pipeline_alerts.arn
+}
+
 # ── Lambda Functions ───────────────────────────────────────────
 
 resource "aws_lambda_function" "parser" {
@@ -471,6 +576,10 @@ resource "aws_lambda_function" "parser" {
   role          = aws_iam_role.parser.arn
   timeout       = 300
   memory_size   = 256
+
+  dead_letter_config {
+    target_arn = aws_sqs_queue.pipeline_failures.arn
+  }
 
   environment {
     variables = {
@@ -496,6 +605,10 @@ resource "aws_lambda_function" "worker" {
   role          = aws_iam_role.worker.arn
   timeout       = 900
   memory_size   = 256
+
+  dead_letter_config {
+    target_arn = aws_sqs_queue.pipeline_failures.arn
+  }
 
   environment {
     variables = {
@@ -652,4 +765,14 @@ output "s3_bucket_arn" {
 output "audit_table_arn" {
   description = "DynamoDB audit table ARN"
   value       = aws_dynamodb_table.audit.arn
+}
+
+output "pipeline_failure_dlq_arn" {
+  description = "SQS DLQ for failed Lambda async invocations (replay source)"
+  value       = aws_sqs_queue.pipeline_failures.arn
+}
+
+output "pipeline_alerts_topic_arn" {
+  description = "SNS topic that fires on Step Function failure / timeout / abort"
+  value       = aws_sns_topic.pipeline_alerts.arn
 }

--- a/skills/iam-departures-remediation/tests/test_cross_cloud_workers.py
+++ b/skills/iam-departures-remediation/tests/test_cross_cloud_workers.py
@@ -86,7 +86,7 @@ class TestRemediationResult:
 
 class TestAzureEntra:
     def test_dry_run_produces_all_steps(self):
-        from src.lambda_worker.clouds import azure_entra
+        from lambda_worker.clouds import azure_entra
 
         result = asyncio.get_event_loop().run_until_complete(azure_entra.remediate_user("user-id-123", "tenant-abc", dry_run=True))
         assert result.status == RemediationStatus.DRY_RUN
@@ -100,7 +100,7 @@ class TestAzureEntra:
         assert result.steps[5].action == "delete_user"
 
     def test_required_permissions(self):
-        from src.lambda_worker.clouds import azure_entra
+        from lambda_worker.clouds import azure_entra
 
         perms = azure_entra.get_required_permissions()
         assert "User.ReadWrite.All" in perms
@@ -108,7 +108,7 @@ class TestAzureEntra:
         assert "DelegatedPermissionGrant.ReadWrite.All" in perms
 
     def test_identity_type_is_entra_user(self):
-        from src.lambda_worker.clouds import azure_entra
+        from lambda_worker.clouds import azure_entra
 
         result = asyncio.get_event_loop().run_until_complete(azure_entra.remediate_user("user@domain.com", "tenant-123", dry_run=True))
         assert result.identity_type == "entra_user"
@@ -119,7 +119,7 @@ class TestAzureEntra:
 
 class TestGCPIAM:
     def test_sa_dry_run_produces_all_steps(self):
-        from src.lambda_worker.clouds import gcp_iam
+        from lambda_worker.clouds import gcp_iam
 
         result = asyncio.get_event_loop().run_until_complete(
             gcp_iam.remediate_service_account(
@@ -137,7 +137,7 @@ class TestGCPIAM:
         assert result.steps[3].action == "delete_service_account"
 
     def test_workspace_user_dry_run(self):
-        from src.lambda_worker.clouds import gcp_iam
+        from lambda_worker.clouds import gcp_iam
 
         result = asyncio.get_event_loop().run_until_complete(gcp_iam.remediate_workspace_user("user@domain.com", dry_run=True))
         assert result.status == RemediationStatus.DRY_RUN
@@ -145,7 +145,7 @@ class TestGCPIAM:
         assert len(result.steps) == 2
 
     def test_required_permissions(self):
-        from src.lambda_worker.clouds import gcp_iam
+        from lambda_worker.clouds import gcp_iam
 
         perms = gcp_iam.get_required_permissions()
         assert "roles/iam.serviceAccountAdmin" in perms
@@ -157,7 +157,7 @@ class TestGCPIAM:
 
 class TestSnowflake:
     def test_dry_run_produces_all_steps(self):
-        from src.lambda_worker.clouds import snowflake_user
+        from lambda_worker.clouds import snowflake_user
 
         result = asyncio.get_event_loop().run_until_complete(snowflake_user.remediate_user("departing_user", "myaccount", dry_run=True))
         assert result.status == RemediationStatus.DRY_RUN
@@ -171,20 +171,20 @@ class TestSnowflake:
         assert result.steps[5].action == "verify_dropped"
 
     def test_identity_type_is_snowflake_user(self):
-        from src.lambda_worker.clouds import snowflake_user
+        from lambda_worker.clouds import snowflake_user
 
         result = asyncio.get_event_loop().run_until_complete(snowflake_user.remediate_user("test_user", "acct", dry_run=True))
         assert result.identity_type == "snowflake_user"
 
     def test_implicit_roles_skipped(self):
         """PUBLIC role must be in the skip list."""
-        from src.lambda_worker.clouds.snowflake_user import _IMPLICIT_ROLES
+        from lambda_worker.clouds.snowflake_user import _IMPLICIT_ROLES
 
         assert "PUBLIC" in _IMPLICIT_ROLES
 
     def test_ownership_object_types(self):
         """All major Snowflake object types should be in the transfer list."""
-        from src.lambda_worker.clouds.snowflake_user import _OWNERSHIP_OBJECT_TYPES
+        from lambda_worker.clouds.snowflake_user import _OWNERSHIP_OBJECT_TYPES
 
         assert "TABLES" in _OWNERSHIP_OBJECT_TYPES
         assert "VIEWS" in _OWNERSHIP_OBJECT_TYPES
@@ -197,7 +197,7 @@ class TestSnowflake:
 
 class TestDatabricks:
     def test_dry_run_produces_all_steps(self):
-        from src.lambda_worker.clouds import databricks_scim
+        from lambda_worker.clouds import databricks_scim
 
         result = asyncio.get_event_loop().run_until_complete(databricks_scim.remediate_user("user@company.com", dry_run=True))
         assert result.status == RemediationStatus.DRY_RUN
@@ -209,7 +209,7 @@ class TestDatabricks:
         assert result.steps[3].action == "delete_account_user"
 
     def test_workspace_only_skips_account_ops(self):
-        from src.lambda_worker.clouds import databricks_scim
+        from lambda_worker.clouds import databricks_scim
 
         # workspace_only still needs workspace client, but dry_run skips all
         result = asyncio.get_event_loop().run_until_complete(
@@ -219,14 +219,14 @@ class TestDatabricks:
         assert result.status == RemediationStatus.DRY_RUN
 
     def test_required_permissions(self):
-        from src.lambda_worker.clouds import databricks_scim
+        from lambda_worker.clouds import databricks_scim
 
         perms = databricks_scim.get_required_permissions()
         assert any("Workspace admin" in p for p in perms)
         assert any("Account admin" in p for p in perms)
 
     def test_identity_type(self):
-        from src.lambda_worker.clouds import databricks_scim
+        from lambda_worker.clouds import databricks_scim
 
         result = asyncio.get_event_loop().run_until_complete(databricks_scim.remediate_user("user@co.com", dry_run=True))
         assert result.identity_type == "databricks_user"
@@ -252,7 +252,7 @@ class TestCrossCloudComparison:
         assert cloud.value == expected_type
 
     def test_all_workers_have_required_permissions(self):
-        from src.lambda_worker.clouds import azure_entra, databricks_scim, gcp_iam, snowflake_user
+        from lambda_worker.clouds import azure_entra, databricks_scim, gcp_iam, snowflake_user
 
         for module in [azure_entra, gcp_iam, snowflake_user, databricks_scim]:
             perms = module.get_required_permissions()
@@ -260,7 +260,7 @@ class TestCrossCloudComparison:
             assert len(perms) > 0
 
     def test_all_dry_runs_return_correct_status(self):
-        from src.lambda_worker.clouds import azure_entra, databricks_scim, gcp_iam, snowflake_user
+        from lambda_worker.clouds import azure_entra, databricks_scim, gcp_iam, snowflake_user
 
         results = [
             asyncio.get_event_loop().run_until_complete(azure_entra.remediate_user("u", "t", dry_run=True)),

--- a/skills/iam-departures-remediation/tests/test_reconciler.py
+++ b/skills/iam-departures-remediation/tests/test_reconciler.py
@@ -25,20 +25,30 @@ from reconciler.sources import (
 
 # ── Fixtures ────────────────────────────────────────────────────────
 
+# Frozen reference time so record_hash is deterministic across calls.
+# (Using datetime.now() inside the fixture made identical calls produce
+# different hashes, which broke test_record_hash_deterministic.)
+_FROZEN_NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    return _FROZEN_NOW
 
 
 def _days_ago(n: int) -> datetime:
     return _now() - timedelta(days=n)
 
 
+# Sentinel so callers can pass terminated_at=None explicitly without the
+# fallback turning it into "30 days ago".
+_UNSET = object()
+
+
 def _make_record(
     email: str = "jane.doe@company.com",
     account_id: str = "123456789012",
     iam_username: str = "jane.doe",
-    terminated_at: datetime | None = None,
+    terminated_at=_UNSET,
     is_rehire: bool = False,
     rehire_date: datetime | None = None,
     iam_deleted: bool = False,
@@ -46,12 +56,16 @@ def _make_record(
     iam_created_at: datetime | None = None,
     status: RemediationStatus = RemediationStatus.PENDING,
 ) -> DepartureRecord:
+    if terminated_at is _UNSET:
+        terminated_at = _days_ago(30)
+    if iam_created_at is None:
+        iam_created_at = _days_ago(365)
     return DepartureRecord(
         email=email,
         recipient_account_id=account_id,
         iam_username=iam_username,
-        iam_created_at=iam_created_at or _days_ago(365),
-        terminated_at=terminated_at or _days_ago(30),
+        iam_created_at=iam_created_at,
+        terminated_at=terminated_at,
         termination_source=TerminationSource.SNOWFLAKE,
         is_rehire=is_rehire,
         rehire_date=rehire_date,

--- a/skills/vuln-remediation-pipeline/tests/test_triage.py
+++ b/skills/vuln-remediation-pipeline/tests/test_triage.py
@@ -8,40 +8,66 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from lambda_triage.handler import Tier, TriagedFinding, classify, parse_sarif, triage
+from lambda_triage.handler import (  # type: ignore[import-not-found]
+    Tier,
+    TriagedFinding,
+    classify,
+    parse_sarif,
+    triage,
+)
+
+
+def _finding(
+    *,
+    vuln_id="CVE-2024-0001",
+    package_name="express",
+    fixed_version="4.19.0",
+    cvss_score=5.0,
+    epss_score=0.1,
+    is_kev=False,
+):
+    return {
+        "vuln_id": vuln_id,
+        "package_name": package_name,
+        "package_version": "4.18.0",
+        "ecosystem": "npm",
+        "fixed_version": fixed_version,
+        "cvss_score": cvss_score,
+        "epss_score": epss_score,
+        "is_kev": is_kev,
+    }
 
 
 class TestClassify:
     def test_kev_is_p0(self):
-        finding = {"is_kev": True, "cvss_score": 5.0, "epss_score": 0.1}
-        assert classify(finding) == Tier.P0
+        f = _finding(is_kev=True, cvss_score=5.0, epss_score=0.1)
+        assert classify(f) == Tier.P0_IMMEDIATE
 
     def test_cvss_9_is_p0(self):
-        finding = {"is_kev": False, "cvss_score": 9.5, "epss_score": 0.1}
-        assert classify(finding) == Tier.P0
+        f = _finding(cvss_score=9.5, epss_score=0.1)
+        assert classify(f) == Tier.P0_IMMEDIATE
 
     def test_high_cvss_high_epss_is_p1(self):
-        finding = {"is_kev": False, "cvss_score": 7.5, "epss_score": 0.8}
-        assert classify(finding) == Tier.P1
+        f = _finding(cvss_score=7.5, epss_score=0.8)
+        assert classify(f) == Tier.P1_URGENT
 
     def test_medium_cvss_is_p2(self):
-        finding = {"is_kev": False, "cvss_score": 5.0, "epss_score": 0.4}
-        assert classify(finding) == Tier.P2
+        f = _finding(cvss_score=5.0, epss_score=0.4)
+        assert classify(f) == Tier.P2_STANDARD
 
     def test_low_everything_is_p3(self):
-        finding = {"is_kev": False, "cvss_score": 2.0, "epss_score": 0.1}
-        assert classify(finding) == Tier.P3
+        f = _finding(cvss_score=2.0, epss_score=0.1)
+        assert classify(f) == Tier.P3_BACKLOG
 
     def test_missing_scores_default_p3(self):
-        finding = {}
-        assert classify(finding) == Tier.P3
+        # classify() reads via .get with defaults of 0/False, so an empty
+        # dict must end up in the lowest backlog tier.
+        assert classify({}) == Tier.P3_BACKLOG
 
 
 class TestParseSarif:
     def test_parse_empty_sarif(self):
-        sarif = {"runs": [{"results": []}]}
-        findings = parse_sarif(sarif)
-        assert findings == []
+        assert parse_sarif({"runs": [{"results": []}]}) == []
 
     def test_parse_sarif_with_result(self):
         sarif = {
@@ -52,7 +78,15 @@ class TestParseSarif:
                             "ruleId": "CVE-2024-1234",
                             "message": {"text": "Vulnerability in express"},
                             "level": "error",
-                            "properties": {"cvss_score": 7.5, "epss_score": 0.6, "is_kev": False},
+                            "properties": {
+                                "package_name": "express",
+                                "package_version": "4.18.0",
+                                "ecosystem": "npm",
+                                "fixed_version": "4.19.0",
+                                "cvss_score": 7.5,
+                                "epss_score": 0.6,
+                                "is_kev": False,
+                            },
                         }
                     ]
                 }
@@ -60,49 +94,64 @@ class TestParseSarif:
         }
         findings = parse_sarif(sarif)
         assert len(findings) == 1
-        assert findings[0]["vulnerability_id"] == "CVE-2024-1234"
+        assert findings[0]["vuln_id"] == "CVE-2024-1234"
+        assert findings[0]["package_name"] == "express"
+        assert findings[0]["cvss_score"] == 7.5
 
 
 class TestTriage:
     @patch("lambda_triage.handler._is_already_remediated", return_value=False)
     @patch("lambda_triage.handler._load_protected_packages", return_value=set())
-    def test_triage_classifies_all(self, mock_protected, mock_remediated):
+    def test_triage_classifies_all(self, _protected, _remediated):
         findings = [
-            {"vulnerability_id": "CVE-1", "is_kev": True, "cvss_score": 9.8, "epss_score": 0.95, "package": "express"},
-            {"vulnerability_id": "CVE-2", "is_kev": False, "cvss_score": 3.0, "epss_score": 0.05, "package": "lodash"},
+            _finding(vuln_id="CVE-1", is_kev=True, cvss_score=9.8, epss_score=0.95),
+            _finding(vuln_id="CVE-2", package_name="lodash", cvss_score=3.0, epss_score=0.05),
         ]
         triaged = triage(findings)
-        tiers = {t.tier for t in triaged if not t.skipped}
-        assert Tier.P0 in tiers
-        assert Tier.P3 in tiers
+        tiers = {t.tier for t in triaged}
+        assert Tier.P0_IMMEDIATE in tiers
+        assert Tier.P3_BACKLOG in tiers
+        assert all(t.skip_reason is None for t in triaged)
 
     @patch("lambda_triage.handler._is_already_remediated", return_value=True)
     @patch("lambda_triage.handler._load_protected_packages", return_value=set())
-    def test_already_remediated_skipped(self, mock_protected, mock_remediated):
-        findings = [{"vulnerability_id": "CVE-1", "is_kev": True, "cvss_score": 9.8, "epss_score": 0.95, "package": "express"}]
-        triaged = triage(findings)
-        assert all(t.skipped for t in triaged)
+    def test_already_remediated_skipped(self, _protected, _remediated):
+        triaged = triage([_finding(is_kev=True, cvss_score=9.8)])
+        assert all(t.tier == Tier.SKIP for t in triaged)
+        assert all(t.skip_reason == "already_remediated" for t in triaged)
 
     @patch("lambda_triage.handler._is_already_remediated", return_value=False)
     @patch("lambda_triage.handler._load_protected_packages", return_value={"lodash"})
-    def test_protected_package_skipped(self, mock_protected, mock_remediated):
-        findings = [{"vulnerability_id": "CVE-1", "is_kev": False, "cvss_score": 5.0, "epss_score": 0.3, "package": "lodash"}]
-        triaged = triage(findings)
-        assert all(t.skipped for t in triaged)
+    def test_protected_package_skipped(self, _protected, _remediated):
+        triaged = triage([_finding(package_name="lodash", cvss_score=5.0, epss_score=0.3)])
+        assert all(t.tier == Tier.SKIP for t in triaged)
+        assert all(t.skip_reason == "protected_package" for t in triaged)
+
+    @patch("lambda_triage.handler._is_already_remediated", return_value=False)
+    @patch("lambda_triage.handler._load_protected_packages", return_value=set())
+    def test_no_fix_skipped(self, _protected, _remediated):
+        triaged = triage([_finding(fixed_version=None, cvss_score=8.0)])
+        assert all(t.tier == Tier.SKIP for t in triaged)
+        assert all(t.skip_reason == "no_fix_available" for t in triaged)
 
 
 class TestTriagedFinding:
     def test_triaged_finding_fields(self):
         tf = TriagedFinding(
-            vulnerability_id="CVE-2024-1234",
-            package="express",
-            tier=Tier.P0,
+            vuln_id="CVE-2024-1234",
+            package_name="express",
+            package_version="4.18.0",
+            ecosystem="npm",
+            fixed_version="4.19.0",
             cvss_score=9.8,
             epss_score=0.95,
             is_kev=True,
-            skipped=False,
-            skip_reason="",
+            tier=Tier.P0_IMMEDIATE,
+            sla_hours=1,
         )
-        assert tf.tier == Tier.P0
+        assert tf.tier == Tier.P0_IMMEDIATE
         assert tf.is_kev is True
-        assert not tf.skipped
+        assert tf.skip_reason is None
+        d = tf.to_dict()
+        assert d["tier"] == "P0"
+        assert d["vuln_id"] == "CVE-2024-1234"


### PR DESCRIPTION
## Summary

Every workflow is now a closed loop: **source → process → action → audit → re-verify**. The IAM pipeline gains the failure surface that was missing (DLQ + SNS alerting), every README/SKILL.md count now matches what `src/checks.py` actually implements, and there's a new top-level agent guardrails contract for AI agents loading these skills.

Net test result: **31 failed / 60 passed → 0 failed / 114 passed** across all 5 real skills.

## What's in here

### Closed-loop diagrams
- **IAM pipeline** now visually shows `HR → Reconciler → S3 → EventBridge → SFN → cloud targets → DynamoDB+S3 audit → warehouse ingest-back → next reconciler verifies → drift loops back`. The DLQ + SNS replay path is drawn explicitly.
- **CSPM**, **GCP**, **Azure**, **vuln-remediation** diagrams all close the loop (`scan → fix → re-scan` with drift detection).
- The original IAM diagram hid `S3 → EventBridge → Step Function`. That gap is closed.

### IAM pipeline gets the failure surface it was missing
Added to **both** `cloudformation.yaml` and `terraform/main.tf` (kept in parity):

| Resource | Purpose |
|---|---|
| `PipelineFailureDlq` (SQS) | KMS-encrypted DLQ, 14-day retention, wired to both Lambdas via `DeadLetterConfig` |
| `PipelineAlertsTopic` (SNS) | KMS-encrypted topic, optional email subscription via `AlertEmail` parameter |
| `StepFunctionFailureRule` (EventBridge) | Fires on `Step Functions Execution Status Change` for `FAILED` / `TIMED_OUT` / `ABORTED`, target = SNS |
| `ParserDlqWritePolicy` / `WorkerDlqWritePolicy` | `sqs:SendMessage` IAM grants for the DLQ |

New parameters: `AlertEmail`, `DlqRetentionSeconds`. New `Conditions:` block for `HasAlertEmail`. Outputs added for the DLQ ARN/URL and SNS topic ARN. CFN parses cleanly (19 resources, 1 condition).

### Honest counts everywhere
- **README** was claiming *10 skills, 159 tests, 18/25/24 CIS checks* → now reads *5 skills, 114 tests, 18/7/6* (matches reality).
- **GCP `SKILL.md`** and **Azure `SKILL.md`** rewritten to list only the functions that actually exist in `src/checks.py`, with a new **"Roadmap — Documented but Not Yet Automated"** section listing what's missing for the full benchmark.
- GitHub repo `About` description updated separately via `gh repo edit`.

### Real test bugs fixed during the audit
| File | Bug | Fix |
|---|---|---|
| `test_reconciler.py` | Fixture used `terminated_at or _days_ago(30)`, so passing `None` silently became "30 days ago". `record_hash` test was non-deterministic because `_now()` ran per-call. | `_UNSET` sentinel + frozen reference time |
| `test_cross_cloud_workers.py` | 16 in-method imports used `from src.lambda_worker.clouds...` while top-of-file correctly used `lambda_worker.clouds...` | Fixed all 16 |
| `cspm-azure-cis-benchmark/tests/test_checks.py` | Referenced `check_2_1_storage_encryption` and `check_4_1_no_open_ssh` which **don't exist** in source | Rewrote against the 6 real functions (`check_2_2_https_only`, `check_2_3_no_public_blob`, `check_2_4_network_rules`, `check_4_1_no_unrestricted_ssh`, `check_4_2_no_unrestricted_rdp`, `check_4_3_nsg_flow_logs`) |
| `vuln-remediation-pipeline/tests/test_triage.py` | Tested `Tier.P0` / `vulnerability_id` / `skipped` against handler that uses `Tier.P0_IMMEDIATE` / `vuln_id` / `skip_reason` | Rewrote to match the current handler API |

### Agent guardrails
- **`CLAUDE.md`** rewritten with a new top-level *"Agent guardrails — REQUIRED reading before invoking these skills"* section. 8 hard rules:
  1. Read-only by default
  2. Human-in-the-loop for destructive actions (grace + deny + rehire layers)
  3. Dry-run is supported everywhere
  4. Cross-account scoping via `aws:PrincipalOrgID`
  5. Audit guarantees (closed loop)
  6. Failure surface (DLQ + SNS + replay)
  7. No telemetry, no exfiltration
  8. Explicit "what an agent should NEVER do" list
- **`AGENTS.md`** created (newer convention picked up by Cursor / Codex / Cortex / Windsurf) — short pointer file mirroring the same hard rules and a "How to use a skill" checklist.
- IAM `SKILL.md` gets DLQ + SNS rows in the *IAM Roles Required* table so the failure path is documented at the skill level.

## Test plan

- [ ] CI runs `pytest skills/*/tests/` for all 5 real skills — expect **114 passed, 0 failed**
- [ ] `cfn-lint skills/iam-departures-remediation/infra/cloudformation.yaml` clean
- [ ] `terraform fmt -check` and `terraform validate` clean in `infra/terraform/`
- [ ] Manual: deploy stack with `AlertEmail=oncall@example.com`, force a Step Function failure, confirm SNS notification fires
- [ ] Manual: invoke worker Lambda with bad payload, confirm message lands in `iam-departures-dlq`
- [ ] Re-emit S3 `Object Created` for the same manifest, confirm pipeline replays idempotently