### PR TITLE
core: enforce skill contract and fix azure flow log checks

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -8,7 +8,8 @@ inputs:
     default: "3.11"
   packages:
     description: Space-delimited packages to install with pip.
-    required: true
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -20,6 +21,7 @@ runs:
         cache: pip
 
     - name: Install dependencies
+      if: ${{ inputs.packages != '' }}
       shell: bash
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,19 @@ jobs:
           packages: ruff
       - run: ruff check skills/ tests/ --config pyproject.toml
 
-  security-scan:
+  skill-contract:
     runs-on: ubuntu-latest
     needs: lint
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: "3.11"
+      - run: python scripts/validate_skill_contract.py
+
+  security-scan:
+    runs-on: ubuntu-latest
+    needs: [lint, skill-contract]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -42,7 +52,7 @@ jobs:
   # ── Unit tests, grouped into category matrices ────────────────
   test-compliance:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +74,7 @@ jobs:
 
   test-remediation:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +92,7 @@ jobs:
 
   test-detection-engineering:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +123,7 @@ jobs:
 
   test-ai-infra-security:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     strategy:
       fail-fast: false
       matrix:
@@ -133,7 +143,7 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -145,7 +155,7 @@ jobs:
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
   validate-iac:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -165,7 +175,7 @@ jobs:
   # ── agent-bom scans (code + skills + fs + IaC with SARIF upload) ─
   agent-bom:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, skill-contract]
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,10 @@ metadata:
 3. Put source code in `src/` within your skill directory
 4. Put infrastructure-as-code in `infra/` (CloudFormation, Terraform)
 5. Put tests in `tests/` — every skill should have tests
-6. Add your skill to the table in `README.md`
+6. Add a `REFERENCES.md` that links only to the official docs, schemas, APIs, or benchmark sources the skill depends on
+7. Make sure `SKILL.md` explicitly includes both `Use when...` and `Do NOT use...`
+8. Add tests for malformed input, provider quirks, and any deprecated API shape you are intentionally supporting during migration
+9. Add your skill to the table in `README.md`
 
 ## Code standards
 
@@ -36,6 +39,9 @@ metadata:
 - Least-privilege IAM — document every permission your skill needs
 - Tests use `pytest` with `moto` for AWS mocking
 - Map to compliance frameworks where applicable (CIS, MITRE, NIST, OWASP)
