### PR TITLE
chore: tighten dependency hygiene and ci lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,20 @@ jobs:
             boto3 moto pytest pytest-cov
             google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
             azure-identity azure-mgmt-network azure-mgmt-resource azure-mgmt-storage
-      - run: >
-          pytest
-          skills/evaluation/cspm-aws-cis-benchmark/tests/
-          skills/evaluation/cspm-gcp-cis-benchmark/tests/
-          skills/evaluation/cspm-azure-cis-benchmark/tests/
-          skills/evaluation/k8s-security-benchmark/tests/
-          skills/evaluation/container-security/tests/
-          -v
+      - name: Run compliance skill suites
+        shell: bash
+        run: |
+          set -euo pipefail
+          for skill in \
+            cspm-aws-cis-benchmark \
+            cspm-gcp-cis-benchmark \
+            cspm-azure-cis-benchmark \
+            k8s-security-benchmark \
+            container-security
+          do
+            echo "==> skills/evaluation/${skill}"
+            pytest "skills/evaluation/${skill}/tests/" -v -o "testpaths=tests"
+          done
 
   test-remediation:
     runs-on: ubuntu-latest
@@ -103,7 +109,7 @@ jobs:
             google-cloud-iam google-cloud-resource-manager google-api-python-client
             azure-identity
             clickhouse-connect databricks-sql-connector httpx snowflake-connector-python
-      - run: pytest skills/remediation/iam-departures-remediation/tests/ -v
+      - run: pytest skills/remediation/iam-departures-remediation/tests/ -v -o "testpaths=tests"
 
   test-detection-engineering:
     runs-on: ubuntu-latest
@@ -114,12 +120,33 @@ jobs:
         with:
           python-version: "3.11"
           packages: pytest pytest-cov
-      - run: >
-          pytest
-          skills/ingestion/
-          skills/detection/
-          skills/view/
-          -v
+      - name: Run ingestion, detection, and view suites
+        shell: bash
+        run: |
+          set -euo pipefail
+          for skill_dir in \
+            skills/ingestion/ingest-cloudtrail-ocsf \
+            skills/ingestion/ingest-vpc-flow-logs-ocsf \
+            skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf \
+            skills/ingestion/ingest-nsg-flow-logs-azure-ocsf \
+            skills/ingestion/ingest-guardduty-ocsf \
+            skills/ingestion/ingest-security-hub-ocsf \
+            skills/ingestion/ingest-gcp-scc-ocsf \
+            skills/ingestion/ingest-azure-defender-for-cloud-ocsf \
+            skills/ingestion/ingest-gcp-audit-ocsf \
+            skills/ingestion/ingest-azure-activity-ocsf \
+            skills/ingestion/ingest-k8s-audit-ocsf \
+            skills/ingestion/ingest-mcp-proxy-ocsf \
+            skills/detection/detect-mcp-tool-drift \
+            skills/detection/detect-privilege-escalation-k8s \
+            skills/detection/detect-sensitive-secret-read-k8s \
+            skills/detection/detect-lateral-movement \
+            skills/view/convert-ocsf-to-sarif \
+            skills/view/convert-ocsf-to-mermaid-attack-flow
+          do
+            echo "==> ${skill_dir}"
+            pytest "${skill_dir}/tests/" -v -o "testpaths=tests"
+          done
 
   test-ai-infra-security:
     runs-on: ubuntu-latest
@@ -134,12 +161,18 @@ jobs:
             boto3 pytest pytest-cov
             google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
             azure-identity azure-mgmt-resource
-      - run: >
-          pytest
-          skills/evaluation/model-serving-security/tests/
-          skills/evaluation/gpu-cluster-security/tests/
-          skills/evaluation/discover-environment/tests/
-          -v
+      - name: Run AI infra skill suites
+        shell: bash
+        run: |
+          set -euo pipefail
+          for skill in \
+            model-serving-security \
+            gpu-cluster-security \
+            discover-environment
+          do
+            echo "==> skills/evaluation/${skill}"
+            pytest "skills/evaluation/${skill}/tests/" -v -o "testpaths=tests"
+          done
 
   test-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write
@@ -32,6 +36,7 @@ jobs:
           python-version: "3.11"
       - run: python scripts/validate_skill_contract.py
       - run: python scripts/validate_skill_integrity.py
+      - run: python scripts/validate_dependency_consistency.py
 
   safe-skill-bar:
     runs-on: ubuntu-latest
@@ -63,119 +68,78 @@ jobs:
           packages: bandit
       - run: bandit -r skills/evaluation/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation mcp-server -c pyproject.toml --severity-level medium
 
-  # ── Unit tests, grouped into category matrices ────────────────
+  # ── Unit tests, grouped into category lanes ───────────────────
   test-compliance:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract, safe-skill-bar]
