### PR TITLE
feat: add OCSF live evidence bridge mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
 
 Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide): `SKILL.md`, `src/`, `tests/`, `REFERENCES.md`, explicit `Use when...`, and explicit `Do NOT use...`.
 
+**OCSF note**
+- `ingest`, `detect`, `evaluate`, and `view` are OCSF-first wire paths
+- `discovery` prefers native OCSF inventory/evidence classes and profiles when they fit
+- where OCSF does not cleanly fit yet, the repo uses deterministic bridge artifacts with an explicit mapping path back to OCSF
+- discovery evidence skills support an `ocsf-live-evidence` bridge mode for Discovery-category OCSF workflows
+
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
 
 ## How it runs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,7 +95,7 @@ This is how the repo stays secure and reliable without turning every skill into 
  └───────────────────────────────────────────────────────────────────┘
 ```
 
-Every data object flowing between layers is **OCSF 1.8 JSONL**. No layer invents a new wire format. Converters (L6) emit *other* formats only for downstream delivery — never as intermediate state.
+Most data objects flowing between layers are **OCSF 1.8 JSONL**. That is the default wire contract for ingest, detect, evaluate, view, and sink paths. Discovery follows this rule where OCSF inventory/evidence classes fit cleanly; otherwise it may emit deterministic bridge artifacts such as environment graphs or CycloneDX-aligned AI BOMs with an explicit mapping path back to OCSF. The current discovery evidence skills also support an explicit `ocsf-live-evidence` bridge mode so Discovery-category pipelines can stay OCSF-shaped without replacing the native deterministic artifact.
 
 ### Visuals
 

--- a/skills/detection-engineering/OCSF_CONTRACT.md
+++ b/skills/detection-engineering/OCSF_CONTRACT.md
@@ -2,6 +2,11 @@
 
 This document pins the exact OCSF fields every skill in `detection-engineering/` must read and write. It is the **only** dependency shared across skills in this category. If you are writing a new ingestion or detection skill, your tests must verify that the output matches this contract.
 
+It also defines the repo-wide OCSF preference for adjacent layers:
+- use a native OCSF class when one exists and fits the artifact cleanly
+- use OCSF profiles and extensions before inventing repo-local fields
+- use a deterministic bridge artifact only when OCSF does not yet model the discovery or BOM shape well enough
+
 ## OCSF version
 
 - Base schema: **OCSF 1.8.0** (current stable — verified against [schema.ocsf.io](https://schema.ocsf.io/)).
@@ -12,6 +17,34 @@ This document pins the exact OCSF fields every skill in `detection-engineering/`
 ```
 contract version: 1.8.0+mcp.2026.04
 ```
+
+## OCSF-first policy beyond detection
+
+The repo is broader than event ingestion and detections, so OCSF usage falls into three buckets:
+
+1. **Native OCSF wire paths**
+   - `ingest-*`
+   - `detect-*`
+   - `evaluate-*`
+   - `convert-*`
+
+2. **Discovery and evidence paths that should prefer native OCSF where it fits**
+   - `Cloud Resources Inventory Info [5023]`
+   - `Software Inventory Info [5020]`
+   - `Live Evidence Info [5040]`
+   - `Base Event [0]` only as a last-resort generic carrier
+
+3. **Documented bridge artifacts**
+   - environment graph snapshots
+   - CycloneDX-aligned AI BOMs
+   - deterministic technical-evidence JSON
+
+Bridge artifacts are allowed only when:
+- the current OCSF schema does not cleanly express the artifact
+- the skill documents the gap and the intended OCSF mapping path
+- the bridge format remains deterministic and validation-friendly
+
+The direction of travel is still toward more native OCSF inventory/evidence use, not away from it.
 
 ## Wire format
 

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -75,7 +75,7 @@ The skill emits one deterministic JSON document:
 - `controls[]` with `evidence-ready` / `partial` / `missing` status per control domain
 - `gaps[]` only when the source artifact cannot support a given evidence domain
 
-This is evidence, not an attestation.
+By default this is native evidence JSON, not an attestation. When `--output-format ocsf-live-evidence` is used, the skill emits a Discovery-category OCSF bridge event for `Live Evidence Info [5040]` and carries the deterministic evidence payload under `unmapped.cloud_security_technical_evidence`.
 
 ## Usage
 
@@ -85,6 +85,9 @@ python src/discover.py inventory.json > cloud-evidence.json
 
 # Limit to PCI-focused evidence
 python src/discover.py inventory.json --framework pci --pretty > pci-evidence.json
+
+# Emit an OCSF Discovery bridge event
+python src/discover.py inventory.json --output-format ocsf-live-evidence > evidence.ocsf.json
 ```
 
 ## Security guardrails

--- a/skills/discovery/discover-cloud-control-evidence/src/discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/src/discover.py
@@ -7,11 +7,13 @@ import json
 import sys
 import uuid
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 SKILL_NAME = "discover-cloud-control-evidence"
 SUPPORTED_FRAMEWORKS = ("pci", "soc2")
+SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-live-evidence")
 FRAMEWORK_LABELS = {
     "pci": "PCI DSS 4.0",
     "soc2": "SOC 2 Security",
@@ -97,6 +99,18 @@ def _normalize_frameworks(frameworks: list[str] | None) -> list[str]:
         if key not in normalized:
             normalized.append(key)
     return normalized
+
+
+def _time_to_epoch_ms(value: str | None) -> int:
+    text = _string(value)
+    if not text:
+        return 0
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return int(datetime.fromisoformat(text).timestamp() * 1000)
+    except ValueError:
+        return 0
 
 
 def _asset(provider: str, service: str, kind: str, identifier: str | None, **kwargs: Any) -> dict[str, Any]:
@@ -693,6 +707,36 @@ def build_evidence(document: dict[str, Any], frameworks: list[str] | None = None
     }
 
 
+def to_ocsf_live_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
+    time_ms = _time_to_epoch_ms(evidence.get("collected_at"))
+    return {
+        "activity_id": 99,
+        "activity_name": "Other",
+        "category_uid": 5,
+        "category_name": "Discovery",
+        "class_uid": 5040,
+        "class_name": "Live Evidence Info",
+        "type_uid": 504099,
+        "type_name": "Live Evidence Info: Other",
+        "severity_id": 1,
+        "severity": "Informational",
+        "time": time_ms,
+        "metadata": {
+            "version": "1.8.0",
+            "product": {
+                "name": "cloud-security",
+                "vendor_name": "msaad00/cloud-security",
+                "feature": {"name": SKILL_NAME},
+            },
+            "profiles": ["cloud", "security_control"],
+        },
+        "message": "Discovery-layer technical control evidence generated from cross-cloud inventory.",
+        "unmapped": {
+            "cloud_security_technical_evidence": evidence,
+        },
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("input", nargs="?", help="JSON file path. Reads stdin when omitted.")
@@ -703,6 +747,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Evidence family to emit. Repeat for multiple values: pci, soc2.",
     )
+    parser.add_argument(
+        "--output-format",
+        choices=SUPPORTED_OUTPUT_FORMATS,
+        default="native",
+        help="Emit native evidence JSON or an OCSF Live Evidence bridge event.",
+    )
     parser.add_argument("-o", "--output", help="Write the evidence JSON to this file.")
     parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
     args = parser.parse_args(argv)
@@ -710,6 +760,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         payload = _load_json(args.input)
         result = build_evidence(payload, args.frameworks)
+        if args.output_format == "ocsf-live-evidence":
+            result = to_ocsf_live_evidence(result)
     except ValueError as exc:
         _warn(str(exc))
         return 2

--- a/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
@@ -13,6 +13,7 @@ _SPEC.loader.exec_module(_MODULE)
 
 build_evidence = _MODULE.build_evidence
 normalize_inventory = _MODULE.normalize_inventory
+to_ocsf_live_evidence = _MODULE.to_ocsf_live_evidence
 
 
 def _aws_snapshot() -> dict:
@@ -112,3 +113,11 @@ class TestBuildEvidence:
             assert "supported provider inventory" in str(exc)
         else:  # pragma: no cover - defensive
             raise AssertionError("expected ValueError")
+
+    def test_can_emit_ocsf_live_evidence_bridge(self):
+        event = to_ocsf_live_evidence(build_evidence(_multi_cloud_snapshot(), ["pci"]))
+        assert event["category_uid"] == 5
+        assert event["class_uid"] == 5040
+        assert event["class_name"] == "Live Evidence Info"
+        assert event["metadata"]["version"] == "1.8.0"
+        assert event["unmapped"]["cloud_security_technical_evidence"]["frameworks"] == ["PCI DSS 4.0"]

--- a/skills/discovery/discover-control-evidence/SKILL.md
+++ b/skills/discovery/discover-control-evidence/SKILL.md
@@ -73,7 +73,7 @@ The skill emits one deterministic JSON document:
 - `controls[]` with evidence-ready / partial / missing status per control domain
 - `gaps[]` only when the source artifact cannot support a given evidence domain
 
-This is evidence, not an attestation.
+By default this is native evidence JSON, not an attestation. When `--output-format ocsf-live-evidence` is used, the skill emits a Discovery-category OCSF bridge event for `Live Evidence Info [5040]` and carries the deterministic evidence payload under `unmapped.cloud_security_technical_evidence`.
 
 ## Usage
 
@@ -86,6 +86,9 @@ python src/discover.py graph.json --framework pci --framework soc2 > evidence.js
 
 # Pretty-print to a file
 python src/discover.py ai-bom.json --pretty -o control-evidence.json
+
+# Emit an OCSF Discovery bridge event
+python src/discover.py graph.json --output-format ocsf-live-evidence > control-evidence.ocsf.json
 ```
 
 ## Security guardrails

--- a/skills/discovery/discover-control-evidence/src/discover.py
+++ b/skills/discovery/discover-control-evidence/src/discover.py
@@ -7,11 +7,13 @@ import json
 import sys
 import uuid
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 SKILL_NAME = "discover-control-evidence"
 SUPPORTED_FRAMEWORKS = ("pci", "soc2")
+SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-live-evidence")
 SECRET_KEYWORDS = (
     "authorization",
     "client_secret",
@@ -86,6 +88,18 @@ def _normalize_frameworks(frameworks: list[str] | None) -> list[str]:
         if key not in normalized:
             normalized.append(key)
     return normalized
+
+
+def _time_to_epoch_ms(value: str | None) -> int:
+    text = _string(value)
+    if not text:
+        return 0
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return int(datetime.fromisoformat(text).timestamp() * 1000)
+    except ValueError:
+        return 0
 
 
 def _asset_key(asset: dict[str, Any]) -> str:
@@ -346,10 +360,46 @@ def build_evidence(document: dict[str, Any], frameworks: list[str] | None = None
     }
 
 
+def to_ocsf_live_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
+    time_ms = _time_to_epoch_ms(evidence.get("collected_at"))
+    return {
+        "activity_id": 99,
+        "activity_name": "Other",
+        "category_uid": 5,
+        "category_name": "Discovery",
+        "class_uid": 5040,
+        "class_name": "Live Evidence Info",
+        "type_uid": 504099,
+        "type_name": "Live Evidence Info: Other",
+        "severity_id": 1,
+        "severity": "Informational",
+        "time": time_ms,
+        "metadata": {
+            "version": "1.8.0",
+            "product": {
+                "name": "cloud-security",
+                "vendor_name": "msaad00/cloud-security",
+                "feature": {"name": SKILL_NAME},
+            },
+            "profiles": ["cloud", "security_control"],
+        },
+        "message": "Discovery-layer technical control evidence generated from inventory artifacts.",
+        "unmapped": {
+            "cloud_security_technical_evidence": evidence,
+        },
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate deterministic technical-control evidence from discovery artifacts.")
     parser.add_argument("input", nargs="?", help="Path to a discovery artifact JSON file. Reads stdin when omitted.")
     parser.add_argument("--framework", dest="frameworks", action="append", help="Evidence family to emit: pci or soc2. Defaults to both.")
+    parser.add_argument(
+        "--output-format",
+        choices=SUPPORTED_OUTPUT_FORMATS,
+        default="native",
+        help="Emit native evidence JSON or an OCSF Live Evidence bridge event.",
+    )
     parser.add_argument("-o", "--output", help="Write JSON output to this file instead of stdout.")
     parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
     args = parser.parse_args(argv)
@@ -357,6 +407,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         document = _load_json(args.input)
         evidence = build_evidence(document, args.frameworks)
+        if args.output_format == "ocsf-live-evidence":
+            evidence = to_ocsf_live_evidence(evidence)
     except Exception as exc:  # pragma: no cover - CLI error path
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/skills/discovery/discover-control-evidence/tests/test_discover.py
+++ b/skills/discovery/discover-control-evidence/tests/test_discover.py
@@ -13,6 +13,7 @@ _SPEC.loader.exec_module(_MODULE)
 
 build_evidence = _MODULE.build_evidence
 normalize_source = _MODULE.normalize_source
+to_ocsf_live_evidence = _MODULE.to_ocsf_live_evidence
 
 
 def _bom() -> dict:
@@ -125,3 +126,11 @@ class TestBuildEvidence:
             assert "CycloneDX AI BOM" in str(exc)
         else:  # pragma: no cover - defensive
             raise AssertionError("expected ValueError")
+
+    def test_can_emit_ocsf_live_evidence_bridge(self):
+        event = to_ocsf_live_evidence(build_evidence(_bom(), ["soc2"]))
+        assert event["category_uid"] == 5
+        assert event["class_uid"] == 5040
+        assert event["class_name"] == "Live Evidence Info"
+        assert event["metadata"]["version"] == "1.8.0"
+        assert event["unmapped"]["cloud_security_technical_evidence"]["frameworks"] == ["SOC 2 Security"]


### PR DESCRIPTION
Summary
- add `--output-format ocsf-live-evidence` to both discovery evidence skills so they can emit a Discovery-category OCSF bridge event for `Live Evidence Info [5040]`
- keep native deterministic evidence JSON as the default output to avoid breaking current consumers
- update README, architecture, and OCSF contract docs so the repo explicitly prefers native OCSF classes first, with bridge artifacts only where the schema does not cleanly fit yet

Validation
- `uv run ruff check skills/discovery/discover-control-evidence/src/discover.py skills/discovery/discover-control-evidence/tests/test_discover.py skills/discovery/discover-cloud-control-evidence/src/discover.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py --config pyproject.toml`
- `uv run pytest skills/discovery/discover-control-evidence/tests/test_discover.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py -q -o addopts='--import-mode=importlib'`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`

Notes
- this is an explicit bridge mode, not a silent format change
- the OCSF wrapper carries the deterministic evidence payload under `unmapped.cloud_security_technical_evidence`
- native evidence JSON remains the default for current downstream consumers