### PR TITLE
feat: add cross-cloud control evidence discovery skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
             skills/discovery/discover-environment \
             skills/discovery/discover-ai-bom \
             skills/discovery/discover-control-evidence \
+            skills/discovery/discover-cloud-control-evidence \
             skills/evaluation/model-serving-security \
             skills/evaluation/gpu-cluster-security
           do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Skills are organised into layered categories. See [`skills/README.md`](skills/RE
 - `discover-environment`
 - `discover-ai-bom`
 - `discover-control-evidence`
+- `discover-cloud-control-evidence`
 
 **`detection/`** (OCSF → OCSF Detection Finding 2004 + MITRE)
 - `detect-mcp-tool-drift`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is loosely based on Keep a Changelog.
 - [`docs/FRAMEWORK_MAPPINGS.md`](docs/FRAMEWORK_MAPPINGS.md) to consolidate ATT&CK, ATLAS, CIS, NIST, OWASP, SOC 2, ISO, and PCI coverage across the repo.
 - First `discovery/` layer AI BOM skill, `discover-ai-bom`, which turns AI asset inventory snapshots into a deterministic CycloneDX-aligned BOM.
 - First discovery-layer technical evidence skill, `discover-control-evidence`, which turns discovery artifacts into deterministic PCI / SOC 2 evidence JSON.
+- `discover-cloud-control-evidence`, which turns AWS, GCP, and Azure inventory snapshots into deterministic PCI / SOC 2 technical evidence JSON.
 
 ### Changed
 - Removed the redirect-only `skills/ai-infra-security/` and `skills/compliance-cis-mitre/` stubs after the layered skill reshape settled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,11 @@ skills/
 │   ├── ingest-k8s-audit-ocsf/
 │   └── ingest-mcp-proxy-ocsf/
 │
-├── discovery/                     # inventory / graph / AI BOM
+├── discovery/                     # inventory / graph / AI BOM / evidence
 │   ├── discover-environment/
-│   └── discover-ai-bom/
-│   └── discover-control-evidence/
+│   ├── discover-ai-bom/
+│   ├── discover-control-evidence/
+│   └── discover-cloud-control-evidence/
 │
 ├── detection/                     # OCSF → Detection Finding 2004 + MITRE
 │   ├── detect-mcp-tool-drift/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,25 @@
 [![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
 [![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
 
-**OCSF-native security skills for cloud and AI systems.** Normalise every source to **OCSF 1.8** on the wire, then compose ingest → discover → detect → evaluate → view → remediate flows like Unix pipes. Built for direct CLI use, CI, serverless pipelines, and a thin local MCP wrapper. Read-only by default, least-privilege, zero-trust, closed-loop.
+**OCSF-native security skills for cloud and AI systems.** Compose `ingest → discover → detect → evaluate → view → remediate` like Unix pipes. Run the same skill code from the CLI, CI, MCP, or persistent pipelines.
 
-The repo is intentionally broader than CSPM: cloud security, container security, AI infra security, detection engineering, compliance evaluation, and future inventory/enrichment skills such as AI BOM generation all fit here as long as they stay deterministic, auditable, and grounded in official specs.
+**What it is**
+- Cross-cloud and AI security skills, not just CSPM
+- Read-only by default, least-privilege, zero-trust
+- Deterministic, auditable, and grounded in official vendor docs
 
-For coding agents, start with [AGENTS.md](AGENTS.md). For Claude-specific project memory, see [CLAUDE.md](CLAUDE.md). For Claude/Codex/Cortex MCP usage, see [docs/agent-integrations.md](docs/agent-integrations.md) and the project-scoped [`.mcp.json`](.mcp.json).
+**Start here**
+- Agents: [AGENTS.md](AGENTS.md)
+- Claude Code memory: [CLAUDE.md](CLAUDE.md)
+- MCP usage: [docs/agent-integrations.md](docs/agent-integrations.md) and [`.mcp.json`](.mcp.json)
+- Architecture and visuals: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/DIAGRAMS.md](docs/DIAGRAMS.md)
+
+![Repo architecture](docs/images/repo-architecture.svg)
+
+**Visuals**
+- [Repo architecture](docs/images/repo-architecture.svg)
+- [IAM departures flow](docs/images/iam-departures-data-flow.svg)
+- [Detection pipeline](docs/images/detection-pipeline.svg)
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
@@ -24,13 +38,13 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
 | Layer | Role | Output |
 |---|---|---|
 | **Ingest** | Per-source raw log → OCSF | API / Network / HTTP / Application Activity |
-| **Discover** | point-in-time inventory / graph / AI BOM | deterministic JSON graph or CycloneDX-aligned BOM |
+| **Discover** | point-in-time inventory / graph / evidence / AI BOM | deterministic JSON graph, evidence JSON, or CycloneDX-aligned BOM |
 | **Detect** | OCSF → finding + MITRE ATT&CK | Detection Finding (class 2004) |
 | **Evaluate** | OCSF → framework check | Compliance Finding (class 2003) — CIS / NIST / SOC 2 |
 | **View** | OCSF → SARIF / Mermaid / graph | GitHub Security tab, PR comments, dashboards |
 | **Remediate** | Finding → action (HITL-gated, audited) | Dual-write audit row |
 
-Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide) — `SKILL.md` with trigger phrases and a `Do NOT use…` clause, `src/`, `tests/`, golden fixtures, `REFERENCES.md`. Runs from the CLI, in CI, or via any agent that reads `SKILL.md` (Claude Desktop, Cursor, Codex, Cortex, Windsurf).
+Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide): `SKILL.md`, `src/`, `tests/`, `REFERENCES.md`, explicit `Use when...`, and explicit `Do NOT use...`.
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
 
@@ -94,8 +108,9 @@ skills/
 │
 ├── discovery/                      "Point-in-time inventory and graph evidence"
 │   ├── discover-environment                      → MITRE ATT&CK + ATLAS graph overlay
-│   └── discover-ai-bom                           → CycloneDX-aligned AI BOM
-│   └── discover-control-evidence                 → PCI / SOC 2 technical evidence JSON
+│   ├── discover-ai-bom                           → CycloneDX-aligned AI BOM
+│   ├── discover-control-evidence                 → PCI / SOC 2 technical evidence JSON
+│   └── discover-cloud-control-evidence           → Cross-cloud PCI / SOC 2 evidence JSON
 │
 ├── detection/                      "What attack pattern does this event stream show?"
 │   ├── detect-lateral-movement                    → T1021 / T1078.004 cross-cloud pivot

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,6 +66,7 @@ This is how the repo stays secure and reliable without turning every skill into 
 │ L2  DISCOVER /      inventory + context                           │
 │     ENRICH          discover-environment, discover-ai-bom,        │
 │                     discover-control-evidence,                    │
+│                     discover-cloud-control-evidence,              │
 │                     enrich-asset-inventory, enrich-geoip,         │
 │                     enrich-mitre-navigator, enrich-pii-redact     │
  ├───────────────────────────────────────────────────────────────────┤
@@ -112,7 +113,7 @@ The rule for this repo is simple: keep the architecture readable in Markdown, an
 |---|---|---|---|---|
 | L0 | sources | (external) | n/a | vendor stories #30–#36, Ramp (PR Y), Snowflake audit (PR Z) |
 | L1 | `ingest-*` | **shipping** | cloudtrail, aws-vpc-flow, gcp-vpc-flow, azure-nsg-flow, guardduty, security-hub, gcp-scc, azure-defender, gcp-audit, azure-activity, k8s-audit, mcp-proxy | okta, github, workspace, slack, ramp |
-| L2 | `discovery/` + `enrich-*` | **shipping / planned** | discover-environment, discover-ai-bom, discover-control-evidence | PR X (asset-inventory, geoip, mitre-navigator, **pii-redact is P0 before any sink in regulated env**) |
+| L2 | `discovery/` + `enrich-*` | **shipping / planned** | discover-environment, discover-ai-bom, discover-control-evidence, discover-cloud-control-evidence | PR X (asset-inventory, geoip, mitre-navigator, **pii-redact is P0 before any sink in regulated env**) |
 | L3 | `detect-*` | **shipping** | lateral-movement, privesc-k8s, sensitive-secret-read-k8s, mcp-tool-drift | credential-access per cloud, unusual-assume-role, vector-store-poisoning |
 | L4 | `evaluate-*` | **shipping** | cspm-aws/gcp/azure-cis-benchmark, k8s-security-benchmark, container-security | evaluate-cis-aws-foundations (#29), NIST AI RMF, SOC2, PCI |
 | L5 | `remediate-*` | **shipping** | iam-departures-remediation | auto-close-exposed-s3, revoke-long-lived-key, patch-inspector-finding |

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -17,7 +17,7 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - `test-detection-engineering`
   - OCSF ingest, detect, and convert skills in one grouped lane
 - `test-ai-infra`
-  - discovery, evidence, model serving, GPU, and AI inventory/BOM skills in one grouped lane
+  - discovery, cross-cloud evidence, model serving, GPU, and AI inventory/BOM skills in one grouped lane
 - `test-integration`
   - cross-skill contracts and pipe-level regression tests
 - `validate-iac`

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -67,6 +67,7 @@ ATLAS is present today, but coverage is narrower than ATT&CK.
 | `model-serving-security` | explicit ATLAS coverage in skill docs and checks |
 | `discover-ai-bom` | inventory artifact for future ATLAS / AI RMF evidence joins |
 | `discover-control-evidence` | evidence package that preserves ATLAS / AI RMF context from discovery artifacts |
+| `discover-cloud-control-evidence` | cross-cloud evidence package that preserves ATT&CK / ATLAS / AI RMF inventory context |
 
 Recommended expansion:
 - make ATLAS mappings more explicit in `gpu-cluster-security`
@@ -94,6 +95,7 @@ uniform than classic cloud posture.
 |---|---|
 | `discover-ai-bom` | CycloneDX ML-BOM, NIST AI RMF, MITRE ATLAS, PCI, SOC 2 |
 | `discover-control-evidence` | PCI DSS 4.0, SOC 2 TSC, CycloneDX ML-BOM, MITRE ATLAS |
+| `discover-cloud-control-evidence` | PCI DSS 4.0, SOC 2 TSC, NIST AI RMF, MITRE ATT&CK, MITRE ATLAS |
 | `model-serving-security` | MITRE ATLAS, NIST CSF, OWASP LLM Top 10, SOC 2 |
 | `gpu-cluster-security` | MITRE ATT&CK, NIST CSF, CIS Controls, CIS Kubernetes |
 | `discover-environment` | MITRE ATT&CK, MITRE ATLAS, NIST CSF |

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -22,7 +22,7 @@ tool_map = MODULE.tool_map
 class TestDiscovery:
     def test_discovers_all_skills(self):
         skills = discover_skills(REPO_ROOT)
-        assert len(skills) == 29
+        assert len(skills) == 30
         assert {skill.name for skill in skills} >= {
             "ingest-cloudtrail-ocsf",
             "detect-lateral-movement",
@@ -34,6 +34,7 @@ class TestDiscovery:
             "ingest-azure-defender-for-cloud-ocsf",
             "discover-ai-bom",
             "discover-control-evidence",
+            "discover-cloud-control-evidence",
         }
 
     def test_marks_remediation_skill_without_cli_entrypoint_as_unsupported(self):
@@ -48,6 +49,7 @@ class TestDiscovery:
         assert "model-serving-security" in tools
         assert "discover-ai-bom" in tools
         assert "discover-control-evidence" in tools
+        assert "discover-cloud-control-evidence" in tools
 
 
 class TestToolDefinition:

--- a/skills/README.md
+++ b/skills/README.md
@@ -54,6 +54,7 @@ Read-only inventory, graph, and AI BOM skills.
 | [`discover-environment`](discovery/discover-environment/) | Multi-cloud discovery / graph overlay |
 | [`discover-ai-bom`](discovery/discover-ai-bom/) | AI asset inventory → CycloneDX-aligned AI BOM |
 | [`discover-control-evidence`](discovery/discover-control-evidence/) | Discovery artifact → PCI / SOC 2 technical evidence JSON |
+| [`discover-cloud-control-evidence`](discovery/discover-cloud-control-evidence/) | Cross-cloud inventory → PCI / SOC 2 technical evidence JSON |
 
 ## evaluation/
 

--- a/skills/discovery/discover-cloud-control-evidence/REFERENCES.md
+++ b/skills/discovery/discover-cloud-control-evidence/REFERENCES.md
@@ -1,0 +1,15 @@
+# References
+
+Only official sources are allowed here. This skill relies on:
+
+- PCI DSS standards overview: https://www.pcisecuritystandards.org/standards/pci-dss/
+- AICPA / SOC reporting overview: https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2
+- AWS Security Best Practices and IAM docs: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- AWS CloudTrail user guide: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html
+- Google Cloud IAM overview: https://cloud.google.com/iam/docs/overview
+- Google Cloud Audit Logs overview: https://cloud.google.com/logging/docs/audit
+- Azure identity and access management overview: https://learn.microsoft.com/en-us/azure/security/fundamentals/identity-management-overview
+- Azure Monitor diagnostic settings: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/diagnostic-settings
+- NIST AI Risk Management Framework: https://www.nist.gov/itl/ai-risk-management-framework
+- MITRE ATT&CK: https://attack.mitre.org/
+- MITRE ATLAS: https://atlas.mitre.org/

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: discover-cloud-control-evidence
+description: >-
+  Generate deterministic technical-control evidence from raw cross-cloud
+  inventory snapshots. Supports AWS, GCP, and Azure inventory inputs and
+  produces a machine-readable evidence package for PCI DSS 4.0 and SOC 2
+  security reviews without claiming attestation. Use when the user mentions
+  PCI evidence, SOC 2 evidence, cloud inventory evidence, audit evidence, or
+  wants a reviewable JSON package showing identity surface, externally exposed
+  assets, encryption coverage, logging coverage, and key-management coverage
+  across cloud environments. Do NOT use as a benchmark evaluator, compliance
+  certification tool, or remediation planner. Do NOT use on raw logs or OCSF
+  findings.
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+. Read-only. Accepts raw cloud inventory JSON from
+  stdin or a file path. Produces deterministic JSON evidence suitable for CLI,
+  CI, MCP, and persistent pipelines.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-security
+  source: https://github.com/msaad00/cloud-security/tree/main/skills/discovery/discover-cloud-control-evidence
+  version: 0.1.0
+  frameworks:
+    - PCI DSS 4.0
+    - SOC 2 TSC
+    - NIST AI RMF
+    - MITRE ATT&CK
+    - MITRE ATLAS
+  cloud: multi
+  capability: read-only
+---
+
+# discover-cloud-control-evidence
+
+Transforms raw AWS, GCP, and Azure inventory snapshots into a technical
+evidence package. The goal is to summarize inventory-backed control evidence
+for cloud and AI estates without pretending that discovery alone proves
+compliance.
+
+## Use when
+
+- You need machine-readable PCI DSS 4.0 or SOC 2 evidence from cloud inventory
+- You want to summarize raw AWS, GCP, or Azure inventory into review-ready evidence
+- You need stable JSON that highlights identities, public exposure, encryption, logging, and key-management coverage
+- You want an evidence package that can be diffed over time or attached to tickets and audit reviews
+
+## Do NOT use
+
+- As a benchmark or control pass/fail engine
+- As a replacement for auditor judgement or formal attestation
+- On raw logs, OCSF findings, or security alerts
+- To infer exploitability or blast radius on its own
+
+## Input contract
+
+The skill accepts one JSON document with any mix of these provider snapshots:
+
+- `aws`
+- `gcp`
+- `azure`
+
+Each provider section may include relevant inventory such as identities,
+storage, logging, encryption, key management, network policies, public IPs,
+endpoints, or AI service inventory. The skill only processes the providers and
+services present in the supplied input.
+
+## Output contract
+
+The skill emits one deterministic JSON document:
+
+- `artifact_type: technical-control-evidence`
+- `frameworks[]` with the requested evidence families
+- `inventory_summary` with providers, services, asset counts, and control-surface counts
+- `controls[]` with `evidence-ready` / `partial` / `missing` status per control domain
+- `gaps[]` only when the source artifact cannot support a given evidence domain
+
+This is evidence, not an attestation.
+
+## Usage
+
+```bash
+# Build evidence from a mixed AWS/GCP/Azure inventory snapshot
+python src/discover.py inventory.json > cloud-evidence.json
+
+# Limit to PCI-focused evidence
+python src/discover.py inventory.json --framework pci --pretty > pci-evidence.json
+```
+
+## Security guardrails
+
+- Read-only only. No network calls, no subprocesses, no writes outside the requested output file.
+- Secret-like fields are dropped before evidence is generated.
+- Unknown or empty source shapes fail closed with a non-zero exit.
+- The skill never emits `compliant` / `non-compliant`; it only reports evidence presence and gaps.
+
+## See also
+
+- [`../discover-control-evidence/SKILL.md`](../discover-control-evidence/SKILL.md) — evidence from AI BOM and graph artifacts
+- [`../discover-environment/SKILL.md`](../discover-environment/SKILL.md) — graph inventory generation
+- [`../discover-ai-bom/SKILL.md`](../discover-ai-bom/SKILL.md) — AI BOM generation

--- a/skills/discovery/discover-cloud-control-evidence/src/discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/src/discover.py
@@ -1,0 +1,726 @@
+"""Generate technical control evidence from raw AWS, GCP, and Azure inventory snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "discover-cloud-control-evidence"
+SUPPORTED_FRAMEWORKS = ("pci", "soc2")
+FRAMEWORK_LABELS = {
+    "pci": "PCI DSS 4.0",
+    "soc2": "SOC 2 Security",
+}
+SECRET_KEYWORDS = (
+    "authorization",
+    "client_secret",
+    "connection_string",
+    "credential",
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "access_key",
+)
+PUBLIC_CIDRS = {"0.0.0.0/0", "::/0", "*", "internet", "any"}
+
+
+def _load_json(path: str | None) -> dict[str, Any]:
+    if path:
+        return json.loads(Path(path).read_text())
+    return json.load(sys.stdin)
+
+
+def _warn(message: str) -> None:
+    print(f"warning: {message}", file=sys.stderr)
+
+
+def _string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "enabled", "enforced"}
+    return bool(value)
+
+
+def _clean(mapping: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in mapping.items() if value not in (None, "", [], {})}
+
+
+def _secret_like(key: str) -> bool:
+    key = key.lower().replace("-", "_")
+    return any(fragment in key for fragment in SECRET_KEYWORDS)
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, child in value.items():
+            if _secret_like(key):
+                continue
+            cleaned_child = _sanitize(child)
+            if cleaned_child in (None, {}, []):
+                continue
+            cleaned[key] = cleaned_child
+        return cleaned
+    if isinstance(value, list):
+        cleaned_list = [_sanitize(item) for item in value]
+        return [item for item in cleaned_list if item not in (None, {}, [])]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _normalize_frameworks(frameworks: list[str] | None) -> list[str]:
+    if not frameworks:
+        return list(SUPPORTED_FRAMEWORKS)
+    normalized = []
+    for item in frameworks:
+        key = item.strip().lower()
+        if key not in SUPPORTED_FRAMEWORKS:
+            raise ValueError(
+                f"unsupported framework `{item}`; supported values: {', '.join(SUPPORTED_FRAMEWORKS)}"
+            )
+        if key not in normalized:
+            normalized.append(key)
+    return normalized
+
+
+def _asset(provider: str, service: str, kind: str, identifier: str | None, **kwargs: Any) -> dict[str, Any]:
+    if not _string(identifier):
+        raise ValueError(f"{provider}:{service}:{kind} asset is missing an identifier")
+    return _clean(
+        {
+            "provider": provider,
+            "service": service,
+            "kind": kind,
+            "id": identifier,
+            **kwargs,
+        }
+    )
+
+
+def _is_public_cidr(value: Any) -> bool:
+    text = (_string(value) or "").lower()
+    return text in PUBLIC_CIDRS
+
+
+def _aws_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    assets: list[dict[str, Any]] = []
+    iam = snapshot.get("iam", {}) or {}
+    ec2 = snapshot.get("ec2", {}) or {}
+    s3 = snapshot.get("s3", {}) or {}
+    kms = snapshot.get("kms", {}) or {}
+    cloudtrail = snapshot.get("cloudtrail", {}) or {}
+    bedrock = snapshot.get("bedrock", {}) or {}
+    sagemaker = snapshot.get("sagemaker", {}) or {}
+
+    for user in iam.get("users", []):
+        assets.append(
+            _asset(
+                "aws",
+                "iam",
+                "user",
+                user.get("UserName") or user.get("Arn"),
+                name=user.get("UserName"),
+                mfa_enabled=_bool(user.get("MFAEnabled")),
+            )
+        )
+    for role in iam.get("roles", []):
+        assets.append(
+            _asset(
+                "aws",
+                "iam",
+                "role",
+                role.get("RoleName") or role.get("Arn"),
+                name=role.get("RoleName"),
+            )
+        )
+    for bucket in s3.get("buckets", []):
+        encrypted = _bool(bucket.get("encrypted")) or bool(bucket.get("kms_key_id") or bucket.get("encryption"))
+        assets.append(
+            _asset(
+                "aws",
+                "s3",
+                "bucket",
+                bucket.get("Name") or bucket.get("Arn"),
+                name=bucket.get("Name"),
+                encrypted=encrypted,
+                public=_bool(bucket.get("public")) or _bool(bucket.get("public_access")),
+                logged=_bool(bucket.get("logging_enabled")),
+            )
+        )
+    for key in kms.get("keys", []):
+        assets.append(
+            _asset(
+                "aws",
+                "kms",
+                "key",
+                key.get("KeyId") or key.get("Arn"),
+                name=key.get("Alias"),
+                rotation_enabled=_bool(key.get("RotationEnabled")),
+            )
+        )
+    for trail in cloudtrail.get("trails", []):
+        assets.append(
+            _asset(
+                "aws",
+                "cloudtrail",
+                "audit-trail",
+                trail.get("Name") or trail.get("TrailARN"),
+                name=trail.get("Name"),
+                logged=_bool(trail.get("IsLogging")),
+                encrypted=bool(trail.get("KmsKeyId")),
+                multi_region=_bool(trail.get("IsMultiRegionTrail")),
+            )
+        )
+    for instance in ec2.get("instances", []):
+        assets.append(
+            _asset(
+                "aws",
+                "ec2",
+                "instance",
+                instance.get("InstanceId"),
+                name=instance.get("InstanceId"),
+                public=bool(instance.get("PublicIpAddress") or instance.get("PublicDnsName")),
+                encrypted=_bool(instance.get("Encrypted")),
+            )
+        )
+    for group in ec2.get("security_groups", []):
+        public = any(
+            _is_public_cidr(rule.get("cidr") or rule.get("CidrIp") or rule.get("source"))
+            for rule in group.get("ingress", [])
+            if isinstance(rule, dict)
+        )
+        assets.append(
+            _asset(
+                "aws",
+                "ec2",
+                "network-policy",
+                group.get("GroupId"),
+                name=group.get("GroupName"),
+                public=public,
+            )
+        )
+    for model in bedrock.get("custom_models", []):
+        assets.append(
+            _asset(
+                "aws",
+                "bedrock",
+                "model",
+                model.get("modelArn"),
+                name=model.get("modelName"),
+            )
+        )
+    for endpoint in sagemaker.get("endpoints", []):
+        assets.append(
+            _asset(
+                "aws",
+                "sagemaker",
+                "endpoint",
+                endpoint.get("EndpointArn") or endpoint.get("EndpointName"),
+                name=endpoint.get("EndpointName"),
+                public=_bool(endpoint.get("public")),
+            )
+        )
+    return assets
+
+
+def _gcp_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    assets: list[dict[str, Any]] = []
+    iam = snapshot.get("iam", {}) or {}
+    compute = snapshot.get("compute", {}) or {}
+    storage = snapshot.get("storage", {}) or {}
+    kms = snapshot.get("kms", {}) or {}
+    logging = snapshot.get("logging", {}) or {}
+    vertex = snapshot.get("vertex_ai", {}) or {}
+
+    for account in iam.get("service_accounts", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "iam",
+                "service-account",
+                account.get("email") or account.get("name"),
+                name=account.get("displayName") or account.get("email"),
+                disabled=_bool(account.get("disabled")),
+            )
+        )
+    for bucket in storage.get("buckets", []):
+        encrypted = bool(bucket.get("defaultKmsKeyName") or bucket.get("encryption"))
+        assets.append(
+            _asset(
+                "gcp",
+                "storage",
+                "bucket",
+                bucket.get("name"),
+                name=bucket.get("name"),
+                encrypted=encrypted,
+                public=_bool(bucket.get("public")),
+                logged=_bool(bucket.get("logging")),
+            )
+        )
+    for key in kms.get("keys", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "kms",
+                "key",
+                key.get("name"),
+                name=key.get("name"),
+                rotation_enabled=bool(key.get("rotationPeriod") or key.get("nextRotationTime")),
+            )
+        )
+    for sink in logging.get("sinks", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "logging",
+                "logging-sink",
+                sink.get("name"),
+                name=sink.get("name"),
+                logged=True,
+            )
+        )
+    for instance in compute.get("instances", []):
+        public = False
+        for nic in instance.get("networkInterfaces", []) or []:
+            if nic.get("accessConfigs"):
+                public = True
+                break
+        assets.append(
+            _asset(
+                "gcp",
+                "compute",
+                "instance",
+                instance.get("id") or instance.get("name"),
+                name=instance.get("name"),
+                public=public,
+            )
+        )
+    for firewall in compute.get("firewalls", []):
+        public = any(_is_public_cidr(source) for source in firewall.get("sourceRanges", []) or [])
+        assets.append(
+            _asset(
+                "gcp",
+                "compute",
+                "firewall-rule",
+                firewall.get("name"),
+                name=firewall.get("name"),
+                public=public,
+            )
+        )
+    for model in vertex.get("models", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "vertex-ai",
+                "model",
+                model.get("name"),
+                name=model.get("displayName") or model.get("name"),
+            )
+        )
+    for endpoint in vertex.get("endpoints", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "vertex-ai",
+                "endpoint",
+                endpoint.get("name"),
+                name=endpoint.get("displayName") or endpoint.get("name"),
+                public=_bool(endpoint.get("public")),
+            )
+        )
+    return assets
+
+
+def _azure_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    assets: list[dict[str, Any]] = []
+    entra = snapshot.get("entra", {}) or {}
+    compute = snapshot.get("compute", {}) or {}
+    storage = snapshot.get("storage", {}) or {}
+    key_vault = snapshot.get("key_vault", {}) or {}
+    monitor = snapshot.get("monitor", {}) or {}
+    network = snapshot.get("network", {}) or {}
+    ai_foundry = snapshot.get("ai_foundry", {}) or {}
+
+    for user in entra.get("users", []):
+        assets.append(
+            _asset(
+                "azure",
+                "entra",
+                "user",
+                user.get("id") or user.get("userPrincipalName"),
+                name=user.get("userPrincipalName") or user.get("displayName"),
+            )
+        )
+    for principal in entra.get("service_principals", []):
+        assets.append(
+            _asset(
+                "azure",
+                "entra",
+                "service-principal",
+                principal.get("id") or principal.get("appId"),
+                name=principal.get("displayName") or principal.get("appId"),
+            )
+        )
+    for identity in entra.get("managed_identities", []):
+        assets.append(
+            _asset(
+                "azure",
+                "entra",
+                "managed-identity",
+                identity.get("id") or identity.get("clientId"),
+                name=identity.get("name") or identity.get("clientId"),
+            )
+        )
+    for account in storage.get("accounts", []):
+        encrypted = _bool(account.get("encrypted")) or _bool(account.get("encryption_enabled"))
+        assets.append(
+            _asset(
+                "azure",
+                "storage",
+                "storage-account",
+                account.get("id") or account.get("name"),
+                name=account.get("name"),
+                encrypted=encrypted,
+                public=_bool(account.get("allowBlobPublicAccess")),
+                logged=_bool(account.get("logging_enabled")),
+            )
+        )
+    for vault in key_vault.get("vaults", []):
+        assets.append(
+            _asset(
+                "azure",
+                "key-vault",
+                "key-vault",
+                vault.get("id") or vault.get("name"),
+                name=vault.get("name"),
+                public=_bool(vault.get("publicNetworkAccess")),
+            )
+        )
+    for setting in monitor.get("diagnostic_settings", []):
+        assets.append(
+            _asset(
+                "azure",
+                "monitor",
+                "diagnostic-setting",
+                setting.get("id") or setting.get("name"),
+                name=setting.get("name"),
+                logged=True,
+            )
+        )
+    for vm in compute.get("virtual_machines", []):
+        assets.append(
+            _asset(
+                "azure",
+                "compute",
+                "virtual-machine",
+                vm.get("id") or vm.get("name"),
+                name=vm.get("name"),
+                public=_bool(vm.get("public_ip")) or _bool(vm.get("publicIpAddress")),
+                encrypted=_bool(vm.get("encryption_at_host")),
+            )
+        )
+    for nsg in network.get("nsgs", []):
+        public = False
+        for rule in nsg.get("securityRules", []) or []:
+            access = (_string(rule.get("access")) or "").lower()
+            direction = (_string(rule.get("direction")) or "").lower()
+            source = (
+                _string(rule.get("sourceAddressPrefix"))
+                or _string(rule.get("source"))
+                or _string(rule.get("sourceAddressPrefixes"))
+            )
+            if access == "allow" and direction in {"inbound", ""} and _is_public_cidr(source):
+                public = True
+                break
+        assets.append(
+            _asset(
+                "azure",
+                "network",
+                "network-policy",
+                nsg.get("id") or nsg.get("name"),
+                name=nsg.get("name"),
+                public=public,
+            )
+        )
+    for deployment in ai_foundry.get("deployments", []):
+        assets.append(
+            _asset(
+                "azure",
+                "ai-foundry",
+                "endpoint",
+                deployment.get("id") or deployment.get("name"),
+                name=deployment.get("name"),
+                public=_bool(deployment.get("public")),
+            )
+        )
+    return assets
+
+
+def normalize_inventory(document: dict[str, Any]) -> dict[str, Any]:
+    sanitized = _sanitize(document)
+    providers: list[str] = []
+    assets: list[dict[str, Any]] = []
+
+    if isinstance(sanitized.get("aws"), dict):
+        providers.append("aws")
+        assets.extend(_aws_assets(sanitized["aws"]))
+    if isinstance(sanitized.get("gcp"), dict):
+        providers.append("gcp")
+        assets.extend(_gcp_assets(sanitized["gcp"]))
+    if isinstance(sanitized.get("azure"), dict):
+        providers.append("azure")
+        assets.extend(_azure_assets(sanitized["azure"]))
+
+    if not providers or not assets:
+        raise ValueError("input must include at least one supported provider inventory with assets")
+
+    deduped = {}
+    for asset in assets:
+        deduped[(asset["provider"], asset["service"], asset["kind"], asset["id"])] = asset
+
+    return {
+        "source_kind": "cloud-inventory-snapshot",
+        "source_id": sanitized.get("inventory_id") or sanitized.get("snapshot_id"),
+        "collected_at": sanitized.get("collected_at") or sanitized.get("captured_at"),
+        "providers": sorted(providers),
+        "assets": sorted(deduped.values(), key=lambda item: json.dumps(item, sort_keys=True)),
+    }
+
+
+def _summaries(normalized: dict[str, Any]) -> dict[str, Any]:
+    assets = normalized["assets"]
+    services = sorted({_string(asset.get("service")) or "unknown" for asset in assets})
+    kinds = Counter((_string(asset.get("kind")) or "unknown") for asset in assets)
+
+    identity_assets = [
+        asset
+        for asset in assets
+        if asset["kind"] in {"user", "role", "service-account", "service-principal", "managed-identity"}
+    ]
+    public_assets = [asset for asset in assets if _bool(asset.get("public"))]
+    encrypted_assets = [asset for asset in assets if _bool(asset.get("encrypted"))]
+    logging_assets = [asset for asset in assets if _bool(asset.get("logged"))]
+    key_assets = [asset for asset in assets if asset["kind"] in {"key", "key-vault"}]
+
+    return {
+        "providers": normalized["providers"],
+        "services": services,
+        "asset_count": len(assets),
+        "kind_counts": dict(sorted(kinds.items())),
+        "control_surface_counts": {
+            "identity_assets": len(identity_assets),
+            "public_assets": len(public_assets),
+            "encrypted_assets": len(encrypted_assets),
+            "logging_assets": len(logging_assets),
+            "key_assets": len(key_assets),
+        },
+    }
+
+
+def _status(has_enough: bool, has_some: bool) -> str:
+    if has_enough:
+        return "evidence-ready"
+    if has_some:
+        return "partial"
+    return "missing"
+
+
+def _control(
+    framework: str,
+    control_id: str,
+    title: str,
+    description: str,
+    evidence: list[dict[str, Any]],
+    gaps: list[str],
+) -> dict[str, Any]:
+    status = _status(not gaps and bool(evidence), bool(evidence))
+    return {
+        "framework": FRAMEWORK_LABELS[framework],
+        "control_id": control_id,
+        "title": title,
+        "status": status,
+        "description": description,
+        "evidence": evidence,
+        "gaps": gaps,
+    }
+
+
+def _sample(assets: list[dict[str, Any]], limit: int = 5) -> list[dict[str, Any]]:
+    return [
+        _clean(
+            {
+                "provider": asset.get("provider"),
+                "service": asset.get("service"),
+                "kind": asset.get("kind"),
+                "id": asset.get("id"),
+                "name": asset.get("name"),
+            }
+        )
+        for asset in assets[:limit]
+    ]
+
+
+def _controls_for(framework: str, normalized: dict[str, Any]) -> list[dict[str, Any]]:
+    assets = normalized["assets"]
+    identities = [
+        asset
+        for asset in assets
+        if asset["kind"] in {"user", "role", "service-account", "service-principal", "managed-identity"}
+    ]
+    public_assets = [asset for asset in assets if _bool(asset.get("public"))]
+    encrypted_assets = [asset for asset in assets if _bool(asset.get("encrypted"))]
+    logging_assets = [asset for asset in assets if _bool(asset.get("logged"))]
+    key_assets = [asset for asset in assets if asset["kind"] in {"key", "key-vault"}]
+
+    if framework == "pci":
+        return [
+            _control(
+                framework,
+                "inventory.identity-surface",
+                "Identity inventory evidence",
+                "Inventory-backed evidence for cloud identities, roles, and service principals.",
+                _sample(identities),
+                [] if identities else ["No identity inventory present in the supplied snapshot."],
+            ),
+            _control(
+                framework,
+                "inventory.external-exposure",
+                "External exposure evidence",
+                "Inventory-backed evidence for public endpoints, public IPs, and permissive network controls.",
+                _sample(public_assets),
+                [] if public_assets else ["No explicit external exposure inventory was present in the supplied snapshot."],
+            ),
+            _control(
+                framework,
+                "inventory.encryption-and-keys",
+                "Encryption and key-management evidence",
+                "Inventory-backed evidence for encrypted assets and key-management surfaces.",
+                _sample(encrypted_assets + key_assets),
+                [] if encrypted_assets or key_assets else [
+                    "No encryption or key-management inventory was present in the supplied snapshot."
+                ],
+            ),
+            _control(
+                framework,
+                "inventory.audit-logging",
+                "Audit logging evidence",
+                "Inventory-backed evidence for CloudTrail, audit logs, diagnostic settings, or equivalent logging surfaces.",
+                _sample(logging_assets),
+                [] if logging_assets else ["No logging inventory was present in the supplied snapshot."],
+            ),
+        ]
+
+    return [
+        _control(
+            framework,
+            "cc6.identity-and-access",
+            "Identity and access evidence",
+            "Inventory-backed evidence for users, roles, service accounts, and service principals.",
+            _sample(identities),
+            [] if identities else ["No identity inventory present in the supplied snapshot."],
+        ),
+        _control(
+            framework,
+            "cc6.external-surface",
+            "External surface evidence",
+            "Inventory-backed evidence for public assets and permissive network controls.",
+            _sample(public_assets),
+            [] if public_assets else ["No explicit public-surface inventory was present in the supplied snapshot."],
+        ),
+        _control(
+            framework,
+            "cc6.protection-of-data",
+            "Data protection evidence",
+            "Inventory-backed evidence for encryption-enabled resources and key-management systems.",
+            _sample(encrypted_assets + key_assets),
+            [] if encrypted_assets or key_assets else [
+                "No encryption or key-management inventory was present in the supplied snapshot."
+            ],
+        ),
+        _control(
+            framework,
+            "cc7.logging-and-monitoring",
+            "Logging and monitoring evidence",
+            "Inventory-backed evidence for audit logging and diagnostic coverage.",
+            _sample(logging_assets),
+            [] if logging_assets else ["No logging inventory was present in the supplied snapshot."],
+        ),
+    ]
+
+
+def build_evidence(document: dict[str, Any], frameworks: list[str] | None = None) -> dict[str, Any]:
+    normalized = normalize_inventory(document)
+    selected = _normalize_frameworks(frameworks)
+    controls = [control for framework in selected for control in _controls_for(framework, normalized)]
+    summary = _summaries(normalized)
+
+    evidence_key = {
+        "source_kind": normalized["source_kind"],
+        "source_id": normalized.get("source_id"),
+        "collected_at": normalized.get("collected_at"),
+        "providers": normalized["providers"],
+        "summary": summary,
+        "controls": controls,
+    }
+    evidence_id = str(uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(evidence_key, sort_keys=True)))
+
+    return {
+        "artifact_type": "technical-control-evidence",
+        "generated_by": SKILL_NAME,
+        "evidence_id": evidence_id,
+        "source_kind": normalized["source_kind"],
+        "source_id": normalized.get("source_id"),
+        "collected_at": normalized.get("collected_at"),
+        "frameworks": [FRAMEWORK_LABELS[framework] for framework in selected],
+        "inventory_summary": summary,
+        "controls": controls,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument(
+        "--framework",
+        action="append",
+        dest="frameworks",
+        default=None,
+        help="Evidence family to emit. Repeat for multiple values: pci, soc2.",
+    )
+    parser.add_argument("-o", "--output", help="Write the evidence JSON to this file.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = _load_json(args.input)
+        result = build_evidence(payload, args.frameworks)
+    except ValueError as exc:
+        _warn(str(exc))
+        return 2
+
+    json_text = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True)
+    if args.output:
+        Path(args.output).write_text(f"{json_text}\n")
+    else:
+        sys.stdout.write(f"{json_text}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
@@ -1,0 +1,114 @@
+"""Tests for discover-cloud-control-evidence."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "discover.py"
+_SPEC = importlib.util.spec_from_file_location("discover_cloud_control_evidence", _SRC)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+build_evidence = _MODULE.build_evidence
+normalize_inventory = _MODULE.normalize_inventory
+
+
+def _aws_snapshot() -> dict:
+    return {
+        "inventory_id": "aws-snap-1",
+        "collected_at": "2026-04-12T02:00:00Z",
+        "aws": {
+            "iam": {
+                "users": [{"UserName": "alice", "MFAEnabled": True}],
+                "roles": [{"RoleName": "ml-runtime-role"}],
+            },
+            "s3": {
+                "buckets": [
+                    {
+                        "Name": "ml-artifacts",
+                        "encrypted": True,
+                        "public": False,
+                        "logging_enabled": True,
+                        "token": "drop-me",
+                    }
+                ]
+            },
+            "kms": {"keys": [{"KeyId": "key-1", "RotationEnabled": True}]},
+            "cloudtrail": {"trails": [{"Name": "org-trail", "IsLogging": True, "KmsKeyId": "arn:kms"}]},
+            "ec2": {
+                "instances": [{"InstanceId": "i-123", "PublicIpAddress": "1.2.3.4"}],
+                "security_groups": [{"GroupId": "sg-1", "GroupName": "public-sg", "ingress": [{"cidr": "0.0.0.0/0"}]}],
+            },
+        },
+    }
+
+
+def _multi_cloud_snapshot() -> dict:
+    return {
+        "snapshot_id": "multi-1",
+        "captured_at": "2026-04-12T03:00:00Z",
+        "aws": {
+            "bedrock": {"custom_models": [{"modelArn": "arn:aws:bedrock:model/guard", "modelName": "guard-model"}]}
+        },
+        "gcp": {
+            "iam": {"service_accounts": [{"email": "svc@example.iam.gserviceaccount.com"}]},
+            "logging": {"sinks": [{"name": "org-sink"}]},
+            "compute": {"instances": [{"id": "gce-1", "name": "gce-1", "networkInterfaces": [{"accessConfigs": [{}]}]}]},
+        },
+        "azure": {
+            "entra": {"managed_identities": [{"id": "mi-1", "name": "mi-prod"}]},
+            "storage": {"accounts": [{"id": "st-1", "name": "stprod", "encrypted": True}]},
+            "monitor": {"diagnostic_settings": [{"id": "diag-1", "name": "diag-prod"}]},
+            "ai_foundry": {"deployments": [{"id": "dep-1", "name": "chat-prod", "public": True}]},
+        },
+    }
+
+
+class TestNormalizeInventory:
+    def test_accepts_aws_snapshot(self):
+        normalized = normalize_inventory(_aws_snapshot())
+        assert normalized["source_kind"] == "cloud-inventory-snapshot"
+        assert normalized["providers"] == ["aws"]
+        assert len(normalized["assets"]) >= 6
+
+    def test_accepts_multi_cloud_snapshot(self):
+        normalized = normalize_inventory(_multi_cloud_snapshot())
+        assert normalized["providers"] == ["aws", "azure", "gcp"]
+        assert any(asset["provider"] == "azure" for asset in normalized["assets"])
+        assert any(asset["provider"] == "gcp" for asset in normalized["assets"])
+
+
+class TestBuildEvidence:
+    def test_builds_pci_and_soc2_controls(self):
+        evidence = build_evidence(_aws_snapshot())
+        assert evidence["artifact_type"] == "technical-control-evidence"
+        assert evidence["frameworks"] == ["PCI DSS 4.0", "SOC 2 Security"]
+        assert len(evidence["controls"]) == 8
+
+    def test_drops_secret_like_properties(self):
+        normalized = normalize_inventory(_aws_snapshot())
+        bucket = next(asset for asset in normalized["assets"] if asset["kind"] == "bucket")
+        assert "token" not in bucket
+
+    def test_framework_filter(self):
+        evidence = build_evidence(_multi_cloud_snapshot(), ["soc2"])
+        assert evidence["frameworks"] == ["SOC 2 Security"]
+        assert {control["framework"] for control in evidence["controls"]} == {"SOC 2 Security"}
+
+    def test_deterministic_output(self):
+        assert build_evidence(_multi_cloud_snapshot()) == build_evidence(_multi_cloud_snapshot())
+
+    def test_reports_missing_logging_when_absent(self):
+        evidence = build_evidence({"aws": {"iam": {"users": [{"UserName": "alice"}]}}}, ["pci"])
+        logging_control = next(control for control in evidence["controls"] if control["control_id"] == "inventory.audit-logging")
+        assert logging_control["status"] == "missing"
+
+    def test_invalid_input_raises(self):
+        try:
+            build_evidence({"unexpected": True})
+        except ValueError as exc:
+            assert "supported provider inventory" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected ValueError")

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -44,13 +44,14 @@ DEPENDENCIES = _load_module(
 class TestSkillValidationCommon:
     def test_discovers_skills_and_entrypoints(self):
         skills = COMMON.discover_skill_contracts()
-        assert len(skills) >= 29
+        assert len(skills) >= 30
         names = {skill.name for skill in skills}
         assert "detect-lateral-movement" in names
         assert "ingest-gcp-scc-ocsf" in names
         assert "ingest-azure-defender-for-cloud-ocsf" in names
         assert "discover-ai-bom" in names
         assert "discover-control-evidence" in names
+        assert "discover-cloud-control-evidence" in names
 
         ingest = next(skill for skill in skills if skill.name == "ingest-cloudtrail-ocsf")
         assert ingest.entrypoint is not None


### PR DESCRIPTION
Summary
- add a read-only discovery skill that turns raw AWS, GCP, and Azure inventory snapshots into deterministic PCI DSS 4.0 and SOC 2 technical evidence JSON
- keep the skill input-scoped and cross-cloud: it only processes the provider sections present in the supplied snapshot and sanitizes secret-like fields before generating evidence
- wire the new skill through docs, CI, MCP discovery tests, and framework mappings so the repo state stays aligned with the shipped capability
- tighten the README hero so the public surface is more concise and visibly includes the repo architecture graphic

Validation
- `uv run ruff check skills/discovery/discover-cloud-control-evidence/src/discover.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py mcp-server/tests/test_tool_registry.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml`
- `uv run pytest skills/discovery/discover-cloud-control-evidence/tests/test_discover.py skills/discovery/discover-control-evidence/tests/test_discover.py skills/discovery/discover-ai-bom/tests/test_discover.py skills/discovery/discover-environment/tests mcp-server/tests/test_tool_registry.py tests/integration/test_skill_validation_scripts.py -q -o addopts='--import-mode=importlib'`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_dependency_consistency.py`
- `python scripts/validate_safe_skill_bar.py`

Notes
- this is technical evidence generation, not compliance attestation
- the output is deterministic JSON for CLI, CI, MCP, and persistent pipelines
- discovery outputs remain deterministic inventory or evidence artifacts today; ingest, detect, evaluate, and view remain the primary OCSF wire paths