### PR TITLE
feat: centralize skill validation and integrity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: python scripts/validate_skill_contract.py
+      - run: python scripts/validate_skill_integrity.py
 
   safe-skill-bar:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ metadata:
 2. Add or modify skills following the structure above
 3. Ensure tests pass: `pytest skills/<layer>/your-skill/tests/ -v`
 4. Ensure linting passes: `ruff check .`
-5. Open a PR against `main` with a clear description
+5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, and `python scripts/validate_safe_skill_bar.py`
+6. Open a PR against `main` with a clear description
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | **Static analysis** | Unsafe parsing, missing imports, style drift | `ruff check` + `ruff format --check` + `bandit` on every PR |
 | **Hardcoded-secret grep** | Leaked `AKIA…` / `sk-…` / `ghp_…` tokens before they ship | CI lint job, repo-wide on every push |
 | **`REFERENCES.md` per skill** | Fabricated APIs, opaque dependencies, undocumented IAM | Presence enforced by CI; manual review on new skills |
+| **Skill integrity validator** | Name drift, MCP metadata drift, unapproved reference domains, dangerous runtime patterns | `scripts/validate_skill_integrity.py` in CI and integration tests |
 | **`agent-bom` scans** | Vulnerable deps, IaC misconfig, shadow AI components | `code` / `skills scan` / `fs` / `iac` on every push; findings land in GitHub Security tab under `agent-bom-iac` |
 
 </details>

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = ROOT / "skills"
+
+NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+URL_RE = re.compile(r"https://[^\s)>\"]+")
+
+ENTRYPOINT_CANDIDATES = (
+    "src/ingest.py",
+    "src/detect.py",
+    "src/convert.py",
+    "src/checks.py",
+    "src/discover.py",
+)
+
+OFFICIAL_REFERENCE_HOSTS = {
+    "attack.mitre.org",
+    "atlas.mitre.org",
+    "boto3.amazonaws.com",
+    "clickhouse.com",
+    "cloud.google.com",
+    "community.workday.com",
+    "datatracker.ietf.org",
+    "developers.google.com",
+    "docs.aws.amazon.com",
+    "docs.databricks.com",
+    "docs.docker.com",
+    "docs.nvidia.com",
+    "docs.oasis-open.org",
+    "docs.snowflake.com",
+    "genai.owasp.org",
+    "grpc.github.io",
+    "kubernetes.io",
+    "learn.microsoft.com",
+    "mermaid.js.org",
+    "modelcontextprotocol.io",
+    "nvidia.custhelp.com",
+    "ocsf.io",
+    "schema.ocsf.io",
+    "www.aicpa-cima.com",
+    "www.cisecurity.org",
+    "www.iso.org",
+    "www.nist.gov",
+    "www.pcisecuritystandards.org",
+}
+
+ALLOWED_GITHUB_PREFIXES = (
+    "NVIDIA/dcgm-exporter",
+    "NVIDIA/nvidia-container-toolkit",
+    "cncf-tags/container-device-interface",
+    "falcosecurity/rules",
+    "msaad00/agent-bom",
+    "opencontainers/image-spec",
+)
+
+
+@dataclass(frozen=True)
+class SkillContract:
+    name: str
+    description: str
+    category: str
+    skill_dir: Path
+    frontmatter: dict[str, str]
+    skill_text: str
+    entrypoint: Path | None
+
+    @property
+    def references_path(self) -> Path:
+        return self.skill_dir / "REFERENCES.md"
+
+    @property
+    def is_write_capable(self) -> bool:
+        if self.frontmatter.get("capability", "").startswith("write-"):
+            return True
+        return self.category == "remediation" or self.name.startswith(("remediate-", "sink-", "runner-"))
+
+
+def iter_skill_dirs() -> list[Path]:
+    return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
+
+
+def extract_frontmatter(skill_md: Path) -> str:
+    text = skill_md.read_text()
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        raise ValueError(f"{skill_md} missing YAML frontmatter")
+    return match.group(1)
+
+
+def parse_frontmatter(frontmatter: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    lines = frontmatter.splitlines()
+    idx = 0
+
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.strip() or line.startswith(" "):
+            idx += 1
+            continue
+        if ":" not in line:
+            idx += 1
+            continue
+
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+
+        if not value or value in {">-", "|", ">"}:
+            idx += 1
+            block: list[str] = []
+            while idx < len(lines):
+                child = lines[idx]
+                if child.startswith("  "):
+                    block.append(child.strip())
+                    idx += 1
+                    continue
+                if not child.strip():
+                    idx += 1
+                    continue
+                break
+            data[key] = " ".join(part for part in block if part)
+            continue
+
+        data[key] = value.strip("\"'")
+        idx += 1
+
+    return data
+
+
+def resolve_entrypoint(skill_dir: Path) -> Path | None:
+    for candidate in ENTRYPOINT_CANDIDATES:
+        path = skill_dir / candidate
+        if path.exists():
+            return path
+    return None
+
+
+def discover_skill_contracts() -> list[SkillContract]:
+    skills: list[SkillContract] = []
+    for skill_dir in iter_skill_dirs():
+        skill_md = skill_dir / "SKILL.md"
+        text = skill_md.read_text()
+        frontmatter = parse_frontmatter(extract_frontmatter(skill_md))
+        skills.append(
+            SkillContract(
+                name=frontmatter.get("name", ""),
+                description=frontmatter.get("description", ""),
+                category=skill_dir.parent.name,
+                skill_dir=skill_dir,
+                frontmatter=frontmatter,
+                skill_text=text,
+                entrypoint=resolve_entrypoint(skill_dir),
+            )
+        )
+    return skills
+
+
+def extract_reference_urls(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return URL_RE.findall(path.read_text())
+
+
+def reference_url_allowed(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+
+    host = parsed.netloc.lower()
+    if host in OFFICIAL_REFERENCE_HOSTS:
+        return True
+
+    if host == "github.com":
+        path = parsed.path.strip("/")
+        return any(path.startswith(prefix) for prefix in ALLOWED_GITHUB_PREFIXES)
+
+    return False

--- a/scripts/validate_safe_skill_bar.py
+++ b/scripts/validate_safe_skill_bar.py
@@ -4,8 +4,7 @@ import re
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
-SKILLS_ROOT = ROOT / "skills"
+from skill_validation_common import ROOT, SKILLS_ROOT, discover_skill_contracts
 
 SUBPROCESS_PATTERNS = (
     "import subprocess",
@@ -23,10 +22,6 @@ WILDCARD_PATTERNS = (
 )
 
 POLICY_SUFFIXES = (".json", ".tf", ".yaml", ".yml")
-
-
-def iter_skill_dirs() -> list[Path]:
-    return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
 
 
 def is_write_skill(skill_dir: Path) -> bool:
@@ -101,7 +96,8 @@ def validate_wildcards() -> list[str]:
 
 def main() -> int:
     errors: list[str] = []
-    for skill_dir in iter_skill_dirs():
+    for skill in discover_skill_contracts():
+        skill_dir = skill.skill_dir
         errors.extend(validate_read_only_no_subprocess(skill_dir))
         errors.extend(validate_write_skill_dry_run(skill_dir))
     errors.extend(validate_wildcards())

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -1,51 +1,31 @@
 from __future__ import annotations
 
-import re
 import sys
-from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
-SKILLS_ROOT = ROOT / "skills"
-NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
-FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
-NAME_FIELD_RE = re.compile(r"^name:\s*([^\n]+)$", re.MULTILINE)
-
-
-def iter_skill_dirs() -> list[Path]:
-    return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
+from skill_validation_common import NAME_RE, ROOT, discover_skill_contracts
 
 
 def main() -> int:
     errors: list[str] = []
     checked = 0
 
-    for skill_dir in iter_skill_dirs():
+    for skill in discover_skill_contracts():
         checked += 1
-        skill_md = skill_dir / "SKILL.md"
-        text = skill_md.read_text()
-        rel = skill_dir.relative_to(ROOT)
+        rel = skill.skill_dir.relative_to(ROOT)
 
         for required in ("src", "tests", "REFERENCES.md"):
-            if not (skill_dir / required).exists():
+            if not (skill.skill_dir / required).exists():
                 errors.append(f"{rel}: missing required path `{required}`")
 
-        match = FRONTMATTER_RE.match(text)
-        if not match:
-            errors.append(f"{rel}: SKILL.md missing YAML frontmatter")
-            continue
-
-        frontmatter = match.group(1)
-        name_match = NAME_FIELD_RE.search(frontmatter)
-        if not name_match:
+        if not skill.name:
             errors.append(f"{rel}: frontmatter missing `name`")
         else:
-            name = name_match.group(1).strip().strip("\"'")
-            if not NAME_RE.fullmatch(name):
-                errors.append(f"{rel}: invalid skill name `{name}`")
+            if not NAME_RE.fullmatch(skill.name):
+                errors.append(f"{rel}: invalid skill name `{skill.name}`")
 
-        if "Use when" not in text:
+        if "Use when" not in skill.skill_text:
             errors.append(f"{rel}: SKILL.md must include `Use when`")
-        if "Do NOT use" not in text:
+        if "Do NOT use" not in skill.skill_text:
             errors.append(f"{rel}: SKILL.md must include `Do NOT use`")
 
     if errors:

--- a/scripts/validate_skill_integrity.py
+++ b/scripts/validate_skill_integrity.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+from skill_validation_common import (
+    ROOT,
+    discover_skill_contracts,
+    extract_reference_urls,
+    reference_url_allowed,
+)
+
+DANGEROUS_CODE_PATTERNS = {
+    r"\beval\(": "eval() is not allowed in shipped skill code",
+    r"(?<!\.)\bexec\(": "exec() is not allowed in shipped skill code",
+    r"\bpickle\.loads\(": "pickle.loads() is not allowed in shipped skill code",
+    r"\byaml\.load\(": "yaml.load() is not allowed; use yaml.safe_load() if needed",
+    r"\bmarshal\.loads\(": "marshal.loads() is not allowed in shipped skill code",
+}
+
+
+def _load_tool_registry():
+    path = ROOT / "mcp-server" / "src" / "tool_registry.py"
+    spec = importlib.util.spec_from_file_location("cloud_security_tool_registry_integrity", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def validate_unique_names() -> list[str]:
+    errors: list[str] = []
+    seen: dict[str, Path] = {}
+    for skill in discover_skill_contracts():
+        if not skill.name:
+            continue
+        previous = seen.get(skill.name)
+        if previous:
+            errors.append(
+                f"{skill.skill_dir.relative_to(ROOT)}: duplicate skill name `{skill.name}`"
+                f" already used by {previous.relative_to(ROOT)}"
+            )
+        else:
+            seen[skill.name] = skill.skill_dir
+    return errors
+
+
+def validate_name_to_path_alignment() -> list[str]:
+    errors: list[str] = []
+    for skill in discover_skill_contracts():
+        rel = skill.skill_dir.relative_to(ROOT)
+        if not skill.name:
+            continue
+        if skill.name != skill.skill_dir.name:
+            errors.append(f"{rel}: frontmatter name `{skill.name}` must match directory name")
+    return errors
+
+
+def validate_references() -> list[str]:
+    errors: list[str] = []
+    for skill in discover_skill_contracts():
+        rel = skill.references_path.relative_to(ROOT)
+        urls = extract_reference_urls(skill.references_path)
+        if not urls:
+            errors.append(f"{rel}: REFERENCES.md must include at least one https:// reference")
+            continue
+        for url in urls:
+            if not reference_url_allowed(url):
+                errors.append(f"{rel}: unapproved reference source `{url}`")
+    return errors
+
+
+def validate_dangerous_code() -> list[str]:
+    errors: list[str] = []
+    compiled = [(re.compile(pattern), message) for pattern, message in DANGEROUS_CODE_PATTERNS.items()]
+    for skill in discover_skill_contracts():
+        for path in sorted((skill.skill_dir / "src").rglob("*.py")):
+            text = path.read_text()
+            for pattern, message in compiled:
+                if pattern.search(text):
+                    errors.append(f"{path.relative_to(ROOT)}: {message}")
+    return errors
+
+
+def validate_mcp_alignment() -> list[str]:
+    errors: list[str] = []
+    registry = _load_tool_registry()
+    registry_map = {skill.name: skill for skill in registry.discover_skills(ROOT)}
+    contracts = {skill.name: skill for skill in discover_skill_contracts()}
+
+    if set(registry_map) != set(contracts):
+        missing = sorted(set(contracts) - set(registry_map))
+        extra = sorted(set(registry_map) - set(contracts))
+        if missing:
+            errors.append(f"mcp-server: missing skills from registry discovery: {', '.join(missing)}")
+        if extra:
+            errors.append(f"mcp-server: unexpected skills in registry discovery: {', '.join(extra)}")
+
+    for name, contract in contracts.items():
+        registry_skill = registry_map.get(name)
+        if registry_skill is None:
+            continue
+        if registry_skill.description != contract.description:
+            errors.append(
+                f"{contract.skill_dir.relative_to(ROOT)}: MCP description drift for `{name}`"
+            )
+        expected_support = contract.entrypoint is not None
+        if registry_skill.supported != expected_support:
+            errors.append(
+                f"{contract.skill_dir.relative_to(ROOT)}: MCP supported flag drift for `{name}`"
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors.extend(validate_unique_names())
+    errors.extend(validate_name_to_path_alignment())
+    errors.extend(validate_references())
+    errors.extend(validate_dangerous_code())
+    errors.extend(validate_mcp_alignment())
+
+    if errors:
+        print("Skill integrity validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("Skill integrity validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+COMMON = _load_module(
+    "cloud_security_skill_validation_common_test",
+    SCRIPTS / "skill_validation_common.py",
+)
+CONTRACT = _load_module(
+    "cloud_security_validate_skill_contract_test",
+    SCRIPTS / "validate_skill_contract.py",
+)
+SAFE = _load_module(
+    "cloud_security_validate_safe_skill_bar_test",
+    SCRIPTS / "validate_safe_skill_bar.py",
+)
+INTEGRITY = _load_module(
+    "cloud_security_validate_skill_integrity_test",
+    SCRIPTS / "validate_skill_integrity.py",
+)
+
+
+class TestSkillValidationCommon:
+    def test_discovers_skills_and_entrypoints(self):
+        skills = COMMON.discover_skill_contracts()
+        assert len(skills) >= 27
+        names = {skill.name for skill in skills}
+        assert "detect-lateral-movement" in names
+        assert "ingest-gcp-scc-ocsf" in names
+        assert "ingest-azure-defender-for-cloud-ocsf" in names
+
+        ingest = next(skill for skill in skills if skill.name == "ingest-cloudtrail-ocsf")
+        assert ingest.entrypoint is not None
+        assert ingest.entrypoint.name == "ingest.py"
+
+    def test_reference_policy_accepts_known_official_hosts(self):
+        assert COMMON.reference_url_allowed("https://docs.aws.amazon.com/IAM/latest/APIReference/")
+        assert COMMON.reference_url_allowed("https://attack.mitre.org/techniques/T1021/")
+        assert COMMON.reference_url_allowed("https://github.com/opencontainers/image-spec")
+        assert not COMMON.reference_url_allowed("http://example.com/not-https")
+        assert not COMMON.reference_url_allowed("https://example.com/not-approved")
+
+
+class TestValidationScripts:
+    def test_contract_validator_passes(self):
+        assert CONTRACT.main() == 0
+
+    def test_safe_skill_validator_passes(self):
+        assert SAFE.main() == 0
+
+    def test_integrity_validator_passes(self):
+        assert INTEGRITY.main() == 0


### PR DESCRIPTION
## Summary
- centralize shared skill discovery and metadata parsing in one validator module
- add a repo-wide integrity validator for name drift, MCP metadata drift, unapproved reference domains, and dangerous runtime patterns
- keep the existing contract and safe-skill checks, but refactor them onto the shared common layer
- add integration coverage so the validator stack is exercised in tests, not just CI scripts
- wire the integrity validator into the existing skill-contract CI lane without adding another visible top-level check

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_safe_skill_bar.py
- uv run pytest tests/integration/ mcp-server/tests/ -q
- uv run ruff check scripts tests/integration/test_skill_validation_scripts.py --config pyproject.toml

## Why
This keeps the repo scalable and accurate: shared policy lives once at the repo level, while individual skills keep only their fixtures and behavior-specific tests. It also gives us managed control over skill drift and integrity without duplicating validation logic across every skill.
