### PR TITLE
docs(skills): add Do-NOT clauses to match Anthropic skills-guide spec

### DIFF
--- a/skills/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/cspm-aws-cis-benchmark/SKILL.md
@@ -2,10 +2,12 @@
 name: cspm-aws-cis-benchmark
 description: >-
   Assess AWS accounts against CIS AWS Foundations Benchmark v3.0. Runs 18 automated
-  checks across IAM, Storage, Logging, and Networking. Produces per-control pass/fail
-  results with remediation commands. Use when the user mentions AWS CIS benchmark,
-  cloud security posture, IAM hygiene audit, S3 public access check, or CloudTrail
-  validation.
+  read-only checks across IAM, Storage, Logging, and Networking. Produces per-control
+  pass/fail results with remediation commands. Use when the user mentions AWS CIS
+  benchmark, cloud security posture, IAM hygiene audit, S3 public access check, or
+  CloudTrail validation. Do NOT use for GCP, Azure, or on-prem; do NOT use this skill
+  to remediate findings (it is assessment-only and has zero write permissions) — pair
+  with iam-departures-remediation or vuln-remediation-pipeline for fixes.
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, boto3, and AWS credentials with SecurityAudit managed policy

--- a/skills/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/cspm-azure-cis-benchmark/SKILL.md
@@ -2,9 +2,12 @@
 name: cspm-azure-cis-benchmark
 description: >-
   Assess Azure subscriptions against a curated subset of CIS Azure Foundations
-  Benchmark v2.1. Automates 6 high-impact checks across Storage and Networking.
-  Use when the user mentions Azure CIS benchmark, Azure storage security, or
-  unrestricted SSH/RDP detection in NSGs.
+  Benchmark v2.1. Automates 6 high-impact read-only checks across Storage and
+  Networking. Use when the user mentions Azure CIS benchmark, Azure storage
+  security, or unrestricted SSH/RDP detection in NSGs. Do NOT use for AWS or GCP;
+  do NOT use to remediate findings (assessment-only, Reader role only); do NOT
+  claim full CIS Azure coverage — only 6 controls are implemented, see the Roadmap
+  section in this file for the gap.
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, azure-identity, azure-mgmt-storage, azure-mgmt-network.

--- a/skills/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/cspm-gcp-cis-benchmark/SKILL.md
@@ -2,9 +2,12 @@
 name: cspm-gcp-cis-benchmark
 description: >-
   Assess GCP projects against a curated subset of CIS GCP Foundations Benchmark v3.0
-  controls. Automates 7 high-impact checks across IAM, Cloud Storage, and VPC
-  networking. Use when the user mentions GCP CIS benchmark, GCP security posture,
-  service account key audit, or public bucket detection.
+  controls. Automates 7 high-impact read-only checks across IAM, Cloud Storage, and
+  VPC networking. Use when the user mentions GCP CIS benchmark, GCP security posture,
+  service account key audit, or public bucket detection. Do NOT use for AWS or Azure;
+  do NOT use to remediate findings (assessment-only, zero write permissions); do NOT
+  claim full CIS GCP coverage — only 7 controls are implemented, see the Roadmap
+  section in this file for the gap.
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-compute.

--- a/skills/iam-departures-remediation/SKILL.md
+++ b/skills/iam-departures-remediation/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: iam-departures-remediation
 description: >-
-  Auto-remediate AWS IAM users belonging to departed employees. Reconciles HR
-  termination data (Workday via Snowflake, Databricks, ClickHouse, or direct API)
-  against IAM, exports change-detected manifests to S3, and triggers a Step Function
-  pipeline that safely deletes IAM users with all dependencies. Use when the user
-  mentions departed employees, IAM cleanup, termination remediation, offboarding
-  automation, or stale credential removal.
+  Auto-remediate IAM users belonging to departed employees across AWS, Azure Entra,
+  GCP, Snowflake, and Databricks. Reconciles HR termination data (Workday via
+  Snowflake, Databricks, ClickHouse, or direct API) against IAM, exports
+  change-detected manifests to S3, and triggers a Step Function pipeline that
+  safely deletes IAM principals with all dependencies through a 13-step cleanup.
+  Every action is grace-period-gated (7 days default), rehire-aware, deny-listed
+  for root/break-glass/emergency users, and dual-audited (DynamoDB + S3). Use when
+  the user mentions departed employees, IAM cleanup, termination remediation,
+  offboarding automation, or stale credential removal. Do NOT use this skill to
+  bypass the grace period, call the Step Function directly (always go through
+  EventBridge), disable deny policies, or write to the audit table by hand — those
+  are closed-loop guarantees that must not be broken. Do NOT use for access
+  provisioning; this skill only deactivates and deletes.
 license: Apache-2.0
 compatibility: >-
   Requires AWS CLI, Python 3.11+, and boto3. Lambdas deploy to AWS. HR data