-    strategy:
-      fail-fast: false
-      matrix:
-        skill:
-          - cspm-aws-cis-benchmark
-          - cspm-gcp-cis-benchmark
-          - cspm-azure-cis-benchmark
-          - k8s-security-benchmark
-          - container-security
-    name: test-compliance (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: boto3 moto pytest pytest-cov
-      - working-directory: skills/evaluation/${{ matrix.skill }}
-        run: pytest tests/ -v -o "testpaths=tests"
+          packages: >-
+            boto3 moto pytest pytest-cov
+            google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
+            azure-identity azure-mgmt-network azure-mgmt-resource azure-mgmt-storage
+      - run: >
+          pytest
+          skills/evaluation/cspm-aws-cis-benchmark/tests/
+          skills/evaluation/cspm-gcp-cis-benchmark/tests/
+          skills/evaluation/cspm-azure-cis-benchmark/tests/
+          skills/evaluation/k8s-security-benchmark/tests/
+          skills/evaluation/container-security/tests/
+          -v
 
   test-remediation:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract, safe-skill-bar]
-    strategy:
-      fail-fast: false
-      matrix:
-        skill:
-          - iam-departures-remediation
-    name: test-remediation (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: boto3 moto pytest pytest-cov
-      - working-directory: skills/remediation/${{ matrix.skill }}
-        run: pytest tests/ -v -o "testpaths=tests"
+          packages: >-
+            boto3 moto pytest pytest-cov
+            google-cloud-iam google-cloud-resource-manager google-api-python-client
+            azure-identity
+            clickhouse-connect databricks-sql-connector httpx snowflake-connector-python
+      - run: pytest skills/remediation/iam-departures-remediation/tests/ -v
 
   test-detection-engineering:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract, safe-skill-bar]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - skill: ingest-cloudtrail-ocsf
-            category: ingestion
-          - skill: ingest-vpc-flow-logs-ocsf
-            category: ingestion
-          - skill: ingest-vpc-flow-logs-gcp-ocsf
-            category: ingestion
-          - skill: ingest-nsg-flow-logs-azure-ocsf
-            category: ingestion
-          - skill: ingest-guardduty-ocsf
-            category: ingestion
-          - skill: ingest-security-hub-ocsf
-            category: ingestion
-          - skill: ingest-gcp-scc-ocsf
-            category: ingestion
-          - skill: ingest-azure-defender-for-cloud-ocsf
-            category: ingestion
-          - skill: ingest-gcp-audit-ocsf
-            category: ingestion
-          - skill: ingest-azure-activity-ocsf
-            category: ingestion
-          - skill: ingest-k8s-audit-ocsf
-            category: ingestion
-          - skill: ingest-mcp-proxy-ocsf
-            category: ingestion
-          - skill: detect-mcp-tool-drift
-            category: detection
-          - skill: detect-privilege-escalation-k8s
-            category: detection
-          - skill: detect-sensitive-secret-read-k8s
-            category: detection
-          - skill: detect-lateral-movement
-            category: detection
-          - skill: convert-ocsf-to-sarif
-            category: view
-          - skill: convert-ocsf-to-mermaid-attack-flow
-            category: view
-    name: test-detection-engineering (${{ matrix.skill }})
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
           packages: pytest pytest-cov
-      - working-directory: skills/${{ matrix.category }}/${{ matrix.skill }}
-        run: pytest tests/ -v -o "testpaths=tests"
+      - run: >
+          pytest
+          skills/ingestion/
+          skills/detection/
+          skills/view/
+          -v
 
   test-ai-infra-security:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract, safe-skill-bar]
-    strategy:
-      fail-fast: false
-      matrix:
-        skill:
-          - model-serving-security
-          - gpu-cluster-security
-          - discover-environment
-    name: test-ai-infra (${{ matrix.skill }})
+    name: test-ai-infra
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: pytest pytest-cov
-      - working-directory: skills/evaluation/${{ matrix.skill }}
-        run: pytest tests/ -v -o "testpaths=tests"
+          packages: >-
+            boto3 pytest pytest-cov
+            google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
+            azure-identity azure-mgmt-resource
+      - run: >
+          pytest
+          skills/evaluation/model-serving-security/tests/
+          skills/evaluation/gpu-cluster-security/tests/
+          skills/evaluation/discover-environment/tests/
+          -v
 
   test-integration:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is loosely based on Keep a Changelog.
 ### Changed
 - Removed the redirect-only `skills/ai-infra-security/` and `skills/compliance-cis-mitre/` stubs after the layered skill reshape settled.
 - Reframed `skills/detection-engineering/` as a shared OCSF contract and golden-fixture namespace rather than a temporary transition root.
