### PR TITLE
ci(agent-bom): scan CloudFormation + Terraform, upload SARIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,64 @@ jobs:
         run: agent-bom skills scan skills/ -f json -o skills-audit.json --verbose || true
       - name: Scan filesystem for packages and CVEs
         run: agent-bom fs skills/ -f json -o fs-scan.json || true
+      - name: Scan IaC (CloudFormation + Terraform)
+        run: |
+          agent-bom iac \
+            skills/iam-departures-remediation/infra/cloudformation.yaml \
+            skills/iam-departures-remediation/infra/cross_account_stackset.yaml \
+            skills/iam-departures-remediation/infra/terraform/main.tf \
+            -f json -o iac-scan.json || true
+      - name: Scan IaC (SARIF for code scanning)
+        run: |
+          agent-bom iac \
+            skills/iam-departures-remediation/infra/cloudformation.yaml \
+            skills/iam-departures-remediation/infra/cross_account_stackset.yaml \
+            skills/iam-departures-remediation/infra/terraform/main.tf \
+            -f sarif -o iac-scan.sarif || true
+      - name: Normalise SARIF (handle agent-bom empty-result quirk)
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json, os
+          path = "iac-scan.sarif"
+          stub = {
+              "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+              "version": "2.1.0",
+              "runs": [{
+                  "tool": {"driver": {"name": "agent-bom-iac", "version": "0.76.2", "informationUri": "https://github.com/msaad00/agent-bom"}},
+                  "results": []
+              }]
+          }
+          if not os.path.exists(path):
+              json.dump(stub, open(path, "w"))
+              print("wrote stub SARIF (file missing)")
+          else:
+              try:
+                  doc = json.load(open(path))
+              except Exception as e:
+                  json.dump(stub, open(path, "w"))
+                  print(f"wrote stub SARIF (json parse failed: {e})")
+              else:
+                  if not (isinstance(doc, dict) and "runs" in doc):
+                      json.dump(stub, open(path, "w"))
+                      print("wrote stub SARIF (not SARIF-shaped)")
+                  else:
+                      print(f"SARIF ok: {len(doc.get('runs', []))} runs")
+          PY
+      - name: Upload IaC SARIF to GitHub code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: iac-scan.sarif
+          category: agent-bom-iac
+        continue-on-error: true
       - name: Print results summary
         if: always()
         run: |
-          echo "=== Code Scan ===" && cat code-scan.json 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
+          echo "=== Code Scan ==="    && cat code-scan.json    2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
           echo "=== Skills Audit ===" && cat skills-audit.json 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
-          echo "=== FS Scan ===" && cat fs-scan.json 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
+          echo "=== FS Scan ==="      && cat fs-scan.json      2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
+          echo "=== IaC Scan ==="     && cat iac-scan.json     2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
       - name: Upload scan artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -126,6 +178,8 @@ jobs:
             code-scan.json
             skills-audit.json
             fs-scan.json
+            iac-scan.json
+            iac-scan.sarif
           if-no-files-found: ignore
 
   validate-cloudformation:

--- a/README.md
+++ b/README.md
@@ -165,9 +165,12 @@ flowchart LR
 |--------|------|
 | Lint | ruff check + format |
 | Tests | pytest per skill |
-| CloudFormation | cfn-lint validation |
-| Terraform | terraform validate |
-| Security | bandit + hardcoded secret grep on `skills/*/src/` |
+| CloudFormation | `cfn-lint` validation on all `infra/*.yaml` |
+| Terraform | `terraform validate` on `infra/terraform/` |
+| Security | `bandit` + hardcoded-secret grep on `skills/*/src/` |
+| **agent-bom** | `code` (AI components) · `skills scan` (skill audit) · `fs` (packages + CVEs) · **`iac` (CloudFormation + Terraform)** with SARIF upload to the GitHub Security tab |
+
+The "Scanned by agent-bom" badge above is backed by that last row — every push to `main` runs all four agent-bom scans against the repo, and the IaC findings land in GitHub code scanning.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

The README has a *Scanned by agent-bom* badge but the CI was only running three of the four scans (`code`, `skills scan`, `fs`). It was **not** running `agent-bom iac` on any CloudFormation or Terraform — so the new DLQ + SNS + EventBridge resources from #14 had never been seen by agent-bom's IaC scanner.

This PR closes that gap and makes the badge fully justified.

## What's in here

- Adds an `agent-bom iac` step to the existing `agent-bom` CI job, scanning:
  - `skills/iam-departures-remediation/infra/cloudformation.yaml`
  - `skills/iam-departures-remediation/infra/cross_account_stackset.yaml`
  - `skills/iam-departures-remediation/infra/terraform/main.tf`
- Generates SARIF and uploads to GitHub code scanning under category `agent-bom-iac`, so any IaC findings land in the **Security → Code scanning** tab automatically.
- Adds a small normaliser step that handles an `agent-bom iac` quirk: when there are zero findings the SARIF formatter currently emits plain JSON `{"total": 0, "findings": []}` instead of a SARIF skeleton, which would break `codeql-action/upload-sarif`. The normaliser swaps in a minimal valid SARIF (`runs: [{tool, results: []}]`) when the file isn't SARIF-shaped.
- Updates the README CI table to list **all four** agent-bom scans the badge is backed by.

## Test plan

- [x] `agent-bom iac` runs locally against all 3 IaC files: 0 misconfigurations
- [x] Normaliser script tested locally against the empty-result JSON output
- [ ] CI agent-bom job stays green (it's `continue-on-error: true` anyway, but we want the SARIF upload to actually succeed)
- [ ] After merge, a fresh IaC misconfiguration in any of the 3 files surfaces under **Security → Code scanning** tagged `agent-bom-iac`