--- a/skills/vuln-remediation-pipeline/SKILL.md
+++ b/skills/vuln-remediation-pipeline/SKILL.md
@@ -2,11 +2,16 @@
 name: vuln-remediation-pipeline
 description: >-
   Auto-remediate vulnerabilities found in AI agent supply chains. Ingests scan
-  results from agent-bom (SARIF/JSON), triages by EPSS exploitability and CISA
-  KEV status, generates dependency upgrade PRs, rotates exposed credentials, and
-  quarantines compromised MCP servers. Use when the user mentions vulnerability
-  remediation, patch automation, credential rotation, MCP server quarantine, or
-  supply chain fix pipeline.
+  results from agent-bom (SARIF/JSON), triages by CVSS, EPSS exploitability, and
+  CISA KEV status into P0-P3 tiers with SLAs, then generates dependency upgrade
+  PRs, rotates exposed credentials, and quarantines compromised MCP servers. Every
+  finding is checked against a protected-package SSM list and a DynamoDB
+  already-remediated log before any action. Use when the user mentions
+  vulnerability remediation, patch automation, credential rotation, MCP server
+  quarantine, or supply chain fix pipeline. Do NOT use this skill to bypass the
+  protected-package list, auto-remediate findings without a fixed_version, or
+  skip the idempotency check against the audit table. Do NOT use for first-time
+  scanning (use agent-bom for scanning; this skill is the fix-side of the loop).
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, boto3, and GitHub CLI (gh). Lambdas deploy to AWS.


### PR DESCRIPTION
## Why

Cross-checked our 5 `SKILL.md` frontmatters against the [Anthropic Agent Skills spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide) and against the canonical Anthropic skills in [`anthropics/skills`](https://github.com/anthropics/skills) (`docx`, `pdf`).

**Spec-compliance status:** ✅ all 5 skills already pass the hard rules
- `name`: ≤64 chars, matches `^[a-z0-9-]+$`, no reserved words ✅
- `description`: ≤1024 chars, non-empty, no XML tags ✅
- `SKILL.md` at root, tracked size ≤30 MB ✅ (largest is iam-departures at 246 KB)

**Correction on `allowed-tools`:** I initially suggested adding an `allowed-tools` frontmatter field as a self-enforcing guardrail. I was wrong — I double-checked the spec and verified it against the canonical Anthropic skills: **`allowed-tools` is a Claude Code slash-command field, not a skills-spec field.** Not adding it.

**The pattern Anthropic actually uses** (see `docx` SKILL.md):

> *"…Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation."*

They bake constraints into the `description` itself. The routing layer (whoever decides which skill fires) respects the prose because it's part of the trigger text. That's the self-enforcing layer I wanted — no non-spec fields required.

## What

Added a `Do NOT …` clause to each of the 5 descriptions:

| Skill | Do-NOT clause |
|---|---|
| `cspm-aws-cis-benchmark` | Not for GCP/Azure, not for remediation (assessment-only, zero write permissions) |
| `cspm-gcp-cis-benchmark` | Not for AWS/Azure, not for remediation; do not claim full CIS GCP coverage (only 7 controls) |
| `cspm-azure-cis-benchmark` | Not for AWS/GCP, not for remediation; do not claim full CIS Azure coverage (only 6 controls) |
| `iam-departures-remediation` | Do not bypass grace period, EventBridge, or deny policies; do not write to audit table by hand; not for provisioning |
| `vuln-remediation-pipeline` | Do not bypass protected-package list, findings without `fixed_version`, or idempotency check; not for scanning |

## Verification

- [x] All 5 descriptions re-checked against the 1024-char limit
  - `cspm-aws`: 566 / 1024
  - `cspm-gcp`: 528 / 1024
  - `cspm-azure`: 498 / 1024
  - `iam-departures`: 983 / 1024 (tightest — 41 chars headroom)
  - `vuln-remediation`: 842 / 1024
- [x] YAML `>-` folded blocks still parse to flat strings (verified with `yaml.safe_load`)
- [x] All 114 tests still pass across the 5 real skills
- [ ] CI green