### PR TITLE
docs: add agent integration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,5 +69,6 @@ If you see a remediation step that succeeded but no audit row, treat it as a fai
 
 - Full guardrails and rationale: [`CLAUDE.md`](CLAUDE.md)
 - Per-skill contract: `skills/<skill-name>/SKILL.md`
+- Agent-specific guidance and current integration gaps: [`docs/agent-integrations.md`](docs/agent-integrations.md)
 - Architecture diagrams (closed loops): [`README.md`](README.md)
 - Security model: [`SECURITY.md`](SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **OCSF-native detection engineering and posture for cloud and AI infrastructure.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → detect → view skills like Unix pipes. MITRE ATT&CK inside every finding. Read-only, agentless, least-privilege, closed-loop.
 
+For coding agents, start with [AGENTS.md](AGENTS.md). For Claude/Codex-specific guidance and current integration gaps, see [docs/agent-integrations.md](docs/agent-integrations.md).
+
 ```bash
 python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
   | python skills/detection-engineering/detect-privilege-escalation-k8s/src/detect.py \
@@ -114,6 +116,7 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md) | Wire format pinning for OCSF 1.8 + MITRE ATT&CK v14 |
 | [`SECURITY_BAR.md`](SECURITY_BAR.md) | Per-principle verification matrix — every skill graded against every principle |
 | [`SECURITY.md`](SECURITY.md) | Coordinated disclosure policy |
+| [`docs/agent-integrations.md`](docs/agent-integrations.md) | How Claude, Codex CLI, and AGENTS.md-aware tools should use this repo today |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to add a new skill |
 
 ## Contributing

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -1,0 +1,77 @@
+# Agent Integrations
+
+This repo is a good fit for coding agents because each skill is already packaged
+as a compact contract: `SKILL.md`, implementation code, tests, and infrastructure.
+This document explains how to use that structure with Claude-oriented tooling,
+Codex CLI, and generic AGENTS.md-aware agents.
+
+## What Exists Today
+
+- Root-level [AGENTS.md](../AGENTS.md) for repo-wide instructions
+- Skill-level `SKILL.md` files that explain when a skill should be used
+- JSON, console, and SARIF outputs that are easy for agents and CI systems to consume
+
+## What Does Not Exist Yet
+
+- A native MCP server shipped by this repo
+- Agent-callable tools generated directly from the skills
+- Automated Claude/Codex wrappers around the benchmark and remediation flows
+
+Document those gaps clearly. Do not describe the repo as MCP-native until a real
+server or tool layer ships.
+
+## Claude / Anthropic Usage
+
+- Use the root `AGENTS.md` as the repo-level instruction file.
+- Use each `SKILL.md` as the task-specific contract for the nearest skill directory.
+- Treat the benchmark scripts as read-only assessment tools and the IAM departures
+  automation as a controlled remediation workflow.
+
+Example prompts:
+
+- "Audit the AWS CIS skill and verify its checks against the official AWS docs."
+- "Update the IAM departures docs to prefer Secrets Manager and preserve EventBridge as the trigger path."
+- "Add regression tests for pagination in the AWS CIS benchmark skill."
+
+## Codex CLI Usage
+
+- Codex reads `AGENTS.md`, so keep repo-level commands and safety rules there.
+- When working inside a skill, read that skill's `SKILL.md` before editing code.
+- Use focused test commands for the touched skill instead of generic repo-wide commands when possible.
+
+## Recommended MCP Setup
+
+Until this repo ships its own MCP server, use generic tooling such as:
+
+- filesystem access for repo reads and edits
+- Git or GitHub integration for PR workflows
+- cloud-vendor MCP tools only if they are explicitly configured in your environment
+
+Example shape for a local MCP config:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}
+```
+
+Keep this external to the repo unless you are ready to support it as a real project contract.
+
+## Recommended Next Step
+
+If you want first-class Claude/Codex integration, the right next implementation is:
+
+1. expose each skill as a callable tool behind a small MCP server
+2. map inputs and outputs onto the existing skill contracts
+3. keep remediation skills explicit about dry-run, approval boundaries, and audit outputs
+
+## References
+
+- AGENTS.md open format: https://agents.md/
+- Anthropic skills guide: https://platform.claude.com/docs/en/build-with-claude/skills-guide?curius=1426
+- Anthropic MCP docs: https://docs.anthropic.com/en/docs/mcp

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -155,7 +155,10 @@ for deployable templates.
 
 ## Data Sources
 
-Configure one HR data source via environment variables:
+Configure one HR data source via environment variables. These variable names are
+the runtime interface, not the recommended storage mechanism. In production,
+inject them from AWS Secrets Manager, SSM Parameter Store, Vault, workload
+identity, or an equivalent secret store.
 
 | Source | Required Env Vars |
 |--------|-------------------|
@@ -164,6 +167,8 @@ Configure one HR data source via environment variables:
 | Databricks | `DATABRICKS_HOST`, `DATABRICKS_TOKEN` |
 | ClickHouse | `CLICKHOUSE_HOST`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` |
 | Workday API | `WORKDAY_API_URL`, `WORKDAY_CLIENT_ID`, `WORKDAY_CLIENT_SECRET` |
+
+Prefer the storage-integration or federation path where the source platform supports it.
 
 ## Security Principles
 

--- a/skills/remediation/iam-departures-remediation/examples.md
+++ b/skills/remediation/iam-departures-remediation/examples.md
@@ -73,19 +73,16 @@ python -m pytest tests/test_parser_lambda.py -v
 python -m pytest tests/test_worker_lambda.py -v
 ```
 
-## Example: Manual Step Function Execution
+## Example: Test Trigger via S3 and EventBridge
 
 ```bash
-# Trigger a test execution with a specific manifest
-aws stepfunctions start-execution \
-  --state-machine-arn arn:aws:states:us-east-1:111111111111:stateMachine:iam-departures-pipeline \
-  --input '{
-    "detail": {
-      "bucket": { "name": "my-security-remediation-bucket" },
-      "object": { "key": "departures/2026-03-01.json" }
-    }
-  }'
+# Upload a manifest to the bucket and let EventBridge start the Step Function
+aws s3 cp sample-manifest.json \
+  s3://my-security-remediation-bucket/departures/2026-03-01.json
 ```
+
+This is the preferred manual test path because it exercises the same event-driven
+entrypoint used in production instead of bypassing EventBridge.
 
 ## Example: Query Audit Records
 

--- a/skills/remediation/iam-departures-remediation/reference.md
+++ b/skills/remediation/iam-departures-remediation/reference.md
@@ -5,6 +5,19 @@ and cross-cloud roadmap.
 
 ---
 
+## Secrets and Identity Guidance
+
+- Treat env vars in examples as runtime injection points, not as a recommendation
+  to store plaintext secrets in shell profiles or templates.
+- Prefer AWS Secrets Manager, SSM Parameter Store, Vault, workload identity,
+  Snowflake Storage Integration, and similar short-lived or managed-secret paths.
+- Keep the event-driven trigger path intact: manifest lands in S3, EventBridge
+  starts the Step Function, and the Step Function invokes parser and worker Lambdas.
+- If you need a manual test, upload a manifest to the trigger bucket instead of
+  calling the Step Function directly. That exercises the same production entrypoint.
+
+---
+
 ## Architecture Diagram
 
 ```


### PR DESCRIPTION
## Summary
- add a root `AGENTS.md` aligned to the open AGENTS.md convention
- document Claude/Codex usage and the current MCP boundary in `docs/agent-integrations.md`
- update README to point agents at the right entrypoints
- tighten IAM departures docs around secret-manager injection and the event-driven trigger path

## Notes
- this PR is intentionally docs-only and does not claim that the repo ships its own MCP server today
- the guidance is aligned to https://agents.md/ and Anthropic's public skills/MCP docs
