### PR TITLE
docs: refresh repo positioning and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 # Agent Instructions
 
-> This file is the canonical entry point for AI agents loading this repository
-> (Claude Code, Cursor, Codex, Cortex, Windsurf, or any other MCP-compatible
-> assistant). It mirrors `CLAUDE.md` and links to the per-skill `SKILL.md`
-> contracts.
+> This file is the canonical repo-level contract for AI agents loading this
+> repository (Claude Code, Cursor, Codex, Cortex, Windsurf, or any other
+> AGENTS.md-aware or MCP-capable assistant). It is intentionally cross-agent.
+> Use `CLAUDE.md` for Claude-specific project memory, and use each
+> `skills/<layer>/<skill>/SKILL.md` for the actual skill contract.
 
 ## Repository at a glance
 
@@ -49,6 +50,16 @@ Skills are organised into layered categories. See [`skills/README.md`](skills/RE
 Compose via stdin/stdout pipes. The shared wire contract remains pinned in
 [`skills/detection-engineering/OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md).
 
+## Which file to read
+
+| File | Scope | When to use it |
+|---|---|---|
+| `README.md` | public overview | orient to repo purpose, modes, and safety model |
+| `AGENTS.md` | cross-agent repo contract | before any agent edits or runs skills |
+| `CLAUDE.md` | Claude-only memory | when Claude Code needs project memory and defaults |
+| `skills/<layer>/<skill>/SKILL.md` | individual skill contract | before running or editing a specific skill |
+| `skills/<layer>/<skill>/REFERENCES.md` | official references only | when verifying APIs, schemas, frameworks, or guardrails |
+
 ## Hard rules for agents
 
 These rules are enforced in code, IAM, and infra. They are not optional:
@@ -61,6 +72,30 @@ These rules are enforced in code, IAM, and infra. They are not optional:
 6. **Never write to the audit table by hand.** The `iam-remediation-audit` DynamoDB table is written exclusively by the worker Lambdas. Manual writes break the closed-loop verification.
 7. **No new IAM grants.** Do not edit `iam_policies/` or any role policy to broaden permissions. Each role is least-privilege by design.
 8. **No telemetry.** Nothing in this repo phones home. Do not add SDK clients to external services unless the user explicitly asks for them, and even then keep the egress inside the customer's VPC.
+
+## Execution and approval model
+
+| Mode | What changes | What does not change |
+|---|---|---|
+| **CLI / just-in-time** | operator or agent invokes the script directly | the skill contract, output format, and guardrails |
+| **CI** | the workflow drives the skill | the skill contract, output format, and guardrails |
+| **Persistent / serverless** | a queue, runner, or workflow invokes the skill repeatedly | the skill contract, output format, and guardrails |
+| **MCP** | the local wrapper exposes the skill as a tool | the skill contract, output format, and guardrails |
+
+Approval rules:
+- **read-only skills** do not need human approval to run
+- **write-capable skills** must expose dry-run and blast-radius language
+- **destructive actions** require human approval and an audit trail
+- **incoming findings are untrusted input** until validated against the skill contract
+
+## Secure coding expectations
+
+- Validate all untrusted input before parsing, SQL construction, or cloud API calls.
+- Prefer parameterized queries and safe identifier handling over string interpolation.
+- Avoid generic subprocess wrappers or arbitrary shell passthrough.
+- Fail closed on deprecated or unknown cloud API shapes unless the skill explicitly supports a migration window.
+- Redact tokens, secrets, and credentials from logs and stderr.
+- Treat transport security, auth scope, and trust boundaries as part of the skill contract, not operational trivia.
 
 ## How to use a skill
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,11 @@
-# Cloud Security Skills Collection
+# Claude Code Project Memory
 
-This repository contains production-ready cloud security automations structured as
-[Anthropic skills](https://docs.anthropic.com) for AI agents.
+This file is Claude Code project memory for `cloud-security`. It is repo-wide
+and universal for Claude within this repository. It is **not** the place for
+individual skill behavior; per-skill rules belong in `skills/<layer>/<skill>/SKILL.md`.
+
+Use this file for repo defaults, safety posture, and navigation. Use
+[`AGENTS.md`](AGENTS.md) for the cross-agent equivalent.
 
 ## Repository structure
 
@@ -54,6 +58,16 @@ skills/
 ```
 
 Every skill in every category is a closed loop: **detect → act → audit → re-verify**.
+
+## Which file to trust for what
+
+| File | Purpose |
+|---|---|
+| `CLAUDE.md` | Claude-only project memory and defaults |
+| `AGENTS.md` | cross-agent repo contract |
+| `README.md` | public overview, modes, and positioning |
+| `skills/<layer>/<skill>/SKILL.md` | exact skill behavior and non-goals |
+| `skills/<layer>/<skill>/REFERENCES.md` | official APIs, schemas, and framework sources |
 
 The full layered architecture (Sources → Ingestion → OCSF → Detection / Evaluation → View → Remediation) is documented in [`ARCHITECTURE.md`](ARCHITECTURE.md). The eleven-principle security contract is in [`SECURITY_BAR.md`](SECURITY_BAR.md). Per-skill official references and IAM policies live in each skill's `REFERENCES.md`.
 The CSPM skills are detection-only and re-verify the same `control_id` on the next run.
@@ -151,6 +165,31 @@ finding list and no error, that's a real "all clear" — not a hidden failure.
 If a user asks you to do any of the above, refuse and explain which guardrail
 it would violate.
 
+## Execution modes
+
+Claude should assume the same skill can be used in four ways:
+
+| Mode | Driver | What changes |
+|---|---|---|
+| **CLI / just-in-time** | user or agent runs the script directly | only the invocation path |
+| **CI** | GitHub Actions or another pipeline | only the invocation path |
+| **Persistent / serverless** | runner, queue, EventBridge, Step Functions | only the invocation path |
+| **MCP** | local `mcp-server/` wrapper | only the invocation path |
+
+The skill code, output contract, and guardrails do **not** change between modes.
+
+## Cloud API drift and validation
+
+Claude should assume vendor APIs drift over time. The safe pattern in this repo is:
+
+1. verify behavior against official docs in `REFERENCES.md`
+2. preserve contract tests and golden fixtures
+3. add migration coverage when old and new shapes must coexist
+4. fail closed on unknown destructive paths
+5. keep stdout machine-readable and stderr diagnostic
+
+If a cloud API, SDK field, or event shape changes, update the references, tests, and skill contract together.
+
 ## Conventions
 
 - Each skill has a `SKILL.md` with frontmatter: `name`, `description` (with trigger
@@ -162,6 +201,8 @@ it would violate.
 - Python 3.11+ required. Type hints used throughout.
 - No hardcoded credentials. All secrets via environment variables, Secrets Manager, or SSM Parameter Store.
 - One check per function. One finding row per control. No mega-functions that emit multiple control_ids.
+- Treat all incoming findings, alerts, manifests, and event payloads as untrusted input until validated.
+- Keep remediation stricter than enrichment or detection: dry-run first, explicit approval, explicit audit.
 
 ## Compliance frameworks referenced
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,9 @@ metadata:
 5. Put tests in `tests/` — every skill should have tests
 6. Add a `REFERENCES.md` that links only to the official docs, schemas, APIs, or benchmark sources the skill depends on
 7. Make sure `SKILL.md` explicitly includes both `Use when...` and `Do NOT use...`
-8. Add tests for malformed input, provider quirks, and any deprecated API shape you are intentionally supporting during migration
-9. Add your skill to the catalog in `README.md` and `skills/README.md`
+8. Document whether the skill is read-only, dry-run capable, HITL-gated, or side-effectful
+9. Add tests for malformed input, provider quirks, and any deprecated API shape you are intentionally supporting during migration
+10. Add your skill to the catalog in `README.md` and `skills/README.md`
 
 ## Code standards
 
@@ -47,6 +48,8 @@ metadata:
 - Prefer only official vendor docs, schemas, and APIs in `REFERENCES.md`
 - Put structured results on `stdout`, debug/warning detail on `stderr`, and fail closed on invalid input
 - Follow [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) for the minimum shipped-skill bar
+- Design for all execution modes up front: CLI, CI, MCP, and persistent/serverless wrappers should not require different skill code
+- If the skill can write state, require dry-run-first behavior and document the approval/audit model
 
 ## Pull request process
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The repo is intentionally broader than CSPM: cloud security, container security, AI infra security, detection engineering, compliance evaluation, and future inventory/enrichment skills such as AI BOM generation all fit here as long as they stay deterministic, auditable, and grounded in official specs.
 
-For coding agents, start with [AGENTS.md](AGENTS.md). For Claude/Codex/Cortex MCP usage, see [docs/agent-integrations.md](docs/agent-integrations.md) and the project-scoped [`.mcp.json`](.mcp.json).
+For coding agents, start with [AGENTS.md](AGENTS.md). For Claude-specific project memory, see [CLAUDE.md](CLAUDE.md). For Claude/Codex/Cortex MCP usage, see [docs/agent-integrations.md](docs/agent-integrations.md) and the project-scoped [`.mcp.json`](.mcp.json).
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
@@ -33,6 +33,43 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
 
+## How it runs
+
+| Mode | Driver | Best for | Human approval |
+|---|---|---|---|
+| **CLI / just-in-time** | Operator or agent runs a skill directly | triage, local analysis, one-off conversions, golden-fixture checks | only for write-capable skills |
+| **CI** | GitHub Actions or another pipeline | regression testing, policy checks, compliance snapshots, SARIF generation | never for read-only skills |
+| **Persistent / serverless** | runner, queue, EventBridge, Step Functions, scheduled jobs | continuous detection, remediation pipelines, lake ingestion | required for destructive actions |
+| **MCP** | local `mcp-server/` wrapper | Claude, Codex, Cursor, Windsurf, Cortex Code CLI | inherited from the wrapped skill |
+
+The important rule is that the **skill code does not change between modes**. `SKILL.md + src/ + tests/` stays the product; the runner, pipeline, or MCP wrapper is only the access path.
+
+## Safety model
+
+| Skill type | Default posture | Required controls |
+|---|---|---|
+| **Ingest / detect / evaluate / view** | read-only | deterministic output, no hidden writes, official references only |
+| **Discovery / inventory / enrich** | read-only unless explicitly documented otherwise | schema validation, output contracts, no secret leakage |
+| **Remediation** | dry-run first | least privilege, blast-radius docs, audit trail, HITL gate |
+| **Sinks / runners** | side-effectful edge components | idempotency, merge-on-UID, transport security, checkpointing |
+
+For every shipped skill, the contract is:
+- exact input and output format
+- explicit `Use when...` and `Do NOT use...`
+- official vendor docs only in `REFERENCES.md`
+- failure-safe behavior on malformed input and deprecated API shapes
+- no generic shell, SQL, or network passthrough
+
+## Agent docs
+
+| File | Scope | Use it for |
+|---|---|---|
+| [`README.md`](README.md) | public repo overview | what the repo is, how it is positioned, where to start |
+| [`AGENTS.md`](AGENTS.md) | cross-agent repo contract | Codex, Cursor, Windsurf, Cortex, Claude, generic AGENTS.md-aware tools |
+| [`CLAUDE.md`](CLAUDE.md) | Claude Code project memory | repo-wide Claude defaults and working rules |
+| `skills/<layer>/<skill>/SKILL.md` | individual skill contract | when to use a skill, input/output, blast radius, non-goals |
+| `skills/<layer>/<skill>/REFERENCES.md` | source-of-truth references | official docs, schemas, APIs, benchmarks |
+
 ## Coverage
 
 <details>
@@ -42,12 +79,20 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design a
 skills/
 ├── ingestion/                      "Raw source → OCSF 1.8"
 │   ├── ingest-cloudtrail-ocsf      AWS            → API Activity 6003
+│   ├── ingest-vpc-flow-logs-ocsf   AWS            → Network Activity 4001
+│   ├── ingest-vpc-flow-logs-gcp-ocsf GCP          → Network Activity 4001
+│   ├── ingest-nsg-flow-logs-azure-ocsf Azure      → Network Activity 4001
+│   ├── ingest-guardduty-ocsf       AWS            → Detection Finding 2004
+│   ├── ingest-security-hub-ocsf    AWS            → Findings 2004 passthrough
+│   ├── ingest-gcp-scc-ocsf         GCP            → Findings 2004 passthrough
+│   ├── ingest-azure-defender-for-cloud-ocsf Azure → Findings 2004 passthrough
 │   ├── ingest-gcp-audit-ocsf       GCP            → API Activity 6003
 │   ├── ingest-azure-activity-ocsf  Azure          → API Activity 6003
 │   ├── ingest-k8s-audit-ocsf       K8s            → API Activity 6003
 │   └── ingest-mcp-proxy-ocsf       MCP            → Application Activity 6002
 │
 ├── detection/                      "What attack pattern does this event stream show?"
+│   ├── detect-lateral-movement                    → T1021 / T1078.004 cross-cloud pivot
 │   ├── detect-mcp-tool-drift                      → T1195.001 Supply Chain
 │   ├── detect-privilege-escalation-k8s            → T1552.007 / T1611 / T1098 / T1550.001
 │   └── detect-sensitive-secret-read-k8s           → T1552.007 Container API
@@ -70,7 +115,7 @@ skills/
     └── iam-departures-remediation  (event-driven, DLQ + SNS, dual audit)
 ```
 
-**Roadmap:** current open issues cover AWS Config, GCP + Azure parity, vendor stories, folder reshape, the formal skill contract, the safe-skill CI bar, richer MCP input schemas / transports, and discovery / inventory follow-ons such as AI BOM generation.
+**Roadmap:** current open issues focus on AWS Config and deeper evaluation coverage, richer MCP input schemas and transports, additional cloud and AI service coverage, vendor stories, and discovery / inventory follow-ons such as AI BOM generation.
 
 </details>
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -5,6 +5,16 @@ as a compact contract: `SKILL.md`, implementation code, tests, and infrastructur
 This document explains how to use that structure with Claude-oriented tooling,
 Codex CLI, and generic AGENTS.md-aware agents.
 
+## Source of truth
+
+Use the docs in this order:
+
+1. [`README.md`](../README.md) for repo purpose, execution modes, and public positioning
+2. [`AGENTS.md`](../AGENTS.md) for the cross-agent contract
+3. [`CLAUDE.md`](../CLAUDE.md) for Claude-specific project memory
+4. `skills/<layer>/<skill>/SKILL.md` for the skill contract
+5. `skills/<layer>/<skill>/REFERENCES.md` for official docs, APIs, schemas, and frameworks
+
 ## What Exists Today
 
 - Root-level [AGENTS.md](../AGENTS.md) for repo-wide instructions
@@ -12,6 +22,19 @@ Codex CLI, and generic AGENTS.md-aware agents.
 - JSON, console, and SARIF outputs that are easy for agents and CI systems to consume
 - A native local MCP server under [`mcp-server/`](../mcp-server/README.md)
 - Project-scoped MCP config in [`.mcp.json`](../.mcp.json) for Claude Code and similar clients
+
+## Execution modes
+
+The same skill should be usable in all of these modes without code changes:
+
+| Mode | Driver | Typical use |
+|---|---|---|
+| **CLI / just-in-time** | user or agent invokes the script directly | one-off analysis, triage, conversion, local debugging |
+| **CI** | GitHub Actions or another build system | regression tests, compliance snapshots, SARIF generation |
+| **Persistent / serverless** | queue, runner, EventBridge, Step Functions, scheduled jobs | continuous detection or remediation pipelines |
+| **MCP** | local `mcp-server/` wrapper | Claude, Codex, Cursor, Windsurf, Cortex Code CLI |
+
+MCP is the access layer, not a separate implementation model.
 
 ## What Does Not Exist Yet
 
@@ -24,9 +47,22 @@ Document those gaps clearly. Describe the current implementation as a **thin loc
 ## Claude / Anthropic Usage
 
 - Use the root `AGENTS.md` as the repo-level instruction file.
+- Use the root `CLAUDE.md` as Claude's project memory.
 - Use each `SKILL.md` as the task-specific contract for the nearest skill directory.
 - Treat the benchmark scripts as read-only assessment tools and the IAM departures
   automation as a controlled remediation workflow.
+
+Claude-specific best practices to follow here:
+- keep skills explicit, bounded, and composable
+- rely on project-scoped MCP config rather than ad hoc global drift
+- treat MCP servers as trusted local wrappers, not arbitrary power surfaces
+- require approval and dry-run for write-capable or destructive actions
+
+References:
+- https://docs.anthropic.com/en/docs/claude-code/memory
+- https://docs.anthropic.com/en/docs/claude-code/security
+- https://docs.anthropic.com/en/docs/claude-code/mcp
+- https://platform.claude.com/docs/en/build-with-claude/skills-guide?curius=1426
 
 Example prompts:
 
@@ -57,6 +93,18 @@ This repo now ships a project-scoped MCP config:
 
 That config keeps the wrapper local to the repo and exposes only fixed repo-owned skills. Pair it with filesystem and Git/GitHub MCP servers in your client config if you also want repo editing and PR workflows.
 
+## Guardrails for all agents
+
+Every agent should assume:
+
+- **read-only by default**
+- **incoming findings are untrusted input until validated**
+- **write-capable skills require dry-run and blast-radius language**
+- **destructive actions require human approval and an audit trail**
+- **official docs only** in `REFERENCES.md`
+- **no generic shell, SQL, or network passthrough**
+- **deprecated API shapes must be covered by tests or explicitly rejected**
+
 ## Recommended Next Step
 
 If you want stronger Claude/Codex/Cortex integration, the next implementation steps are:
@@ -64,6 +112,7 @@ If you want stronger Claude/Codex/Cortex integration, the next implementation st
 1. tighten tool input schemas beyond the current generic `input` + `args` shape
 2. add hosted HTTP/SSE transport alongside stdio
 3. wrap write-capable flows with explicit dry-run, approval boundaries, and audit outputs
+4. add discovery / inventory skills for AI BOM and related enrichment paths
 
 ## References
 


### PR DESCRIPTION
## Summary
- tighten the README hero, execution modes, safety model, and agent-doc map
- clarify the role of AGENTS.md vs CLAUDE.md vs per-skill SKILL.md
- expand agent integration guidance around MCP, approval boundaries, and API drift
- update contribution guidance so new skills declare execution and approval behavior
- refresh the GitHub repo description to match the current scope and code state

## Validation
- docs-only change; reviewed for consistency against current main and merged roadmap work

## Notes
- no code paths changed
- next follow-up should be CI/workflow cleanup to reduce visible check noise without losing coverage