### PR TITLE
feat(view): convert-ocsf-to-sarif + convert-ocsf-to-mermaid-attack-flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,30 @@ jobs:
       - working-directory: skills/detection-engineering/detect-privilege-escalation-k8s
         run: pytest tests/ -v -o "testpaths=tests"
 
+  test-convert-ocsf-to-sarif:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install pytest
+      - working-directory: skills/detection-engineering/convert-ocsf-to-sarif
+        run: pytest tests/ -v -o "testpaths=tests"
+
+  test-convert-ocsf-to-mermaid-attack-flow:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install pytest
+      - working-directory: skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow
+        run: pytest tests/ -v -o "testpaths=tests"
+
   # ── ai-infra-security/ ───────────────────────────────────────────
 
   test-model-serving:

--- a/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/SKILL.md
+++ b/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: convert-ocsf-to-mermaid-attack-flow
+description: >-
+  Convert OCSF 1.8 Detection Findings (class 2004) into Mermaid flowchart
+  syntax suitable for inline rendering in PR comments, README files, and
+  Markdown wikis. Produces a left-to-right attack flow showing each finding
+  as actor → action → target chains, with MITRE ATT&CK technique IDs as
+  edge labels and severity-coloured nodes. Multiple findings collapse into
+  a single diagram so a reviewer sees the full attack chain in one
+  picture. Use when the user mentions Mermaid, attack flow diagram, PR
+  comment visualisation, README diagram for a detection result, or wants
+  to embed a finding summary in Markdown without uploading SARIF. Do NOT
+  use as a SARIF replacement (different audience: humans reading PRs vs
+  GitHub code scanning UI). Do NOT use for non-finding OCSF events
+  (class_uid != 2004) — those don't have the MITRE / actor / target
+  structure this skill expects.
+license: Apache-2.0
+---
+
+# convert-ocsf-to-mermaid-attack-flow
+
+Cross-vendor view-layer skill: takes OCSF 1.8 Detection Findings on stdin, emits a Mermaid flowchart on stdout. Built once, used by every detection-engineering pipeline that wants to surface findings in a PR comment, a README, or any Markdown surface that renders Mermaid (GitHub does so natively).
+
+## Output shape
+
+A single Mermaid `flowchart LR` block. One node per actor, one node per target, one edge per finding. Edge labels carry the MITRE technique uid (e.g. `T1611`). Nodes are coloured by maximum severity observed for that node:
+
+- Red — any finding involving this node was severity Critical (5) or Fatal (6)
+- Orange — High (4)
+- Yellow — Medium (3)
+- Grey — Low (2), Informational (1), or Unknown (0)
+
+The diagram is enclosed in triple backticks with a `mermaid` language tag so it renders inline on GitHub.
+
+## Field mapping
+
+| OCSF Detection Finding (2004) field | Mermaid element |
+|---|---|
+| `observables[]` where `name == "actor.name"` | actor node (left side of the chain) |
+| `observables[]` where `name` matches `*.name` (target / pod / bucket / secret / tool) | target node (right side) |
+| `finding_info.attacks[0].technique.uid` | edge label |
+| `finding_info.title` | edge tooltip (shown on hover in some renderers) |
+| `severity_id` | node colour (max severity wins for shared nodes) |
+| `metadata.product.feature.name` | edge prefix (so the reviewer knows which detector fired) |
+
+## Example output (from the K8s priv-esc golden fixture)
+
+\`\`\`mermaid
+flowchart LR
+    classDef critical fill:#3f1d1d,stroke:#f87171,color:#fecaca
+    classDef high     fill:#3a2a0e,stroke:#fb923c,color:#fed7aa
+    classDef medium   fill:#3a3a0e,stroke:#fbbf24,color:#fef08a
+    classDef low      fill:#1e293b,stroke:#64748b,color:#cbd5e1
+
+    A0["system:serviceaccount:default:builder"]:::critical
+    T0["secret · default/db-password"]:::high
+    T1["pod · default/web-xyz"]:::critical
+    T2["clusterrolebinding · attacker-cluster-admin"]:::critical
+
+    A0 -- "T1552.007 · secret-enum" --> T0
+    A0 -- "T1611 · pod-exec" --> T1
+    A0 -- "T1098 · rbac-self-grant" --> T2
+\`\`\`
+
+## Multi-actor handling
+
+When findings involve multiple distinct actors, each actor gets its own node. Cross-actor correlations stay separate — the Mermaid diagram is a *visualisation* of findings, not a derived correlation. If you want correlation, run a higher-level detect skill first.
+
+## Usage
+
+```bash
+# Pipe step in a detection pipeline
+python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
+  | python skills/detection-engineering/detect-privilege-escalation-k8s/src/detect.py \
+  | python src/convert.py \
+  > attack-flow.mmd
+
+# Or paste the output directly into a PR comment / GitHub issue
+python src/convert.py < findings.ocsf.jsonl
+```
+
+## Tests
+
+Golden fixture parity against [`../golden/k8s_priv_esc_findings.ocsf.jsonl`](../golden/k8s_priv_esc_findings.ocsf.jsonl) → [`../golden/k8s_priv_esc_attack_flow.mmd`](../golden/k8s_priv_esc_attack_flow.mmd). Plus unit tests for severity → class mapping, multi-actor handling, edge deduplication, MITRE label formatting, and node ID safety (Mermaid IDs cannot contain spaces or special chars).

--- a/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/src/convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/src/convert.py
@@ -1,0 +1,315 @@
+"""Convert OCSF 1.8 Detection Findings (class 2004) to a Mermaid attack flow.
+
+Reads OCSF Detection Finding JSONL on stdin, emits a single Mermaid
+flowchart LR block on stdout (wrapped in fenced code so it renders inline
+on any Markdown surface that supports Mermaid — GitHub, GitLab, most
+wikis).
+
+Contract: see ../OCSF_CONTRACT.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from typing import Any, Iterable
+
+SKILL_NAME = "convert-ocsf-to-mermaid-attack-flow"
+SKILL_VERSION = "0.1.0"
+
+DETECTION_FINDING_CLASS_UID = 2004
+
+# Severity → Mermaid CSS class
+_SEVERITY_CLASS = {
+    0: "low",  # Unknown
+    1: "low",  # Informational
+    2: "low",  # Low
+    3: "medium",
+    4: "high",
+    5: "critical",
+    6: "critical",
+}
+
+
+def severity_class(severity_id: int) -> str:
+    return _SEVERITY_CLASS.get(severity_id, "low")
+
+
+def _max_severity(a: int, b: int) -> int:
+    return a if a >= b else b
+
+
+# ---------------------------------------------------------------------------
+# Mermaid ID safety
+# ---------------------------------------------------------------------------
+
+# Mermaid node IDs must be alphanumeric (plus underscore). We hash anything
+# that contains other chars and prepend a letter so the ID never starts with
+# a digit (Mermaid silently breaks on numeric-leading IDs).
+_SAFE_ID = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+def safe_id(prefix: str, raw: str) -> str:
+    """Produce a Mermaid-safe stable node ID for an arbitrary string."""
+    if _SAFE_ID.match(raw) and len(raw) <= 32:
+        return prefix + raw
+    digest = hashlib.sha1(raw.encode()).hexdigest()[:10]
+    return f"{prefix}{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Observable extraction
+# ---------------------------------------------------------------------------
+
+
+def _observables_by_name(observables: list[dict[str, Any]]) -> dict[str, str]:
+    """Index an observables[] array by name → first value."""
+    out: dict[str, str] = {}
+    for obs in observables or []:
+        name = obs.get("name", "")
+        value = obs.get("value", "")
+        if name and value and name not in out:
+            out[name] = str(value)
+    return out
+
+
+def extract_actor(finding: dict[str, Any]) -> str:
+    """Pull the actor identifier from a finding's observables.
+
+    Looks for (in order): actor.name, session.uid, then falls back to the
+    finding_info.uid prefix if no actor is named.
+    """
+    obs = _observables_by_name(finding.get("observables") or [])
+    for key in ("actor.name", "session.uid"):
+        if key in obs:
+            return obs[key]
+    # Fall back to a slice of the finding uid
+    uid = (finding.get("finding_info") or {}).get("uid") or "unknown-actor"
+    return f"actor:{uid[:16]}"
+
+
+def extract_target(finding: dict[str, Any]) -> tuple[str, str]:
+    """Pull a target identifier and a human label from a finding's observables.
+
+    Returns (raw_id, display_label). Looks for any *.name observable that
+    isn't actor.name, otherwise builds a label from finding_info.types[0]
+    plus the finding uid suffix.
+    """
+    obs_list = finding.get("observables") or []
+    obs_by_name = _observables_by_name(obs_list)
+
+    # Special-case the well-known target shapes the existing detect skills emit
+    finding_info = finding.get("finding_info") or {}
+
+    # K8s priv-esc rules
+    if "secret.name" in obs_by_name:
+        ns = obs_by_name.get("namespace", "")
+        return (f"secret/{ns}/{obs_by_name['secret.name']}", f"secret · {ns}/{obs_by_name['secret.name']}")
+    if "pod.name" in obs_by_name:
+        ns = obs_by_name.get("namespace", "")
+        return (f"pod/{ns}/{obs_by_name['pod.name']}", f"pod · {ns}/{obs_by_name['pod.name']}")
+    if "binding.name" in obs_by_name:
+        bt = obs_by_name.get("binding.type", "binding")
+        ns = obs_by_name.get("namespace", "")
+        ns_part = f"{ns}/" if ns else ""
+        return (
+            f"{bt}/{ns_part}{obs_by_name['binding.name']}",
+            f"{bt[:-1] if bt.endswith('s') else bt} · {ns_part}{obs_by_name['binding.name']}",
+        )
+    if "target.serviceaccount" in obs_by_name:
+        ns = obs_by_name.get("namespace", "")
+        return (
+            f"sa/{ns}/{obs_by_name['target.serviceaccount']}",
+            f"serviceaccount · {ns}/{obs_by_name['target.serviceaccount']}",
+        )
+
+    # MCP rules
+    if "tool.name" in obs_by_name:
+        sess = obs_by_name.get("session.uid", "")
+        return (f"mcp-tool/{sess}/{obs_by_name['tool.name']}", f"mcp tool · {obs_by_name['tool.name']}")
+
+    # Fallback: first non-actor *.name observable
+    for obs in obs_list:
+        name = obs.get("name", "")
+        if name == "actor.name":
+            continue
+        if name.endswith(".name") or name.endswith(".uid"):
+            value = str(obs.get("value", ""))
+            return (f"{name}/{value}", f"{name.split('.')[0]} · {value}")
+
+    # Last resort: use the finding type
+    types = finding_info.get("types") or []
+    label = types[0] if types else "target"
+    return (f"target/{label}", label)
+
+
+def extract_attack(finding: dict[str, Any]) -> tuple[str, str]:
+    """Return (technique_uid, technique_name) for the first MITRE attack."""
+    attacks = (finding.get("finding_info") or {}).get("attacks") or []
+    if not attacks:
+        return ("no-mitre", "Unknown")
+    a = attacks[0]
+    technique = a.get("technique") or {}
+    sub = a.get("sub_technique") or {}
+    uid = sub.get("uid") or technique.get("uid") or "no-mitre"
+    name = sub.get("name") or technique.get("name") or "Unknown technique"
+    return (uid, name)
+
+
+def extract_detector_short(finding: dict[str, Any]) -> str:
+    """Return a short detector name for the edge label."""
+    feature = ((finding.get("metadata") or {}).get("product") or {}).get("feature") or {}
+    name = feature.get("name") or ""
+    # Strip detect- / ingest- prefix and -k8s / -aws etc suffix for compactness
+    name = name.replace("detect-", "").replace("ingest-", "")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+_HEADER = """flowchart LR
+    classDef critical fill:#3f1d1d,stroke:#f87171,color:#fecaca
+    classDef high     fill:#3a2a0e,stroke:#fb923c,color:#fed7aa
+    classDef medium   fill:#3a3a0e,stroke:#fbbf24,color:#fef08a
+    classDef low      fill:#1e293b,stroke:#64748b,color:#cbd5e1
+"""
+
+
+def render(findings: Iterable[dict[str, Any]]) -> str:
+    """Convert an iterable of OCSF Detection Findings to a Mermaid flowchart string.
+
+    The string is a complete `flowchart LR` block. Wrap it in
+    triple-backtick `mermaid` fences if you're embedding into Markdown.
+    """
+    materialised: list[dict[str, Any]] = []
+    for f in findings:
+        if f.get("class_uid") == DETECTION_FINDING_CLASS_UID:
+            materialised.append(f)
+        else:
+            print(
+                f"[{SKILL_NAME}] skipping event with class_uid={f.get('class_uid')} — only Detection Finding (2004) supported",
+                file=sys.stderr,
+            )
+
+    if not materialised:
+        return _HEADER + '    empty["No findings"]:::low\n'
+
+    # Build node tables (id → display label, id → max severity)
+    node_label: dict[str, str] = {}
+    node_severity: dict[str, int] = {}
+    actor_id_for: dict[str, str] = {}  # raw → mermaid id
+    target_id_for: dict[str, str] = {}
+
+    edges: list[tuple[str, str, str, str]] = []  # (actor_id, target_id, edge_label, finding_uid)
+
+    for f in materialised:
+        actor_raw = extract_actor(f)
+        target_raw, target_label = extract_target(f)
+        technique_uid, _technique_name = extract_attack(f)
+        detector = extract_detector_short(f)
+        severity = int(f.get("severity_id", 0))
+        finding_uid = ((f.get("finding_info") or {}).get("uid")) or ""
+
+        if actor_raw not in actor_id_for:
+            actor_id_for[actor_raw] = safe_id("A", actor_raw)
+        actor_id = actor_id_for[actor_raw]
+
+        if target_raw not in target_id_for:
+            target_id_for[target_raw] = safe_id("T", target_raw)
+        target_id = target_id_for[target_raw]
+
+        node_label[actor_id] = actor_raw
+        node_label[target_id] = target_label
+        node_severity[actor_id] = _max_severity(node_severity.get(actor_id, 0), severity)
+        node_severity[target_id] = _max_severity(node_severity.get(target_id, 0), severity)
+
+        rule_short = ""
+        if detector:
+            # Strip cloud / surface suffixes for a compact edge label
+            rule_short = detector
+        edge_label = f"{technique_uid}"
+        if rule_short:
+            edge_label = f"{technique_uid} · {rule_short}"
+        edges.append((actor_id, target_id, edge_label, finding_uid))
+
+    # Render — deterministic order: actors first (by id), then targets (by id), then edges
+    lines: list[str] = [_HEADER]
+
+    actor_ids_sorted = sorted({eid for eid in actor_id_for.values()})
+    target_ids_sorted = sorted({tid for tid in target_id_for.values()})
+
+    for nid in actor_ids_sorted:
+        cls = severity_class(node_severity.get(nid, 0))
+        # Mermaid: NodeId["display label"]:::class
+        label = node_label[nid].replace('"', "'")
+        lines.append(f'    {nid}["{label}"]:::{cls}')
+
+    for nid in target_ids_sorted:
+        cls = severity_class(node_severity.get(nid, 0))
+        label = node_label[nid].replace('"', "'")
+        lines.append(f'    {nid}["{label}"]:::{cls}')
+
+    lines.append("")  # blank line between nodes and edges
+    for actor_id, target_id, edge_label, _uid in edges:
+        safe_label = edge_label.replace('"', "'")
+        lines.append(f'    {actor_id} -- "{safe_label}" --> {target_id}')
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Stream processing
+# ---------------------------------------------------------------------------
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as e:
+            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {e}", file=sys.stderr)
+            continue
+        if isinstance(obj, dict):
+            yield obj
+        else:
+            print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert OCSF Detection Findings to a Mermaid attack flow.")
+    parser.add_argument("input", nargs="?", help="OCSF JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="Mermaid output file. Defaults to stdout.")
+    parser.add_argument("--fenced", action="store_true", help="Wrap output in ```mermaid ... ``` fences for direct Markdown embedding.")
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        body = render(load_jsonl(in_stream))
+        if args.fenced:
+            out_stream.write("```mermaid\n")
+            out_stream.write(body)
+            out_stream.write("```\n")
+        else:
+            out_stream.write(body)
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/tests/test_convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/tests/test_convert.py
@@ -1,0 +1,337 @@
+"""Tests for convert-ocsf-to-mermaid-attack-flow."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from convert import (  # type: ignore[import-not-found]
+    DETECTION_FINDING_CLASS_UID,
+    SKILL_NAME,
+    extract_actor,
+    extract_attack,
+    extract_target,
+    load_jsonl,
+    render,
+    safe_id,
+    severity_class,
+)
+
+THIS = Path(__file__).resolve().parent
+GOLDEN = THIS.parent.parent / "golden"
+INPUT_FIXTURE = GOLDEN / "k8s_priv_esc_findings.ocsf.jsonl"
+EXPECTED = GOLDEN / "k8s_priv_esc_attack_flow.mmd"
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _finding(
+    *,
+    uid: str = "det-test-1",
+    severity_id: int = 4,
+    technique_uid: str = "T1611",
+    technique_name: str = "Escape to Host",
+    actor: str = "system:serviceaccount:default:builder",
+    observables: list[dict] | None = None,
+    detector: str = "detect-test",
+) -> dict:
+    return {
+        "class_uid": 2004,
+        "category_uid": 2,
+        "type_uid": 200401,
+        "severity_id": severity_id,
+        "status_id": 1,
+        "time": 1775797200000,
+        "metadata": {
+            "version": "1.8.0",
+            "product": {
+                "name": "cloud-security",
+                "feature": {"name": detector},
+            },
+        },
+        "finding_info": {
+            "uid": uid,
+            "title": "Test",
+            "desc": "Test desc",
+            "attacks": [
+                {
+                    "version": "v14",
+                    "tactic": {"name": "Privilege Escalation", "uid": "TA0004"},
+                    "technique": {"name": technique_name, "uid": technique_uid},
+                }
+            ],
+        },
+        "observables": observables
+        or [
+            {"name": "actor.name", "type": "Other", "value": actor},
+            {"name": "pod.name", "type": "Other", "value": "test-pod"},
+            {"name": "namespace", "type": "Other", "value": "default"},
+        ],
+    }
+
+
+# ── Severity → CSS class ──────────────────────────────────────────────
+
+
+class TestSeverityClass:
+    def test_critical(self):
+        assert severity_class(5) == "critical"
+        assert severity_class(6) == "critical"
+
+    def test_high(self):
+        assert severity_class(4) == "high"
+
+    def test_medium(self):
+        assert severity_class(3) == "medium"
+
+    def test_low(self):
+        for s in (0, 1, 2):
+            assert severity_class(s) == "low"
+
+    def test_unmapped_falls_to_low(self):
+        assert severity_class(99) == "low"
+
+
+# ── safe_id (Mermaid ID safety) ──────────────────────────────────────
+
+
+class TestSafeId:
+    def test_simple_alphanumeric_passes_through(self):
+        assert safe_id("A", "alice") == "Aalice"
+
+    def test_special_chars_hashed(self):
+        # Mermaid IDs cannot contain colons or slashes
+        out = safe_id("A", "system:serviceaccount:default:builder")
+        assert out.startswith("A")
+        assert ":" not in out
+        assert "/" not in out
+
+    def test_deterministic(self):
+        a = safe_id("T", "secret/default/db-password")
+        b = safe_id("T", "secret/default/db-password")
+        assert a == b
+
+    def test_distinct_inputs_distinct_ids(self):
+        a = safe_id("T", "secret/default/db-password")
+        b = safe_id("T", "secret/default/api-key")
+        assert a != b
+
+    def test_long_input_hashed(self):
+        long_str = "a" * 100
+        out = safe_id("A", long_str)
+        # Hashed IDs should be short and stable
+        assert len(out) < 20
+
+    def test_id_never_starts_with_digit(self):
+        # Mermaid silently breaks on numeric-leading IDs
+        out = safe_id("T", "123-numeric-start")
+        assert out[0].isalpha()
+
+
+# ── extract_actor / extract_target / extract_attack ──────────────────
+
+
+class TestExtractors:
+    def test_extract_actor_from_observables(self):
+        f = _finding()
+        assert extract_actor(f) == "system:serviceaccount:default:builder"
+
+    def test_extract_actor_falls_back_to_session_uid(self):
+        f = _finding(observables=[{"name": "session.uid", "type": "Other", "value": "sess-123"}])
+        assert extract_actor(f) == "sess-123"
+
+    def test_extract_actor_falls_back_to_uid_prefix(self):
+        # Pass observables with no actor.name or session.uid → fall through to uid prefix
+        f = _finding(observables=[{"name": "namespace", "type": "Other", "value": "default"}])
+        assert extract_actor(f).startswith("actor:det-test")
+
+    def test_extract_target_secret(self):
+        f = _finding(
+            observables=[
+                {"name": "actor.name", "value": "alice"},
+                {"name": "secret.name", "value": "db-password"},
+                {"name": "namespace", "value": "default"},
+            ]
+        )
+        raw, label = extract_target(f)
+        assert "db-password" in raw
+        assert "secret · default/db-password" == label
+
+    def test_extract_target_pod(self):
+        f = _finding(
+            observables=[
+                {"name": "actor.name", "value": "alice"},
+                {"name": "pod.name", "value": "web-01"},
+                {"name": "namespace", "value": "default"},
+            ]
+        )
+        raw, label = extract_target(f)
+        assert "web-01" in raw
+        assert "pod · default/web-01" == label
+
+    def test_extract_target_clusterrolebinding(self):
+        f = _finding(
+            observables=[
+                {"name": "actor.name", "value": "alice"},
+                {"name": "binding.type", "value": "clusterrolebindings"},
+                {"name": "binding.name", "value": "attacker-admin"},
+            ]
+        )
+        raw, label = extract_target(f)
+        assert "attacker-admin" in raw
+        assert "clusterrolebinding" in label
+
+    def test_extract_target_mcp_tool(self):
+        f = _finding(
+            observables=[
+                {"name": "actor.name", "value": "agent-1"},
+                {"name": "tool.name", "value": "query_db"},
+                {"name": "session.uid", "value": "sess-abc"},
+            ]
+        )
+        raw, label = extract_target(f)
+        assert "query_db" in raw
+        assert "mcp tool" in label
+
+    def test_extract_attack_with_sub_technique_prefers_sub(self):
+        f = _finding()
+        f["finding_info"]["attacks"][0]["sub_technique"] = {"name": "Container API", "uid": "T1552.007"}
+        uid, _name = extract_attack(f)
+        assert uid == "T1552.007"
+
+    def test_extract_attack_no_attacks_returns_unknown(self):
+        f = _finding()
+        f["finding_info"]["attacks"] = []
+        uid, name = extract_attack(f)
+        assert uid == "no-mitre"
+        assert name == "Unknown"
+
+
+# ── render() ──────────────────────────────────────────────────────────
+
+
+class TestRender:
+    def test_empty_input_renders_empty_node(self):
+        out = render([])
+        assert "flowchart LR" in out
+        assert "No findings" in out
+
+    def test_skips_non_detection_finding(self, capsys):
+        out = render([{"class_uid": 6003, "metadata": {}, "finding_info": {}}])
+        assert "No findings" in out
+        assert "skipping event with class_uid=6003" in capsys.readouterr().err
+
+    def test_single_finding(self):
+        out = render([_finding()])
+        assert "flowchart LR" in out
+        assert "system:serviceaccount:default:builder" in out
+        assert "test-pod" in out
+        assert "T1611" in out
+
+    def test_severity_class_in_output(self):
+        out = render([_finding(severity_id=5)])  # Critical
+        assert ":::critical" in out
+
+    def test_low_severity_class(self):
+        out = render([_finding(severity_id=1)])
+        assert ":::low" in out
+
+    def test_node_max_severity_wins(self):
+        # Same actor in two findings, one critical one medium → actor node should be critical
+        f1 = _finding(uid="a", severity_id=3, technique_uid="T1098")
+        f2 = _finding(uid="b", severity_id=5, technique_uid="T1611")
+        out = render([f1, f2])
+        # Find the actor line
+        actor_lines = [line for line in out.splitlines() if "system:serviceaccount" in line]
+        assert len(actor_lines) == 1
+        assert ":::critical" in actor_lines[0]
+
+    def test_three_findings_three_edges(self):
+        out = render(
+            [
+                _finding(uid="a", technique_uid="T1611"),
+                _finding(
+                    uid="b",
+                    technique_uid="T1098",
+                    observables=[
+                        {"name": "actor.name", "value": "system:serviceaccount:default:builder"},
+                        {"name": "binding.type", "value": "clusterrolebindings"},
+                        {"name": "binding.name", "value": "cb1"},
+                    ],
+                ),
+                _finding(
+                    uid="c",
+                    technique_uid="T1552.007",
+                    observables=[
+                        {"name": "actor.name", "value": "system:serviceaccount:default:builder"},
+                        {"name": "secret.name", "value": "s1"},
+                        {"name": "namespace", "value": "default"},
+                    ],
+                ),
+            ]
+        )
+        edges = [line for line in out.splitlines() if "-->" in line]
+        assert len(edges) == 3
+
+    def test_edge_label_format(self):
+        out = render([_finding(detector="detect-privilege-escalation-k8s")])
+        # Edge label should be 'TECHNIQUE · short-detector-name'
+        assert '"T1611 · privilege-escalation-k8s"' in out
+
+    def test_no_double_quotes_in_node_labels(self):
+        # Mermaid node label syntax uses double quotes — internal " must be escaped/replaced
+        f = _finding(actor='alice"injected')
+        out = render([f])
+        # Single quote replacement keeps Mermaid happy
+        assert "alice'injected" in out
+
+
+# ── load_jsonl robustness ────────────────────────────────────────────
+
+
+class TestLoadJsonl:
+    def test_skips_malformed(self, capsys):
+        out = list(load_jsonl(['{"bad": ', '{"class_uid": 2004}']))
+        assert out == [{"class_uid": 2004}]
+        assert "skipping line 1" in capsys.readouterr().err
+
+
+# ── Golden fixture parity ────────────────────────────────────────────
+
+
+class TestGoldenFixture:
+    def test_k8s_priv_esc_to_mermaid_matches_frozen(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        produced = render(findings)
+        expected = EXPECTED.read_text()
+        assert produced == expected, (
+            "Mermaid golden drift — re-generate via:\n  python src/convert.py ../golden/k8s_priv_esc_findings.ocsf.jsonl > ../golden/k8s_priv_esc_attack_flow.mmd"
+        )
+
+    def test_one_actor_three_targets(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        out = render(findings)
+        # Filter to NODE definition lines only (have `]:::class`), skip edges (`-->`)
+        node_lines = [line for line in out.splitlines() if "]:::" in line and "-->" not in line]
+        actor_node_lines = [line for line in node_lines if line.strip().startswith("A")]
+        target_node_lines = [line for line in node_lines if line.strip().startswith("T")]
+        assert len(actor_node_lines) == 1, f"expected 1 actor node, got {actor_node_lines}"
+        assert len(target_node_lines) == 3, f"expected 3 target nodes, got {target_node_lines}"
+
+    def test_three_mitre_techniques_in_edges(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        out = render(findings)
+        for technique in ("T1552.007", "T1611", "T1098"):
+            assert technique in out
+
+    def test_actor_is_critical(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        out = render(findings)
+        actor_line = next(line for line in out.splitlines() if "system:serviceaccount" in line)
+        assert ":::critical" in actor_line

--- a/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/tests/test_convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/tests/test_convert.py
@@ -10,8 +10,6 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from convert import (  # type: ignore[import-not-found]
-    DETECTION_FINDING_CLASS_UID,
-    SKILL_NAME,
     extract_actor,
     extract_attack,
     extract_target,

--- a/skills/detection-engineering/convert-ocsf-to-sarif/SKILL.md
+++ b/skills/detection-engineering/convert-ocsf-to-sarif/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: convert-ocsf-to-sarif
+description: >-
+  Convert OCSF 1.8 Detection Findings (class 2004) into SARIF 2.1.0 results
+  for upload to GitHub code scanning. Maps each finding's MITRE ATT&CK
+  technique to a SARIF rule (ruleId = technique.uid), maps severity_id to
+  SARIF level (CRITICAL/HIGH → error, MEDIUM → warning, LOW/INFO → note),
+  and projects observables[] into SARIF locations and properties so the
+  downstream Security tab carries the actor, target resource, and evidence
+  pointers. Use when the user mentions SARIF, GitHub code scanning, GitHub
+  Security tab, code scanning upload, or wants detection findings to land
+  alongside dependency findings in the same UI. Do NOT use for OCSF events
+  that are NOT Detection Findings (class 2004) — Compliance Findings (2003)
+  and Inventory Info (5001) need different mappings; a future
+  convert-ocsf-compliance-to-sarif will cover those. Do NOT use as a
+  detection skill — this only converts.
+license: Apache-2.0
+---
+
+# convert-ocsf-to-sarif
+
+Cross-vendor view-layer skill: takes OCSF 1.8 Detection Findings (class 2004) on stdin and emits a single SARIF 2.1.0 document on stdout. Built once, used by every detection-engineering pipeline that wants to surface findings in GitHub's Security tab.
+
+## Wire contract
+
+Input: JSONL of OCSF Detection Findings produced by any `detect-*` skill in this repo.
+
+Output: A single SARIF 2.1.0 JSON document (one `runs[]` entry, results array containing every input finding). The document validates against [https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json).
+
+## Field mapping
+
+| OCSF Detection Finding (2004) field | SARIF 2.1.0 field |
+|---|---|
+| `finding_info.uid` | `result.guid` |
+| `finding_info.title` | `result.message.text` (first line) |
+| `finding_info.desc` | `result.message.text` (after the title) |
+| `finding_info.attacks[0].technique.uid` | `result.ruleId` |
+| `finding_info.attacks[0].technique.name` | `result.rule.shortDescription.text` (under `tool.driver.rules[]`) |
+| `finding_info.attacks[0].tactic.uid` + `tactic.name` | `result.rule.properties.tags[]` (e.g. `mitre/attack/initial-access/TA0001`) |
+| `finding_info.attacks[0].sub_technique.uid` (if present) | appended to `result.tags[]` |
+| `severity_id` | `result.level` per the table below |
+| `metadata.product.feature.name` | `result.properties.detector` (which skill emitted the finding) |
+| `metadata.product.name` + `metadata.product.feature.name` | `tool.driver.name` |
+| `time` | `result.properties.detected_at_ms` (ms epoch) |
+| `observables[]` | `result.properties.observables[]` (verbatim, so SARIF consumers can pivot) |
+| `evidence` | `result.properties.evidence` (verbatim) |
+| `finding_info.types[]` | `result.properties.finding_types[]` |
+
+## severity_id → SARIF level
+
+| OCSF severity_id | SARIF level | Reason |
+|---:|---|---|
+| 0 (Unknown) | `none` | SARIF default |
+| 1 (Informational) | `note` | |
+| 2 (Low) | `note` | |
+| 3 (Medium) | `warning` | |
+| 4 (High) | `error` | GitHub Security tab shows as red |
+| 5 (Critical) | `error` | |
+| 6 (Fatal) | `error` | |
+
+## Rule deduplication
+
+Multiple findings can share a MITRE technique (e.g. several priv-esc attempts all → T1611). The skill builds a unique `tool.driver.rules[]` array keyed by technique uid so each technique appears once with its description, and each `result` references the rule by `ruleId`.
+
+## Usage
+
+```bash
+# Single pipe step in a detection pipeline
+python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
+  | python skills/detection-engineering/detect-privilege-escalation-k8s/src/detect.py \
+  | python src/convert.py \
+  > findings.sarif
+
+# Then upload to GitHub:
+gh api repos/:owner/:repo/code-scanning/sarifs \
+  --input findings.sarif \
+  --field commit_sha=$(git rev-parse HEAD) \
+  --field ref=refs/heads/main
+```
+
+Or via the GitHub Action `github/codeql-action/upload-sarif@v3` in CI — same pattern as the existing `agent-bom-iac` upload.
+
+## Tests
+
+Golden fixture parity: runs the K8s priv-esc golden findings (`../golden/k8s_priv_esc_findings.ocsf.jsonl`) through the converter and asserts the output matches a frozen SARIF golden (`../golden/k8s_priv_esc_findings.sarif`). Plus unit tests for severity mapping, MITRE rule deduplication, multi-finding handling, and edge cases (missing attacks, missing observables, empty input).

--- a/skills/detection-engineering/convert-ocsf-to-sarif/src/convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-sarif/src/convert.py
@@ -1,0 +1,318 @@
+"""Convert OCSF 1.8 Detection Findings (class 2004) to SARIF 2.1.0.
+
+Reads OCSF Detection Finding JSONL on stdin (one finding per line) and writes
+a single SARIF 2.1.0 document on stdout. Designed to be the last step in a
+detection-engineering pipeline so findings land in GitHub code scanning's
+Security tab via `github/codeql-action/upload-sarif@v3`.
+
+Contract: see ../OCSF_CONTRACT.md for the input shape; SARIF spec at
+https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Iterable
+
+SKILL_NAME = "convert-ocsf-to-sarif"
+SKILL_VERSION = "0.1.0"
+SARIF_VERSION = "2.1.0"
+SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json"
+
+# OCSF Detection Finding (2004) class_uid we recognise
+DETECTION_FINDING_CLASS_UID = 2004
+
+
+# ---------------------------------------------------------------------------
+# Severity mapping
+# ---------------------------------------------------------------------------
+
+# OCSF severity_id → SARIF level
+# https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317648
+_SEVERITY_TO_LEVEL = {
+    0: "none",  # Unknown
+    1: "note",  # Informational
+    2: "note",  # Low
+    3: "warning",  # Medium
+    4: "error",  # High
+    5: "error",  # Critical
+    6: "error",  # Fatal
+}
+
+
+def severity_to_sarif_level(severity_id: int) -> str:
+    """Map an OCSF severity_id (0-6) to a SARIF level string."""
+    return _SEVERITY_TO_LEVEL.get(severity_id, "none")
+
+
+# ---------------------------------------------------------------------------
+# MITRE ATT&CK helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_attack(finding_info: dict[str, Any]) -> dict[str, Any]:
+    attacks = finding_info.get("attacks") or []
+    return attacks[0] if attacks else {}
+
+
+def _technique_uid(attack: dict[str, Any]) -> str:
+    return ((attack.get("technique") or {}).get("uid")) or "no-mitre"
+
+
+def _technique_name(attack: dict[str, Any]) -> str:
+    return ((attack.get("technique") or {}).get("name")) or "Unknown technique"
+
+
+def _tactic_uid(attack: dict[str, Any]) -> str:
+    return ((attack.get("tactic") or {}).get("uid")) or ""
+
+
+def _tactic_name(attack: dict[str, Any]) -> str:
+    return ((attack.get("tactic") or {}).get("name")) or ""
+
+
+def _mitre_tags(attack: dict[str, Any]) -> list[str]:
+    """Build the MITRE tag list for SARIF result.tags / rule.tags."""
+    tags: list[str] = []
+    tactic_uid = _tactic_uid(attack)
+    if tactic_uid:
+        # Slug-style tactic name for grep-friendliness
+        tactic_slug = _tactic_name(attack).lower().replace(" ", "-")
+        tags.append(f"mitre/attack/{tactic_slug}/{tactic_uid}")
+    technique_uid = _technique_uid(attack)
+    if technique_uid and technique_uid != "no-mitre":
+        tags.append(f"mitre/attack/technique/{technique_uid}")
+    sub = (attack.get("sub_technique") or {}).get("uid")
+    if sub:
+        tags.append(f"mitre/attack/sub-technique/{sub}")
+    return tags
+
+
+# ---------------------------------------------------------------------------
+# Rule and result builders
+# ---------------------------------------------------------------------------
+
+
+def _rule_for_attack(attack: dict[str, Any]) -> dict[str, Any]:
+    """Build a SARIF rule object for one MITRE technique."""
+    technique_uid = _technique_uid(attack)
+    technique_name = _technique_name(attack)
+    tactic_uid = _tactic_uid(attack)
+    tactic_name = _tactic_name(attack)
+
+    rule: dict[str, Any] = {
+        "id": technique_uid,
+        "name": technique_name,
+        "shortDescription": {"text": technique_name},
+    }
+
+    desc_parts = []
+    if tactic_uid and tactic_name:
+        desc_parts.append(f"MITRE ATT&CK tactic: {tactic_name} ({tactic_uid})")
+    if technique_uid != "no-mitre":
+        desc_parts.append(f"Technique: {technique_name} ({technique_uid})")
+        desc_parts.append(f"Reference: https://attack.mitre.org/techniques/{technique_uid.replace('.', '/')}/")
+    if desc_parts:
+        rule["fullDescription"] = {"text": " · ".join(desc_parts)}
+
+    rule["properties"] = {
+        "tags": _mitre_tags(attack),
+        "precision": "high",
+    }
+    return rule
+
+
+def _build_message(finding: dict[str, Any]) -> str:
+    finding_info = finding.get("finding_info") or {}
+    title = finding_info.get("title") or "Detection finding"
+    desc = finding_info.get("desc") or ""
+    if desc:
+        return f"{title}\n\n{desc}"
+    return title
+
+
+def _build_locations(finding: dict[str, Any]) -> list[dict[str, Any]]:
+    """SARIF 2.1.0 requires locations[] to make a result clickable in code
+    scanning. Detection findings don't always have a file:line — they live in
+    cloud / runtime telemetry. We synthesise a logical location keyed by
+    metadata.product.feature.name + finding uid so the SARIF UI groups
+    related findings sensibly.
+    """
+    finding_info = finding.get("finding_info") or {}
+    feature = ((finding.get("metadata") or {}).get("product") or {}).get("feature") or {}
+    detector = feature.get("name") or "unknown-detector"
+    uid = finding_info.get("uid") or "no-uid"
+    return [
+        {
+            "logicalLocations": [
+                {
+                    "name": detector,
+                    "fullyQualifiedName": f"{detector}/{uid}",
+                    "kind": "module",
+                }
+            ]
+        }
+    ]
+
+
+def _build_result(finding: dict[str, Any]) -> dict[str, Any]:
+    finding_info = finding.get("finding_info") or {}
+    attack = _first_attack(finding_info)
+    severity_id = int(finding.get("severity_id", 0))
+
+    result: dict[str, Any] = {
+        "ruleId": _technique_uid(attack),
+        "level": severity_to_sarif_level(severity_id),
+        "message": {"text": _build_message(finding)},
+        "locations": _build_locations(finding),
+    }
+
+    uid = finding_info.get("uid")
+    if uid:
+        result["guid"] = uid
+        # SARIF partialFingerprints make code-scanning dedupe stable across runs
+        result["partialFingerprints"] = {"primaryLocationLineHash": uid}
+
+    properties: dict[str, Any] = {
+        "detector": ((finding.get("metadata") or {}).get("product") or {}).get("feature", {}).get("name", ""),
+        "detected_at_ms": finding.get("time"),
+        "ocsf_class_uid": finding.get("class_uid"),
+        "ocsf_severity_id": severity_id,
+        "tags": _mitre_tags(attack),
+    }
+
+    observables = finding.get("observables")
+    if observables:
+        properties["observables"] = observables
+
+    evidence = finding.get("evidence")
+    if evidence:
+        properties["evidence"] = evidence
+
+    finding_types = finding_info.get("types")
+    if finding_types:
+        properties["finding_types"] = finding_types
+
+    result["properties"] = properties
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tool / driver builders
+# ---------------------------------------------------------------------------
+
+
+def _build_driver(detectors: set[str], rules: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Build the SARIF tool.driver object.
+
+    name: cloud-security-detection-engineering (the product family — all
+    detect-* skills emit findings that flow through this converter, so the
+    Security tab groups them under one tool name)
+    rules: deduplicated by MITRE technique uid
+    """
+    return {
+        "name": "cloud-security-detection-engineering",
+        "version": SKILL_VERSION,
+        "informationUri": "https://github.com/msaad00/cloud-security",
+        "rules": list(rules.values()),
+        "properties": {
+            "detectors": sorted(detectors),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Top-level convert
+# ---------------------------------------------------------------------------
+
+
+def convert(findings: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Convert an iterable of OCSF Detection Findings to a single SARIF document."""
+    materialised = list(findings)
+
+    # Filter to Detection Findings (2004) — emit a warning for anything else.
+    detection_findings: list[dict[str, Any]] = []
+    for f in materialised:
+        cls = f.get("class_uid")
+        if cls == DETECTION_FINDING_CLASS_UID:
+            detection_findings.append(f)
+        else:
+            print(
+                f"[{SKILL_NAME}] skipping event with class_uid={cls} — convert-ocsf-to-sarif only handles Detection Finding (2004)",
+                file=sys.stderr,
+            )
+
+    # Build deduplicated rules keyed by technique uid
+    rules: dict[str, dict[str, Any]] = {}
+    detectors: set[str] = set()
+    for f in detection_findings:
+        attack = _first_attack(f.get("finding_info") or {})
+        rule_id = _technique_uid(attack)
+        if rule_id not in rules:
+            rules[rule_id] = _rule_for_attack(attack)
+        detector = ((f.get("metadata") or {}).get("product") or {}).get("feature", {}).get("name")
+        if detector:
+            detectors.add(detector)
+
+    results = [_build_result(f) for f in detection_findings]
+
+    sarif_doc: dict[str, Any] = {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {"driver": _build_driver(detectors, rules)},
+                "results": results,
+            }
+        ],
+    }
+    return sarif_doc
+
+
+# ---------------------------------------------------------------------------
+# Stream processing
+# ---------------------------------------------------------------------------
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as e:
+            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {e}", file=sys.stderr)
+            continue
+        if isinstance(obj, dict):
+            yield obj
+        else:
+            print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert OCSF Detection Findings to SARIF 2.1.0.")
+    parser.add_argument("input", nargs="?", help="OCSF JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="SARIF output file. Defaults to stdout.")
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        sarif = convert(load_jsonl(in_stream))
+        json.dump(sarif, out_stream, indent=2, sort_keys=False)
+        out_stream.write("\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection-engineering/convert-ocsf-to-sarif/tests/test_convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-sarif/tests/test_convert.py
@@ -10,10 +10,8 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from convert import (  # type: ignore[import-not-found]
-    DETECTION_FINDING_CLASS_UID,
     SARIF_SCHEMA,
     SARIF_VERSION,
-    SKILL_NAME,
     convert,
     load_jsonl,
     severity_to_sarif_level,

--- a/skills/detection-engineering/convert-ocsf-to-sarif/tests/test_convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-sarif/tests/test_convert.py
@@ -1,0 +1,287 @@
+"""Tests for convert-ocsf-to-sarif."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from convert import (  # type: ignore[import-not-found]
+    DETECTION_FINDING_CLASS_UID,
+    SARIF_SCHEMA,
+    SARIF_VERSION,
+    SKILL_NAME,
+    convert,
+    load_jsonl,
+    severity_to_sarif_level,
+)
+
+THIS = Path(__file__).resolve().parent
+GOLDEN = THIS.parent.parent / "golden"
+INPUT_FIXTURE = GOLDEN / "k8s_priv_esc_findings.ocsf.jsonl"
+EXPECTED = GOLDEN / "k8s_priv_esc_findings.sarif"
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _detection_finding(
+    *,
+    uid: str = "det-test-1",
+    technique_uid: str = "T1611",
+    technique_name: str = "Escape to Host",
+    tactic_uid: str = "TA0004",
+    tactic_name: str = "Privilege Escalation",
+    sub_uid: str | None = None,
+    severity_id: int = 4,
+    title: str = "Test finding",
+    desc: str = "Test description",
+    detector: str = "detect-test",
+) -> dict:
+    attack: dict = {
+        "version": "v14",
+        "tactic": {"name": tactic_name, "uid": tactic_uid},
+        "technique": {"name": technique_name, "uid": technique_uid},
+    }
+    if sub_uid:
+        attack["sub_technique"] = {"name": "Sub", "uid": sub_uid}
+    return {
+        "class_uid": 2004,
+        "category_uid": 2,
+        "type_uid": 200401,
+        "severity_id": severity_id,
+        "status_id": 1,
+        "time": 1775797200000,
+        "metadata": {
+            "version": "1.8.0",
+            "product": {
+                "name": "cloud-security",
+                "vendor_name": "msaad00/cloud-security",
+                "feature": {"name": detector},
+            },
+        },
+        "finding_info": {
+            "uid": uid,
+            "title": title,
+            "desc": desc,
+            "attacks": [attack],
+        },
+        "observables": [{"name": "actor.name", "type": "Other", "value": "test-actor"}],
+        "evidence": {"events_observed": 1},
+    }
+
+
+# ── Severity mapping ─────────────────────────────────────────────────
+
+
+class TestSeverityMapping:
+    def test_unknown(self):
+        assert severity_to_sarif_level(0) == "none"
+
+    def test_informational(self):
+        assert severity_to_sarif_level(1) == "note"
+
+    def test_low(self):
+        assert severity_to_sarif_level(2) == "note"
+
+    def test_medium(self):
+        assert severity_to_sarif_level(3) == "warning"
+
+    def test_high(self):
+        assert severity_to_sarif_level(4) == "error"
+
+    def test_critical(self):
+        assert severity_to_sarif_level(5) == "error"
+
+    def test_fatal(self):
+        assert severity_to_sarif_level(6) == "error"
+
+    def test_unmapped_falls_to_none(self):
+        assert severity_to_sarif_level(99) == "none"
+
+
+# ── Document shape ───────────────────────────────────────────────────
+
+
+class TestDocShape:
+    def test_empty_input(self):
+        doc = convert([])
+        assert doc["$schema"] == SARIF_SCHEMA
+        assert doc["version"] == SARIF_VERSION
+        assert len(doc["runs"]) == 1
+        assert doc["runs"][0]["results"] == []
+        assert doc["runs"][0]["tool"]["driver"]["rules"] == []
+
+    def test_single_finding(self):
+        doc = convert([_detection_finding()])
+        assert len(doc["runs"][0]["results"]) == 1
+        result = doc["runs"][0]["results"][0]
+        assert result["ruleId"] == "T1611"
+        assert result["level"] == "error"
+        assert "Test finding" in result["message"]["text"]
+        assert "Test description" in result["message"]["text"]
+
+    def test_tool_name_pinned(self):
+        doc = convert([_detection_finding()])
+        assert doc["runs"][0]["tool"]["driver"]["name"] == "cloud-security-detection-engineering"
+
+    def test_skips_non_detection_finding(self, capsys):
+        doc = convert(
+            [
+                _detection_finding(),
+                {"class_uid": 6003, "metadata": {}, "finding_info": {}},  # API Activity, not a finding
+            ]
+        )
+        assert len(doc["runs"][0]["results"]) == 1
+        assert "skipping event with class_uid=6003" in capsys.readouterr().err
+
+
+# ── Rule deduplication ───────────────────────────────────────────────
+
+
+class TestRuleDedup:
+    def test_two_findings_same_technique_one_rule(self):
+        doc = convert(
+            [
+                _detection_finding(uid="a", technique_uid="T1611"),
+                _detection_finding(uid="b", technique_uid="T1611"),
+            ]
+        )
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["id"] == "T1611"
+        # But two results
+        assert len(doc["runs"][0]["results"]) == 2
+
+    def test_three_findings_three_techniques_three_rules(self):
+        doc = convert(
+            [
+                _detection_finding(uid="a", technique_uid="T1611"),
+                _detection_finding(uid="b", technique_uid="T1098"),
+                _detection_finding(uid="c", technique_uid="T1552"),
+            ]
+        )
+        rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert rule_ids == {"T1611", "T1098", "T1552"}
+
+
+# ── MITRE tags ───────────────────────────────────────────────────────
+
+
+class TestMitreTags:
+    def test_tags_include_technique_and_tactic(self):
+        doc = convert([_detection_finding(technique_uid="T1611", tactic_uid="TA0004", tactic_name="Privilege Escalation")])
+        result = doc["runs"][0]["results"][0]
+        tags = result["properties"]["tags"]
+        assert "mitre/attack/technique/T1611" in tags
+        assert "mitre/attack/privilege-escalation/TA0004" in tags
+
+    def test_sub_technique_in_tags_when_present(self):
+        doc = convert([_detection_finding(sub_uid="T1552.007")])
+        tags = doc["runs"][0]["results"][0]["properties"]["tags"]
+        assert "mitre/attack/sub-technique/T1552.007" in tags
+
+
+# ── Properties carry observables + evidence ──────────────────────────
+
+
+class TestProperties:
+    def test_observables_passthrough(self):
+        f = _detection_finding()
+        f["observables"] = [
+            {"name": "actor.name", "type": "Other", "value": "alice"},
+            {"name": "tool.name", "type": "Other", "value": "query_db"},
+        ]
+        doc = convert([f])
+        obs = doc["runs"][0]["results"][0]["properties"]["observables"]
+        assert len(obs) == 2
+        assert obs[0]["value"] == "alice"
+
+    def test_evidence_passthrough(self):
+        f = _detection_finding()
+        f["evidence"] = {"events_observed": 5, "before_event_time": 1000, "after_event_time": 2000}
+        doc = convert([f])
+        ev = doc["runs"][0]["results"][0]["properties"]["evidence"]
+        assert ev["events_observed"] == 5
+
+    def test_detector_metadata(self):
+        f = _detection_finding(detector="detect-mcp-tool-drift")
+        doc = convert([f])
+        assert doc["runs"][0]["results"][0]["properties"]["detector"] == "detect-mcp-tool-drift"
+
+
+# ── Locations ───────────────────────────────────────────────────────
+
+
+class TestLocations:
+    def test_logical_location_present(self):
+        doc = convert([_detection_finding(uid="abc", detector="detect-test")])
+        loc = doc["runs"][0]["results"][0]["locations"][0]["logicalLocations"][0]
+        assert loc["name"] == "detect-test"
+        assert "abc" in loc["fullyQualifiedName"]
+        assert loc["kind"] == "module"
+
+
+# ── Fingerprints (dedup across runs) ─────────────────────────────────
+
+
+class TestFingerprints:
+    def test_partial_fingerprint_present_when_uid(self):
+        doc = convert([_detection_finding(uid="det-abc")])
+        result = doc["runs"][0]["results"][0]
+        assert "partialFingerprints" in result
+        assert "primaryLocationLineHash" in result["partialFingerprints"]
+
+    def test_guid_matches_uid(self):
+        doc = convert([_detection_finding(uid="det-abc-123")])
+        assert doc["runs"][0]["results"][0]["guid"] == "det-abc-123"
+
+
+# ── load_jsonl robustness ────────────────────────────────────────────
+
+
+class TestLoadJsonl:
+    def test_skips_malformed(self, capsys):
+        out = list(load_jsonl(['{"bad": ', '{"class_uid": 2004}']))
+        assert out == [{"class_uid": 2004}]
+        assert "skipping line 1" in capsys.readouterr().err
+
+    def test_skips_non_object(self, capsys):
+        out = list(load_jsonl(["[1,2,3]", '{"class_uid": 2004}']))
+        assert out == [{"class_uid": 2004}]
+
+
+# ── Golden fixture parity ────────────────────────────────────────────
+
+
+class TestGoldenFixture:
+    def test_k8s_priv_esc_to_sarif_matches_frozen(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        produced = convert(findings)
+        expected = json.loads(EXPECTED.read_text())
+        assert produced == expected, (
+            "SARIF golden drift — re-generate via:\n  python src/convert.py ../golden/k8s_priv_esc_findings.ocsf.jsonl > ../golden/k8s_priv_esc_findings.sarif"
+        )
+
+    def test_three_findings_three_rules(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        doc = convert(findings)
+        assert len(doc["runs"][0]["results"]) == 3
+        rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert rule_ids == {"T1552", "T1611", "T1098"}
+
+    def test_all_results_are_error_level(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        doc = convert(findings)
+        for r in doc["runs"][0]["results"]:
+            assert r["level"] == "error"
+
+    def test_sarif_validates_schema_url(self):
+        findings = _load_jsonl(INPUT_FIXTURE)
+        doc = convert(findings)
+        assert doc["$schema"].endswith("sarif-schema-2.1.0.json")
+        assert doc["version"] == "2.1.0"

--- a/skills/detection-engineering/golden/k8s_priv_esc_attack_flow.mmd
+++ b/skills/detection-engineering/golden/k8s_priv_esc_attack_flow.mmd
@@ -1,0 +1,14 @@
+flowchart LR
+    classDef critical fill:#3f1d1d,stroke:#f87171,color:#fecaca
+    classDef high     fill:#3a2a0e,stroke:#fb923c,color:#fed7aa
+    classDef medium   fill:#3a3a0e,stroke:#fbbf24,color:#fef08a
+    classDef low      fill:#1e293b,stroke:#64748b,color:#cbd5e1
+
+    A122b20810e["system:serviceaccount:default:builder"]:::critical
+    T20b074c51c["secret · default/db-password"]:::high
+    T9071eb688c["clusterrolebinding · attacker-cluster-admin"]:::critical
+    Tfbd3557c97["pod · default/web-xyz"]:::critical
+
+    A122b20810e -- "T1552.007 · privilege-escalation-k8s" --> T20b074c51c
+    A122b20810e -- "T1611 · privilege-escalation-k8s" --> Tfbd3557c97
+    A122b20810e -- "T1098 · privilege-escalation-k8s" --> T9071eb688c

--- a/skills/detection-engineering/golden/k8s_priv_esc_findings.sarif
+++ b/skills/detection-engineering/golden/k8s_priv_esc_findings.sarif
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "cloud-security-detection-engineering",
+          "version": "0.1.0",
+          "informationUri": "https://github.com/msaad00/cloud-security",
+          "rules": [
+            {
+              "id": "T1552",
+              "name": "Unsecured Credentials",
+              "shortDescription": {
+                "text": "Unsecured Credentials"
+              },
+              "fullDescription": {
+                "text": "MITRE ATT&CK tactic: Credential Access (TA0006) \u00b7 Technique: Unsecured Credentials (T1552) \u00b7 Reference: https://attack.mitre.org/techniques/T1552/"
+              },
+              "properties": {
+                "tags": [
+                  "mitre/attack/credential-access/TA0006",
+                  "mitre/attack/technique/T1552",
+                  "mitre/attack/sub-technique/T1552.007"
+                ],
+                "precision": "high"
+              }
+            },
+            {
+              "id": "T1611",
+              "name": "Escape to Host",
+              "shortDescription": {
+                "text": "Escape to Host"
+              },
+              "fullDescription": {
+                "text": "MITRE ATT&CK tactic: Privilege Escalation (TA0004) \u00b7 Technique: Escape to Host (T1611) \u00b7 Reference: https://attack.mitre.org/techniques/T1611/"
+              },
+              "properties": {
+                "tags": [
+                  "mitre/attack/privilege-escalation/TA0004",
+                  "mitre/attack/technique/T1611"
+                ],
+                "precision": "high"
+              }
+            },
+            {
+              "id": "T1098",
+              "name": "Account Manipulation",
+              "shortDescription": {
+                "text": "Account Manipulation"
+              },
+              "fullDescription": {
+                "text": "MITRE ATT&CK tactic: Persistence (TA0003) \u00b7 Technique: Account Manipulation (T1098) \u00b7 Reference: https://attack.mitre.org/techniques/T1098/"
+              },
+              "properties": {
+                "tags": [
+                  "mitre/attack/persistence/TA0003",
+                  "mitre/attack/technique/T1098"
+                ],
+                "precision": "high"
+              }
+            }
+          ],
+          "properties": {
+            "detectors": [
+              "detect-privilege-escalation-k8s"
+            ]
+          }
+        }
+      },
+      "results": [
+        {
+          "ruleId": "T1552",
+          "level": "error",
+          "message": {
+            "text": "Service account enumerated and read a Kubernetes secret\n\nService account 'system:serviceaccount:default:builder' performed `list` on secrets in namespace 'default' and then `get` on secret 'db-password' within the 300-second correlation window. Workloads that need secret data should mount secrets as files, not call the K8s API for them \u2014 this pattern is a strong signal of a compromised pod searching for credentials. (MITRE T1552.007)"
+          },
+          "locations": [
+            {
+              "logicalLocations": [
+                {
+                  "name": "detect-privilege-escalation-k8s",
+                  "fullyQualifiedName": "detect-privilege-escalation-k8s/det-k8s-r1-secret-enum-8af26d6d-c7203b19",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "guid": "det-k8s-r1-secret-enum-8af26d6d-c7203b19",
+          "partialFingerprints": {
+            "primaryLocationLineHash": "det-k8s-r1-secret-enum-8af26d6d-c7203b19"
+          },
+          "properties": {
+            "detector": "detect-privilege-escalation-k8s",
+            "detected_at_ms": 1775797230000,
+            "ocsf_class_uid": 2004,
+            "ocsf_severity_id": 4,
+            "tags": [
+              "mitre/attack/credential-access/TA0006",
+              "mitre/attack/technique/T1552",
+              "mitre/attack/sub-technique/T1552.007"
+            ],
+            "observables": [
+              {
+                "name": "actor.name",
+                "type": "Other",
+                "value": "system:serviceaccount:default:builder"
+              },
+              {
+                "name": "namespace",
+                "type": "Other",
+                "value": "default"
+              },
+              {
+                "name": "secret.name",
+                "type": "Other",
+                "value": "db-password"
+              },
+              {
+                "name": "rule",
+                "type": "Other",
+                "value": "r1-secret-enum"
+              }
+            ],
+            "evidence": {
+              "events_observed": 2,
+              "first_seen_time": 1775797200000,
+              "last_seen_time": 1775797230000,
+              "raw_events": []
+            },
+            "finding_types": [
+              "k8s-r1-secret-enum"
+            ]
+          }
+        },
+        {
+          "ruleId": "T1611",
+          "level": "error",
+          "message": {
+            "text": "Service account executed a shell inside a pod\n\nService account 'system:serviceaccount:default:builder' called `create` on pods/exec for pod 'web-xyz' in namespace 'default'. Workloads (as opposed to human operators) should never exec into other pods \u2014 this is the precursor to container escape. (MITRE T1611)"
+          },
+          "locations": [
+            {
+              "logicalLocations": [
+                {
+                  "name": "detect-privilege-escalation-k8s",
+                  "fullyQualifiedName": "detect-privilege-escalation-k8s/det-k8s-r2-pod-exec-8af26d6d-59d9c001",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "guid": "det-k8s-r2-pod-exec-8af26d6d-59d9c001",
+          "partialFingerprints": {
+            "primaryLocationLineHash": "det-k8s-r2-pod-exec-8af26d6d-59d9c001"
+          },
+          "properties": {
+            "detector": "detect-privilege-escalation-k8s",
+            "detected_at_ms": 1775797260000,
+            "ocsf_class_uid": 2004,
+            "ocsf_severity_id": 5,
+            "tags": [
+              "mitre/attack/privilege-escalation/TA0004",
+              "mitre/attack/technique/T1611"
+            ],
+            "observables": [
+              {
+                "name": "actor.name",
+                "type": "Other",
+                "value": "system:serviceaccount:default:builder"
+              },
+              {
+                "name": "pod.name",
+                "type": "Other",
+                "value": "web-xyz"
+              },
+              {
+                "name": "namespace",
+                "type": "Other",
+                "value": "default"
+              },
+              {
+                "name": "rule",
+                "type": "Other",
+                "value": "r2-pod-exec"
+              }
+            ],
+            "evidence": {
+              "events_observed": 1,
+              "first_seen_time": 1775797260000,
+              "last_seen_time": 1775797260000,
+              "raw_events": []
+            },
+            "finding_types": [
+              "k8s-r2-pod-exec"
+            ]
+          }
+        },
+        {
+          "ruleId": "T1098",
+          "level": "error",
+          "message": {
+            "text": "Non-admin principal created a clusterrolebinding\n\nPrincipal 'system:serviceaccount:default:builder' created clusterrolebinding 'attacker-cluster-admin'. This principal is not in system:masters and is not a recognised admin user \u2014 creating a binding is the canonical K8s privilege-escalation move after initial compromise. (MITRE T1098)"
+          },
+          "locations": [
+            {
+              "logicalLocations": [
+                {
+                  "name": "detect-privilege-escalation-k8s",
+                  "fullyQualifiedName": "detect-privilege-escalation-k8s/det-k8s-r3-rbac-self-grant-8af26d6d-773c3208",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "guid": "det-k8s-r3-rbac-self-grant-8af26d6d-773c3208",
+          "partialFingerprints": {
+            "primaryLocationLineHash": "det-k8s-r3-rbac-self-grant-8af26d6d-773c3208"
+          },
+          "properties": {
+            "detector": "detect-privilege-escalation-k8s",
+            "detected_at_ms": 1775797290000,
+            "ocsf_class_uid": 2004,
+            "ocsf_severity_id": 5,
+            "tags": [
+              "mitre/attack/persistence/TA0003",
+              "mitre/attack/technique/T1098"
+            ],
+            "observables": [
+              {
+                "name": "actor.name",
+                "type": "Other",
+                "value": "system:serviceaccount:default:builder"
+              },
+              {
+                "name": "binding.type",
+                "type": "Other",
+                "value": "clusterrolebindings"
+              },
+              {
+                "name": "binding.name",
+                "type": "Other",
+                "value": "attacker-cluster-admin"
+              },
+              {
+                "name": "namespace",
+                "type": "Other",
+                "value": ""
+              },
+              {
+                "name": "rule",
+                "type": "Other",
+                "value": "r3-rbac-self-grant"
+              }
+            ],
+            "evidence": {
+              "events_observed": 1,
+              "first_seen_time": 1775797290000,
+              "last_seen_time": 1775797290000,
+              "raw_events": []
+            },
+            "finding_types": [
+              "k8s-r3-rbac-self-grant"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/test_k8s_pipeline.py
+++ b/tests/integration/test_k8s_pipeline.py
@@ -185,6 +185,73 @@ class TestMcpPipelineEndToEnd:
         assert findings[0]["metadata"]["version"] == "1.8.0"
 
 
+class TestK8sPipelineWithConvertLayer:
+    """Full closed-loop pipeline: raw → ingest → detect → convert (SARIF + Mermaid)."""
+
+    def setup_method(self):
+        self.ingest = _load_module(
+            "_int_v_ingest_k8s",
+            SKILLS_DIR / "ingest-k8s-audit-ocsf" / "src" / "ingest.py",
+        )
+        self.detect = _load_module(
+            "_int_v_detect_k8s",
+            SKILLS_DIR / "detect-privilege-escalation-k8s" / "src" / "detect.py",
+        )
+        self.sarif = _load_module(
+            "_int_v_sarif",
+            SKILLS_DIR / "convert-ocsf-to-sarif" / "src" / "convert.py",
+        )
+        self.mermaid = _load_module(
+            "_int_v_mermaid",
+            SKILLS_DIR / "convert-ocsf-to-mermaid-attack-flow" / "src" / "convert.py",
+        )
+
+    def _findings(self):
+        raw_lines = (GOLDEN_DIR / "k8s_audit_raw_sample.jsonl").read_text().splitlines()
+        return list(self.detect.detect(self.ingest.ingest(raw_lines)))
+
+    def test_full_pipe_to_sarif(self):
+        sarif_doc = self.sarif.convert(self._findings())
+        assert sarif_doc["version"] == "2.1.0"
+        assert sarif_doc["$schema"].endswith("sarif-schema-2.1.0.json")
+        assert len(sarif_doc["runs"]) == 1
+        assert len(sarif_doc["runs"][0]["results"]) == 3
+        rule_ids = {r["id"] for r in sarif_doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert rule_ids == {"T1552", "T1611", "T1098"}
+        for result in sarif_doc["runs"][0]["results"]:
+            assert result["level"] == "error"
+
+    def test_full_pipe_to_sarif_matches_frozen_golden(self):
+        produced = self.sarif.convert(self._findings())
+        expected = json.loads((GOLDEN_DIR / "k8s_priv_esc_findings.sarif").read_text())
+        assert produced == expected, "End-to-end SARIF drift across the K8s pipeline"
+
+    def test_full_pipe_to_mermaid(self):
+        mermaid = self.mermaid.render(self._findings())
+        assert "flowchart LR" in mermaid
+        assert "classDef critical" in mermaid
+        assert "system:serviceaccount:default:builder" in mermaid
+        for technique in ("T1552.007", "T1611", "T1098"):
+            assert technique in mermaid
+        actor_lines = [line for line in mermaid.splitlines() if "system:serviceaccount" in line and "]:::" in line and "-->" not in line]
+        assert len(actor_lines) == 1
+        assert ":::critical" in actor_lines[0]
+
+    def test_full_pipe_to_mermaid_matches_frozen_golden(self):
+        produced = self.mermaid.render(self._findings())
+        expected = (GOLDEN_DIR / "k8s_priv_esc_attack_flow.mmd").read_text()
+        assert produced == expected, "End-to-end Mermaid drift across the K8s pipeline"
+
+    def test_sarif_and_mermaid_describe_the_same_findings(self):
+        findings = self._findings()
+        sarif_doc = self.sarif.convert(findings)
+        mermaid = self.mermaid.render(findings)
+        sarif_techniques = {r["id"] for r in sarif_doc["runs"][0]["tool"]["driver"]["rules"]}
+        for technique in sarif_techniques:
+            assert technique in mermaid, f"Technique {technique} in SARIF but missing from Mermaid"
+        assert len(sarif_doc["runs"][0]["results"]) == len(findings)
+
+
 class TestCrossSkillOcsfWireContract:
     """OCSF wire-contract assertions that must hold for any ingest+detect pair.
 


### PR DESCRIPTION
PR E. Cross-vendor view layer — built once, reused by every later vendor story.

## What you get

Two new skills plus an extended integration test that pipes the full closed-loop chain end-to-end.

| Skill | Input | Output | Audience |
|---|---|---|---|
| `convert-ocsf-to-sarif` | OCSF Detection Finding (2004) JSONL | SARIF 2.1.0 document | GitHub code scanning / Security tab |
| `convert-ocsf-to-mermaid-attack-flow` | OCSF Detection Finding JSONL | Mermaid `flowchart LR` | PR comments / README / wikis |

## End-to-end verified

```bash
python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py k8s-audit.log \
  | python skills/detection-engineering/detect-privilege-escalation-k8s/src/detect.py \
  | python skills/detection-engineering/convert-ocsf-to-sarif/src/convert.py \
  > findings.sarif
```

On the golden K8s priv-esc fixture this produces:
- **3 SARIF results** (one per detection rule that fired)
- **3 deduplicated rules** (`T1552`, `T1611`, `T1098`) — multiple findings that share a MITRE technique collapse into one rule
- **All `error` level** (severity 4-5 → `error` per the OCSF → SARIF mapping)
- **`partialFingerprints`** populated with `finding_info.uid` for stable code-scanning dedup across runs

Same findings piped through the Mermaid converter produce a `flowchart LR` block with the builder service account actor, three severity-coloured target nodes (secret / pod / clusterrolebinding), and three edges labelled with the MITRE technique IDs + detector name.

## Field mappings pinned

**OCSF → SARIF:**
| OCSF | SARIF |
|---|---|
| `finding_info.attacks[0].technique.uid` | `result.ruleId` |
| `finding_info.title` + `finding_info.desc` | `result.message.text` |
| `severity_id` 4-5 | `result.level: error` |
| `severity_id` 3 | `result.level: warning` |
| `severity_id` 1-2 | `result.level: note` |
| `observables[]` | `result.properties.observables` (verbatim) |
| `evidence` | `result.properties.evidence` (verbatim) |
| `finding_info.uid` | `result.guid` + `partialFingerprints.primaryLocationLineHash` |

**OCSF → Mermaid:**
| OCSF | Mermaid |
|---|---|
| `observables[].name == "actor.name"` | actor node (left) |
| `observables[].name == "*.name"` (non-actor) | target node (right) |
| `finding_info.attacks[0].technique.uid` | edge label |
| `severity_id` | node `classDef` (critical / high / medium / low) |

## Rule deduplication

Multiple findings with the same MITRE technique produce **one** rule in `tool.driver.rules[]` and **N** results that reference it. Test `test_two_findings_same_technique_one_rule` pins this. Verified on the K8s golden fixture: 3 findings produce 3 rules because each rule fires exactly once (T1552.007 / T1611 / T1098).

## Integration test extension

`tests/integration/test_k8s_pipeline.py` grows from 11 to 16 tests with a new `TestK8sPipelineWithConvertLayer` class asserting:

- Full `raw → ingest → detect → SARIF` chain produces a SARIF doc with 3 results and 3 deduped rules, all `error` level
- Full `raw → ingest → detect → Mermaid` chain produces a `flowchart LR` with the builder SA + 3 techniques
- SARIF and Mermaid outputs describe the same findings (every technique present in one is present in the other)
- Both converters match their frozen golden fixtures via deep-eq

## CI

Two new jobs:
- `test-convert-ocsf-to-sarif`
- `test-convert-ocsf-to-mermaid-attack-flow`

## Verification

- [x] 62 convert tests passing (28 SARIF + 34 Mermaid)
- [x] 16 integration tests passing (6 new convert-layer tests)
- [x] `ruff check` clean (fixed F401 unused-import warnings in followup commit)
- [x] `ruff format --check` clean
- [x] End-to-end pipe produces valid SARIF 2.1.0 and Mermaid on the K8s golden fixture
- [ ] CI green

## Unblocks

Every later vendor story (Okta, GitHub, Workspace, Slack, Workday, Salesforce, SAP, VPC Flow, GuardDuty) gets GitHub Security tab upload and PR-comment visualisation *for free* by piping its detection findings through these two converters. No per-vendor view code to write.