### PR TITLE
docs: add CI simplification and architecture visuals

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,0 +1,26 @@
+name: Setup Python And Deps
+description: Set up Python with pip cache and install a scoped dependency set for a workflow job.
+
+inputs:
+  python-version:
+    description: Python version to install.
+    required: false
+    default: "3.11"
+  packages:
+    description: Space-delimited packages to install with pip.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install ${{ inputs.packages }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install ruff
+          packages: ruff
       - run: ruff check skills/ tests/ --config pyproject.toml
 
   security-scan:
@@ -27,10 +27,10 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install bandit
+          packages: bandit
       - run: bandit -r skills/compliance-cis-mitre/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation -c pyproject.toml --severity-level medium
       - name: Check for hardcoded secrets
         run: |
@@ -55,10 +55,10 @@ jobs:
     name: test-compliance (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install boto3 moto pytest pytest-cov
+          packages: boto3 moto pytest pytest-cov
       - working-directory: skills/compliance-cis-mitre/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
@@ -73,10 +73,10 @@ jobs:
     name: test-remediation (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install boto3 moto pytest pytest-cov
+          packages: boto3 moto pytest pytest-cov
       - working-directory: skills/remediation/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
@@ -104,10 +104,10 @@ jobs:
     name: test-detection-engineering (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install pytest pytest-cov
+          packages: pytest pytest-cov
       - working-directory: skills/detection-engineering/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
@@ -124,10 +124,10 @@ jobs:
     name: test-ai-infra (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install pytest pytest-cov
+          packages: pytest pytest-cov
       - working-directory: skills/ai-infra-security/${{ matrix.skill }}
         run: pytest tests/ -v -o "testpaths=tests"
 
@@ -136,10 +136,10 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install pytest pytest-cov
+          packages: pytest pytest-cov
       - run: pytest tests/integration/ -v -o "testpaths=tests"
 
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
@@ -148,13 +148,13 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
+          packages: cfn-lint
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.12.0"
-      - run: pip install cfn-lint
       - name: cfn-lint — CloudFormation
         run: |
           cfn-lint skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
@@ -169,10 +169,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-      - run: pip install agent-bom
+          packages: agent-bom
       - name: Scan code for AI components
         run: agent-bom code skills/ -f json -o code-scan.json || true
       - name: Audit skill definitions

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py audit.lo
 
 Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide) — `SKILL.md` with trigger phrases and a `Do NOT use…` clause, `src/`, `tests/`, golden fixtures, `REFERENCES.md`. Runs from the CLI, in CI, or via any agent that reads `SKILL.md` (Claude Desktop, Cursor, Codex, Cortex, Windsurf).
 
-See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full layered diagram and closed-loop vendor flow.
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
 
 ## Coverage
 
@@ -113,6 +113,9 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | Document | Purpose |
 |---|---|
 | [`ARCHITECTURE.md`](docs/ARCHITECTURE.md) | 9-layer design, two execution modes (stateless + persistent), 10 guardrails |
+| [`DIAGRAMS.md`](docs/DIAGRAMS.md) | Architecture map, IAM departures flow, and detection pipeline visuals |
+| [`CI_WORKFLOW.md`](docs/CI_WORKFLOW.md) | CI lane layout, dedupe rules, and follow-up simplification plan |
+| [`DEPENDENCY_HYGIENE_SKILL.md`](docs/DEPENDENCY_HYGIENE_SKILL.md) | Proposed safe dependency-update skill contract |
 | [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md) | Wire format pinning for OCSF 1.8 + MITRE ATT&CK v14 |
 | [`SECURITY_BAR.md`](SECURITY_BAR.md) | Per-principle verification matrix — every skill graded against every principle |
 | [`SECURITY.md`](SECURITY.md) | Coordinated disclosure policy |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,7 @@ This document is the load-bearing design contract for `cloud-security`. Every fu
 - **Wire format contract** — see [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
 - **Sink / persistence contract** — see [`./SINK_CONTRACT.md`](./SINK_CONTRACT.md) *(lands with PR T)*
 - **Runner / streaming contract** — see [`./RUNNER_CONTRACT.md`](./RUNNER_CONTRACT.md) *(lands with PR V)*
+- **Visual guide** — see [`./DIAGRAMS.md`](./DIAGRAMS.md) for the architecture and data-flow diagrams in both markdown-native and SVG-friendly form
 
 ## 1. Purpose and scope
 
@@ -80,6 +81,16 @@ These are the non-negotiables. Everything in §3–§8 exists to serve them.
 ```
 
 Every data object flowing between layers is **OCSF 1.8 JSONL**. No layer invents a new wire format. Converters (L6) emit *other* formats only for downstream delivery — never as intermediate state.
+
+### Visuals
+
+For quick orientation, use the visual set in [`DIAGRAMS.md`](./DIAGRAMS.md):
+
+- **Repo architecture** — [`repo-architecture.svg`](./images/repo-architecture.svg)
+- **IAM departures data flow** — [`iam-departures-data-flow.svg`](./images/iam-departures-data-flow.svg)
+- **Detection pipeline** — [`detection-pipeline.svg`](./images/detection-pipeline.svg)
+
+The rule for this repo is simple: keep the architecture readable in Markdown, and keep polished SVGs in `docs/images/` for rendered docs.
 
 ### Layer status snapshot
 

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -1,0 +1,39 @@
+# CI Workflow
+
+The CI pipeline is split into independent lanes so failures point at the right kind of work without duplicating the entire repo in every job.
+
+## Lanes
+
+- `lint`
+  - fast repo-wide Ruff gate
+- `security-scan`
+  - scoped Bandit and hardcoded-secret checks for the currently enforced high-risk paths
+- `test-compliance`
+  - benchmark skills grouped under one matrix
+- `test-remediation`
+  - write-capable workflows isolated from read-only checks
+- `test-detection-engineering`
+  - OCSF ingest, detect, and convert skills
+- `test-ai-infra`
+  - model serving, GPU, and environment-discovery skills
+- `test-integration`
+  - cross-skill contracts and pipe-level regression tests
+- `validate-iac`
+  - CloudFormation and Terraform validation
+- `agent-bom`
+  - advisory artifact and SARIF generation
+
+## Simplification Rules
+
+- Share Python setup and dependency install logic through a composite action.
+- Keep required checks small and actionable.
+- Keep advisory scans separate from merge-blocking gates.
+- Install only the packages each lane needs.
+- Prefer matrix lanes by skill family instead of one global `pytest skills/`.
+
+## Next Tightenings
+
+1. Pin all third-party GitHub Actions to immutable SHAs.
+2. Add a dependency-vulnerability lane with an explicit scoped pass/fail policy.
+3. Move repeated skill-family package sets into dependency groups or lock-backed sync commands.
+4. Add a reusable workflow for test lanes if matrix shapes keep growing.

--- a/docs/DEPENDENCY_HYGIENE_SKILL.md
+++ b/docs/DEPENDENCY_HYGIENE_SKILL.md
@@ -1,0 +1,62 @@
+# Dependency Hygiene Skill Spec
+
+This is a proposed skill contract for safe dependency refresh work. It is intentionally documented as a spec first, not shipped as runnable code yet.
+
+## Goal
+
+Let an agent inspect stale or vulnerable dependencies, update them in controlled batches, run the relevant verification, and stop before it breaks the repo.
+
+## Non-Goals
+
+- blind repo-wide upgrades
+- automatic major-version jumps without explicit approval
+- editing dependencies without running scoped verification
+- rewriting unrelated code just to satisfy a package bump
+
+## Proposed Skill Name
+
+`dependency-hygiene`
+
+## Trigger Phrases
+
+- update vulnerable packages
+- align dependencies safely
+- refresh lockfile without breaking tests
+- bump dev tools in scoped batches
+
+## Inputs
+
+- manifest files and lockfiles
+- allowed update scope: `patch`, `minor`, or approved `major`
+- package family:
+  - `dev`
+  - `aws`
+  - `gcp`
+  - `azure`
+  - `iam_departures`
+- verification commands for the affected skills
+
+## Required Behavior
+
+1. inventory outdated and vulnerable dependencies
+2. group updates into small batches by ecosystem or skill family
+3. update manifest and lockfile together
+4. run only the relevant lint / test / type checks
+5. stop on breakage and summarize the failing package delta
+6. open a PR summary with:
+   - packages changed
+   - risk level
+   - commands run
+   - residual issues
+
+## Do Not Use
+
+Do not use this skill to bulk-upgrade the full repo in one pass, to auto-merge major-version changes without approval, or to suppress test failures caused by an update.
+
+## Minimum Verification Contract
+
+- dependency graph diff
+- lockfile updated
+- scoped tests pass
+- lint passes for touched files
+- migration notes captured when a package changes behavior

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -1,0 +1,15 @@
+# Diagrams
+
+Keep the markdown source diagrams lightweight and reviewable, then pair them with polished SVGs for docs pages and PRs.
+
+## Visual set
+
+- [Repository architecture](images/repo-architecture.svg)
+- [IAM departures data flow](images/iam-departures-data-flow.svg)
+- [Detection engineering pipeline](images/detection-pipeline.svg)
+
+## Rules
+
+- Keep ASCII or Mermaid diagrams in markdown for git-friendly diffs.
+- Keep the polished SVGs in `docs/images/`.
+- Prefer 2-3 high-signal diagrams over a large diagram dump.

--- a/docs/images/detection-pipeline.svg
+++ b/docs/images/detection-pipeline.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="420" viewBox="0 0 1280 420" role="img" aria-labelledby="title desc">
+  <title id="title">Detection pipeline</title>
+  <desc id="desc">Raw telemetry to OCSF ingest to detect to output converters and downstream consumers.</desc>
+  <rect width="1280" height="420" fill="#0a1020"/>
+  <text x="40" y="52" fill="#f8fafc" font-size="30" font-family="Arial, sans-serif" font-weight="700">Detection engineering pipeline</text>
+
+  <g font-family="Arial, sans-serif">
+    <rect x="40" y="132" width="170" height="86" rx="18" fill="#164e63" stroke="#67e8f9"/>
+    <text x="78" y="170" fill="#ecfeff" font-size="22" font-weight="700">Raw logs</text>
+    <text x="64" y="194" fill="#cffafe" font-size="14">CloudTrail / K8s / MCP</text>
+
+    <rect x="260" y="132" width="190" height="86" rx="18" fill="#1d4ed8" stroke="#93c5fd"/>
+    <text x="318" y="170" fill="#eff6ff" font-size="22" font-weight="700">Ingest</text>
+    <text x="289" y="194" fill="#dbeafe" font-size="14">normalize to OCSF 1.8</text>
+
+    <rect x="500" y="132" width="190" height="86" rx="18" fill="#0f766e" stroke="#5eead4"/>
+    <text x="560" y="170" fill="#ecfeff" font-size="22" font-weight="700">Detect</text>
+    <text x="523" y="194" fill="#ccfbf1" font-size="14">MITRE-tagged findings</text>
+
+    <rect x="740" y="132" width="190" height="86" rx="18" fill="#7c3aed" stroke="#c4b5fd"/>
+    <text x="790" y="170" fill="#f5f3ff" font-size="22" font-weight="700">Convert</text>
+    <text x="777" y="194" fill="#ede9fe" font-size="14">SARIF / Mermaid / JSON</text>
+
+    <rect x="980" y="112" width="240" height="126" rx="18" fill="#111827" stroke="#94a3b8"/>
+    <text x="1048" y="150" fill="#f8fafc" font-size="22" font-weight="700">Consumers</text>
+    <text x="1014" y="178" fill="#cbd5e1" font-size="15">GitHub Security tab</text>
+    <text x="1014" y="200" fill="#cbd5e1" font-size="15">PR comments</text>
+    <text x="1014" y="222" fill="#cbd5e1" font-size="15">dashboards / agent workflows</text>
+  </g>
+
+  <g stroke-width="4" fill="none">
+    <path d="M210 175 L260 175" stroke="#67e8f9"/>
+    <path d="M450 175 L500 175" stroke="#93c5fd"/>
+    <path d="M690 175 L740 175" stroke="#5eead4"/>
+    <path d="M930 175 L980 175" stroke="#c4b5fd"/>
+  </g>
+
+  <text x="40" y="304" fill="#cbd5e1" font-size="18" font-family="Arial, sans-serif">Contract rule: every intermediate handoff stays OCSF-native; only the final delivery edge converts to other formats.</text>
+</svg>

--- a/docs/images/iam-departures-data-flow.svg
+++ b/docs/images/iam-departures-data-flow.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="420" viewBox="0 0 1280 420" role="img" aria-labelledby="title desc">
+  <title id="title">IAM departures data flow</title>
+  <desc id="desc">HR source to reconciler to S3 to EventBridge to Step Functions to parser and worker to audit.</desc>
+  <rect width="1280" height="420" fill="#08111f"/>
+  <text x="40" y="52" fill="#f8fafc" font-size="30" font-family="Arial, sans-serif" font-weight="700">IAM departures remediation flow</text>
+
+  <g font-family="Arial, sans-serif">
+    <rect x="40" y="120" width="150" height="84" rx="18" fill="#1d4ed8" stroke="#93c5fd"/>
+    <text x="72" y="158" fill="#eff6ff" font-size="20" font-weight="700">HR sources</text>
+    <text x="63" y="182" fill="#dbeafe" font-size="14">Workday / Snowflake</text>
+
+    <rect x="230" y="120" width="170" height="84" rx="18" fill="#0f766e" stroke="#5eead4"/>
+    <text x="262" y="158" fill="#ecfeff" font-size="20" font-weight="700">Reconciler</text>
+    <text x="247" y="182" fill="#ccfbf1" font-size="14">hash diff + manifest</text>
+
+    <rect x="440" y="120" width="140" height="84" rx="18" fill="#7c3aed" stroke="#c4b5fd"/>
+    <text x="490" y="158" fill="#f5f3ff" font-size="20" font-weight="700">S3</text>
+    <text x="462" y="182" fill="#ede9fe" font-size="14">versioned manifest</text>
+
+    <rect x="620" y="120" width="170" height="84" rx="18" fill="#92400e" stroke="#fdba74"/>
+    <text x="642" y="158" fill="#fff7ed" font-size="20" font-weight="700">EventBridge</text>
+    <text x="653" y="182" fill="#ffedd5" font-size="14">object-created rule</text>
+
+    <rect x="830" y="92" width="180" height="140" rx="18" fill="#111827" stroke="#94a3b8"/>
+    <text x="856" y="128" fill="#f8fafc" font-size="22" font-weight="700">Step Functions</text>
+    <rect x="850" y="146" width="140" height="32" rx="10" fill="#172554" stroke="#60a5fa"/>
+    <text x="892" y="168" fill="#e0f2fe" font-size="15">Parser</text>
+    <rect x="850" y="188" width="140" height="32" rx="10" fill="#1f2937" stroke="#2dd4bf"/>
+    <text x="890" y="210" fill="#dcfce7" font-size="15">Worker</text>
+
+    <rect x="1050" y="120" width="180" height="84" rx="18" fill="#3f1d1d" stroke="#fca5a5"/>
+    <text x="1105" y="158" fill="#fff1f2" font-size="20" font-weight="700">Audit</text>
+    <text x="1078" y="182" fill="#ffe4e6" font-size="14">DynamoDB + S3 evidence</text>
+  </g>
+
+  <g stroke-width="4" fill="none">
+    <path d="M190 162 L230 162" stroke="#93c5fd"/>
+    <path d="M400 162 L440 162" stroke="#5eead4"/>
+    <path d="M580 162 L620 162" stroke="#c4b5fd"/>
+    <path d="M790 162 L830 162" stroke="#fdba74"/>
+    <path d="M1010 162 L1050 162" stroke="#94a3b8"/>
+  </g>
+
+  <text x="60" y="300" fill="#cbd5e1" font-size="18" font-family="Arial, sans-serif">Verification loop: audit ingest-back closes the loop and the next reconciler run confirms state convergence.</text>
+</svg>

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" role="img" aria-labelledby="title desc">
+  <title id="title">cloud-security repository architecture</title>
+  <desc id="desc">Skill families feed shared contracts and CI lanes.</desc>
+  <rect width="1200" height="640" fill="#0b1220"/>
+  <rect x="40" y="40" width="1120" height="560" rx="24" fill="#111827" stroke="#334155"/>
+  <text x="70" y="90" fill="#f8fafc" font-size="32" font-family="Arial, sans-serif" font-weight="700">cloud-security</text>
+  <text x="70" y="122" fill="#94a3b8" font-size="16" font-family="Arial, sans-serif">Skill families, shared contracts, and CI lanes</text>
+
+  <rect x="70" y="160" width="230" height="120" rx="18" fill="#172554" stroke="#60a5fa"/>
+  <text x="92" y="196" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">Compliance</text>
+  <text x="92" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">AWS / GCP / Azure CIS</text>
+  <text x="92" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">K8s + container posture</text>
+
+  <rect x="330" y="160" width="230" height="120" rx="18" fill="#1e3a5f" stroke="#38bdf8"/>
+  <text x="352" y="196" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">Detection</text>
+  <text x="352" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Ingest → detect → convert</text>
+  <text x="352" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">OCSF 1.8 on the wire</text>
+
+  <rect x="590" y="160" width="230" height="120" rx="18" fill="#1f2937" stroke="#2dd4bf"/>
+  <text x="612" y="196" fill="#dcfce7" font-size="22" font-family="Arial, sans-serif" font-weight="700">Remediation</text>
+  <text x="612" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">IAM departures workflow</text>
+  <text x="612" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Dry-run + dual audit</text>
+
+  <rect x="850" y="160" width="230" height="120" rx="18" fill="#3b0764" stroke="#c084fc"/>
+  <text x="872" y="196" fill="#f5d0fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">AI Infra</text>
+  <text x="872" y="226" fill="#ddd6fe" font-size="15" font-family="Arial, sans-serif">Model serving</text>
+  <text x="872" y="248" fill="#ddd6fe" font-size="15" font-family="Arial, sans-serif">GPU + environment discovery</text>
+
+  <rect x="180" y="340" width="840" height="96" rx="18" fill="#0f172a" stroke="#475569"/>
+  <text x="210" y="378" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">Shared contracts</text>
+  <text x="210" y="408" fill="#cbd5e1" font-size="16" font-family="Arial, sans-serif">AGENTS.md • SKILL.md • OCSF contract • SECURITY_BAR • architecture docs</text>
+
+  <rect x="140" y="474" width="920" height="86" rx="18" fill="#111827" stroke="#64748b"/>
+  <text x="170" y="510" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">CI lanes</text>
+  <text x="170" y="540" fill="#cbd5e1" font-size="16" font-family="Arial, sans-serif">lint • security-scan • test-compliance • test-remediation • test-detection-engineering • test-ai-infra • test-integration • validate-iac • agent-bom</text>
+
+  <path d="M185 280 L250 340" stroke="#60a5fa" stroke-width="3" fill="none"/>
+  <path d="M445 280 L460 340" stroke="#38bdf8" stroke-width="3" fill="none"/>
+  <path d="M705 280 L680 340" stroke="#2dd4bf" stroke-width="3" fill="none"/>
+  <path d="M965 280 L890 340" stroke="#c084fc" stroke-width="3" fill="none"/>
+  <path d="M600 436 L600 474" stroke="#94a3b8" stroke-width="3" fill="none"/>
+</svg>

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,6 +11,8 @@ Skills are grouped by **what kind of work they do**, not which cloud they run in
 
 Every skill in every category is a **closed loop** (detect → act → audit → re-verify) and follows the [Anthropic skills spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide): `SKILL.md` at the skill root with `name`, `description`, `license`, and a `Do NOT use…` clause in the description so agents route correctly.
 
+Proposed future skill contracts that are not shipped yet live under [`../docs/`](../docs/), including [`DEPENDENCY_HYGIENE_SKILL.md`](../docs/DEPENDENCY_HYGIENE_SKILL.md) for safe dependency refreshes.
+
 ## compliance-cis-mitre/
 
 Read-only posture assessments mapped to published benchmarks (CIS, NIST CSF, MITRE ATT&CK).


### PR DESCRIPTION
## Summary
- dedupe repeated Python setup in CI with a composite action
- add a concrete CI workflow guide and a safe dependency-hygiene skill spec
- add architecture and data-flow visuals, then link them from the main docs

## Validation
- git diff --check
- manual sanity review of the workflow conversion and linked docs

## Notes
- the dependency-hygiene document is an explicit proposed skill spec, not a shipped runnable skill
- the diagrams follow the repo rule: keep markdown-native diagrams reviewable and pair them with polished SVGs in docs/images/