+- Collapsed the largest CI matrices into grouped test lanes and added workflow concurrency so superseded PR runs cancel instead of flooding the queue.
+- Added repo-level dependency/import consistency validation and aligned missing cloud SDK declarations in `pyproject.toml`.
 
 ### Documentation
 - Clarified the repo-level release model: one repo version, lightweight per-skill contract metadata, no full per-skill semver yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ metadata:
 2. Add or modify skills following the structure above
 3. Ensure tests pass: `pytest skills/<layer>/your-skill/tests/ -v`
 4. Ensure linting passes: `ruff check .`
-5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, and `python scripts/validate_safe_skill_bar.py`
+5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, `python scripts/validate_dependency_consistency.py`, and `python scripts/validate_safe_skill_bar.py`
 6. Open a PR against `main` with a clear description
 
 ## Security

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -11,13 +11,13 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - `safe-skill-bar`
   - policy lane for abuse resistance, write-path guardrails, wildcard IAM exceptions, secrets scan, and dependency audit against the repo's declared project dependencies
 - `test-compliance`
-  - benchmark skills grouped under one matrix
+  - benchmark skills grouped under one lane
 - `test-remediation`
   - write-capable workflows isolated from read-only checks
 - `test-detection-engineering`
-  - OCSF ingest, detect, and convert skills
+  - OCSF ingest, detect, and convert skills in one grouped lane
 - `test-ai-infra`
-  - model serving, GPU, and environment-discovery skills
+  - model serving, GPU, and environment-discovery skills in one grouped lane
 - `test-integration`
   - cross-skill contracts and pipe-level regression tests
 - `validate-iac`
@@ -31,13 +31,14 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - Keep required checks small and actionable.
 - Keep advisory scans separate from merge-blocking gates.
 - Install only the packages each lane needs.
-- Prefer matrix lanes by skill family instead of one global `pytest skills/`.
+- Prefer grouped layer lanes over per-skill matrix fan-out when the skill family can share one dependency set.
+- Cancel stale in-flight runs on the same PR branch so queued checks do not pile up behind superseded pushes.
 
 ## Next Tightenings
 
 1. Pin all third-party GitHub Actions to immutable SHAs.
-2. Move repeated skill-family package sets into dependency groups or lock-backed sync commands.
-3. Add a reusable workflow for test lanes if matrix shapes keep growing.
+2. Move repeated skill-family package sets into lock-backed sync commands once the dependency groups settle further.
+3. Add a reusable workflow for test lanes only if grouped lanes stop being sufficient.
 
 ## Dependency Policy
 
@@ -48,3 +49,5 @@ Dependency refreshes should land in grouped batches, not one-package PR spam:
 - `deps: cloud-sdks`
 
 Use the dependency hygiene skill spec as the review contract for those batches.