+- Prefer only official vendor docs, schemas, and APIs in `REFERENCES.md`
+- Put structured results on `stdout`, debug/warning detail on `stderr`, and fail closed on invalid input
+- Follow [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) for the minimum shipped-skill bar
 
 ## Pull request process
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
 [![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
 
-**OCSF-native detection engineering and posture for cloud and AI infrastructure.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → detect → view skills like Unix pipes. MITRE ATT&CK inside every finding. Read-only, agentless, least-privilege, closed-loop.
+**OCSF-native security skills for cloud and AI systems.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → detect → evaluate → view → remediate flows like Unix pipes. Built for direct CLI use, CI, serverless pipelines, and agent wrappers. Read-only by default, least-privilege, zero-trust, closed-loop.
+
+The repo is intentionally broader than CSPM: cloud security, container security, AI infra security, detection engineering, compliance evaluation, and future inventory/enrichment skills such as AI BOM generation all fit here as long as they stay deterministic, auditable, and grounded in official specs.
 
 For coding agents, start with [AGENTS.md](AGENTS.md). For Claude/Codex-specific guidance and current integration gaps, see [docs/agent-integrations.md](docs/agent-integrations.md).
 
@@ -66,7 +68,7 @@ skills/
     └── discover-environment        (MITRE ATT&CK + ATLAS graph overlay)
 ```
 
-**Roadmap:** 14 open issues ([#26](https://github.com/msaad00/cloud-security/issues/26)–[#39](https://github.com/msaad00/cloud-security/issues/39)) covering VPC Flow / GuardDuty / Security Hub / AWS Config / Okta / GitHub / Workspace / Slack / Workday / Salesforce / SAP / GCP + Azure parity / folder reshape.
+**Roadmap:** current open issues cover AWS Config, GCP + Azure parity, vendor stories, folder reshape, a thin MCP wrapper, the formal skill contract, the safe-skill CI bar, and discovery / inventory follow-ons such as AI BOM generation.
 
 </details>
 
@@ -116,6 +118,7 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | [`DIAGRAMS.md`](docs/DIAGRAMS.md) | Architecture map, IAM departures flow, and detection pipeline visuals |
 | [`CI_WORKFLOW.md`](docs/CI_WORKFLOW.md) | CI lane layout, dedupe rules, and follow-up simplification plan |
 | [`DEPENDENCY_HYGIENE_SKILL.md`](docs/DEPENDENCY_HYGIENE_SKILL.md) | Proposed safe dependency-update skill contract |
+| [`SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) | Minimum files, metadata, and guardrails for shipped skills |
 | [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md) | Wire format pinning for OCSF 1.8 + MITRE ATT&CK v14 |
 | [`SECURITY_BAR.md`](SECURITY_BAR.md) | Per-principle verification matrix — every skill graded against every principle |
 | [`SECURITY.md`](SECURITY.md) | Coordinated disclosure policy |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,18 @@ These are the non-negotiables. Everything in §3–§8 exists to serve them.
 9. **Dry-run everywhere writes happen.** `--dry-run` is mandatory for every `remediate-*` and `sink-*` skill. It prints the SQL / API calls it *would* make without making them.
 10. **Audit the auditor.** Every sink write and every remediation action emits *itself* as an OCSF Application Activity (6002) event, so the tool's own actions are findable in the same pipeline it feeds.
 
+## 2.1 Validation, debugging, and API-drift policy
+
+The repo cannot assume cloud APIs stay still. Providers deprecate fields, add enum values, rename resources, or change SDK defaults. We treat that as a normal engineering event, not an exceptional one.
+
+1. **Validate before use.** Skills validate untrusted input before cloud calls, parsing, or conversion. Unknown shapes fail closed unless the skill explicitly supports partial-pass handling.
+2. **Use official contracts only.** `REFERENCES.md` links only to official docs, schemas, benchmarks, or SDK references. If a behavior is not grounded in a credible source, it does not belong in a shipped skill.
+3. **Debug cleanly.** Structured output goes to `stdout`; warnings, skips, and operator hints go to `stderr`; contract-breaking failures exit non-zero.
+4. **Capture drift in tests.** When AWS, Azure, GCP, Kubernetes, or another source adds or deprecates fields, we add regression coverage for both the old and new shapes during the migration window.
+5. **Migrate intentionally.** Deprecated APIs are removed only after the replacement path is tested, documented, and reflected in `REFERENCES.md`.
+
+This is how the repo stays secure and reliable without turning every skill into an over-general abstraction layer.
+
 ## 3. The 9 layers
 
 ```
@@ -98,7 +110,7 @@ The rule for this repo is simple: keep the architecture readable in Markdown, an
 |---|---|---|---|---|
 | L0 | sources | (external) | n/a | vendor stories #30–#36, Ramp (PR Y), Snowflake audit (PR Z) |
 | L1 | `ingest-*` | **shipping** | cloudtrail, vpc-flow-logs, guardduty, security-hub, gcp-audit, azure-activity, k8s-audit, mcp-proxy | gcp-vpc-flow, azure-nsg-flow, okta, github, workspace, slack, ramp |
-| L2 | `enrich-*` | **planned** | none | PR X (asset-inventory, geoip, mitre-navigator, **pii-redact is P0 before any sink in regulated env**) |
+| L2 | `enrich-*` | **planned** | none | PR X (asset-inventory, geoip, mitre-navigator, inventory / **AI BOM** generation, **pii-redact is P0 before any sink in regulated env**) |
 | L3 | `detect-*` | **shipping** | lateral-movement-aws, privesc-k8s, sensitive-secret-read-k8s, mcp-tool-drift | credential-access per cloud, unusual-assume-role, vector-store-poisoning |
 | L4 | `evaluate-*` | **shipping** | cspm-aws/gcp/azure-cis-benchmark, k8s-security-benchmark, container-security | evaluate-cis-aws-foundations (#29), NIST AI RMF, SOC2, PCI |
 | L5 | `remediate-*` | **shipping** | iam-departures-remediation | auto-close-exposed-s3, revoke-long-lived-key, patch-inspector-finding |
@@ -147,6 +159,17 @@ runners/runner-eventhubs-to-bigquery    # Azure Event Hubs → skill → BigQuer
 ```
 
 Properties: persistent state lives *only* in the runner (checkpoint) and sink (materialised rows). The skills themselves remain stateless, so failure recovery is: re-drive the runner from the last checkpoint, let idempotent sink merges collapse the duplicates.
+
+### Where AI BOM fits
+
+An AI BOM capability belongs in the **discovery / inventory path**, not as the identity of the repo.
+
+- **Collection** lives near L0/L1 when enumerating models, gateways, vector stores, runtimes, policies, and dependencies from vendor APIs or config exports.
+- **Normalization** should emit OCSF-compatible inventory or application-context records rather than inventing a new private schema.
+- **Enrichment** belongs in L2 when joining model inventory, framework metadata, package provenance, and control coverage into a usable graph.
+- **Evaluation** belongs in L4 when mapping that inventory to MITRE ATLAS, NIST AI RMF, OWASP LLM Top 10, or other AI-security frameworks.
+
+That keeps AI BOM as one valuable skill family inside `cloud-security`, instead of pulling the whole repo away from its broader cloud + AI security scope.
 
 ### Why this works: idempotency
 

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -1,0 +1,102 @@
+# Skill Contract
+
+This document defines the minimum contract for a shipped skill in `cloud-security`.
+
+The goal is to keep skills:
+
+- easy for humans to review
+- safe for agents to call
+- grounded in official references
+- deterministic enough to test and trust
+
+## Required layout
+
+Every shipped skill under `skills/<category>/<skill-name>/` must include:
+
+- `SKILL.md`
+- `src/`
+- `tests/`
+- `REFERENCES.md`
+
+Optional:
+
+- `infra/`
+- `examples/`
+- `RUNBOOK.md`
+
+## Required metadata
+
+`SKILL.md` must include YAML frontmatter with:
+
+- `name`
+- `description`
+- `license`
+
+Rules:
+
+- `name` must match `^[a-z0-9-]+$`
+- `name` must be 64 characters or fewer
+- `description` must clearly state when the skill should be used
+- `description` must clearly state what the skill must not be used for
+
+## Required language
+
+Each `SKILL.md` must contain both:
+
+- `Use when`
+- `Do NOT use`
+
+This keeps routing explicit and guardrails visible for Claude, Codex, Cursor, Windsurf, Cortex Code CLI, and other MCP-aware agents.
+
+## Required references
+
+`REFERENCES.md` must point to the official documentation, schema, API, benchmark, or framework the skill relies on.
+
+Examples:
+
+- AWS / Azure / GCP official docs
+- Kubernetes docs
+- OCSF schema docs
+- MITRE ATT&CK / MITRE ATLAS
+- SARIF spec
+
+## Required behavior
+
+- read-only by default unless the skill is explicitly a remediation/write path
+- no hidden side effects
+- deterministic output where practical
+- explicit input/output shape
+- defensive parsing on untrusted input
+
+## Required validation and error handling
+
+- validate every untrusted input boundary before calling a cloud API or parser
+- fail closed on unknown or malformed data
+- write machine-usable results to `stdout` and human debugging detail to `stderr`
+- return non-zero exit codes on contract-breaking failures
+- surface partial-data / skipped-record behavior explicitly rather than silently dropping it
+
+## API drift and deprecation handling
+
+- cite only official docs, schemas, APIs, or benchmarks in `REFERENCES.md`
+- prefer stable SDKs and documented API versions over ad hoc REST calls
+- pin dependencies at the repo level and update them in grouped batches
+- add or update tests whenever a provider changes response shape, enum values, or required fields
+- treat deprecated APIs as a compatibility event: document the replacement, add coverage for both shapes during migration, then remove the old path intentionally
+
+## Required tests
+
+- at least one test module under `tests/`
+- golden fixtures where they make sense
+- malformed input or failure-path coverage for parsers and converters
+- regression coverage for provider-specific parsing quirks or deprecated/alternate response shapes
+
+## CI enforcement
+
+CI currently validates:
+
+- required files exist
+- `name` format is valid
+- `Use when` and `Do NOT use` are present
+
+The contract will expand over time, but new CI rules should only be added when the current tree already satisfies them.

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = ROOT / "skills"
+NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+NAME_FIELD_RE = re.compile(r"^name:\s*([^\n]+)$", re.MULTILINE)
+
+
+def iter_skill_dirs() -> list[Path]:
+    return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
+
+
+def main() -> int:
+    errors: list[str] = []
+    checked = 0
+
+    for skill_dir in iter_skill_dirs():
+        checked += 1
+        skill_md = skill_dir / "SKILL.md"
+        text = skill_md.read_text()
+        rel = skill_dir.relative_to(ROOT)
+
+        for required in ("src", "tests", "REFERENCES.md"):
+            if not (skill_dir / required).exists():
+                errors.append(f"{rel}: missing required path `{required}`")
+
+        match = FRONTMATTER_RE.match(text)
+        if not match:
+            errors.append(f"{rel}: SKILL.md missing YAML frontmatter")
+            continue
+
+        frontmatter = match.group(1)
+        name_match = NAME_FIELD_RE.search(frontmatter)
+        if not name_match:
+            errors.append(f"{rel}: frontmatter missing `name`")
+        else:
+            name = name_match.group(1).strip().strip("\"'")
+            if not NAME_RE.fullmatch(name):
+                errors.append(f"{rel}: invalid skill name `{name}`")
+
+        if "Use when" not in text:
+            errors.append(f"{rel}: SKILL.md must include `Use when`")
+        if "Do NOT use" not in text:
+            errors.append(f"{rel}: SKILL.md must include `Do NOT use`")
+
+    if errors:
+        print("Skill contract validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print(f"Skill contract validation passed for {checked} skills.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ai-infra-security/discover-environment/SKILL.md
+++ b/skills/ai-infra-security/discover-environment/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Discover cloud infrastructure and map it to a security graph with MITRE ATT&CK
   and ATLAS technique overlays. Outputs graph JSON with nodes (resources, IAM,
   services, network) and edges (relationships, attack vectors). Supports AWS,
-  GCP, Azure, or static config input via the appropriate read-only SDK. Use
-  when the user mentions environment discovery, cloud inventory, infrastructure
+  GCP, Azure, or static config input via the appropriate read-only SDK. Use when
+  the user mentions environment discovery, cloud inventory, infrastructure
   mapping, attack surface mapping, cloud resource graph, or MITRE technique
   mapping. Do NOT use for posture assessment against a published benchmark
   (use cspm-aws/gcp/azure-cis-benchmark) or to drive remediation directly —

--- a/skills/compliance-cis-mitre/cspm-azure-cis-benchmark/REFERENCES.md
+++ b/skills/compliance-cis-mitre/cspm-azure-cis-benchmark/REFERENCES.md
@@ -16,7 +16,7 @@ AI Foundry controls are tracked in the Roadmap section of
 | Section | Provider | Method | Why |
 |---|---|---|---|
 | Storage | `Microsoft.Storage` | `storageAccounts.list` | HTTPS-only (CIS 2.2), public blob (CIS 2.3), network rules (CIS 2.4) |
-| Networking | `Microsoft.Network` | `networkSecurityGroups.listAll`, `networkWatchers.listAll` | Unrestricted SSH/RDP (CIS 4.1, 4.2), NSG flow logs (CIS 4.3) |
+| Networking | `Microsoft.Network` | `networkSecurityGroups.listAll`, `networkWatchers.listAll`, `flowLogs.list` | Unrestricted SSH/RDP (CIS 4.1, 4.2), NSG flow logs (CIS 4.3) |
 
 ## Required role
 
@@ -28,11 +28,12 @@ If you want a tighter custom role, the minimal action set is:
 ```json
 {
   "Name": "cspm-azure-cis-benchmark-reader",
-  "Actions": [
-    "Microsoft.Storage/storageAccounts/read",
-    "Microsoft.Network/networkSecurityGroups/read",
-    "Microsoft.Network/networkWatchers/read"
-  ],
+    "Actions": [
+      "Microsoft.Storage/storageAccounts/read",
+      "Microsoft.Network/networkSecurityGroups/read",
+      "Microsoft.Network/networkWatchers/read",
+      "Microsoft.Network/networkWatchers/flowLogs/read"
+    ],
   "AssignableScopes": ["/subscriptions/{subscriptionId}"]
 }
 ```
@@ -42,6 +43,7 @@ If you want a tighter custom role, the minimal action set is:
 - **azure-identity** — https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme
 - **azure-mgmt-storage** — https://learn.microsoft.com/en-us/python/api/overview/azure/storage
 - **azure-mgmt-network** — https://learn.microsoft.com/en-us/python/api/overview/azure/network
+- **FlowLogsOperations.list** — https://learn.microsoft.com/en-us/python/api/azure-mgmt-network/azure.mgmt.network.operations.flowlogsoperations?view=azure-python
 
 Authentication uses `DefaultAzureCredential`, so the skill works with
 Azure CLI login (`az login`), managed identity, environment variables,

--- a/skills/compliance-cis-mitre/cspm-azure-cis-benchmark/src/checks.py
+++ b/skills/compliance-cis-mitre/cspm-azure-cis-benchmark/src/checks.py
@@ -188,7 +188,18 @@ def _check_nsg_port(network_client, port: int, control_id: str, title: str) -> F
 def check_4_3_nsg_flow_logs(network_client, subscription_id: str) -> Finding:
     """CIS 4.3 — NSG flow logs enabled."""
     try:
+        nsgs = list(network_client.network_security_groups.list_all())
         watchers = list(network_client.network_watchers.list_all())
+        if not nsgs:
+            return Finding(
+                control_id="4.3",
+                title="NSG flow logs enabled",
+                section="networking",
+                severity="MEDIUM",
+                status="PASS",
+                detail="No Network Security Groups found",
+                nist_csf="DE.CM-1",
+            )
         if not watchers:
             return Finding(
                 control_id="4.3",
@@ -196,16 +207,54 @@ def check_4_3_nsg_flow_logs(network_client, subscription_id: str) -> Finding:
                 section="networking",
                 severity="MEDIUM",
                 status="FAIL",
-                detail="No Network Watchers found",
+                detail=f"No Network Watchers found for {len(nsgs)} NSG(s)",
                 nist_csf="DE.CM-1",
+                resources=[getattr(nsg, "id", getattr(nsg, "name", "unknown")) for nsg in nsgs],
             )
+
+        enabled_targets: set[str] = set()
+        for watcher in watchers:
+            watcher_name = getattr(watcher, "name", "")
+            watcher_id = getattr(watcher, "id", "") or ""
+            resource_group_name = ""
+            parts = watcher_id.split("/")
+            for idx, part in enumerate(parts):
+                if part.lower() == "resourcegroups" and idx + 1 < len(parts):
+                    resource_group_name = parts[idx + 1]
+                    break
+            if not watcher_name or not resource_group_name:
+                continue
+            for flow_log in network_client.flow_logs.list(resource_group_name, watcher_name):
+                if not getattr(flow_log, "enabled", False):
+                    continue
+                target_id = getattr(flow_log, "target_resource_id", "") or ""
+                if target_id:
+                    enabled_targets.add(target_id.lower())
+
+        missing = [
+            getattr(nsg, "id", getattr(nsg, "name", "unknown"))
+            for nsg in nsgs
+            if (getattr(nsg, "id", "") or "").lower() not in enabled_targets
+        ]
+        if missing:
+            return Finding(
+                control_id="4.3",
+                title="NSG flow logs enabled",
+                section="networking",
+                severity="MEDIUM",
+                status="FAIL",
+                detail=f"{len(missing)} NSG(s) without enabled flow logs",
+                nist_csf="DE.CM-1",
+                resources=missing,
+            )
+
         return Finding(
             control_id="4.3",
             title="NSG flow logs enabled",
             section="networking",
             severity="MEDIUM",
             status="PASS",
-            detail=f"{len(watchers)} Network Watcher(s) found — verify flow logs per NSG",
+            detail=f"Enabled flow logs found for all {len(nsgs)} NSG(s)",
             nist_csf="DE.CM-1",
         )
     except Exception as e:

--- a/skills/compliance-cis-mitre/cspm-azure-cis-benchmark/tests/test_checks.py
+++ b/skills/compliance-cis-mitre/cspm-azure-cis-benchmark/tests/test_checks.py
@@ -92,6 +92,10 @@ class TestNetworkChecks:
     def _nsg_with_rule(self, name, *, port="22", source="*", access="Allow", direction="Inbound"):
         nsg = MagicMock()
         nsg.name = name
+        nsg.id = (
+            f"/subscriptions/{SUB_ID}/resourceGroups/rg-net/providers/"
+            f"Microsoft.Network/networkSecurityGroups/{name}"
+        )
         rule = MagicMock()
         rule.name = "rule0"
         rule.direction = direction
@@ -124,16 +128,58 @@ class TestNetworkChecks:
 
     def test_4_3_no_watchers_fails(self):
         client = MagicMock()
+        client.network_security_groups.list_all.return_value = [self._nsg_with_rule("nsg-a")]
         client.network_watchers.list_all.return_value = []
         f = check_4_3_nsg_flow_logs(client, SUB_ID)
         assert f.control_id == "4.3"
         assert f.status == "FAIL"
 
-    def test_4_3_with_watchers_passes(self):
+    def test_4_3_with_enabled_logs_passes(self):
         client = MagicMock()
-        client.network_watchers.list_all.return_value = [MagicMock()]
+        watcher = MagicMock()
+        watcher.name = "nw-eastus"
+        watcher.id = (
+            f"/subscriptions/{SUB_ID}/resourceGroups/NetworkWatcherRG/providers/"
+            "Microsoft.Network/networkWatchers/nw-eastus"
+        )
+        client.network_security_groups.list_all.return_value = [
+            self._nsg_with_rule("nsg-a"),
+            self._nsg_with_rule("nsg-b"),
+        ]
+        client.network_watchers.list_all.return_value = [watcher]
+        flow_log_a = MagicMock(enabled=True)
+        flow_log_a.target_resource_id = (
+            f"/subscriptions/{SUB_ID}/resourceGroups/rg-net/providers/"
+            "Microsoft.Network/networkSecurityGroups/nsg-a"
+        )
+        flow_log_b = MagicMock(enabled=True)
+        flow_log_b.target_resource_id = (
+            f"/subscriptions/{SUB_ID}/resourceGroups/rg-net/providers/"
+            "Microsoft.Network/networkSecurityGroups/nsg-b"
+        )
+        client.flow_logs.list.return_value = [flow_log_a, flow_log_b]
         f = check_4_3_nsg_flow_logs(client, SUB_ID)
         assert f.status == "PASS"
+        assert "all 2 NSG" in f.detail
+
+    def test_4_3_missing_logs_fail(self):
+        client = MagicMock()
+        watcher = MagicMock()
+        watcher.name = "nw-eastus"
+        watcher.id = (
+            f"/subscriptions/{SUB_ID}/resourceGroups/NetworkWatcherRG/providers/"
+            "Microsoft.Network/networkWatchers/nw-eastus"
+        )
+        nsg_a = self._nsg_with_rule("nsg-a")
+        nsg_b = self._nsg_with_rule("nsg-b")
+        client.network_security_groups.list_all.return_value = [nsg_a, nsg_b]
+        client.network_watchers.list_all.return_value = [watcher]
+        flow_log = MagicMock(enabled=True)
+        flow_log.target_resource_id = nsg_a.id
+        client.flow_logs.list.return_value = [flow_log]
+        f = check_4_3_nsg_flow_logs(client, SUB_ID)
+        assert f.status == "FAIL"
+        assert nsg_b.id in f.resources
 
 
 class TestFindingStructure:

--- a/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/REFERENCES.md
+++ b/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/REFERENCES.md
@@ -1,0 +1,15 @@
+# References — convert-ocsf-to-mermaid-attack-flow
+
+## Standards and formats
+
+- **Mermaid flowchart syntax** — https://mermaid.js.org/syntax/flowchart.html
+- **OCSF schema** — https://schema.ocsf.io/1.8.0/
+- **MITRE ATT&CK** — https://attack.mitre.org/
+
+## Why this skill exists
+
+This skill turns OCSF Detection Findings into a human-readable visual flow that works in Markdown surfaces such as GitHub pull requests and docs pages.
+
+## Required permissions
+
+None. This is a local conversion skill with no external calls.

--- a/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/src/convert.py
+++ b/skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/src/convert.py
@@ -56,7 +56,7 @@ def safe_id(prefix: str, raw: str) -> str:
     """Produce a Mermaid-safe stable node ID for an arbitrary string."""
     if _SAFE_ID.match(raw) and len(raw) <= 32:
         return prefix + raw
-    digest = hashlib.sha1(raw.encode()).hexdigest()[:10]
+    digest = hashlib.sha1(raw.encode(), usedforsecurity=False).hexdigest()[:10]
     return f"{prefix}{digest}"
 
 

--- a/skills/detection-engineering/convert-ocsf-to-sarif/REFERENCES.md
+++ b/skills/detection-engineering/convert-ocsf-to-sarif/REFERENCES.md
@@ -1,0 +1,16 @@
+# References — convert-ocsf-to-sarif
+
+## Standards and schemas
+
+- **SARIF 2.1.0 schema** — https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json
+- **SARIF 2.1.0 specification** — https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+- **OCSF schema** — https://schema.ocsf.io/1.8.0/
+- **MITRE ATT&CK** — https://attack.mitre.org/
+
+## Why this skill exists
+
+This skill projects OCSF Detection Findings into a format GitHub code scanning and other SARIF consumers can render directly.
+
+## Required permissions
+
+None. This is a local conversion skill. Uploading the resulting SARIF to GitHub or another system is the caller's responsibility.

--- a/skills/detection-engineering/detect-lateral-movement-aws/REFERENCES.md
+++ b/skills/detection-engineering/detect-lateral-movement-aws/REFERENCES.md
@@ -1,0 +1,16 @@
+# References — detect-lateral-movement-aws
+
+## Source formats and schemas
+
+- **AWS CloudTrail user guide** — https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html
+- **Amazon VPC Flow Logs** — https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
+- **OCSF schema** — https://schema.ocsf.io/1.8.0/
+
+## Threat framework
+
+- **MITRE ATT&CK T1021 Remote Services** — https://attack.mitre.org/techniques/T1021/
+- **MITRE ATT&CK T1078.004 Cloud Accounts** — https://attack.mitre.org/techniques/T1078/004/
+
+## Required permissions
+
+None for the detector itself. It consumes already-normalized OCSF events from upstream ingest skills.

--- a/skills/detection-engineering/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/detection-engineering/ingest-k8s-audit-ocsf/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   (Create / Read / Update / Delete) from the K8s verb. Sets status_id from
   responseStatus.code. Captures objectRef (resource, namespace, name, apiGroup)
   in resources[] with enough precision for detectors to spot
-  service-account-token-theft, privileged-pod creation, and secret access. Use
-  when the user mentions Kubernetes audit logs, kube-apiserver audit sink,
+  service-account-token-theft, privileged-pod creation, and secret access.
+  Use when the user mentions Kubernetes audit logs, kube-apiserver audit sink,
   OCSF pipeline for K8s, k8s detection engineering, or feeding K8s audit into
   a SIEM. Do NOT use for container runtime logs (different source), kubelet
   logs (different source), or CloudTrail / GCP audit / Azure activity (use the

--- a/skills/detection-engineering/ingest-security-hub-ocsf/tests/test_ingest.py
+++ b/skills/detection-engineering/ingest-security-hub-ocsf/tests/test_ingest.py
@@ -2,32 +2,33 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
-import os
-import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+_SRC = Path(__file__).resolve().parent.parent / "src" / "ingest.py"
+_SPEC = importlib.util.spec_from_file_location("ingest_security_hub", _SRC)
+assert _SPEC and _SPEC.loader
+_INGEST = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_INGEST)
 
-from ingest import (  # type: ignore[import-not-found]
-    ASFF_REQUIRED_FIELDS,
-    CATEGORY_UID,
-    CLASS_UID,
-    OCSF_VERSION,
-    SEVERITY_CRITICAL,
-    SEVERITY_HIGH,
-    SEVERITY_INFORMATIONAL,
-    SEVERITY_LOW,
-    SEVERITY_MEDIUM,
-    SKILL_NAME,
-    TYPE_UID,
-    convert_finding,
-    extract_attacks,
-    ingest,
-    iter_raw_findings,
-    severity_to_id,
-    validate_asff,
-)
+ASFF_REQUIRED_FIELDS = _INGEST.ASFF_REQUIRED_FIELDS
+CATEGORY_UID = _INGEST.CATEGORY_UID
+CLASS_UID = _INGEST.CLASS_UID
+OCSF_VERSION = _INGEST.OCSF_VERSION
+SEVERITY_CRITICAL = _INGEST.SEVERITY_CRITICAL
+SEVERITY_HIGH = _INGEST.SEVERITY_HIGH
+SEVERITY_INFORMATIONAL = _INGEST.SEVERITY_INFORMATIONAL
+SEVERITY_LOW = _INGEST.SEVERITY_LOW
+SEVERITY_MEDIUM = _INGEST.SEVERITY_MEDIUM
+SKILL_NAME = _INGEST.SKILL_NAME
+TYPE_UID = _INGEST.TYPE_UID
+convert_finding = _INGEST.convert_finding
+extract_attacks = _INGEST.extract_attacks
+ingest = _INGEST.ingest
+iter_raw_findings = _INGEST.iter_raw_findings
+severity_to_id = _INGEST.severity_to_id
+validate_asff = _INGEST.validate_asff
 
 THIS = Path(__file__).resolve().parent
 GOLDEN = THIS.parent.parent / "golden"

--- a/skills/detection-engineering/ingest-vpc-flow-logs-ocsf/REFERENCES.md
+++ b/skills/detection-engineering/ingest-vpc-flow-logs-ocsf/REFERENCES.md
@@ -1,0 +1,14 @@
+# References — ingest-vpc-flow-logs-ocsf
+
+## Source format
+
+- **Amazon VPC Flow Logs** — https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
+- **Available VPC Flow Log fields** — https://docs.aws.amazon.com/vpc/latest/userguide/flow-log-records.html
+
+## Schema
+
+- **OCSF schema** — https://schema.ocsf.io/1.8.0/
+
+## Required permissions
+
+No AWS API permissions are required by this skill itself. It reads already-exported flow log records from stdin or local files.

--- a/skills/detection-engineering/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py
+++ b/skills/detection-engineering/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py
@@ -2,30 +2,31 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
-import os
-import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+_SRC = Path(__file__).resolve().parent.parent / "src" / "ingest.py"
+_SPEC = importlib.util.spec_from_file_location("ingest_vpc_flow_logs", _SRC)
+assert _SPEC and _SPEC.loader
+_INGEST = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_INGEST)
 
-from ingest import (  # type: ignore[import-not-found]
-    ACTIVITY_DENIED,
-    ACTIVITY_TRAFFIC,
-    ACTIVITY_UNKNOWN,
-    CATEGORY_UID,
-    CLASS_UID,
-    OCSF_VERSION,
-    SKILL_NAME,
-    activity_id_for_action,
-    convert_record,
-    decode_tcp_flags,
-    ingest,
-    parse_header,
-    parse_record,
-    protocol_name,
-    sec_to_ms,
-)
+ACTIVITY_DENIED = _INGEST.ACTIVITY_DENIED
+ACTIVITY_TRAFFIC = _INGEST.ACTIVITY_TRAFFIC
+ACTIVITY_UNKNOWN = _INGEST.ACTIVITY_UNKNOWN
+CATEGORY_UID = _INGEST.CATEGORY_UID
+CLASS_UID = _INGEST.CLASS_UID
+OCSF_VERSION = _INGEST.OCSF_VERSION
+SKILL_NAME = _INGEST.SKILL_NAME
+activity_id_for_action = _INGEST.activity_id_for_action
+convert_record = _INGEST.convert_record
+decode_tcp_flags = _INGEST.decode_tcp_flags
+ingest = _INGEST.ingest
+parse_header = _INGEST.parse_header
+parse_record = _INGEST.parse_record
+protocol_name = _INGEST.protocol_name
+sec_to_ms = _INGEST.sec_to_ms
 
 THIS = Path(__file__).resolve().parent
 GOLDEN = THIS.parent.parent / "golden"
@@ -165,19 +166,15 @@ class TestParseHeader:
 
 class TestParseRecord:
     def test_default_v5(self):
-        from ingest import _DEFAULT_V5_FIELDS  # type: ignore[import-not-found]
-
         line = "5 111122223333 eni-abc 10.0.0.1 10.0.0.2 80 443 6 5 320 1775797200 1775797260 ACCEPT OK"
-        rec = parse_record(line, _DEFAULT_V5_FIELDS)
+        rec = parse_record(line, _INGEST._DEFAULT_V5_FIELDS)
         assert rec is not None
         assert rec["srcaddr"] == "10.0.0.1"
         assert rec["dstaddr"] == "10.0.0.2"
         assert rec["action"] == "ACCEPT"
 
     def test_too_few_tokens(self):
-        from ingest import _DEFAULT_V5_FIELDS  # type: ignore[import-not-found]
-
-        assert parse_record("5 111122223333", _DEFAULT_V5_FIELDS) is None
+        assert parse_record("5 111122223333", _INGEST._DEFAULT_V5_FIELDS) is None
 
 
 # ── convert_record ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- replace the Azure CIS 4.3 flow-log stub with real NSG flow-log verification
- add a minimal repo-wide skill contract plus CI validation for required skill structure and guardrail language
- add missing official REFERENCES.md files and tighten README / architecture / contributing guidance around API drift, testing, and AI BOM placement
- fix the Mermaid SHA-1 Bandit finding and harden cross-skill test loading for aggregate test runs

## Validation
- `python scripts/validate_skill_contract.py`
- `uv run pytest skills/compliance-cis-mitre/cspm-azure-cis-benchmark/tests/test_checks.py skills/detection-engineering/ingest-security-hub-ocsf/tests/test_ingest.py skills/detection-engineering/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py -q`
- `uv run ruff check skills/compliance-cis-mitre/cspm-azure-cis-benchmark/src/checks.py skills/compliance-cis-mitre/cspm-azure-cis-benchmark/tests/test_checks.py skills/detection-engineering/convert-ocsf-to-mermaid-attack-flow/src/convert.py skills/detection-engineering/ingest-security-hub-ocsf/tests/test_ingest.py skills/detection-engineering/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py scripts/validate_skill_contract.py`

## Notes
- refs #62
- refs #63
- leaves the thin MCP wrapper for follow-up under #61