### PR TITLE
core: add thin mcp wrapper for skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: "3.11"
           packages: ruff
-      - run: ruff check skills/ tests/ --config pyproject.toml
+      - run: ruff check skills/ tests/ mcp-server/ scripts/ --config pyproject.toml
 
   skill-contract:
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: "3.11"
           packages: bandit
-      - run: bandit -r skills/compliance-cis-mitre/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation -c pyproject.toml --severity-level medium
+      - run: bandit -r skills/compliance-cis-mitre/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation mcp-server -c pyproject.toml --severity-level medium
       - name: Check for hardcoded secrets
         run: |
           ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/*/*/src/ --include="*.py" || exit 1
@@ -150,7 +150,7 @@ jobs:
         with:
           python-version: "3.11"
           packages: pytest pytest-cov
-      - run: pytest tests/integration/ -v -o "testpaths=tests"
+      - run: pytest tests/integration/ mcp-server/tests/ -v -o "testpaths=tests"
 
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
   validate-iac:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "cloud-security": {
+      "command": "python3",
+      "args": ["mcp-server/src/server.py"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
 [![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
 
-**OCSF-native security skills for cloud and AI systems.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → detect → evaluate → view → remediate flows like Unix pipes. Built for direct CLI use, CI, serverless pipelines, and agent wrappers. Read-only by default, least-privilege, zero-trust, closed-loop.
+**OCSF-native security skills for cloud and AI systems.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → detect → evaluate → view → remediate flows like Unix pipes. Built for direct CLI use, CI, serverless pipelines, and a thin local MCP wrapper. Read-only by default, least-privilege, zero-trust, closed-loop.
 
 The repo is intentionally broader than CSPM: cloud security, container security, AI infra security, detection engineering, compliance evaluation, and future inventory/enrichment skills such as AI BOM generation all fit here as long as they stay deterministic, auditable, and grounded in official specs.
 
-For coding agents, start with [AGENTS.md](AGENTS.md). For Claude/Codex-specific guidance and current integration gaps, see [docs/agent-integrations.md](docs/agent-integrations.md).
+For coding agents, start with [AGENTS.md](AGENTS.md). For Claude/Codex/Cortex MCP usage, see [docs/agent-integrations.md](docs/agent-integrations.md) and the project-scoped [`.mcp.json`](.mcp.json).
 
 ```bash
 python skills/detection-engineering/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
@@ -68,7 +68,7 @@ skills/
     └── discover-environment        (MITRE ATT&CK + ATLAS graph overlay)
 ```
 
-**Roadmap:** current open issues cover AWS Config, GCP + Azure parity, vendor stories, folder reshape, a thin MCP wrapper, the formal skill contract, the safe-skill CI bar, and discovery / inventory follow-ons such as AI BOM generation.
+**Roadmap:** current open issues cover AWS Config, GCP + Azure parity, vendor stories, folder reshape, the formal skill contract, the safe-skill CI bar, richer MCP input schemas / transports, and discovery / inventory follow-ons such as AI BOM generation.
 
 </details>
 
@@ -117,6 +117,7 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | [`ARCHITECTURE.md`](docs/ARCHITECTURE.md) | 9-layer design, two execution modes (stateless + persistent), 10 guardrails |
 | [`DIAGRAMS.md`](docs/DIAGRAMS.md) | Architecture map, IAM departures flow, and detection pipeline visuals |
 | [`CI_WORKFLOW.md`](docs/CI_WORKFLOW.md) | CI lane layout, dedupe rules, and follow-up simplification plan |
+| [`mcp-server/README.md`](mcp-server/README.md) | Thin local MCP wrapper for auto-discovered skills |
 | [`DEPENDENCY_HYGIENE_SKILL.md`](docs/DEPENDENCY_HYGIENE_SKILL.md) | Proposed safe dependency-update skill contract |
 | [`SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) | Minimum files, metadata, and guardrails for shipped skills |
 | [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md) | Wire format pinning for OCSF 1.8 + MITRE ATT&CK v14 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,7 +117,7 @@ The rule for this repo is simple: keep the architecture readable in Markdown, an
 | L6 | `convert-*` | **shipping** | ocsf-to-sarif, ocsf-to-mermaid-attack-flow | to-sigma, to-splunk-cim, to-jira, to-opa-rego |
 | L7 | `sinks/` | **planned** | none | PR T (snowflake), PR W (security-lake), PR AA (clickhouse), bigquery |
 | L8 | `query/` + packs | **planned** | none | PR T ships the first Cortex query pack alongside sink-snowflake |
-| L9 | `mcp-server/` | **planned** | none | PR U — the unlock for Cortex Code CLI integration |
+| L9 | `mcp-server/` | **shipping** | thin stdio wrapper | tighter input schemas, HTTP/SSE transport, remediation-safe wrappers |
 
 ## 4. Two execution modes
 
@@ -304,13 +304,13 @@ This section is the heart of the design. Without it, each agent (Claude Code, Co
                                             stdout JSONL out)
 ```
 
-### How `mcp-server/` works (PR U)
+### How `mcp-server/` works
 
-1. **Auto-discovery** — walks `skills/*/*/SKILL.md`, parses the frontmatter (`name`, `description`, `capability`), and derives the entrypoint (`src/<ingest|detect|checks|convert|...>.py`).
+1. **Auto-discovery** — walks `skills/*/*/SKILL.md`, parses the frontmatter (`name`, `description`), classifies the skill (`read-only` vs write-capable), and resolves a fixed entrypoint (`src/<ingest|detect|checks|convert|discover>.py`).
 2. **Tool spec generation** — each skill becomes one MCP tool. Tool name = `SKILL.md` `name` field. Tool description = the full frontmatter `description` (which already leads with "Use when…" and closes with "Do NOT use…" per the Anthropic pattern).
-3. **Input schema** — derived from the skill's `argparse` spec. Required JSONL input is modeled as a tool parameter `input: string` (inline JSONL) or `input_uri: string` (S3/GS/blob URL the server will fetch).
-4. **Invocation** — the server shells out to `python3 <skill-path>/src/<entry>.py`, streams the tool's `input` to the skill's stdin, captures stdout, wraps non-zero exits as MCP errors with stderr attached.
-5. **Transport** — stdio (local) and HTTP/SSE (remote). stdio is enough for Claude Code and Cortex Code CLI; HTTP/SSE is for hosted multi-agent deployments.
+3. **Input schema** — current implementation exposes a conservative `input: string` (stdin payload) and `args: string[]` (fixed CLI args passed to the skill entrypoint). This keeps the wrapper thin and avoids inventing a second API surface. Tighter CLI-derived schemas are a follow-up.
+4. **Invocation** — the server shells out to `python3 <skill-path>/src/<entry>.py`, streams the tool's `input` to the skill's stdin, captures stdout, and wraps non-zero exits as MCP tool errors with stderr attached.
+5. **Transport** — stdio (local) ships now. HTTP/SSE stays a follow-up for hosted deployments.
 
 ### Why MCP and not a bespoke API
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -10,15 +10,16 @@ Codex CLI, and generic AGENTS.md-aware agents.
 - Root-level [AGENTS.md](../AGENTS.md) for repo-wide instructions
 - Skill-level `SKILL.md` files that explain when a skill should be used
 - JSON, console, and SARIF outputs that are easy for agents and CI systems to consume
+- A native local MCP server under [`mcp-server/`](../mcp-server/README.md)
+- Project-scoped MCP config in [`.mcp.json`](../.mcp.json) for Claude Code and similar clients
 
 ## What Does Not Exist Yet
 
-- A native MCP server shipped by this repo
-- Agent-callable tools generated directly from the skills
-- Automated Claude/Codex wrappers around the benchmark and remediation flows
+- Hosted HTTP/SSE transport for remote MCP deployments
+- Tight per-skill input schemas derived from each CLI instead of the current conservative `input` + `args` wrapper
+- A direct MCP wrapper for the serverless remediation workflow
 
-Document those gaps clearly. Do not describe the repo as MCP-native until a real
-server or tool layer ships.
+Document those gaps clearly. Describe the current implementation as a **thin local MCP wrapper** over the existing skills, not a separate execution model.
 
 ## Claude / Anthropic Usage
 
@@ -41,37 +42,32 @@ Example prompts:
 
 ## Recommended MCP Setup
 
-Until this repo ships its own MCP server, use generic tooling such as:
-
-- filesystem access for repo reads and edits
-- Git or GitHub integration for PR workflows
-- cloud-vendor MCP tools only if they are explicitly configured in your environment
-
-Example shape for a local MCP config:
+This repo now ships a project-scoped MCP config:
 
 ```json
 {
   "mcpServers": {
-    "filesystem": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    "cloud-security": {
+      "command": "python3",
+      "args": ["mcp-server/src/server.py"]
     }
   }
 }
 ```
 
-Keep this external to the repo unless you are ready to support it as a real project contract.
+That config keeps the wrapper local to the repo and exposes only fixed repo-owned skills. Pair it with filesystem and Git/GitHub MCP servers in your client config if you also want repo editing and PR workflows.
 
 ## Recommended Next Step
 
-If you want first-class Claude/Codex integration, the right next implementation is:
+If you want stronger Claude/Codex/Cortex integration, the next implementation steps are:
 
-1. expose each skill as a callable tool behind a small MCP server
-2. map inputs and outputs onto the existing skill contracts
-3. keep remediation skills explicit about dry-run, approval boundaries, and audit outputs
+1. tighten tool input schemas beyond the current generic `input` + `args` shape
+2. add hosted HTTP/SSE transport alongside stdio
+3. wrap write-capable flows with explicit dry-run, approval boundaries, and audit outputs
 
 ## References
 
 - AGENTS.md open format: https://agents.md/
 - Anthropic skills guide: https://platform.claude.com/docs/en/build-with-claude/skills-guide?curius=1426
 - Anthropic MCP docs: https://docs.anthropic.com/en/docs/mcp
+- Anthropic Claude Code MCP docs: https://docs.anthropic.com/en/docs/claude-code/mcp

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,24 @@
+# MCP Server
+
+Thin stdio MCP wrapper for `cloud-security`.
+
+This server does not replace the existing skills model. It auto-discovers
+`skills/*/*/SKILL.md`, resolves each supported skill to its existing Python
+entrypoint, and exposes those skills as MCP tools for Claude Code, Codex,
+Cursor, Windsurf, Cortex Code CLI, and other MCP clients.
+
+Design rules:
+
+- no arbitrary shell execution
+- no generic "run anything" tool
+- no hidden runtime install path
+- fixed local repo-owned entrypoints only
+- direct CLI usage of skills stays unchanged
+
+Run locally:
+
+```bash
+python3 mcp-server/src/server.py
+```
+
+Project-scoped Claude Code config lives in the repo root at [`.mcp.json`](../.mcp.json).

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CURRENT_DIR = Path(__file__).resolve().parent
+if str(CURRENT_DIR) not in sys.path:
+    sys.path.insert(0, str(CURRENT_DIR))
+
+from tool_registry import build_command, repo_root, tool_definition, tool_map  # noqa: E402
+
+SERVER_NAME = "cloud-security"
+SERVER_VERSION = "0.1.0"
+PROTOCOL_VERSION = "2025-06-18"
+DEFAULT_TIMEOUT_SECONDS = 60
+
+
+def _error_response(request_id: Any, code: int, message: str, data: Any | None = None) -> dict[str, Any]:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": err}
+
+
+def _result_response(request_id: Any, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _read_message(stream) -> dict[str, Any] | None:
+    headers: dict[str, str] = {}
+    while True:
+        line = stream.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("utf-8").split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+
+    length = int(headers.get("content-length", "0"))
+    if length <= 0:
+        return None
+    payload = stream.read(length)
+    return json.loads(payload.decode("utf-8"))
+
+
+def _write_message(stream, message: dict[str, Any]) -> None:
+    payload = json.dumps(message).encode("utf-8")
+    stream.write(f"Content-Length: {len(payload)}\r\n\r\n".encode("utf-8"))
+    stream.write(payload)
+    stream.flush()
+
+
+def _validate_args(raw_args: Any) -> list[str]:
+    if raw_args is None:
+        return []
+    if not isinstance(raw_args, list) or not all(isinstance(arg, str) for arg in raw_args):
+        raise ValueError("`args` must be an array of strings")
+    return raw_args
+
+
+def _validate_input(raw_input: Any) -> str:
+    if raw_input is None:
+        return ""
+    if not isinstance(raw_input, str):
+        raise ValueError("`input` must be a string")
+    return raw_input
+
+
+def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
+    tools = tool_map()
+    if name not in tools:
+        raise KeyError(f"unknown tool `{name}`")
+
+    skill = tools[name]
+    args = _validate_args((arguments or {}).get("args"))
+    stdin_text = _validate_input((arguments or {}).get("input"))
+
+    if not skill.read_only and "--dry-run" not in args:
+        raise ValueError("write-capable tools must be called with `--dry-run`")
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    timeout_seconds = int(env.get("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    completed = subprocess.run(
+        build_command(skill, args),
+        input=stdin_text,
+        text=True,
+        capture_output=True,
+        cwd=repo_root(),
+        env=env,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+    output_text = completed.stdout or completed.stderr or ""
+    result = {
+        "content": [{"type": "text", "text": output_text}],
+        "structuredContent": {
+            "skill": skill.name,
+            "category": skill.category,
+            "capability": skill.capability,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "exit_code": completed.returncode,
+        },
+        "isError": completed.returncode != 0,
+    }
+    return result
+
+
+def _handle_request(message: dict[str, Any]) -> dict[str, Any] | None:
+    method = message.get("method")
+    request_id = message.get("id")
+
+    if method == "notifications/initialized":
+        return None
+
+    if method == "initialize":
+        return _result_response(
+            request_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+
+    if method == "ping":
+        return _result_response(request_id, {})
+
+    if method == "tools/list":
+        tools = [tool_definition(skill) for skill in tool_map().values()]
+        return _result_response(request_id, {"tools": tools})
+
+    if method == "tools/call":
+        params = message.get("params") or {}
+        name = params.get("name")
+        if not isinstance(name, str):
+            return _error_response(request_id, -32602, "`tools/call` requires a string `name`")
+        try:
+            return _result_response(request_id, _call_tool(name, params.get("arguments")))
+        except KeyError as exc:
+            return _error_response(request_id, -32601, str(exc))
+        except ValueError as exc:
+            return _error_response(request_id, -32602, str(exc))
+        except subprocess.TimeoutExpired as exc:
+            return _error_response(request_id, -32000, f"tool timed out after {exc.timeout}s")
+
+    return _error_response(request_id, -32601, f"method not found: {method}")
+
+
+def serve() -> int:
+    while True:
+        message = _read_message(sys.stdin.buffer)
+        if message is None:
+            return 0
+        response = _handle_request(message)
+        if response is not None:
+            _write_message(sys.stdout.buffer, response)
+
+
+if __name__ == "__main__":
+    raise SystemExit(serve())

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+ENTRYPOINT_CANDIDATES = (
+    "src/ingest.py",
+    "src/detect.py",
+    "src/convert.py",
+    "src/checks.py",
+    "src/discover.py",
+)
+
+
+@dataclass(frozen=True)
+class SkillSpec:
+    name: str
+    description: str
+    category: str
+    capability: str
+    skill_dir: Path
+    entrypoint: Path | None
+
+    @property
+    def supported(self) -> bool:
+        return self.entrypoint is not None
+
+    @property
+    def read_only(self) -> bool:
+        return self.capability == "read-only"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def iter_skill_dirs(root: Path | None = None) -> list[Path]:
+    base = (root or repo_root()) / "skills"
+    return sorted(path.parent for path in base.glob("*/*/SKILL.md"))
+
+
+def _extract_frontmatter(skill_md: Path) -> str:
+    text = skill_md.read_text()
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        raise ValueError(f"{skill_md} missing YAML frontmatter")
+    return match.group(1)
+
+
+def _parse_frontmatter(frontmatter: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    lines = frontmatter.splitlines()
+    idx = 0
+
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.strip():
+            idx += 1
+            continue
+        if line.startswith(" "):
+            idx += 1
+            continue
+        if ":" not in line:
+            idx += 1
+            continue
+
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+
+        if not value or value in {">-", "|", ">"}:
+            idx += 1
+            block: list[str] = []
+            while idx < len(lines):
+                child = lines[idx]
+                if child.startswith("  "):
+                    block.append(child.strip())
+                    idx += 1
+                    continue
+                if not child.strip():
+                    idx += 1
+                    continue
+                break
+            data[key] = " ".join(part for part in block if part)
+            continue
+
+        data[key] = value.strip("\"'")
+        idx += 1
+
+    return data
+
+
+def _derive_capability(skill_dir: Path, metadata: dict[str, str]) -> str:
+    if "capability" in metadata and metadata["capability"]:
+        return metadata["capability"]
+    category = skill_dir.parent.name
+    if category == "remediation" or skill_dir.name.startswith("remediate-"):
+        return "write-remediation"
+    if skill_dir.name.startswith("sink-"):
+        return "write-sink"
+    if skill_dir.name.startswith("runner-"):
+        return "write-runner"
+    return "read-only"
+
+
+def _resolve_entrypoint(skill_dir: Path) -> Path | None:
+    for candidate in ENTRYPOINT_CANDIDATES:
+        path = skill_dir / candidate
+        if path.exists():
+            return path
+    return None
+
+
+def discover_skills(root: Path | None = None) -> list[SkillSpec]:
+    base = root or repo_root()
+    specs: list[SkillSpec] = []
+    for skill_dir in iter_skill_dirs(base):
+        metadata = _parse_frontmatter(_extract_frontmatter(skill_dir / "SKILL.md"))
+        specs.append(
+            SkillSpec(
+                name=metadata["name"],
+                description=metadata["description"],
+                category=skill_dir.parent.name,
+                capability=_derive_capability(skill_dir, metadata),
+                skill_dir=skill_dir,
+                entrypoint=_resolve_entrypoint(skill_dir),
+            )
+        )
+    return specs
+
+
+def supported_skills(root: Path | None = None) -> list[SkillSpec]:
+    return [skill for skill in discover_skills(root) if skill.supported]
+
+
+def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
+    description = "Inline stdin payload for the skill. Use this for JSON or JSONL filters."
+    if skill.entrypoint and skill.entrypoint.name == "checks.py":
+        description = "Optional stdin payload. Most benchmark/check skills use explicit CLI args instead."
+    return {
+        "type": "object",
+        "properties": {
+            "input": {
+                "type": "string",
+                "description": description,
+            },
+            "args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Explicit CLI arguments forwarded to the fixed skill entrypoint.",
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+def tool_definition(skill: SkillSpec) -> dict[str, object]:
+    tool: dict[str, object] = {
+        "name": skill.name,
+        "description": skill.description,
+        "inputSchema": tool_input_schema(skill),
+        "annotations": {
+            "readOnlyHint": skill.read_only,
+            "destructiveHint": not skill.read_only,
+            "idempotentHint": skill.read_only,
+        },
+    }
+    return tool
+
+
+def tool_map(root: Path | None = None) -> dict[str, SkillSpec]:
+    return {skill.name: skill for skill in supported_skills(root)}
+
+
+def build_command(skill: SkillSpec, args: list[str]) -> list[str]:
+    if not skill.entrypoint:
+        raise ValueError(f"skill {skill.name} has no supported entrypoint")
+    return [sys.executable, str(skill.entrypoint), *args]

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+GOLDEN_DIR = REPO_ROOT / "skills" / "detection-engineering" / "golden"
+
+
+def _send_message(proc: subprocess.Popen[bytes], payload: dict) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    proc.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8"))
+    proc.stdin.write(body)
+    proc.stdin.flush()
+
+
+def _read_message(proc: subprocess.Popen[bytes]) -> dict:
+    headers: dict[str, str] = {}
+    while True:
+        line = proc.stdout.readline()
+        assert line, proc.stderr.read().decode("utf-8")
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("utf-8").split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    length = int(headers["content-length"])
+    return json.loads(proc.stdout.read(length).decode("utf-8"))
+
+
+def _start_server() -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [sys.executable, str(SERVER_PATH)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=REPO_ROOT,
+    )
+
+
+def _initialize(proc: subprocess.Popen[bytes]) -> None:
+    _send_message(proc, {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    response = _read_message(proc)
+    assert response["result"]["serverInfo"]["name"] == "cloud-security"
+    _send_message(proc, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+
+class TestMcpServer:
+    def test_tools_list_exposes_supported_skills(self):
+        proc = _start_server()
+        try:
+            _initialize(proc)
+            _send_message(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+            response = _read_message(proc)
+            names = {tool["name"] for tool in response["result"]["tools"]}
+            assert "ingest-cloudtrail-ocsf" in names
+            assert "detect-lateral-movement-aws" in names
+            assert "model-serving-security" in names
+            assert "iam-departures-remediation" not in names
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    def test_can_call_ingest_detect_and_evaluate_tools(self, tmp_path: Path):
+        proc = _start_server()
+        try:
+            _initialize(proc)
+
+            raw_cloudtrail = (GOLDEN_DIR / "cloudtrail_raw_sample.jsonl").read_text()
+            _send_message(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "ingest-cloudtrail-ocsf", "arguments": {"input": raw_cloudtrail}},
+                },
+            )
+            ingest_response = _read_message(proc)
+            assert ingest_response["result"]["isError"] is False
+            ingest_lines = [
+                json.loads(line)
+                for line in ingest_response["result"]["structuredContent"]["stdout"].splitlines()
+                if line.strip()
+            ]
+            assert ingest_lines[0]["class_uid"] == 6003
+
+            detect_input = (GOLDEN_DIR / "aws_lateral_movement_input.ocsf.jsonl").read_text()
+            _send_message(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {"name": "detect-lateral-movement-aws", "arguments": {"input": detect_input}},
+                },
+            )
+            detect_response = _read_message(proc)
+            assert detect_response["result"]["isError"] is False
+            finding_lines = [
+                json.loads(line)
+                for line in detect_response["result"]["structuredContent"]["stdout"].splitlines()
+                if line.strip()
+            ]
+            assert finding_lines[0]["class_uid"] == 2004
+
+            config_path = tmp_path / "model-serving.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "endpoints": [
+                            {
+                                "name": "inference",
+                                "auth": {"type": "oauth2", "enabled": True, "roles": ["admin", "user"]},
+                                "rate_limit": {"enabled": True, "rpm": 100},
+                                "limits": {"max_tokens": 4096},
+                                "url": "https://model.internal:8443",
+                                "visibility": "private",
+                            }
+                        ],
+                        "containers": [
+                            {
+                                "name": "model",
+                                "security_context": {
+                                    "privileged": False,
+                                    "readOnlyRootFilesystem": True,
+                                    "runAsNonRoot": True,
+                                    "runAsUser": 1000,
+                                },
+                            }
+                        ],
+                        "safety": {
+                            "output_filter": True,
+                            "prompt_injection": True,
+                            "enabled": True,
+                            "categories": ["violence", "hate", "self-harm", "sexual"],
+                        },
+                        "guardrails": {"enabled": True},
+                        "logging": {"log_requests": True, "redact_pii": True},
+                        "models": [{"name": "claude", "version": "3.5-sonnet-20241022"}],
+                    }
+                )
+            )
+            _send_message(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "model-serving-security",
+                        "arguments": {"args": [str(config_path), "--output", "json"]},
+                    },
+                },
+            )
+            evaluate_response = _read_message(proc)
+            assert evaluate_response["result"]["isError"] is False
+            findings = json.loads(evaluate_response["result"]["structuredContent"]["stdout"])
+            assert findings
+            assert all(finding["status"] not in {"FAIL", "ERROR"} for finding in findings)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = REPO_ROOT / "mcp-server" / "src" / "tool_registry.py"
+SPEC = importlib.util.spec_from_file_location("cloud_security_tool_registry", REGISTRY_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+build_command = MODULE.build_command
+discover_skills = MODULE.discover_skills
+supported_skills = MODULE.supported_skills
+tool_definition = MODULE.tool_definition
+tool_map = MODULE.tool_map
+
+
+class TestDiscovery:
+    def test_discovers_all_skills(self):
+        skills = discover_skills(REPO_ROOT)
+        assert len(skills) == 23
+        assert {skill.name for skill in skills} >= {
+            "ingest-cloudtrail-ocsf",
+            "detect-lateral-movement-aws",
+            "cspm-aws-cis-benchmark",
+            "iam-departures-remediation",
+        }
+
+    def test_marks_remediation_skill_without_cli_entrypoint_as_unsupported(self):
+        skills = {skill.name: skill for skill in discover_skills(REPO_ROOT)}
+        assert skills["iam-departures-remediation"].supported is False
+        assert skills["iam-departures-remediation"].capability == "write-remediation"
+
+    def test_supported_tools_include_ingest_detect_and_evaluate(self):
+        tools = tool_map(REPO_ROOT)
+        assert "ingest-cloudtrail-ocsf" in tools
+        assert "detect-lateral-movement-aws" in tools
+        assert "model-serving-security" in tools
+
+
+class TestToolDefinition:
+    def test_tool_definition_comes_from_skill_metadata(self):
+        skill = tool_map(REPO_ROOT)["ingest-cloudtrail-ocsf"]
+        tool = tool_definition(skill)
+        assert tool["name"] == "ingest-cloudtrail-ocsf"
+        assert "CloudTrail" in tool["description"]
+        assert tool["annotations"]["readOnlyHint"] is True
+        assert tool["inputSchema"]["properties"]["args"]["type"] == "array"
+
+    def test_build_command_uses_fixed_entrypoint(self):
+        skill = tool_map(REPO_ROOT)["detect-lateral-movement-aws"]
+        command = build_command(skill, ["--output", "findings.jsonl"])
+        assert command[1].endswith("skills/detection-engineering/detect-lateral-movement-aws/src/detect.py")
+        assert command[-2:] == ["--output", "findings.jsonl"]


### PR DESCRIPTION
## Summary
- add a thin local `mcp-server/` that auto-discovers supported skills from `SKILL.md` and shells into their existing Python entrypoints
- add end-to-end MCP tests that exercise ingest, detect, and evaluate skills through the server
- add a project-scoped `.mcp.json` for Claude Code and similar clients
- wire `mcp-server` into lint, security-scan, and integration CI jobs
- update README and agent/architecture docs to reflect the shipped wrapper and the remaining MCP follow-ups

## Validation
- `python scripts/validate_skill_contract.py`
- `uv run pytest tests/integration/ mcp-server/tests/ -q`
- `uv run pytest mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py -q`
- `uv run ruff check mcp-server/src mcp-server/tests`
- `uv run bandit -r mcp-server -c pyproject.toml --severity-level medium`

## Notes
- refs #61
- keeps the existing `SKILL.md + src/ + tests/` model as the source of truth
- ships stdio transport now; tighter input schemas and HTTP/SSE stay as follow-up work