### PR TITLE
docs+ci: tighten README, consolidate CI into 9 top-level jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   security-events: write
 
 jobs:
-  # ── Lint ─────────────────────────────────────────────────────────
+  # ── Lint + static analysis ──────────────────────────────────────
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -23,11 +23,25 @@ jobs:
       - run: ruff check skills/ tests/ --config pyproject.toml
       - run: ruff format --check skills/ tests/
 
-  # ── compliance-cis-mitre/ ────────────────────────────────────────
-  # One matrix job per skill, grouped under one logical check so the
-  # PR page shows "test-compliance-cis-mitre" as a single row with a
-  # dropdown to see each skill's result.
-  test-compliance-cis-mitre:
+  security-scan:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install bandit
+      - run: bandit -r skills/ -c pyproject.toml --severity-level medium || true
+      - name: Check for hardcoded secrets
+        run: |
+          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/*/*/src/ --include="*.py" || exit 1
+          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/*/*/src/ --include="*.py" || exit 1
+          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/*/*/src/ --include="*.py" || exit 1
+          echo "No hardcoded secrets found in source code"
+
+  # ── Unit tests, grouped into category matrices ────────────────
+  test-compliance:
     runs-on: ubuntu-latest
     needs: lint
     strategy:
@@ -49,7 +63,6 @@ jobs:
       - working-directory: skills/compliance-cis-mitre/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
-  # ── remediation/ ─────────────────────────────────────────────────
   test-remediation:
     runs-on: ubuntu-latest
     needs: lint
@@ -68,11 +81,7 @@ jobs:
       - working-directory: skills/remediation/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
-  # ── detection-engineering — ingestion skills ─────────────────────
-  # One matrix cell per ingest skill. Per-skill isolation is required
-  # because every `ingest-*-ocsf/tests/test_ingest.py` shares the same
-  # module name and pytest cannot collect them in a single run.
-  test-detection-engineering-ingest:
+  test-detection-engineering:
     runs-on: ubuntu-latest
     needs: lint
     strategy:
@@ -84,48 +93,12 @@ jobs:
           - ingest-azure-activity-ocsf
           - ingest-k8s-audit-ocsf
           - ingest-mcp-proxy-ocsf
-    name: test-de-ingest (${{ matrix.skill }})
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install pytest
-      - working-directory: skills/detection-engineering/${{ matrix.skill }}
-        run: pytest tests/ -v -o "testpaths=tests"
-
-  # ── detection-engineering — detectors ────────────────────────────
-  test-detection-engineering-detect:
-    runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      fail-fast: false
-      matrix:
-        skill:
           - detect-mcp-tool-drift
           - detect-privilege-escalation-k8s
           - detect-sensitive-secret-read-k8s
-    name: test-de-detect (${{ matrix.skill }})
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install pytest
-      - working-directory: skills/detection-engineering/${{ matrix.skill }}
-        run: pytest tests/ -v -o "testpaths=tests"
-
-  # ── detection-engineering — view-layer convert skills ───────────
-  test-detection-engineering-convert:
-    runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      fail-fast: false
-      matrix:
-        skill:
           - convert-ocsf-to-sarif
           - convert-ocsf-to-mermaid-attack-flow
