### PR TITLE
security: harden snowflake logging and cross-cloud docs

### DIFF
--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -93,8 +93,8 @@ cat merged.ocsf.jsonl \
 ## What does NOT fire
 
 - identity pivot with no subsequent internal traffic → not fired
-- Internal traffic with no preceding `AssumeRole` → not fired (covered by other detectors)
-- `AssumeRole` followed by egress traffic (public internet dst) → not fired (data exfil detector, roadmap)
+- Internal traffic with no preceding identity-pivot anchor (`AssumeRole*`, service-account impersonation, or Azure access-elevation event) → not fired
+- Identity-pivot anchor followed by egress traffic (public internet dst) → not fired (data exfil detector, roadmap)
 - identity pivots with no valid `cloud.provider` or account context → not fired
 - Small flows under 1024 bytes → filtered (scan / handshake noise)
 - `REJECT` flows → not fired (failed connection attempts don't count as movement)

--- a/skills/detection/detect-lateral-movement/tests/test_detect.py
+++ b/skills/detection/detect-lateral-movement/tests/test_detect.py
@@ -277,6 +277,8 @@ class TestCrossCloudAnchors:
         findings = list(detect([anchor, flow]))
         assert len(findings) == 1
         assert findings[0]["observables"][0]["value"] == "GCP"
+        assert findings[0]["finding_info"]["title"].startswith("GCP lateral movement")
+        assert "canonical GCP lateral movement pattern" in findings[0]["finding_info"]["desc"]
 
     def test_azure_identity_pivot_fires(self):
         anchor = _anchor_event(
@@ -294,6 +296,8 @@ class TestCrossCloudAnchors:
         findings = list(detect([anchor, flow]))
         assert len(findings) == 1
         assert findings[0]["observables"][0]["value"] == "Azure"
+        assert findings[0]["finding_info"]["title"].startswith("Azure lateral movement")
+        assert "canonical Azure lateral movement pattern" in findings[0]["finding_info"]["desc"]
 
     def test_provider_mismatch_does_not_fire(self):
         anchor = _anchor_event(provider="AWS", session_uid="aws-session-1")

--- a/skills/remediation/iam-departures-remediation/src/lambda_worker/clouds/snowflake_user.py
+++ b/skills/remediation/iam-departures-remediation/src/lambda_worker/clouds/snowflake_user.py
@@ -72,6 +72,11 @@ _OWNERSHIP_OBJECT_TYPES = [
 _IDENTIFIER_RE = re.compile(r"^[^\x00\r\n]+$")
 
 
+def _configure_snowflake_logging() -> None:
+    """Suppress verbose connector logging before credentials are used."""
+    logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
+
+
 def get_required_permissions() -> list[str]:
     """Return minimum Snowflake privileges needed."""
     return [
@@ -85,6 +90,7 @@ def _get_connection():
     """Create authenticated Snowflake connection."""
     import snowflake.connector
 
+    _configure_snowflake_logging()
     return snowflake.connector.connect(
         account=os.environ["SNOWFLAKE_REMEDIATION_ACCOUNT"],
         user=os.environ["SNOWFLAKE_REMEDIATION_USER"],

--- a/skills/remediation/iam-departures-remediation/src/reconciler/sources.py
+++ b/skills/remediation/iam-departures-remediation/src/reconciler/sources.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def _configure_snowflake_logging() -> None:
+    """Suppress verbose connector logging before credentials are used."""
+    logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
+
+
 class RemediationStatus(Enum):
     """Lifecycle state of a departure record."""
 
@@ -213,6 +218,7 @@ class SnowflakeSource(HRSource):
     def _get_connection(self) -> Any:
         import snowflake.connector
 
+        _configure_snowflake_logging()
         return snowflake.connector.connect(
             account=self.account,
             user=self.user,

--- a/skills/remediation/iam-departures-remediation/tests/test_cross_cloud_workers.py
+++ b/skills/remediation/iam-departures-remediation/tests/test_cross_cloud_workers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -190,6 +191,18 @@ class TestSnowflake:
         assert "VIEWS" in _OWNERSHIP_OBJECT_TYPES
         assert "SCHEMAS" in _OWNERSHIP_OBJECT_TYPES
         assert "STAGES" in _OWNERSHIP_OBJECT_TYPES
+
+    def test_suppresses_verbose_connector_logs(self):
+        from lambda_worker.clouds import snowflake_user
+
+        with patch("lambda_worker.clouds.snowflake_user.logging.getLogger") as mock_get_logger:
+            connector_logger = MagicMock()
+            mock_get_logger.return_value = connector_logger
+
+            snowflake_user._configure_snowflake_logging()
+
+        mock_get_logger.assert_called_once_with("snowflake.connector")
+        connector_logger.setLevel.assert_called_once_with(snowflake_user.logging.WARNING)
 
 
 # ── Databricks ───────────────────────────────────────────────────

--- a/skills/remediation/iam-departures-remediation/tests/test_reconciler.py
+++ b/skills/remediation/iam-departures-remediation/tests/test_reconciler.py
@@ -256,3 +256,17 @@ class TestSourceFactory:
     )
     def test_clickhouse_source_creation(self):
         assert get_source("clickhouse").__class__.__name__ == "ClickHouseSource"
+
+
+class TestSnowflakeLogging:
+    def test_snowflake_source_suppresses_verbose_connector_logs(self):
+        from reconciler import sources
+
+        with patch("reconciler.sources.logging.getLogger") as mock_get_logger:
+            connector_logger = MagicMock()
+            mock_get_logger.return_value = connector_logger
+
+            sources._configure_snowflake_logging()
+
+        mock_get_logger.assert_called_once_with("snowflake.connector")
+        connector_logger.setLevel.assert_called_once_with(sources.logging.WARNING)


### PR DESCRIPTION
## Summary
- suppress verbose Snowflake connector logs in the reconciler and remediation worker before credentials are used
- add regression coverage for the Snowflake logging guard in both reconciler and worker tests
- polish detect-lateral-movement wording and tests so the skill is clearly cross-cloud, not AWS-only

## Validation
- uv run ruff check skills/remediation/iam-departures-remediation/src/reconciler/sources.py skills/remediation/iam-departures-remediation/src/lambda_worker/clouds/snowflake_user.py skills/remediation/iam-departures-remediation/tests/test_reconciler.py skills/remediation/iam-departures-remediation/tests/test_cross_cloud_workers.py skills/detection/detect-lateral-movement/tests/test_detect.py --config pyproject.toml
- uv run pytest skills/remediation/iam-departures-remediation/tests/test_reconciler.py skills/remediation/iam-departures-remediation/tests/test_cross_cloud_workers.py skills/detection/detect-lateral-movement/tests/test_detect.py -q -o addopts='"--import-mode=importlib"'