+
+The `skill-contract` lane also enforces repo-level dependency/import consistency so cloud SDK imports cannot drift away from the declared dependency groups in `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,13 @@ gcp = [
 azure = [
   "azure-identity>=1.17,<2",
   "azure-mgmt-network>=28,<29",
+  "azure-mgmt-resource>=25,<26",
   "azure-mgmt-storage>=21,<22",
 ]
 iam_departures = [
   "clickhouse-connect>=0.7,<1",
   "databricks-sql-connector>=4.2.5,<5",
+  "google-api-python-client>=2,<3",
   "httpx>=0.27,<1",
   "snowflake-connector-python>=4.4.0,<5",
 ]

--- a/scripts/validate_dependency_consistency.py
+++ b/scripts/validate_dependency_consistency.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import ast
+import sys
+import tomllib
+from pathlib import Path
+
+from skill_validation_common import ROOT
+
+PYPROJECT = ROOT / "pyproject.toml"
+
+IMPORT_TO_PACKAGE = {
+    "azure.identity": "azure-identity",
+    "azure.mgmt.network": "azure-mgmt-network",
+    "azure.mgmt.resource": "azure-mgmt-resource",
+    "azure.mgmt.storage": "azure-mgmt-storage",
+    "boto3": "boto3",
+    "botocore": "boto3",
+    "clickhouse_connect": "clickhouse-connect",
+    "databricks": "databricks-sql-connector",
+    "google.cloud.compute_v1": "google-cloud-compute",
+    "google.cloud.iam_admin_v1": "google-cloud-iam",
+    "google.cloud.iam_v1": "google-cloud-iam",
+    "google.cloud.resourcemanager_v3": "google-cloud-resource-manager",
+    "google.cloud.storage": "google-cloud-storage",
+    "googleapiclient": "google-api-python-client",
+    "httpx": "httpx",
+    "moto": "moto",
+    "pytest": "pytest",
+    "snowflake.connector": "snowflake-connector-python",
+}
+
+RUNTIME_ROOTS = (
+    *(ROOT / "skills").glob("*/*/src"),
+    ROOT / "mcp-server" / "src",
+    ROOT / "scripts",
+)
+TEST_ROOTS = (
+    ROOT / "tests",
+    ROOT / "mcp-server" / "tests",
+)
+
+
+def _canonical_package(spec: str) -> str:
+    package = spec.split("[", 1)[0]
+    for marker in (">=", "<=", "==", "~=", "!=", "<", ">"):
+        package = package.split(marker, 1)[0]
+    return package
+
+
+def _load_dependency_groups() -> dict[str, set[str]]:
+    data = tomllib.loads(PYPROJECT.read_text())
+    groups = data.get("dependency-groups", {})
+    return {group: {_canonical_package(spec) for spec in specs} for group, specs in groups.items()}
+
+
+def _iter_python_files(*roots: Path) -> list[Path]:
+    paths: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            paths.append(root)
+            continue
+        if root.exists():
+            paths.extend(sorted(root.rglob("*.py")))
+    return paths
+
+
+def _extract_imports(path: Path) -> set[str]:
+    names: set[str] = set()
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level != 0 or not node.module:
+                continue
+            names.add(node.module)
+            for alias in node.names:
+                if alias.name != "*":
+                    names.add(f"{node.module}.{alias.name}")
+    return names
+
+
+def _required_packages(paths: list[Path]) -> set[str]:
+    imports: set[str] = set()
+    for path in paths:
+        imports.update(_extract_imports(path))
+
+    packages: set[str] = set()
+    for name in imports:
+        for prefix, package in IMPORT_TO_PACKAGE.items():
+            if name == prefix or name.startswith(f"{prefix}."):
+                packages.add(package)
+                break
+    return packages
+
+
+def main() -> int:
+    groups = _load_dependency_groups()
+    errors: list[str] = []
+
+    owners: dict[str, list[str]] = {}
+    for group, packages in groups.items():
+        for package in packages:
+            owners.setdefault(package, []).append(group)
+    for package, group_names in sorted(owners.items()):
+        if len(group_names) > 1:
+            errors.append(
+                f"pyproject.toml: package `{package}` is duplicated across dependency groups: "
+                f"{', '.join(sorted(group_names))}"
+            )
+
+    runtime_required = _required_packages(_iter_python_files(*RUNTIME_ROOTS))
+    runtime_declared = set().union(
+        groups.get("aws", set()),
+        groups.get("gcp", set()),
+        groups.get("azure", set()),
+        groups.get("iam_departures", set()),
+    )
+    for package in sorted(runtime_required - runtime_declared):
+        errors.append(f"pyproject.toml: runtime import requires undeclared package `{package}`")
+
+    test_roots = [*TEST_ROOTS, *(ROOT / "skills").glob("*/*/tests")]
+    test_required = _required_packages(_iter_python_files(*test_roots))
+    dev_declared = groups.get("dev", set())
+    for package in sorted(test_required & {"pytest", "moto"}):
+        if package not in dev_declared:
+            errors.append(f"pyproject.toml: test import requires `{package}` in the dev dependency group")
+
+    if errors:
+        print("Dependency consistency validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("Dependency consistency validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -35,6 +35,10 @@ INTEGRITY = _load_module(
     "cloud_security_validate_skill_integrity_test",
     SCRIPTS / "validate_skill_integrity.py",
 )
+DEPENDENCIES = _load_module(
+    "cloud_security_validate_dependency_consistency_test",
+    SCRIPTS / "validate_dependency_consistency.py",
+)
 
 
 class TestSkillValidationCommon:
@@ -67,3 +71,6 @@ class TestValidationScripts:
 
     def test_integrity_validator_passes(self):
         assert INTEGRITY.main() == 0
+
+    def test_dependency_consistency_validator_passes(self):
+        assert DEPENDENCIES.main() == 0


### PR DESCRIPTION
Summary
- collapse the largest per-skill matrices into grouped test lanes and add workflow concurrency
- add repo-level dependency/import consistency validation and wire it into the skill-contract lane
- align pyproject cloud SDK declarations with the actual runtime imports

Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_dependency_consistency.py
- python scripts/validate_safe_skill_bar.py
- uv run pytest tests/integration/test_skill_validation_scripts.py mcp-server/tests/ -q -o addopts='--import-mode=importlib'
- uv run ruff check scripts/validate_dependency_consistency.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml

Notes
- This reduces GitHub check fan-out substantially while keeping the same broad CI lanes.
- The new validator guards against cloud SDK import drift and undeclared dependency creep at the repo level instead of per-skill one-offs.