-    name: test-de-convert (${{ matrix.skill }})
+    name: test-detection-engineering (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -135,7 +108,6 @@ jobs:
       - working-directory: skills/detection-engineering/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
-  # ── ai-infra-security/ ───────────────────────────────────────────
   test-ai-infra-security:
     runs-on: ubuntu-latest
     needs: lint
@@ -156,10 +128,6 @@ jobs:
       - working-directory: skills/ai-infra-security/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
-  # ── Integration tests ───────────────────────────────────────────
-  # End-to-end pipes across skill boundaries, plus cross-skill OCSF
-  # wire-contract assertions. One check, runs the entire integration
-  # test directory.
   test-integration:
     runs-on: ubuntu-latest
     needs: lint
@@ -171,8 +139,8 @@ jobs:
       - run: pip install pytest
       - run: pytest tests/integration/ -v -o "testpaths=tests"
 
-  # ── IaC validation ──────────────────────────────────────────────
-  validate-cloudformation:
+  # ── IaC validation (CloudFormation + Terraform in one job) ─────
+  validate-iac:
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -180,37 +148,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install cfn-lint
-      - run: cfn-lint skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
-      - run: cfn-lint skills/remediation/iam-departures-remediation/infra/cross_account_stackset.yaml
-
-  validate-terraform:
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.12.0"
-      - run: cd skills/remediation/iam-departures-remediation/infra/terraform && terraform init -backend=false && terraform validate
-
-  # ── Security scan (bandit + hardcoded secret grep) ──────────────
-  security-scan:
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install bandit
-      - run: bandit -r skills/ -c pyproject.toml --severity-level medium || true
-      - name: Check for hardcoded secrets
+      - run: pip install cfn-lint
+      - name: cfn-lint — CloudFormation
         run: |
-          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/*/*/src/ --include="*.py" || exit 1
-          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/*/*/src/ --include="*.py" || exit 1
-          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/*/*/src/ --include="*.py" || exit 1
-          echo "No hardcoded secrets found in source code"
+          cfn-lint skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
+          cfn-lint skills/remediation/iam-departures-remediation/infra/cross_account_stackset.yaml
+      - name: terraform validate
+        run: cd skills/remediation/iam-departures-remediation/infra/terraform && terraform init -backend=false && terraform validate
 
   # ── agent-bom scans (code + skills + fs + IaC with SARIF upload) ─
   agent-bom:
@@ -280,13 +227,6 @@ jobs:
           sarif_file: iac-scan.sarif
           category: agent-bom-iac
         continue-on-error: true
-      - name: Print results summary
-        if: always()
-        run: |
-          echo "=== Code Scan ==="    && cat code-scan.json    2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
-          echo "=== Skills Audit ===" && cat skills-audit.json 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
-          echo "=== FS Scan ==="      && cat fs-scan.json      2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
-          echo "=== IaC Scan ==="     && cat iac-scan.json     2>/dev/null | python3 -m json.tool 2>/dev/null || echo "No results"
       - name: Upload scan artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -3,268 +3,111 @@
 [![CI](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml/badge.svg)](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
 [![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
 
-**OCSF-native detection engineering and posture for cloud and AI infrastructure.** Heavy focus on clusters, containers, Kubernetes, GPUs, model serving, and the AI supply chain — and traditional VMs and cloud control planes alongside.
-
-Architecture is layered: per-source ingestion skills normalise raw logs to **OCSF 1.8** on the wire, then detection skills emit OCSF Detection Findings (class 2004) with MITRE ATT&CK inside `finding_info.attacks[]`, and evaluation skills produce OCSF Compliance Findings (class 2003) mapped to CIS, NIST CSF, ISO 27001, and SOC 2. Skills compose via stdin/stdout pipes — no shared library, no single mega-skill, no vendor connectors. Each layer is independently testable, independently deployable, and independently scoped to least-privilege IAM.
-
-Every skill is built to the same eleven-principle [Security Bar](SECURITY_BAR.md): read-only by default, agentless, least-privilege, defense in depth, closed-loop, secure by design, secure code, secure secrets, no telemetry, human-in-the-loop for destructive actions, and explicit guardrails against rogue or self-escalating skill behaviour.
-
-Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide) — `SKILL.md` with trigger phrases and a `Do NOT use…` clause, `src/`, `tests/`, golden fixtures, `REFERENCES.md` pointing at the official source documentation. Skills run from the CLI, in CI, or via any agent that reads `SKILL.md` (Claude Desktop, Cursor, Codex, Cortex, Windsurf).
+**OCSF-native detection engineering and posture for cloud and AI infrastructure.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → detect → view skills like Unix pipes. MITRE ATT&CK inside every finding. Read-only, agentless, least-privilege, closed-loop.
 
 ```bash
-# Detection pipeline (OCSF on the wire, Unix-style composition)
 python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
   | python skills/detection-engineering/detect-privilege-escalation-k8s/src/detect.py \
-  > findings.ocsf.jsonl
+  | python skills/detection-engineering/convert-ocsf-to-sarif/src/convert.py \
+  > findings.sarif
 ```
 
-## Security & trust
+## Layers
 
-This is a security tool. Trustworthiness is the first feature, not an afterthought. The repo is held to the [SECURITY_BAR.md](SECURITY_BAR.md) — eleven principles, every skill graded against every principle in a per-skill matrix.
+| Layer | Role | Output |
+|---|---|---|
+| **Ingest** | Per-source raw log → OCSF | API / Network / HTTP / Application Activity |
+| **Detect** | OCSF → finding + MITRE ATT&CK | Detection Finding (class 2004) |
+| **Evaluate** | OCSF → framework check | Compliance Finding (class 2003) — CIS / NIST / SOC 2 |
+| **View** | OCSF → SARIF / Mermaid / graph | GitHub Security tab, PR comments, dashboards |
+| **Remediate** | Finding → action (HITL-gated, audited) | Dual-write audit row |
 
-| | What this means |
-|---|---|
-| **Read-only by default** | Posture and detection skills NEVER call write APIs. Remediation skills isolate the write path behind explicit IAM grants and require dry-run as the default. |
-| **Agentless** | No daemons, no in-cluster sidecars, no continuously running processes. Skills are short-lived Python scripts that read what is already there. |
-| **Least privilege** | Each skill documents the EXACT IAM / RBAC permissions it needs in `REFERENCES.md`. The set is minimised to what the skill cannot operate without. |
-| **Defense in depth** | A single failed control never owns the whole story. Posture, detection, remediation, audit, and verification all run in parallel and back each other up. |
-| **Closed loop** | Every workflow has a verification step: detect → finding → action → audit row → re-verify. Drift is itself a detection. |
-| **OCSF on the wire** | All ingest and detect skills speak OCSF 1.8 JSONL. No bespoke shapes. MITRE ATT&CK lives inside `finding_info.attacks[]`. |
-| **Secure by design** | Security is a first-class input to the skill's architecture, not a bolt-on. Read-only is the default, write paths are opt-in, every IAM grant is scoped, every input is parsed defensively, every output is validated against a schema. |
-| **Secure code** | Defensive parsing on every input boundary. No `eval`/`exec`/`pickle.loads` on untrusted data. SQL via parameterised queries only. `bandit` runs in CI. |
-| **Secure secrets, tokens, env vars** | No hardcoded credentials anywhere. Secrets come from cloud secret stores. Tokens are short-lived. Logs scrub credentials before emitting. CI greps for AKIA / `sk-` / `ghp_` patterns. |
-| **No telemetry** | No skill phones home. No SDK clients to external services beyond what the cloud-native APIs the skill scans require. Findings stay local unless the operator explicitly forwards them. |
-| **HITL, no rogue behaviour** | A skill never escalates its own privileges, never adds itself to allow-lists, never asks the agent to bypass a guardrail, never invokes a sibling skill it wasn't explicitly composed with. Destructive actions require a human-approved trigger and a HITL gate (grace periods, deny lists, dry-run defaults). |
+Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide) — `SKILL.md` with trigger phrases and a `Do NOT use…` clause, `src/`, `tests/`, golden fixtures, `REFERENCES.md`. Runs from the CLI, in CI, or via any agent that reads `SKILL.md` (Claude Desktop, Cursor, Codex, Cortex, Windsurf).
 
-**Validation & verification:**
-- Every detection skill is tested against frozen OCSF golden fixtures so a refactor that loses coverage fails CI
-- Every ingest skill emits exactly the OCSF wire shape pinned in [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md)
-- An end-to-end integration test in [`tests/integration/`](tests/integration/) pipes raw logs through the full ingest → detect chain and asserts the output matches the frozen golden findings
-- `ruff check` + `ruff format --check` + `bandit` + hardcoded-secret grep all run on every PR
-- Every skill has a [`REFERENCES.md`](skills/) listing the official documentation, schemas, and IAM policies it relies on — no opaque dependencies, no fabricated APIs
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full layered diagram and closed-loop vendor flow.
 
-See [SECURITY.md](SECURITY.md) for the disclosure policy, [SECURITY_BAR.md](SECURITY_BAR.md) for the per-principle verification matrix, and [ARCHITECTURE.md](ARCHITECTURE.md) for the layered architecture diagram (Sources → Ingestion → OCSF → Detection / Evaluation → View → Remediation).
+## Coverage
 
-## Skills taxonomy
+<details>
+<summary><b>Skills shipped today</b></summary>
 
 ```
 skills/
-├── compliance-cis-mitre/          "Is this config/posture aligned with a published benchmark?"
-├── remediation/                   "Something is wrong — fix it, gated and audited"
-├── detection-engineering/         "What does an attack look like on this surface?"
-└── ai-infra-security/             "AI-native surfaces: models, agents, GPU, topology"
+├── compliance-cis-mitre/           "Aligned with a published benchmark?"
+│   ├── cspm-aws-cis-benchmark      (CIS AWS Foundations v3.0 — 18 checks)
+│   ├── cspm-gcp-cis-benchmark      (CIS GCP Foundations v3.0 — 7 checks)
+│   ├── cspm-azure-cis-benchmark    (CIS Azure Foundations v2.1 — 6 checks)
+│   ├── k8s-security-benchmark      (CIS Kubernetes — 10 checks)
+│   └── container-security          (CIS Docker — 8 checks)
+│
+├── remediation/                    "Fix it, gated and audited"
+│   └── iam-departures-remediation  (event-driven, DLQ + SNS, dual audit)
+│
+├── detection-engineering/          "What does an attack look like on this surface?"
+│   ├── ingest-cloudtrail-ocsf      AWS            → API Activity 6003
+│   ├── ingest-gcp-audit-ocsf       GCP            → API Activity 6003
+│   ├── ingest-azure-activity-ocsf  Azure          → API Activity 6003
+│   ├── ingest-k8s-audit-ocsf       K8s            → API Activity 6003
+│   ├── ingest-mcp-proxy-ocsf       MCP            → Application Activity 6002
+│   ├── detect-mcp-tool-drift                      → T1195.001 Supply Chain
+│   ├── detect-privilege-escalation-k8s            → T1552.007 / T1611 / T1098 / T1550.001
+│   ├── detect-sensitive-secret-read-k8s           → T1552.007 Container API
+│   ├── convert-ocsf-to-sarif                      → GitHub Security tab
+│   └── convert-ocsf-to-mermaid-attack-flow        → PR comments
+│
+└── ai-infra-security/              "AI-native surfaces"
+    ├── model-serving-security      (16 checks — auth / rate limit / egress / safety)
+    ├── gpu-cluster-security        (13 checks — runtime / driver / tenant isolation)
+    └── discover-environment        (MITRE ATT&CK + ATLAS graph overlay)
 ```
 
-See [`skills/README.md`](skills/README.md) for the full category index. The categories are functional, not organisational — a single incident (e.g. a leaked MCP credential) may touch a detection rule, a remediation pipeline, *and* a CIS control. Category = *what kind of work does this skill do*, not *which cloud*.
+**Roadmap:** 14 open issues ([#26](https://github.com/msaad00/cloud-security/issues/26)–[#39](https://github.com/msaad00/cloud-security/issues/39)) covering VPC Flow / GuardDuty / Security Hub / AWS Config / Okta / GitHub / Workspace / Slack / Workday / Salesforce / SAP / GCP + Azure parity / folder reshape.
 
-### compliance-cis-mitre/
+</details>
 
-| Skill | Scope | Checks | Description |
-|-------|-------|--------|-------------|
-| [cspm-aws-cis-benchmark](skills/compliance-cis-mitre/cspm-aws-cis-benchmark/) | AWS | 18 | CIS AWS Foundations v3.0 — IAM, Storage, Logging, Networking |
-| [cspm-gcp-cis-benchmark](skills/compliance-cis-mitre/cspm-gcp-cis-benchmark/) | GCP | 7 | CIS GCP Foundations v3.0 — IAM, Cloud Storage, Networking |
-| [cspm-azure-cis-benchmark](skills/compliance-cis-mitre/cspm-azure-cis-benchmark/) | Azure | 6 | CIS Azure Foundations v2.1 — Storage, Networking |
-| [k8s-security-benchmark](skills/compliance-cis-mitre/k8s-security-benchmark/) | K8s | 10 | CIS Kubernetes — Pod security, RBAC, network policy |
-| [container-security](skills/compliance-cis-mitre/container-security/) | Any | 8 | CIS Docker — Dockerfile best practices + runtime isolation |
+## Security & trust
 
-### remediation/
+This is a security tool. Trustworthiness is the first feature, not an afterthought. Eleven principles pinned in [`SECURITY_BAR.md`](SECURITY_BAR.md), every skill graded against every principle.
 
-| Skill | Scope | Description |
-|-------|-------|-------------|
-| [iam-departures-remediation](skills/remediation/iam-departures-remediation/) | Multi-cloud | Event-driven IAM cleanup for departed employees (HITL grace period, deny list, DLQ + SNS alerts) |
+<details>
+<summary><b>The eleven principles</b></summary>
 
-### detection-engineering/
-
-Detection rules, ingestion pipelines, and threat hunts for cloud control planes, Kubernetes, and AI infrastructure. Every skill reads and writes **OCSF 1.8 JSONL** so they compose via stdin/stdout pipes. See [`skills/detection-engineering/README.md`](skills/detection-engineering/README.md) for the category contract and [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md) for the field-level wire format.
-
-**Ingestion** (raw log → OCSF API Activity `6003` or Application Activity `6002`):
-
-| Skill | Source | OCSF class |
+| # | Principle | What it means |
 |---|---|---|
-| [`ingest-cloudtrail-ocsf`](skills/detection-engineering/ingest-cloudtrail-ocsf/) | AWS CloudTrail | API Activity 6003 |
-| [`ingest-gcp-audit-ocsf`](skills/detection-engineering/ingest-gcp-audit-ocsf/) | GCP Cloud Audit Logs | API Activity 6003 |
-| [`ingest-azure-activity-ocsf`](skills/detection-engineering/ingest-azure-activity-ocsf/) | Azure Activity Logs | API Activity 6003 |
-| [`ingest-k8s-audit-ocsf`](skills/detection-engineering/ingest-k8s-audit-ocsf/) | `kube-apiserver` audit logs | API Activity 6003 |
-| [`ingest-mcp-proxy-ocsf`](skills/detection-engineering/ingest-mcp-proxy-ocsf/) | agent-bom MCP proxy | Application Activity 6002 |
+| 1 | **Read-only by default** | Posture + detection NEVER call write APIs. Remediation isolates the write path behind explicit IAM grants and dry-run defaults. |
+| 2 | **Agentless** | No daemons, no sidecars, no continuously running processes. Short-lived Python scripts that read what's already there. |
+| 3 | **Least privilege** | Each skill documents the EXACT IAM / RBAC permissions it needs in `REFERENCES.md`. Minimal set only. |
+| 4 | **Defense in depth** | Posture + detection + remediation + audit + re-verify all run in parallel and back each other up. |
+| 5 | **Closed loop** | Every workflow has a verification step: detect → finding → action → audit → re-verify. Drift is itself a detection. |
+| 6 | **OCSF on the wire** | All ingest + detect skills speak OCSF 1.8 JSONL. MITRE ATT&CK lives inside `finding_info.attacks[]`. |
+| 7 | **Secure by design** | Security is a first-class input to the skill's architecture, not a bolt-on. |
+| 8 | **Secure code** | Defensive parsing on every input boundary. No `eval`/`exec`/`pickle.loads` on untrusted data. Parameterised SQL only. `bandit` in CI. |
+| 9 | **Secure secrets & tokens** | No hardcoded creds. Secrets from cloud secret stores. Short-lived tokens. Logs scrub creds. CI greps for `AKIA` / `sk-` / `ghp_` patterns. |
+| 10 | **No telemetry** | No phone-home. Findings stay local unless the operator explicitly forwards them. |
+| 11 | **HITL, no rogue behaviour** | A skill never escalates its own privileges, never bypasses guardrails, never invokes siblings it wasn't composed with. Destructive actions require HITL gates. |
 
-**Detection** (OCSF events → OCSF Detection Finding `2004` + MITRE ATT&CK inside `finding_info.attacks[]`):
+</details>
 
-| Skill | Input | MITRE techniques |
-|---|---|---|
-| [`detect-mcp-tool-drift`](skills/detection-engineering/detect-mcp-tool-drift/) | OCSF Application Activity (MCP) | T1195.001 |
-| [`detect-privilege-escalation-k8s`](skills/detection-engineering/detect-privilege-escalation-k8s/) | OCSF API Activity (K8s) | T1552.007, T1611, T1098, T1550.001 |
+<details>
+<summary><b>How trust is verified</b></summary>
 
-### ai-infra-security/
+- **Golden-fixture tests** — every detection skill is tested against frozen OCSF inputs so a refactor that loses coverage fails CI
+- **Wire-contract tests** — every ingest skill emits exactly the OCSF shape pinned in [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md); cross-skill assertions verify every detect skill emits Detection Finding (2004) with MITRE ATT&CK v14
+- **End-to-end integration tests** — `tests/integration/` pipes raw logs through the full ingest → detect → convert chain and deep-equals the frozen SARIF + Mermaid goldens
+- **Static analysis** — `ruff check` + `ruff format --check` + `bandit` + hardcoded-secret grep on every PR
+- **Per-skill `REFERENCES.md`** — every skill lists the official docs, schemas, and IAM policies it depends on. No opaque dependencies, no fabricated APIs
+- **`agent-bom` scans** — `code` / `skills scan` / `fs` / `iac` run on every push; IaC findings land in the GitHub Security tab under `agent-bom-iac`
 
-| Skill | Scope | Checks | Description |
-|-------|-------|--------|-------------|
-| [model-serving-security](skills/ai-infra-security/model-serving-security/) | Any | 16 | Model endpoint auth, rate limiting, egress, safety layers |
-| [gpu-cluster-security](skills/ai-infra-security/gpu-cluster-security/) | Any | 13 | GPU runtime isolation, driver CVEs, InfiniBand, tenant isolation |
-| [discover-environment](skills/ai-infra-security/discover-environment/) | Multi-cloud | — | Map cloud resources to a security graph with MITRE ATT&CK/ATLAS overlays |
+</details>
 
-## Architecture — IAM Departures Remediation
-
-Six numbered stations across two deployment domains, one forward path, one dashed drift loop. Every destructive step happens inside the VPC-isolated Step Function; the reconciler stays stateless outside it.
-
-<p align="center">
-  <img src="docs/images/iam-departures-architecture.svg" alt="IAM Departures Remediation architecture: HR sources and Reconciler in the AWS Corporate Security OU; Parser and Worker Lambdas in a VPC-isolated Step Function; five cloud targets; dual-write audit trail; dashed verification loop back to the reconciler." width="100%"/>
-</p>
-
-**What's intentionally not shown** (to keep the diagram legible):
-- **Failure path** — Lambda async failures → SQS DLQ (`iam-departures-dlq`); Step Function `FAILED`/`TIMED_OUT`/`ABORTED` → EventBridge → SNS (`iam-departures-alerts`). See [`SKILL.md`](skills/remediation/iam-departures-remediation/SKILL.md).
-- **DLQ replay** — stuck executions re-drive through the same EventBridge rule. The pipeline is idempotent.
-- **Extensibility** — new consumers (SIEM forwarder, Slack, secondary region) are additional EventBridge targets. No reconciler or Lambda changes.
-
-## Architecture — CSPM CIS Benchmarks
-
-Closed loop: scan → finding → ticket/PR → fix → re-scan verifies the same control_id is now `pass`. Findings keep their `control_id` so the verification run can prove the gap closed.
-
-```mermaid
-flowchart LR
-    subgraph CLOUD["Cloud Account · read-only"]
-        IAM["IAM / Identity"]
-        STR["Storage"]
-        LOG["Logging + Audit"]
-        NET["Networking"]
-        AI["AI / ML Services"]
-    end
-
-    CHK["checks.py\nread-only SDK calls\nno write permissions"]
-    OUT["Findings\nJSON · SARIF · Console"]
-    SIEM["SIEM / Ticketing\nGitHub code scanning\nJira · Splunk · Datadog"]
-    FIX["Remediation\nIaC PR · console fix\nor exception with TTL"]
-    VERIFY["Next scan run\ncontrol_id == pass\nor drift flagged"]
-
-    IAM & STR & LOG & NET & AI --> CHK --> OUT --> SIEM --> FIX --> VERIFY
-    VERIFY -. re-scan .-> CHK
-
-    style CLOUD fill:#1e293b,stroke:#475569,color:#e2e8f0
-    style CHK fill:#164e63,stroke:#22d3ee,color:#e2e8f0
-    style OUT fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
-    style SIEM fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
-    style FIX fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
-    style VERIFY fill:#172554,stroke:#3b82f6,color:#e2e8f0
-```
-
-## Architecture — Vulnerability Remediation Pipeline
-
-Closed loop: scan → triage → patch → audit → re-scan verifies the CVE is no longer present *and* the package version matches the expected fix version.
-
-```mermaid
-flowchart LR
-    SCAN["Scan Findings\nSARIF / JSON"]
-    TRIAGE["Triage\nEPSS · KEV · CVSS\nP0→P3 SLAs"]
-    FIX["Remediate\nUpgrade · Rotate · Quarantine"]
-    AUDIT["Audit + Verify\nDDB log + S3 evidence"]
-    RESCAN["Re-scan\nCVE absent · version pinned"]
-
-    SCAN --> TRIAGE --> FIX --> AUDIT --> RESCAN
-    RESCAN -. drift .-> SCAN
-
-    style SCAN fill:#1e293b,stroke:#475569,color:#e2e8f0
-    style TRIAGE fill:#164e63,stroke:#22d3ee,color:#e2e8f0
-    style FIX fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
-    style AUDIT fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
-    style RESCAN fill:#172554,stroke:#3b82f6,color:#e2e8f0
-```
-
-## Security Model
-
-```mermaid
-flowchart LR
-    subgraph ZT["Zero Trust"]
-        A1["Cross-account scoped\nby PrincipalOrgID"]
-        A2["STS AssumeRole\nper account"]
-        A3["VPC isolation"]
-    end
-
-    subgraph LP["Least Privilege"]
-        B1["Parser: read-only"]
-        B2["Worker: scoped write"]
-        B3["CSPM: read-only"]
-        B4["Model/GPU: read-only"]
-    end
-
-    subgraph DD["Defense in Depth"]
-        C1["Deny policies on\nprotected accounts"]
-        C2["KMS encryption\neverywhere"]
-        C3["Dual audit trail\nDDB + S3"]
-    end
-
-    style ZT fill:#1e293b,stroke:#60a5fa,color:#e2e8f0
-    style LP fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
-    style DD fill:#1e1b4b,stroke:#a78bfa,color:#e2e8f0
-```
-
-## Compliance Framework Mapping
-
-| Framework | Controls | Skills |
-|-----------|----------|--------|
-| **CIS AWS Foundations v3.0** | 18 controls | cspm-aws |
-| **CIS GCP Foundations v3.0** | 7 controls (subset) | cspm-gcp |
-| **CIS Azure Foundations v2.1** | 6 controls (subset) | cspm-azure |
-| **MITRE ATT&CK** | T1078, T1098, T1087, T1195.001, T1530, T1599 | iam-departures, detect-mcp-tool-drift |
-| **NIST CSF 2.0** | PR.AC, PR.DS, DE.CM, DE.AE, RS.MI, ID.RA | All skills |
-| **CIS Controls v8** | 5.3, 6.1, 6.2, 6.5, 7.1–7.4, 13.1, 16.1 | iam-departures |
-| **SOC 2 TSC** | CC6.1–CC6.3, CC7.1 | iam-departures |
-| **ISO 27001:2022** | A.5.15–A.8.24 | cspm-aws, cspm-gcp, cspm-azure |
-| **PCI DSS 4.0** | 2.2, 7.1, 8.3, 10.1 | cspm skills |
-| **OWASP MCP Top 10** | MCP-04 (supply chain compromise) | detect-mcp-tool-drift |
-
-> CIS GCP and CIS Azure currently automate a curated subset of high-impact controls. The full benchmark coverage is tracked in each skill's `SKILL.md`. PRs that add controls are welcome — keep one check per function and one finding row per control.
-
-## CI/CD Pipeline
-
-| CI Job | What |
-|--------|------|
-| Lint | ruff check + format |
-| Tests | pytest per skill |
-| CloudFormation | `cfn-lint` validation on all `infra/*.yaml` |
-| Terraform | `terraform validate` on `infra/terraform/` |
-| Security | `bandit` + hardcoded-secret grep on `skills/*/src/` |
-| **agent-bom** | `code` (AI components) · `skills scan` (skill audit) · `fs` (packages + CVEs) · **`iac` (CloudFormation + Terraform)** with SARIF upload to the GitHub Security tab |
-
-The "Scanned by agent-bom" badge above is backed by that last row — every push to `main` runs all four agent-bom scans against the repo, and the IaC findings land in GitHub code scanning.
-
-## Quick Start
-
-```bash
-git clone https://github.com/msaad00/cloud-security.git
-cd cloud-security
-
-# compliance-cis-mitre — CSPM CIS benchmarks (read-only)
-pip install boto3 google-cloud-resource-manager azure-identity
-python skills/compliance-cis-mitre/cspm-aws-cis-benchmark/src/checks.py   --region us-east-1
-python skills/compliance-cis-mitre/cspm-gcp-cis-benchmark/src/checks.py   --project my-project
-python skills/compliance-cis-mitre/cspm-azure-cis-benchmark/src/checks.py --subscription <sub-id>
-
-# remediation — dry-run mode (no mutations)
-python skills/remediation/iam-departures-remediation/src/lambda_parser/handler.py --dry-run examples/manifest.json
-
-# detection-engineering — end-to-end pipe: raw MCP proxy → OCSF → Detection Finding
-python skills/detection-engineering/ingest-mcp-proxy-ocsf/src/ingest.py mcp-proxy.jsonl \
-  | python skills/detection-engineering/detect-mcp-tool-drift/src/detect.py \
-  > findings.ocsf.jsonl
-
-# Run all real-skill tests
-pip install pytest boto3 moto
-pytest skills/compliance-cis-mitre/cspm-aws-cis-benchmark/tests/     -v -o "testpaths=tests"
-pytest skills/compliance-cis-mitre/cspm-gcp-cis-benchmark/tests/     -v -o "testpaths=tests"
-pytest skills/compliance-cis-mitre/cspm-azure-cis-benchmark/tests/   -v -o "testpaths=tests"
-pytest skills/remediation/iam-departures-remediation/tests/          -v -o "testpaths=tests"
-pytest skills/detection-engineering/ingest-mcp-proxy-ocsf/tests/     -v -o "testpaths=tests"
-pytest skills/detection-engineering/detect-mcp-tool-drift/tests/     -v -o "testpaths=tests"
-```
+See [`SECURITY.md`](SECURITY.md) for the disclosure policy, [`SECURITY_BAR.md`](SECURITY_BAR.md) for the per-principle verification matrix, and [`ARCHITECTURE.md`](ARCHITECTURE.md) for the layered architecture.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Security
-
-See [SECURITY.md](SECURITY.md).
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). TL;DR — new skills copy the nearest sibling, add `SKILL.md` + `src/` + `tests/` + golden fixtures + `REFERENCES.md`, add a row to the `SECURITY_BAR.md` matrix, open a PR.
 
 ## License
 


### PR DESCRIPTION
Two polish passes in one PR.

## README

**240 → 114 lines** (−52%). Above-the-fold is now one paragraph + one pipe example + a 5-row layer table. Coverage, the eleven security principles, and the trust-verification list moved into `<details>` collapsible sections so the landing page is scannable in under 10 seconds.

**Preserved every piece of information** — skills shipped tree, MITRE technique IDs, check counts, the full eleven-principle table (collapsible), full trust-verification list (collapsible), links to `SECURITY.md` / `SECURITY_BAR.md` / `ARCHITECTURE.md` / `OCSF_CONTRACT.md`.

**Added:** OCSF 1.8 badge, 5-row layer table (Ingest / Detect / Evaluate / View / Remediate), roadmap issue link cluster (#26-#39).

## GitHub About + topics

Description tightened: *"OCSF-native detection engineering + posture for cloud and AI infrastructure. Ingest → detect → view skills compose like Unix pipes. MITRE ATT&CK inside every finding. Read-only · agentless · least-privilege · closed-loop."*

Topics refreshed: `ocsf`, `detection-engineering`, `threat-detection`, `anthropic-skills`, `mitre-attack`, `cloud-security`, `kubernetes`, `cis-benchmark`, `nist`, `ai-security`.

## CI

Further consolidation on top of #42. **12 → 9 top-level jobs.**

| Before | After |
|---|---|
| `test-de-ingest` + `test-de-detect` + `test-de-convert` (3 jobs) | `test-detection-engineering` (1 job, 10 matrix cells) |
| `validate-cloudformation` + `validate-terraform` (2 jobs) | `validate-iac` (1 job, both tools in sequence) |

**Top-level checks on the PR page now:**

1. `lint`
2. `security-scan`
3. `test-compliance` (5 cells)
4. `test-remediation` (1 cell)
5. `test-detection-engineering` (10 cells)
6. `test-ai-infra-security` (3 cells)
7. `test-integration`
8. `validate-iac`
9. `agent-bom`

19 underlying matrix cells unchanged — one row per skill under the parent check with `fail-fast: false`. CI feedback remains granular, but the top-level PR page is ~25% shorter.

## Verification

- [x] `python3 -c yaml.safe_load` parses the new ci.yml cleanly
- [x] 9 top-level jobs, 19 total matrix cells accounted for
- [x] `SECURITY.md` / `SECURITY_BAR.md` / `ARCHITECTURE.md` / `OCSF_CONTRACT.md` / `CONTRIBUTING.md` links verified
- [ ] CI green on the consolidated workflow
- [ ] README renders cleanly on GitHub (collapsible sections expand/collapse as expected)