### PR TITLE
ci: enforce safe skill guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.11"
       - run: python scripts/validate_skill_contract.py
 
-  security-scan:
+  safe-skill-bar:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract]
     steps:
@@ -40,19 +40,32 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: bandit
-      - run: bandit -r skills/compliance-cis-mitre/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation mcp-server -c pyproject.toml --severity-level medium
+          packages: bandit pip-audit
+      - run: python scripts/validate_safe_skill_bar.py
       - name: Check for hardcoded secrets
         run: |
-          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/*/*/src/ --include="*.py" || exit 1
-          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/*/*/src/ --include="*.py" || exit 1
-          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/*/*/src/ --include="*.py" || exit 1
-          echo "No hardcoded secrets found in source code"
+          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/ mcp-server/ scripts/ --include="*.py" || exit 1
+          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/ mcp-server/ scripts/ --include="*.py" || exit 1
+          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/ mcp-server/ scripts/ --include="*.py" || exit 1
+          echo "No hardcoded secrets found in enforced paths"
+      - name: Dependency vulnerability audit
+        run: pip-audit "${{ github.workspace }}"
+
+  security-scan:
+    runs-on: ubuntu-latest
+    needs: [lint, skill-contract, safe-skill-bar]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: "3.11"
+          packages: bandit
+      - run: bandit -r skills/compliance-cis-mitre/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation mcp-server -c pyproject.toml --severity-level medium
 
   # ── Unit tests, grouped into category matrices ────────────────
   test-compliance:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +87,7 @@ jobs:
 
   test-remediation:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     strategy:
       fail-fast: false
       matrix:
@@ -92,7 +105,7 @@ jobs:
 
   test-detection-engineering:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +136,7 @@ jobs:
 
   test-ai-infra-security:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +156,7 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -155,7 +168,7 @@ jobs:
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
   validate-iac:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -175,7 +188,7 @@ jobs:
   # ── agent-bom scans (code + skills + fs + IaC with SARIF upload) ─
   agent-bom:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: [lint, skill-contract, safe-skill-bar]
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
       - run: python scripts/validate_safe_skill_bar.py
       - name: Check for hardcoded secrets
         run: |
-          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/ mcp-server/ scripts/ --include="*.py" || exit 1
-          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/ mcp-server/ scripts/ --include="*.py" || exit 1
-          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/ mcp-server/ scripts/ --include="*.py" || exit 1
-          echo "No hardcoded secrets found in enforced paths"
+          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/*/*/src/ mcp-server/src/ scripts/ --include="*.py" || exit 1
+          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/*/*/src/ mcp-server/src/ scripts/ --include="*.py" || exit 1
+          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/*/*/src/ mcp-server/src/ scripts/ --include="*.py" || exit 1
+          echo "No hardcoded secrets found in enforced executable paths"
       - name: Dependency vulnerability audit
         run: pip-audit "${{ github.workspace }}"
 

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -7,7 +7,9 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - `lint`
   - fast repo-wide Ruff gate
 - `security-scan`
-  - scoped Bandit and hardcoded-secret checks for the currently enforced high-risk paths
+  - scoped Bandit for the currently enforced high-risk paths
+- `safe-skill-bar`
+  - policy lane for abuse resistance, write-path guardrails, wildcard IAM exceptions, secrets scan, and dependency audit against the repo's declared project dependencies
 - `test-compliance`
   - benchmark skills grouped under one matrix
 - `test-remediation`
@@ -34,6 +36,15 @@ The CI pipeline is split into independent lanes so failures point at the right k
 ## Next Tightenings
 
 1. Pin all third-party GitHub Actions to immutable SHAs.
