### PR TITLE
feat: add discovery-layer control evidence skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
           for skill_dir in \
             skills/discovery/discover-environment \
             skills/discovery/discover-ai-bom \
+            skills/discovery/discover-control-evidence \
             skills/evaluation/model-serving-security \
             skills/evaluation/gpu-cluster-security
           do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Skills are organised into layered categories. See [`skills/README.md`](skills/RE
 **`discovery/`** (point-in-time inventory / graph / BOM)
 - `discover-environment`
 - `discover-ai-bom`
+- `discover-control-evidence`
 
 **`detection/`** (OCSF → OCSF Detection Finding 2004 + MITRE)
 - `detect-mcp-tool-drift`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on Keep a Changelog.
 - Repo-wide `CHANGELOG.md` to make material architecture, security, and skill changes discoverable without reading every PR.
 - [`docs/FRAMEWORK_MAPPINGS.md`](docs/FRAMEWORK_MAPPINGS.md) to consolidate ATT&CK, ATLAS, CIS, NIST, OWASP, SOC 2, ISO, and PCI coverage across the repo.
 - First `discovery/` layer AI BOM skill, `discover-ai-bom`, which turns AI asset inventory snapshots into a deterministic CycloneDX-aligned BOM.
+- First discovery-layer technical evidence skill, `discover-control-evidence`, which turns discovery artifacts into deterministic PCI / SOC 2 evidence JSON.
 
 ### Changed
 - Removed the redirect-only `skills/ai-infra-security/` and `skills/compliance-cis-mitre/` stubs after the layered skill reshape settled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ skills/
 ├── discovery/                     # inventory / graph / AI BOM
 │   ├── discover-environment/
 │   └── discover-ai-bom/
+│   └── discover-control-evidence/
 │
 ├── detection/                     # OCSF → Detection Finding 2004 + MITRE
 │   ├── detect-mcp-tool-drift/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ skills/
 ├── discovery/                      "Point-in-time inventory and graph evidence"
 │   ├── discover-environment                      → MITRE ATT&CK + ATLAS graph overlay
 │   └── discover-ai-bom                           → CycloneDX-aligned AI BOM
+│   └── discover-control-evidence                 → PCI / SOC 2 technical evidence JSON
 │
 ├── detection/                      "What attack pattern does this event stream show?"
 │   ├── detect-lateral-movement                    → T1021 / T1078.004 cross-cloud pivot
@@ -119,7 +120,7 @@ skills/
     └── iam-departures-remediation  (event-driven, DLQ + SNS, dual audit)
 ```
 
-**Roadmap:** current open issues focus on AWS Config and deeper evaluation coverage, richer MCP input schemas and transports, additional cloud and AI service coverage, vendor stories, and deeper discovery / inventory follow-ons beyond the first AI BOM capability.
+**Roadmap:** current open issues focus on AWS Config and deeper evaluation coverage, richer MCP input schemas and transports, additional cloud and AI service coverage, vendor stories, and deeper discovery / inventory follow-ons beyond the first AI BOM and evidence capabilities.
 
 </details>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,7 @@ This is how the repo stays secure and reliable without turning every skill into 
  ├───────────────────────────────────────────────────────────────────┤
 │ L2  DISCOVER /      inventory + context                           │
 │     ENRICH          discover-environment, discover-ai-bom,        │
+│                     discover-control-evidence,                    │
 │                     enrich-asset-inventory, enrich-geoip,         │
 │                     enrich-mitre-navigator, enrich-pii-redact     │
  ├───────────────────────────────────────────────────────────────────┤
@@ -111,7 +112,7 @@ The rule for this repo is simple: keep the architecture readable in Markdown, an
 |---|---|---|---|---|
 | L0 | sources | (external) | n/a | vendor stories #30–#36, Ramp (PR Y), Snowflake audit (PR Z) |
 | L1 | `ingest-*` | **shipping** | cloudtrail, aws-vpc-flow, gcp-vpc-flow, azure-nsg-flow, guardduty, security-hub, gcp-scc, azure-defender, gcp-audit, azure-activity, k8s-audit, mcp-proxy | okta, github, workspace, slack, ramp |
-| L2 | `discovery/` + `enrich-*` | **shipping / planned** | discover-environment, discover-ai-bom | PR X (asset-inventory, geoip, mitre-navigator, **pii-redact is P0 before any sink in regulated env**) |
+| L2 | `discovery/` + `enrich-*` | **shipping / planned** | discover-environment, discover-ai-bom, discover-control-evidence | PR X (asset-inventory, geoip, mitre-navigator, **pii-redact is P0 before any sink in regulated env**) |
 | L3 | `detect-*` | **shipping** | lateral-movement, privesc-k8s, sensitive-secret-read-k8s, mcp-tool-drift | credential-access per cloud, unusual-assume-role, vector-store-poisoning |
 | L4 | `evaluate-*` | **shipping** | cspm-aws/gcp/azure-cis-benchmark, k8s-security-benchmark, container-security | evaluate-cis-aws-foundations (#29), NIST AI RMF, SOC2, PCI |
 | L5 | `remediate-*` | **shipping** | iam-departures-remediation | auto-close-exposed-s3, revoke-long-lived-key, patch-inspector-finding |

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -17,7 +17,7 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - `test-detection-engineering`
   - OCSF ingest, detect, and convert skills in one grouped lane
 - `test-ai-infra`
-  - discovery, model serving, GPU, and AI inventory/BOM skills in one grouped lane
+  - discovery, evidence, model serving, GPU, and AI inventory/BOM skills in one grouped lane
 - `test-integration`
   - cross-skill contracts and pipe-level regression tests
 - `validate-iac`

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -66,6 +66,7 @@ ATLAS is present today, but coverage is narrower than ATT&CK.
 | `discover-environment` | graph overlay for AI/ML resources and adversarial ML techniques |
 | `model-serving-security` | explicit ATLAS coverage in skill docs and checks |
 | `discover-ai-bom` | inventory artifact for future ATLAS / AI RMF evidence joins |
+| `discover-control-evidence` | evidence package that preserves ATLAS / AI RMF context from discovery artifacts |
 
 Recommended expansion:
 - make ATLAS mappings more explicit in `gpu-cluster-security`
@@ -92,6 +93,7 @@ uniform than classic cloud posture.
 | Skill | Frameworks called out today |
 |---|---|
 | `discover-ai-bom` | CycloneDX ML-BOM, NIST AI RMF, MITRE ATLAS, PCI, SOC 2 |
+| `discover-control-evidence` | PCI DSS 4.0, SOC 2 TSC, CycloneDX ML-BOM, MITRE ATLAS |
 | `model-serving-security` | MITRE ATLAS, NIST CSF, OWASP LLM Top 10, SOC 2 |
 | `gpu-cluster-security` | MITRE ATT&CK, NIST CSF, CIS Controls, CIS Kubernetes |
 | `discover-environment` | MITRE ATT&CK, MITRE ATLAS, NIST CSF |
@@ -122,6 +124,7 @@ AI BOM is **not** the identity of the repo, but it is now a shipped discovery ca
 Current fit:
 - **collection / inventory input** in `discovery/`
 - **normalization** into a deterministic CycloneDX-aligned AI BOM artifact
+- **technical evidence output** via discovery-layer evidence packaging for PCI and SOC 2 reviews
 - **future evaluation joins** against ATLAS, NIST AI RMF, OWASP LLM Top 10, PCI, and SOC 2 evidence pipelines
 
 That keeps AI BOM as one important capability inside a broader cloud + AI security skills repo.

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -22,7 +22,7 @@ tool_map = MODULE.tool_map
 class TestDiscovery:
     def test_discovers_all_skills(self):
         skills = discover_skills(REPO_ROOT)
-        assert len(skills) == 28
+        assert len(skills) == 29
         assert {skill.name for skill in skills} >= {
             "ingest-cloudtrail-ocsf",
             "detect-lateral-movement",
@@ -33,6 +33,7 @@ class TestDiscovery:
             "ingest-gcp-scc-ocsf",
             "ingest-azure-defender-for-cloud-ocsf",
             "discover-ai-bom",
+            "discover-control-evidence",
         }
 
     def test_marks_remediation_skill_without_cli_entrypoint_as_unsupported(self):
@@ -46,6 +47,7 @@ class TestDiscovery:
         assert "detect-lateral-movement" in tools
         assert "model-serving-security" in tools
         assert "discover-ai-bom" in tools
+        assert "discover-control-evidence" in tools
 
 
 class TestToolDefinition:

--- a/skills/README.md
+++ b/skills/README.md
@@ -53,6 +53,7 @@ Read-only inventory, graph, and AI BOM skills.
 |---|---|
 | [`discover-environment`](discovery/discover-environment/) | Multi-cloud discovery / graph overlay |
 | [`discover-ai-bom`](discovery/discover-ai-bom/) | AI asset inventory → CycloneDX-aligned AI BOM |
+| [`discover-control-evidence`](discovery/discover-control-evidence/) | Discovery artifact → PCI / SOC 2 technical evidence JSON |
 
 ## evaluation/
 

--- a/skills/discovery/discover-control-evidence/REFERENCES.md
+++ b/skills/discovery/discover-control-evidence/REFERENCES.md
@@ -1,0 +1,11 @@
+# References
+
+Only official sources are allowed here. This skill relies on:
+
+- PCI DSS standards overview: https://www.pcisecuritystandards.org/standards/pci-dss/
+- AICPA / SOC reporting overview: https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2
+- CycloneDX capabilities overview (including ML-BOM): https://cyclonedx.org/capabilities/
+- CycloneDX AI models and model cards use case: https://cyclonedx.org/use-cases/ai-models-and-model-cards/
+- CycloneDX software dependency use case (`bom-ref`, dependency graph): https://cyclonedx.org/use-cases/software-dependencies/
+- NIST AI Risk Management Framework: https://www.nist.gov/itl/ai-risk-management-framework
+- MITRE ATLAS: https://atlas.mitre.org/

--- a/skills/discovery/discover-control-evidence/SKILL.md
+++ b/skills/discovery/discover-control-evidence/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: discover-control-evidence
+description: >-
+  Generate deterministic technical-control evidence from discovery-layer
+  inventory artifacts. Supports CycloneDX-aligned AI BOM documents from
+  discover-ai-bom and graph snapshots from discover-environment. Produces a
+  machine-readable evidence package for PCI DSS 4.0 and SOC 2 security reviews
+  without claiming pass/fail attestation. Use when the user mentions PCI
+  evidence, SOC 2 evidence, audit evidence, control evidence, inventory-backed
+  evidence, or wants a reviewable JSON package that shows what AI or cloud
+  assets exist, which services are externally reachable, and which dependency
+  relationships are documented. Do NOT use as a compliance certification tool,
+  benchmark evaluator, or remediation planner. Do NOT use on raw logs or
+  findings — this skill expects inventory artifacts, not events.
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+. Read-only. Accepts discovery-layer JSON from stdin or
+  a file path. Produces deterministic JSON evidence suitable for CLI, CI, MCP,
+  and persistent pipelines.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-security
+  source: https://github.com/msaad00/cloud-security/tree/main/skills/discovery/discover-control-evidence
+  version: 0.1.0
+  frameworks:
+    - PCI DSS 4.0
+    - SOC 2 TSC
+    - CycloneDX ML-BOM
+    - MITRE ATLAS
+  cloud: multi
+  capability: read-only
+---
+
+# discover-control-evidence
+
+Transforms trusted discovery artifacts into a technical evidence package. The
+goal is to give auditors, security engineers, and agents a single JSON document
+that shows what was inventoried and which evidence domains are currently
+covered, without pretending that inventory alone proves compliance.
+
+## Use when
+
+- You need machine-readable evidence for PCI DSS 4.0 or SOC 2 reviews
+- You want to summarize AI BOM or environment-graph artifacts into review-ready evidence
+- You need inventory-backed evidence for endpoints, dependencies, datasets, guardrails, and providers
+- You want stable JSON that can be diffed over time or attached to tickets and audits
+
+## Do NOT use
+
+- As a benchmark or control pass/fail engine
+- As a replacement for auditor judgement or formal attestation
+- On raw logs, OCSF findings, or cloud audit streams
+- To infer exploitability or blast radius on its own
+
+## Input contract
+
+The skill accepts one JSON document in either of these shapes:
+
+1. **CycloneDX-aligned AI BOM**
+   - `bomFormat: CycloneDX`
+   - `components[]`, `services[]`, optional `dependencies[]`
+
+2. **Environment graph**
+   - `nodes[]`, `edges[]`, optional `stats`
+
+## Output contract
+
+The skill emits one deterministic JSON document:
+
+- `artifact_type: technical-control-evidence`
+- `frameworks[]` with the requested evidence families
+- `inventory_summary` with providers, services, asset counts, and dependency counts
+- `controls[]` with evidence-ready / partial / missing status per control domain
+- `gaps[]` only when the source artifact cannot support a given evidence domain
+
+This is evidence, not an attestation.
+
+## Usage
+
+```bash
+# From an AI BOM
+python src/discover.py ai-bom.json > evidence.json
+
+# From an environment graph
+python src/discover.py graph.json --framework pci --framework soc2 > evidence.json
+
+# Pretty-print to a file
+python src/discover.py ai-bom.json --pretty -o control-evidence.json
+```
+
+## Security guardrails
+
+- Read-only only. No network calls, no subprocesses, no writes outside the requested output file.
+- Secret-like fields are dropped before evidence is generated.
+- Unknown source shapes fail closed with a non-zero exit.
+- The skill never emits “compliant” / “non-compliant”; it only reports evidence presence and gaps.
+
+## See also
+
+- [`../discover-ai-bom/SKILL.md`](../discover-ai-bom/SKILL.md) — AI BOM generation
+- [`../discover-environment/SKILL.md`](../discover-environment/SKILL.md) — graph inventory generation
+- [`../../evaluation/model-serving-security/SKILL.md`](../../evaluation/model-serving-security/SKILL.md) — posture checks for AI services

--- a/skills/discovery/discover-control-evidence/src/discover.py
+++ b/skills/discovery/discover-control-evidence/src/discover.py
@@ -1,0 +1,376 @@
+"""Generate technical control evidence from discovery-layer inventory artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "discover-control-evidence"
+SUPPORTED_FRAMEWORKS = ("pci", "soc2")
+SECRET_KEYWORDS = (
+    "authorization",
+    "client_secret",
+    "connection_string",
+    "credential",
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "access_key",
+)
+FRAMEWORK_LABELS = {
+    "pci": "PCI DSS 4.0",
+    "soc2": "SOC 2 Security",
+}
+
+
+def _load_json(path: str | None) -> dict[str, Any]:
+    if path:
+        return json.loads(Path(path).read_text())
+    return json.load(sys.stdin)
+
+
+def _warn(message: str) -> None:
+    print(f"warning: {message}", file=sys.stderr)
+
+
+def _secret_like(key: str) -> bool:
+    key = key.lower().replace("-", "_")
+    return any(fragment in key for fragment in SECRET_KEYWORDS)
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, child in value.items():
+            if _secret_like(key):
+                continue
+            cleaned_child = _sanitize(child)
+            if cleaned_child in (None, {}, []):
+                continue
+            cleaned[key] = cleaned_child
+        return cleaned
+    if isinstance(value, list):
+        cleaned_list = [_sanitize(item) for item in value]
+        return [item for item in cleaned_list if item not in (None, {}, [])]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _clean(mapping: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in mapping.items() if value not in (None, "", [], {})}
+
+
+def _string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_frameworks(frameworks: list[str] | None) -> list[str]:
+    if not frameworks:
+        return list(SUPPORTED_FRAMEWORKS)
+    normalized = []
+    for item in frameworks:
+        key = item.strip().lower()
+        if key not in SUPPORTED_FRAMEWORKS:
+            raise ValueError(f"unsupported framework `{item}`; supported values: {', '.join(SUPPORTED_FRAMEWORKS)}")
+        if key not in normalized:
+            normalized.append(key)
+    return normalized
+
+
+def _asset_key(asset: dict[str, Any]) -> str:
+    provider = _string(asset.get("provider")) or "unknown"
+    service = _string(asset.get("service")) or "unknown"
+    kind = _string(asset.get("kind")) or "unknown"
+    identifier = _string(asset.get("id")) or _string(asset.get("name"))
+    if not identifier:
+        raise ValueError("normalized asset is missing both `id` and `name`")
+    return f"{provider}:{service}:{kind}:{identifier}"
+
+
+def _normalize_bom(document: dict[str, Any]) -> dict[str, Any]:
+    components = document.get("components")
+    services = document.get("services")
+    if not isinstance(components, list) and not isinstance(services, list):
+        raise ValueError("CycloneDX BOM must include `components[]` or `services[]`")
+
+    assets: list[dict[str, Any]] = []
+    for component in components or []:
+        props = {item.get("name"): item.get("value") for item in component.get("properties", []) if isinstance(item, dict)}
+        assets.append(
+            _clean(
+                {
+                    "provider": props.get("cloud-security:provider"),
+                    "service": props.get("cloud-security:service"),
+                    "kind": props.get("cloud-security:kind") or component.get("type"),
+                    "id": component.get("bom-ref"),
+                    "name": component.get("name"),
+                    "version": component.get("version"),
+                }
+            )
+        )
+
+    for service in services or []:
+        props = {item.get("name"): item.get("value") for item in service.get("properties", []) if isinstance(item, dict)}
+        assets.append(
+            _clean(
+                {
+                    "provider": props.get("cloud-security:provider"),
+                    "service": props.get("cloud-security:service"),
+                    "kind": props.get("cloud-security:kind") or "service",
+                    "id": service.get("bom-ref"),
+                    "name": service.get("name"),
+                    "endpoint_url": next(iter(service.get("endpoints", []) or []), None),
+                }
+            )
+        )
+
+    dependencies = [
+        {
+            "source": item.get("ref"),
+            "target": dep,
+        }
+        for item in document.get("dependencies", []) or []
+        if isinstance(item, dict)
+        for dep in item.get("dependsOn", []) or []
+        if _string(item.get("ref")) and _string(dep)
+    ]
+
+    return {
+        "source_kind": "cyclonedx-ai-bom",
+        "source_id": document.get("serialNumber"),
+        "collected_at": ((document.get("metadata") or {}).get("timestamp")),
+        "assets": assets,
+        "dependencies": dependencies,
+    }
+
+
+def _normalize_graph(document: dict[str, Any]) -> dict[str, Any]:
+    nodes = document.get("nodes")
+    edges = document.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        raise ValueError("environment graph must include `nodes[]` and `edges[]`")
+
+    assets = []
+    for node in nodes:
+        dimensions = node.get("dimensions", {}) if isinstance(node, dict) else {}
+        attrs = node.get("attributes", {}) if isinstance(node, dict) else {}
+        if not isinstance(node, dict):
+            continue
+        assets.append(
+            _clean(
+                {
+                    "provider": dimensions.get("cloud_provider"),
+                    "service": dimensions.get("service"),
+                    "kind": node.get("entity_type"),
+                    "id": node.get("id"),
+                    "name": node.get("label"),
+                    "arn": attrs.get("arn"),
+                    "region": dimensions.get("region"),
+                }
+            )
+        )
+
+    relationships = []
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        source = _string(edge.get("source"))
+        target = _string(edge.get("target"))
+        if source and target:
+            relationships.append({"source": source, "target": target, "relationship": edge.get("relationship")})
+
+    return {
+        "source_kind": "environment-graph",
+        "source_id": document.get("scan_id"),
+        "collected_at": document.get("discovered_at"),
+        "assets": assets,
+        "dependencies": relationships,
+    }
+
+
+def normalize_source(document: dict[str, Any]) -> dict[str, Any]:
+    sanitized = _sanitize(document)
+    if sanitized.get("bomFormat") == "CycloneDX":
+        return _normalize_bom(sanitized)
+    if "nodes" in sanitized and "edges" in sanitized:
+        return _normalize_graph(sanitized)
+    raise ValueError("input must be a CycloneDX AI BOM or an environment graph snapshot")
+
+
+def _summaries(normalized: dict[str, Any]) -> dict[str, Any]:
+    assets = normalized["assets"]
+    dependencies = normalized["dependencies"]
+
+    providers = sorted({_string(asset.get("provider")) or "unknown" for asset in assets})
+    services = sorted({_string(asset.get("service")) or "unknown" for asset in assets})
+    kinds = Counter((_string(asset.get("kind")) or "unknown") for asset in assets)
+    external_services = []
+    for asset in assets:
+        endpoint = _string(asset.get("endpoint_url"))
+        if endpoint:
+            external_services.append(
+                _clean(
+                    {
+                        "provider": asset.get("provider"),
+                        "service": asset.get("service"),
+                        "name": asset.get("name"),
+                        "endpoint_url": endpoint,
+                    }
+                )
+            )
+
+    return {
+        "providers": providers,
+        "services": services,
+        "asset_count": len(assets),
+        "dependency_count": len(dependencies),
+        "kind_counts": dict(sorted(kinds.items())),
+        "external_services": sorted(external_services, key=lambda item: json.dumps(item, sort_keys=True)),
+    }
+
+
+def _status(has_enough: bool, has_some: bool) -> str:
+    if has_enough:
+        return "evidence-ready"
+    if has_some:
+        return "partial"
+    return "missing"
+
+
+def _control(framework: str, control_id: str, title: str, description: str, evidence: list[dict[str, Any]], gaps: list[str]) -> dict[str, Any]:
+    status = _status(not gaps and bool(evidence), bool(evidence))
+    return {
+        "framework": FRAMEWORK_LABELS[framework],
+        "control_id": control_id,
+        "title": title,
+        "status": status,
+        "description": description,
+        "evidence": evidence,
+        "gaps": gaps,
+    }
+
+
+def build_evidence(document: dict[str, Any], frameworks: list[str] | None = None) -> dict[str, Any]:
+    normalized = normalize_source(document)
+    selected = _normalize_frameworks(frameworks)
+    summary = _summaries(normalized)
+    providers = summary["providers"]
+    kind_counts = summary["kind_counts"]
+    external_services = summary["external_services"]
+
+    base_evidence = [
+        {"type": "asset-count", "value": summary["asset_count"]},
+        {"type": "providers", "value": providers},
+        {"type": "services", "value": summary["services"]},
+        {"type": "kind-counts", "value": kind_counts},
+        {"type": "dependency-count", "value": summary["dependency_count"]},
+    ]
+
+    controls = []
+    for framework in selected:
+        if framework == "pci":
+            controls.extend(
+                [
+                    _control(
+                        framework,
+                        "inventory.system-components",
+                        "System component inventory evidence",
+                        "Evidence package showing inventoried AI and cloud system components relevant to cardholder-data environments or connected services.",
+                        base_evidence,
+                        [] if summary["asset_count"] else ["No assets were present in the source artifact."],
+                    ),
+                    _control(
+                        framework,
+                        "inventory.external-services",
+                        "Externally reachable service evidence",
+                        "Evidence package listing inventoried externally reachable endpoints and their provider/service context.",
+                        [{"type": "external-services", "value": external_services}] if external_services else [],
+                        [] if external_services else ["No externally reachable services were identified in the source artifact."],
+                    ),
+                ]
+            )
+        if framework == "soc2":
+            controls.extend(
+                [
+                    _control(
+                        framework,
+                        "system.inventory",
+                        "System inventory evidence",
+                        "Evidence package describing the systems, providers, and services currently present in the discovery artifact.",
+                        base_evidence,
+                        [] if summary["asset_count"] else ["No assets were present in the source artifact."],
+                    ),
+                    _control(
+                        framework,
+                        "system.dependencies",
+                        "Dependency and relationship evidence",
+                        "Evidence package summarizing explicit dependencies or graph relationships between inventoried assets.",
+                        [{"type": "dependencies", "value": normalized["dependencies"][:20]}] if normalized["dependencies"] else [],
+                        [] if normalized["dependencies"] else ["No explicit dependencies or graph relationships were present in the source artifact."],
+                    ),
+                ]
+            )
+
+    source_fingerprint = json.dumps(
+        {
+            "source_kind": normalized["source_kind"],
+            "source_id": normalized["source_id"],
+            "frameworks": selected,
+            "summary": summary,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+    return {
+        "artifact_type": "technical-control-evidence",
+        "generated_by": SKILL_NAME,
+        "frameworks": [FRAMEWORK_LABELS[item] for item in selected],
+        "source_kind": normalized["source_kind"],
+        "source_id": normalized["source_id"],
+        "collected_at": normalized.get("collected_at"),
+        "evidence_id": f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, source_fingerprint)}",
+        "inventory_summary": summary,
+        "controls": controls,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate deterministic technical-control evidence from discovery artifacts.")
+    parser.add_argument("input", nargs="?", help="Path to a discovery artifact JSON file. Reads stdin when omitted.")
+    parser.add_argument("--framework", dest="frameworks", action="append", help="Evidence family to emit: pci or soc2. Defaults to both.")
+    parser.add_argument("-o", "--output", help="Write JSON output to this file instead of stdout.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    args = parser.parse_args(argv)
+
+    try:
+        document = _load_json(args.input)
+        evidence = build_evidence(document, args.frameworks)
+    except Exception as exc:  # pragma: no cover - CLI error path
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    payload = json.dumps(evidence, indent=2 if args.pretty else None, sort_keys=args.pretty)
+    if args.pretty:
+        payload += "\n"
+
+    if args.output:
+        Path(args.output).write_text(payload)
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/discovery/discover-control-evidence/tests/test_discover.py
+++ b/skills/discovery/discover-control-evidence/tests/test_discover.py
@@ -1,0 +1,127 @@
+"""Tests for discover-control-evidence."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "discover.py"
+_SPEC = importlib.util.spec_from_file_location("discover_control_evidence", _SRC)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+build_evidence = _MODULE.build_evidence
+normalize_source = _MODULE.normalize_source
+
+
+def _bom() -> dict:
+    return {
+        "bomFormat": "CycloneDX",
+        "serialNumber": "urn:uuid:ai-bom-123",
+        "metadata": {"timestamp": "2026-04-12T00:00:00Z"},
+        "components": [
+            {
+                "bom-ref": "aws:sagemaker:model:model:fraud-v5",
+                "name": "fraud-model",
+                "type": "machine-learning-model",
+                "properties": [
+                    {"name": "cloud-security:provider", "value": "aws"},
+                    {"name": "cloud-security:service", "value": "sagemaker"},
+                    {"name": "cloud-security:kind", "value": "model"},
+                ],
+            }
+        ],
+        "services": [
+            {
+                "bom-ref": "aws:sagemaker:endpoint:endpoint:fraud-prod",
+                "name": "fraud-endpoint",
+                "endpoints": ["https://fraud.example.internal/invoke"],
+                "properties": [
+                    {"name": "cloud-security:provider", "value": "aws"},
+                    {"name": "cloud-security:service", "value": "sagemaker"},
+                    {"name": "cloud-security:kind", "value": "endpoint"},
+                    {"name": "cloud-security:token", "value": "drop-me"},
+                ],
+            }
+        ],
+        "dependencies": [
+            {
+                "ref": "aws:sagemaker:endpoint:endpoint:fraud-prod",
+                "dependsOn": ["aws:sagemaker:model:model:fraud-v5"],
+            }
+        ],
+    }
+
+
+def _graph() -> dict:
+    return {
+        "scan_id": "graph-001",
+        "discovered_at": "2026-04-12T01:00:00Z",
+        "nodes": [
+            {
+                "id": "aws:iam_user:alice",
+                "entity_type": "user",
+                "label": "alice",
+                "dimensions": {"cloud_provider": "aws", "service": "iam"},
+                "attributes": {"arn": "arn:aws:iam::123456789012:user/alice", "password": "drop-me"},
+            },
+            {
+                "id": "aws:lambda:score",
+                "entity_type": "service",
+                "label": "score",
+                "dimensions": {"cloud_provider": "aws", "service": "lambda"},
+            },
+        ],
+        "edges": [{"source": "aws:iam_user:alice", "target": "aws:lambda:score", "relationship": "uses"}],
+    }
+
+
+class TestNormalizeSource:
+    def test_accepts_cyclonedx_bom(self):
+        normalized = normalize_source(_bom())
+        assert normalized["source_kind"] == "cyclonedx-ai-bom"
+        assert len(normalized["assets"]) == 2
+
+    def test_accepts_environment_graph(self):
+        normalized = normalize_source(_graph())
+        assert normalized["source_kind"] == "environment-graph"
+        assert len(normalized["assets"]) == 2
+
+
+class TestBuildEvidence:
+    def test_builds_pci_and_soc2_controls(self):
+        evidence = build_evidence(_bom())
+        assert evidence["artifact_type"] == "technical-control-evidence"
+        assert evidence["frameworks"] == ["PCI DSS 4.0", "SOC 2 Security"]
+        assert len(evidence["controls"]) == 4
+        statuses = {control["status"] for control in evidence["controls"]}
+        assert "evidence-ready" in statuses
+
+    def test_drops_secret_like_properties(self):
+        normalized = normalize_source(_bom())
+        service_asset = next(asset for asset in normalized["assets"] if asset["kind"] == "endpoint")
+        assert "token" not in service_asset
+
+    def test_framework_filter(self):
+        evidence = build_evidence(_graph(), ["soc2"])
+        assert evidence["frameworks"] == ["SOC 2 Security"]
+        assert {control["framework"] for control in evidence["controls"]} == {"SOC 2 Security"}
+
+    def test_deterministic_output(self):
+        left = build_evidence(_bom())
+        right = build_evidence(_bom())
+        assert left == right
+
+    def test_graph_without_external_services_is_partial_for_pci_surface(self):
+        evidence = build_evidence(_graph(), ["pci"])
+        pci_surface = next(control for control in evidence["controls"] if control["control_id"] == "inventory.external-services")
+        assert pci_surface["status"] == "missing"
+
+    def test_invalid_input_raises(self):
+        try:
+            build_evidence({"unexpected": True})
+        except ValueError as exc:
+            assert "CycloneDX AI BOM" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected ValueError")

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -44,12 +44,13 @@ DEPENDENCIES = _load_module(
 class TestSkillValidationCommon:
     def test_discovers_skills_and_entrypoints(self):
         skills = COMMON.discover_skill_contracts()
-        assert len(skills) >= 28
+        assert len(skills) >= 29
         names = {skill.name for skill in skills}
         assert "detect-lateral-movement" in names
         assert "ingest-gcp-scc-ocsf" in names
         assert "ingest-azure-defender-for-cloud-ocsf" in names
         assert "discover-ai-bom" in names
+        assert "discover-control-evidence" in names
 
         ingest = next(skill for skill in skills if skill.name == "ingest-cloudtrail-ocsf")
         assert ingest.entrypoint is not None


### PR DESCRIPTION
Summary
- add a read-only discovery skill that turns AI BOM and environment inventory artifacts into deterministic PCI DSS 4.0 and SOC 2 technical evidence JSON
- wire the new skill through docs, CI, MCP discovery tests, and framework mappings so the repo state matches the shipped capability
- keep the skill input-scoped and cross-cloud: it only processes the providers and assets present in the supplied artifact and sanitizes secret-like fields before generating evidence

Validation
- ruff check on the new skill and touched discovery registry tests
- focused pytest on discover-control-evidence, discover-environment, discover-ai-bom, tool registry, and validator integration tests
- validate_skill_contract.py
- validate_skill_integrity.py
- validate_dependency_consistency.py
- validate_safe_skill_bar.py

Notes
- this is technical evidence generation, not compliance attestation
- the output is deterministic JSON for CLI, CI, MCP, and persistent pipelines