### PR TITLE
audit(skills): add Do-NOT clauses to 5 inherited skills

### DIFF
--- a/skills/ai-infra-security/discover-environment/SKILL.md
+++ b/skills/ai-infra-security/discover-environment/SKILL.md
@@ -4,9 +4,13 @@ description: >-
   Discover cloud infrastructure and map it to a security graph with MITRE ATT&CK
   and ATLAS technique overlays. Outputs graph JSON with nodes (resources, IAM,
   services, network) and edges (relationships, attack vectors). Supports AWS,
-  GCP, Azure, or static config input. Use when the user mentions environment
-  discovery, cloud inventory, infrastructure mapping, attack surface mapping,
-  cloud resource graph, or MITRE technique mapping.
+  GCP, Azure, or static config input via the appropriate read-only SDK. Use
+  when the user mentions environment discovery, cloud inventory, infrastructure
+  mapping, attack surface mapping, cloud resource graph, or MITRE technique
+  mapping. Do NOT use for posture assessment against a published benchmark
+  (use cspm-aws/gcp/azure-cis-benchmark) or to drive remediation directly —
+  this skill produces a graph, not findings, and never mutates cloud state.
+  Do NOT use as a real-time monitor; the graph is a point-in-time snapshot.
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Cloud discovery needs respective SDKs (boto3 for AWS,

--- a/skills/ai-infra-security/gpu-cluster-security/SKILL.md
+++ b/skills/ai-infra-security/gpu-cluster-security/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: gpu-cluster-security
 description: >-
-  Audit the security posture of GPU compute clusters. Checks container runtime
-  isolation, GPU driver CVEs, InfiniBand network segmentation, CUDA compliance,
-  shared memory exposure, model weight encryption, tenant namespace isolation,
-  and GPU monitoring. Works with Kubernetes GPU clusters, Docker GPU workloads,
-  or bare-metal configs. Use when the user mentions GPU security, NVIDIA driver
-  CVE, CUDA audit, GPU cluster hardening, InfiniBand segmentation, GPU tenant
-  isolation, or DCGM monitoring.
+  Audit the security posture of GPU compute clusters. Runs 13 read-only checks
+  covering container runtime isolation, GPU driver CVEs, InfiniBand network
+  segmentation, CUDA compliance, shared memory exposure, model weight encryption,
+  tenant namespace isolation, and DCGM monitoring. Works with Kubernetes GPU
+  clusters, Docker GPU workloads, or bare-metal configs (JSON / YAML input).
+  Use when the user mentions GPU security, NVIDIA driver CVE, CUDA audit, GPU
+  cluster hardening, InfiniBand segmentation, GPU tenant isolation, or DCGM
+  monitoring. Do NOT use to mutate cluster state, query NVIDIA APIs, or trigger
+  driver upgrades — this skill is assessment-only, no network calls. Do NOT use
+  for general K8s posture (use k8s-security-benchmark) or model serving endpoint
+  hardening (use model-serving-security).
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files

--- a/skills/ai-infra-security/model-serving-security/SKILL.md
+++ b/skills/ai-infra-security/model-serving-security/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: model-serving-security
 description: >-
-  Audit the security posture of AI model serving infrastructure. Checks authentication,
-  rate limiting, data egress controls, prompt injection surface, container isolation,
-  TLS enforcement, and safety layer configuration. Works with any serving config
-  (JSON/YAML) — API gateways, Kubernetes deployments, cloud-native serving. Use when
-  the user mentions model endpoint security, serving infrastructure audit, API gateway
-  security, prompt injection protection, model deployment review, or content safety check.
+  Audit the security posture of AI model serving infrastructure. Runs 16 read-only
+  checks covering authentication, rate limiting, data egress controls, prompt
+  injection surface, container isolation, TLS enforcement, and safety-layer
+  configuration. Works with any serving config (JSON / YAML) — API gateways,
+  Kubernetes deployments, cloud-native serving. Use when the user mentions model
+  endpoint security, serving infrastructure audit, API gateway security, prompt
+  injection protection, model deployment review, or content safety check. Do NOT
+  use to send live inference requests, mutate serving configs, or interact with
+  the model — this skill only reads YAML/JSON. Do NOT use for runtime detection
+  of prompt injection inside live traffic (a future detect-prompt-injection skill
+  will cover that). Do NOT use for GPU cluster posture (use gpu-cluster-security).
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files.

--- a/skills/compliance-cis-mitre/container-security/SKILL.md
+++ b/skills/compliance-cis-mitre/container-security/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: container-security
 description: >-
-  Audit container image and runtime security. Checks Dockerfile best practices,
-  image configuration, secrets exposure, base image selection, and runtime
-  isolation. Works with Dockerfile analysis, image config JSON, or runtime
-  dumps. Use when the user mentions container security, Docker hardening,
-  image scanning, Dockerfile audit, or CIS Docker benchmark.
+  Audit container image and runtime security against the CIS Docker Benchmark.
+  Runs 8 read-only checks covering Dockerfile best practices, image
+  configuration, secrets exposure, base image selection, and runtime isolation.
+  Works with Dockerfile text, image config JSON, or runtime dumps. Use when the
+  user mentions container security, Docker hardening, image scanning, Dockerfile
+  audit, or CIS Docker benchmark. Do NOT use to pull, run, or mutate images
+  (this skill only reads configs, it never touches a Docker daemon). Do NOT use
+  for Kubernetes cluster posture (use k8s-security-benchmark) or GPU runtime
+  isolation (use gpu-cluster-security).
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. No Docker daemon needed — works with config files.

--- a/skills/compliance-cis-mitre/k8s-security-benchmark/SKILL.md
+++ b/skills/compliance-cis-mitre/k8s-security-benchmark/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: k8s-security-benchmark
 description: >-
-  Audit Kubernetes cluster and workload security. Checks pod security standards,
-  RBAC hygiene, network policies, secrets management, and image pinning. Works
-  with exported K8s resource JSON or live kubectl output. Use when the user
-  mentions Kubernetes security, pod security, RBAC audit, network policy check,
-  K8s hardening, or CIS Kubernetes benchmark.
+  Audit Kubernetes cluster and workload security against the CIS Kubernetes
+  Benchmark. Runs 10 read-only checks covering pod security standards, RBAC
+  hygiene, network policies, secrets management, and image pinning. Works with
+  exported K8s resource JSON or live kubectl output. Use when the user mentions
+  Kubernetes security, pod security, RBAC audit, network policy check, K8s
+  hardening, or CIS Kubernetes benchmark. Do NOT use for container runtime
+  hardening (use container-security), GPU workload isolation (use
+  gpu-cluster-security), or to mutate cluster state (this skill is assessment-only
+  and never calls write APIs). Do NOT use against a cluster you do not own or
+  have explicit authorisation to scan.
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with exported JSON/YAML.


### PR DESCRIPTION
PR A of 4 from the requested 'finish all 5 of (a)-(e)' batch.

## Audit results

| Skill | SKILL.md claim | Actual functions | Match |
|---|---|---|:-:|
| `k8s-security-benchmark` | 10 checks | 10 in src/checks.py | ✅ |
| `container-security` | 8 checks | 8 in src/checks.py | ✅ |
| `gpu-cluster-security` | 13 checks | 13 in src/checks.py | ✅ |
| `model-serving-security` | 16 checks | 16 in src/checks.py | ✅ |
| `discover-environment` | (graph, no count claim) | n/a | ✅ |

Every quantitative claim in the inherited skills is accurate. My earlier worry about inflation was wrong for these 5.

## What was missing

All 5 inherited SKILL.md files had spec-compliant frontmatter (name ≤64 chars, description ≤1024, license, sensible trigger phrases) but **none of them had the `Do NOT use for X` clause** that the canonical Anthropic skills (`docx`, `pdf`) use as a self-enforcing trigger constraint. The 5 'real' skills already had this from #16.

## What this PR adds

Scoped `Do NOT…` clauses on every inherited skill, fitted to its actual contract:

- **k8s-security-benchmark** — not for runtime, not for GPU, not for write, not without authorisation
- **container-security** — not for K8s posture, not for GPU runtime, no docker daemon access
- **gpu-cluster-security** — not for K8s posture, not for serving endpoints, no NVIDIA API calls, no driver upgrades
- **model-serving-security** — not for live traffic, not for runtime detection, not for GPU posture
- **discover-environment** — not for benchmark posture, not for remediation, not as a real-time monitor (point-in-time only)

## Verification

| Skill | desc length | ≤1024 | Do NOT |
|---|---:|:-:|:-:|
| k8s-security-benchmark | 706 | ✅ | ✅ |
| container-security | 642 | ✅ | ✅ |
| gpu-cluster-security | 805 | ✅ | ✅ |
| model-serving-security | 858 | ✅ | ✅ |
| discover-environment | 752 | ✅ | ✅ |

- [x] 105 tests across the 5 inherited skills still pass
- [x] No source code changes — frontmatter only
- [ ] CI green