-2. Add a dependency-vulnerability lane with an explicit scoped pass/fail policy.
-3. Move repeated skill-family package sets into dependency groups or lock-backed sync commands.
-4. Add a reusable workflow for test lanes if matrix shapes keep growing.
+2. Move repeated skill-family package sets into dependency groups or lock-backed sync commands.
+3. Add a reusable workflow for test lanes if matrix shapes keep growing.
+
+## Dependency Policy
+
+Dependency refreshes should land in grouped batches, not one-package PR spam:
+
+- `deps: github-actions`
+- `deps: python-dev-tools`
+- `deps: cloud-sdks`
+
+Use the dependency hygiene skill spec as the review contract for those batches.

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -98,5 +98,8 @@ CI currently validates:
 - required files exist
 - `name` format is valid
 - `Use when` and `Do NOT use` are present
+- read-only skills do not use subprocess/shell execution
+- write-capable skills document and test dry-run behavior
+- wildcard IAM / RBAC policy entries carry an explicit `WILDCARD_OK` justification
 
 The contract will expand over time, but new CI rules should only be added when the current tree already satisfies them.

--- a/scripts/validate_safe_skill_bar.py
+++ b/scripts/validate_safe_skill_bar.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = ROOT / "skills"
+
+SUBPROCESS_PATTERNS = (
+    "import subprocess",
+    "from subprocess import",
+    "os.system(",
+    "Popen(",
+    "check_output(",
+)
+
+WILDCARD_PATTERNS = (
+    re.compile(r'"Action"\s*:\s*"\*"'),
+    re.compile(r'"Resource"\s*:\s*"\*"'),
+    re.compile(r"\bAction\s*=\s*\"\*\""),
+    re.compile(r"\bResource\s*=\s*\"\*\""),
+)
+
+POLICY_SUFFIXES = (".json", ".tf", ".yaml", ".yml")
+
+
+def iter_skill_dirs() -> list[Path]:
+    return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
+
+
+def is_write_skill(skill_dir: Path) -> bool:
+    category = skill_dir.parent.name
+    name = skill_dir.name
+    return (
+        category == "remediation"
+        or name.startswith("remediate-")
+        or name.startswith("sink-")
+        or name.startswith("runner-")
+    )
+
+
+def validate_read_only_no_subprocess(skill_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if is_write_skill(skill_dir):
+        return errors
+
+    for path in sorted((skill_dir / "src").rglob("*.py")):
+        text = path.read_text()
+        for pattern in SUBPROCESS_PATTERNS:
+            if pattern in text:
+                rel = path.relative_to(ROOT)
+                errors.append(
+                    f"{rel}: read-only skill must not use subprocess/shell pattern `{pattern}`"
+                )
+    return errors
+
+
+def validate_write_skill_dry_run(skill_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not is_write_skill(skill_dir):
+        return errors
+
+    skill_md = (skill_dir / "SKILL.md").read_text().lower()
+    if "dry-run" not in skill_md and "dry_run" not in skill_md:
+        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must document dry-run in SKILL.md")
+
+    tests_dir = skill_dir / "tests"
+    test_text = "\n".join(path.read_text() for path in sorted(tests_dir.rglob("*.py")))
+    if "dry_run" not in test_text and "--dry-run" not in test_text and "dry-run" not in test_text:
+        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must exercise dry-run in tests")
+
+    return errors
+
+
+def _has_wildcard_marker(lines: list[str], line_index: int) -> bool:
+    # JSON IAM statements and Terraform policy blocks can span many lines before
+    # the wildcard resource/action appears. Keep the marker local to the block,
+    # but don't make the validator brittle on line wrapping.
+    start = max(0, line_index - 32)
+    window = "\n".join(lines[start : line_index + 1])
+    return "WILDCARD_OK" in window
+
+
+def validate_wildcards() -> list[str]:
+    errors: list[str] = []
+    for path in sorted(SKILLS_ROOT.rglob("*")):
+        if not path.is_file() or path.suffix not in POLICY_SUFFIXES:
+            continue
+        text = path.read_text()
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            if any(pattern.search(line) for pattern in WILDCARD_PATTERNS):
+                if not _has_wildcard_marker(lines, idx):
+                    rel = path.relative_to(ROOT)
+                    errors.append(
+                        f"{rel}:{idx + 1}: wildcard Action/Resource requires explicit WILDCARD_OK justification"
+                    )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for skill_dir in iter_skill_dirs():
+        errors.extend(validate_read_only_no_subprocess(skill_dir))
+        errors.extend(validate_write_skill_dry_run(skill_dir))
+    errors.extend(validate_wildcards())
+
+    if errors:
+        print("Safe-skill validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("Safe-skill validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -96,6 +96,7 @@ flowchart TD
 
 ## Security Guardrails
 
+- **Dry-run first**: use the parser and cross-cloud worker dry-run paths before any real execution. Planning, examples, and validation should never start with a destructive path.
 - **Deny policies**: Root, `break-glass-*`, and `emergency-*` accounts are protected by explicit IAM deny — the pipeline cannot touch them.
 - **Grace period**: 7-day default window before remediation (configurable). HR corrections within this window prevent accidental deletion.
 - **Rehire safety**: 8 scenarios handled. Active employees with same IAM are always skipped.

--- a/skills/remediation/iam-departures-remediation/infra/iam_policies/parser_execution_role.json
+++ b/skills/remediation/iam-departures-remediation/infra/iam_policies/parser_execution_role.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "Sid": "ValidateIAMUserExists",
+      "Sid": "ValidateIAMUserExists_WILDCARD_OK",
       "Effect": "Allow",
       "Action": [
         "iam:GetUser"

--- a/skills/remediation/iam-departures-remediation/infra/iam_policies/worker_execution_role.json
+++ b/skills/remediation/iam-departures-remediation/infra/iam_policies/worker_execution_role.json
@@ -14,7 +14,7 @@
       }
     },
     {
-      "Sid": "IAMRemediationActions",
+      "Sid": "IAMRemediationActions_WILDCARD_OK",
       "Effect": "Allow",
       "Action": [
         "iam:GetUser",

--- a/skills/remediation/iam-departures-remediation/infra/terraform/main.tf
+++ b/skills/remediation/iam-departures-remediation/infra/terraform/main.tf
@@ -278,6 +278,7 @@ resource "aws_iam_role_policy" "parser" {
         }
       },
       {
+        # WILDCARD_OK: iam:GetUser does not support resource-level scoping.
         Sid      = "ValidateIAMUserExists"
         Effect   = "Allow"
         Action   = ["iam:GetUser"]
@@ -332,6 +333,7 @@ resource "aws_iam_role_policy" "worker" {
         }
       },
       {
+        # WILDCARD_OK: the user-remediation IAM APIs in this block do not support tighter resource scoping.
         Sid    = "IAMRemediationActions"
         Effect = "Allow"
         Action = [
@@ -424,6 +426,7 @@ resource "aws_iam_role_policy" "sfn" {
         Resource = [aws_lambda_function.parser.arn, aws_lambda_function.worker.arn]
       },
       {
+        # WILDCARD_OK: CloudWatch Logs delivery actions in Step Functions require Resource = "*".
         Sid    = "CloudWatchLogs"
         Effect = "Allow"
         Action = [
@@ -435,6 +438,7 @@ resource "aws_iam_role_policy" "sfn" {
         Resource = "*"
       },
       {
+        # WILDCARD_OK: X-Ray telemetry APIs require Resource = "*".
         Sid    = "XRayTracing"
         Effect = "Allow"
         Action = ["xray:PutTraceSegments", "xray:PutTelemetryRecords", "xray:GetSamplingRules", "xray:GetSamplingTargets"]


### PR DESCRIPTION
## Summary
- add a dedicated safe-skill policy lane to CI
- validate dry-run coverage, subprocess restrictions, and explicit wildcard IAM justifications
- document the new guardrails and annotate the current remediation policy exceptions

## Validation
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_skill_contract.py
- uv run pytest skills/remediation/iam-departures-remediation/tests/test_cross_cloud_workers.py -q
- uv run bandit -r mcp-server scripts -c pyproject.toml --severity-level medium
- uv run pip-audit .

## Notes
- dependency audit is wired against the repo project metadata because this repo uses uv.lock, not a pip-compatible lockfile format
- the validator enforces explicit WILDCARD_OK markers for IAM or RBAC wildcard exceptions instead of allowing silent broad permissions