### PR TITLE
feat: add OCSF cloud inventory bridge mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is loosely based on Keep a Changelog.
 - First `discovery/` layer AI BOM skill, `discover-ai-bom`, which turns AI asset inventory snapshots into a deterministic CycloneDX-aligned BOM.
 - First discovery-layer technical evidence skill, `discover-control-evidence`, which turns discovery artifacts into deterministic PCI / SOC 2 evidence JSON.
 - `discover-cloud-control-evidence`, which turns AWS, GCP, and Azure inventory snapshots into deterministic PCI / SOC 2 technical evidence JSON.
+- `discover-environment --output-format ocsf-cloud-resources-inventory`, which emits an OCSF Discovery / Cloud Resources Inventory Info `[5023]` bridge event while preserving the native environment graph under `unmapped`.
 
 ### Changed
 - Removed the redirect-only `skills/ai-infra-security/` and `skills/compliance-cis-mitre/` stubs after the layered skill reshape settled.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
 | Layer | Role | Output |
 |---|---|---|
 | **Ingest** | Per-source raw log → OCSF | API / Network / HTTP / Application Activity |
-| **Discover** | point-in-time inventory / graph / evidence / AI BOM | deterministic JSON graph, evidence JSON, or CycloneDX-aligned BOM |
+| **Discover** | point-in-time inventory / graph / evidence / AI BOM | deterministic JSON graph, OCSF inventory/evidence bridge events, evidence JSON, or CycloneDX-aligned BOM |
 | **Detect** | OCSF → finding + MITRE ATT&CK | Detection Finding (class 2004) |
 | **Evaluate** | OCSF → framework check | Compliance Finding (class 2003) — CIS / NIST / SOC 2 |
 | **View** | OCSF → SARIF / Mermaid / graph | GitHub Security tab, PR comments, dashboards |
@@ -50,6 +50,7 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
 - `ingest`, `detect`, `evaluate`, and `view` are OCSF-first wire paths
 - `discovery` prefers native OCSF inventory/evidence classes and profiles when they fit
 - where OCSF does not cleanly fit yet, the repo uses deterministic bridge artifacts with an explicit mapping path back to OCSF
+- `discover-environment` supports an `ocsf-cloud-resources-inventory` bridge mode
 - discovery evidence skills support an `ocsf-live-evidence` bridge mode for Discovery-category OCSF workflows
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
@@ -113,7 +114,7 @@ skills/
 │   └── ingest-mcp-proxy-ocsf       MCP            → Application Activity 6002
 │
 ├── discovery/                      "Point-in-time inventory and graph evidence"
-│   ├── discover-environment                      → MITRE ATT&CK + ATLAS graph overlay
+│   ├── discover-environment                      → graph JSON or OCSF 5023 inventory bridge
 │   ├── discover-ai-bom                           → CycloneDX-aligned AI BOM
 │   ├── discover-control-evidence                 → PCI / SOC 2 technical evidence JSON
 │   └── discover-cloud-control-evidence           → Cross-cloud PCI / SOC 2 evidence JSON

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,7 +95,7 @@ This is how the repo stays secure and reliable without turning every skill into 
  └───────────────────────────────────────────────────────────────────┘
 ```
 
-Most data objects flowing between layers are **OCSF 1.8 JSONL**. That is the default wire contract for ingest, detect, evaluate, view, and sink paths. Discovery follows this rule where OCSF inventory/evidence classes fit cleanly; otherwise it may emit deterministic bridge artifacts such as environment graphs or CycloneDX-aligned AI BOMs with an explicit mapping path back to OCSF. The current discovery evidence skills also support an explicit `ocsf-live-evidence` bridge mode so Discovery-category pipelines can stay OCSF-shaped without replacing the native deterministic artifact.
+Most data objects flowing between layers are **OCSF 1.8 JSONL**. That is the default wire contract for ingest, detect, evaluate, view, and sink paths. Discovery follows this rule where OCSF inventory/evidence classes fit cleanly; otherwise it may emit deterministic bridge artifacts such as environment graphs or CycloneDX-aligned AI BOMs with an explicit mapping path back to OCSF. The current discovery set now supports explicit bridge modes for `Cloud Resources Inventory Info [5023]` and `Live Evidence Info [5040]`, so Discovery-category pipelines can stay OCSF-shaped without replacing the native deterministic artifact.
 
 ### Visuals
 

--- a/skills/detection-engineering/OCSF_CONTRACT.md
+++ b/skills/detection-engineering/OCSF_CONTRACT.md
@@ -46,6 +46,11 @@ Bridge artifacts are allowed only when:
 
 The direction of travel is still toward more native OCSF inventory/evidence use, not away from it.
 
+Current bridge modes shipped in-tree:
+- `discover-environment --output-format ocsf-cloud-resources-inventory`
+- `discover-control-evidence --output-format ocsf-live-evidence`
+- `discover-cloud-control-evidence --output-format ocsf-live-evidence`
+
 ## Wire format
 
 - All skills read and write **JSONL** (one OCSF event per line).

--- a/skills/discovery/discover-environment/SKILL.md
+++ b/skills/discovery/discover-environment/SKILL.md
@@ -11,6 +11,9 @@ description: >-
   (use cspm-aws/gcp/azure-cis-benchmark) or to drive remediation directly —
   this skill produces a graph, not findings, and never mutates cloud state.
   Do NOT use as a real-time monitor; the graph is a point-in-time snapshot.
+  Native output is deterministic graph JSON. Optional `--output-format
+  ocsf-cloud-resources-inventory` wraps the snapshot as OCSF Discovery / Cloud
+  Resources Inventory Info [5023] while preserving the graph under `unmapped`.
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Cloud discovery needs respective SDKs (boto3 for AWS,
@@ -19,7 +22,7 @@ compatibility: >-
 metadata:
   author: msaad00
   homepage: https://github.com/msaad00/cloud-security
-  source: https://github.com/msaad00/cloud-security/tree/main/skills/evaluation/discover-environment
+  source: https://github.com/msaad00/cloud-security/tree/main/skills/discovery/discover-environment
   version: 0.1.0
   frameworks:
     - MITRE ATT&CK
@@ -36,7 +39,8 @@ metadata:
 Maps cloud infrastructure to a security graph with MITRE ATT&CK and ATLAS
 technique overlays. Each resource becomes a graph node, each relationship
 an edge. Attack techniques are mapped as edges from technique nodes to
-vulnerable resources.
+vulnerable resources. When an OCSF consumer needs inventory-shaped output, the
+same snapshot can be emitted as `Cloud Resources Inventory Info [5023]`.
 
 ## When to Use
 
@@ -44,6 +48,7 @@ vulnerable resources.
 - Visualize IAM → service → storage → network relationships
 - Overlay MITRE ATT&CK techniques on infrastructure for threat modeling
 - Export cloud inventory as graph JSON for any visualization tool
+- Emit an OCSF Discovery bridge event for inventory-oriented pipelines
 - Feed into agent-bom's unified graph for cross-platform posture view
 - Periodic environment drift detection (compare graph snapshots)
 
@@ -155,13 +160,16 @@ python src/discover.py azure --subscription-id SUB_ID
 # Static config (no SDK needed)
 python src/discover.py config --config environment.json
 
-# Save output
+# Save native graph output
 python src/discover.py aws -o environment-graph.json
+
+# Emit an OCSF Cloud Resources Inventory bridge event
+python src/discover.py aws --output-format ocsf-cloud-resources-inventory -o inventory.ocsf.json
 ```
 
 ## Output Format
 
-The graph JSON is standalone — no agent-bom dependency. Any tool can consume it.
+Default output is standalone graph JSON — no agent-bom dependency. Any tool can consume it.
 
 ```json
 {
@@ -192,6 +200,30 @@ The graph JSON is standalone — no agent-bom dependency. Any tool can consume i
     "total_edges": 67,
     "node_types": {"user": 5, "service_account": 12, "cloud_resource": 25},
     "relationship_types": {"contains": 30, "owns": 5, "uses": 8, "exploitable_via": 24}
+  }
+}
+```
+
+Optional OCSF bridge output:
+
+```json
+{
+  "class_uid": 5023,
+  "class_name": "Cloud Resources Inventory Info",
+  "category_uid": 5,
+  "category_name": "Discovery",
+  "activity_id": 99,
+  "activity_name": "inventory_snapshot",
+  "resources": [
+    {
+      "uid": "aws:s3:prod-bucket",
+      "name": "s3://prod-bucket",
+      "type": "cloud_resource"
+    }
+  ],
+  "unmapped": {
+    "bridge_format": "cloud-security.environment-graph.v1",
+    "environment_graph": {}
   }
 }
 ```

--- a/skills/discovery/discover-environment/src/discover.py
+++ b/skills/discovery/discover-environment/src/discover.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-cloud-resources-inventory")
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Graph data model (standalone — no agent-bom dependency)
 # ═══════════════════════════════════════════════════════════════════════════
@@ -103,6 +105,11 @@ def _count_by_attr(items: list, attr: str) -> dict[str, int]:
         val = getattr(item, attr, "unknown")
         counts[val] = counts.get(val, 0) + 1
     return counts
+
+
+def _time_to_epoch_ms(value: str) -> int:
+    normalized = value.replace("Z", "+00:00")
+    return int(datetime.fromisoformat(normalized).timestamp() * 1000)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -722,6 +729,97 @@ def _add_mitre_edges(graph: EnvironmentGraph) -> None:
             )
 
 
+def _build_cloud_object(graph: EnvironmentGraph) -> dict[str, Any] | None:
+    if graph.provider == "static":
+        return None
+
+    cloud: dict[str, Any] = {"provider": graph.provider}
+    if graph.provider == "aws":
+        account_node = next((node for node in graph.nodes if node.id.startswith("aws:account:")), None)
+        if account_node:
+            account_id = account_node.attributes.get("account_id")
+            if account_id:
+                cloud["account"] = {"uid": str(account_id), "name": f"AWS Account {account_id}"}
+    elif graph.provider == "gcp":
+        project_node = next((node for node in graph.nodes if node.id.startswith("gcp:project:")), None)
+        if project_node:
+            project_uid = project_node.id.split(":", 2)[-1]
+            cloud["project_uid"] = project_uid
+            cloud["account"] = {"uid": project_uid, "name": project_node.label}
+    elif graph.provider == "azure":
+        subscription_node = next((node for node in graph.nodes if node.id.startswith("azure:subscription:")), None)
+        if subscription_node:
+            subscription_uid = subscription_node.id.split(":", 2)[-1]
+            cloud["account"] = {"uid": subscription_uid, "name": subscription_node.label}
+
+    if graph.region:
+        cloud["region"] = graph.region
+    return cloud
+
+
+def _node_to_ocsf_resource(node: GraphNode, region: str) -> dict[str, Any]:
+    resource = {
+        "uid": node.id,
+        "name": node.label,
+        "type": node.entity_type,
+        "region": region or node.attributes.get("region") or node.dimensions.get("region"),
+        "labels": sorted(set(node.compliance_tags)),
+        "data": {
+            "attributes": node.attributes,
+            "dimensions": node.dimensions,
+            "severity": node.severity,
+            "risk_score": node.risk_score,
+            "status": node.status,
+        },
+    }
+    if not resource["region"]:
+        resource.pop("region")
+    if not resource["labels"]:
+        resource.pop("labels")
+    return resource
+
+
+def to_ocsf_cloud_resources_inventory(graph: EnvironmentGraph) -> dict[str, Any]:
+    inventory_nodes = [node for node in graph.nodes if not node.id.startswith("mitre:")]
+    message = f"{graph.provider} cloud resource inventory snapshot"
+    event: dict[str, Any] = {
+        "activity_id": 99,
+        "activity_name": "inventory_snapshot",
+        "category_uid": 5,
+        "category_name": "Discovery",
+        "class_uid": 5023,
+        "class_name": "Cloud Resources Inventory Info",
+        "type_uid": 502399,
+        "type_name": "Cloud Resources Inventory Info: Other",
+        "severity_id": 1,
+        "severity": "Informational",
+        "status_id": 1,
+        "status": "Success",
+        "time": _time_to_epoch_ms(graph.discovered_at),
+        "message": message,
+        "metadata": {
+            "version": "1.8.0",
+            "product": {
+                "name": "cloud-security",
+                "vendor_name": "msaad00/cloud-security",
+                "feature": {"name": "discover-environment"},
+            },
+        },
+        "count": len(inventory_nodes),
+        "resources": [_node_to_ocsf_resource(node, graph.region) for node in inventory_nodes],
+        "unmapped": {
+            "environment_graph": graph.to_dict(),
+            "bridge_format": "cloud-security.environment-graph.v1",
+        },
+    }
+    if cloud := _build_cloud_object(graph):
+        event["cloud"] = cloud
+    if inventory_nodes:
+        event["start_time"] = _time_to_epoch_ms(graph.discovered_at)
+        event["end_time"] = _time_to_epoch_ms(graph.discovered_at)
+    return event
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # CLI
 # ═══════════════════════════════════════════════════════════════════════════
@@ -735,6 +833,12 @@ def main() -> None:
     parser.add_argument("--subscription-id", help="Azure subscription ID")
     parser.add_argument("--profile", help="AWS CLI profile name")
     parser.add_argument("--config", help="Path to static config file (for 'config' provider)")
+    parser.add_argument(
+        "--output-format",
+        choices=SUPPORTED_OUTPUT_FORMATS,
+        default="native",
+        help="Output format: native graph JSON or OCSF Cloud Resources Inventory bridge",
+    )
     parser.add_argument("--output", "-o", help="Output file path (default: stdout)")
     args = parser.parse_args()
 
@@ -755,7 +859,13 @@ def main() -> None:
     else:
         parser.error(f"Unknown provider: {args.provider}")
 
-    result = json.dumps(graph.to_dict(), indent=2, default=str)
+    payload: dict[str, Any]
+    if args.output_format == "ocsf-cloud-resources-inventory":
+        payload = to_ocsf_cloud_resources_inventory(graph)
+    else:
+        payload = graph.to_dict()
+
+    result = json.dumps(payload, indent=2, default=str)
 
     if args.output:
         Path(args.output).write_text(result)

--- a/skills/discovery/discover-environment/tests/test_discover.py
+++ b/skills/discovery/discover-environment/tests/test_discover.py
@@ -16,6 +16,7 @@ from discover import (
     GraphNode,
     discover_from_config,
     get_attack_techniques,
+    to_ocsf_cloud_resources_inventory,
 )
 
 
@@ -150,3 +151,71 @@ class TestGraphStats:
         assert stats["node_types"]["user"] == 2
         assert stats["node_types"]["server"] == 1
         assert stats["relationship_types"]["uses"] == 2
+
+
+class TestOcsfCloudInventoryBridge:
+    def test_can_emit_ocsf_cloud_resources_inventory(self):
+        graph = EnvironmentGraph(
+            provider="aws",
+            region="us-east-1",
+            discovered_at="2026-04-13T12:00:00+00:00",
+        )
+        graph.add_node(
+            GraphNode(
+                id="aws:account:123456789012",
+                entity_type="cloud_resource",
+                label="AWS Account 123456789012",
+                attributes={"account_id": "123456789012", "arn": "arn:aws:iam::123456789012:root"},
+                dimensions={"cloud_provider": "aws", "surface": "account"},
+            )
+        )
+        graph.add_node(
+            GraphNode(
+                id="aws:s3:prod-bucket",
+                entity_type="cloud_resource",
+                label="s3://prod-bucket",
+                attributes={"created": "2026-04-13T11:00:00+00:00"},
+                compliance_tags=["MITRE-T1530"],
+                dimensions={"cloud_provider": "aws", "surface": "storage"},
+            )
+        )
+        graph.add_node(
+            GraphNode(
+                id="mitre:T1530",
+                entity_type="vulnerability",
+                label="T1530: Data from Cloud Storage",
+            )
+        )
+        graph.add_edge(
+            GraphEdge(
+                source="mitre:T1530",
+                target="aws:s3:prod-bucket",
+                relationship="exploitable_via",
+                evidence={"technique": "T1530"},
+            )
+        )
+
+        event = to_ocsf_cloud_resources_inventory(graph)
+
+        assert event["class_uid"] == 5023
+        assert event["category_uid"] == 5
+        assert event["activity_id"] == 99
+        assert event["metadata"]["product"]["feature"]["name"] == "discover-environment"
+        assert event["cloud"]["provider"] == "aws"
+        assert event["cloud"]["account"]["uid"] == "123456789012"
+        assert event["count"] == 2
+        assert len(event["resources"]) == 2
+        assert all(resource["uid"] != "mitre:T1530" for resource in event["resources"])
+        assert event["resources"][1]["labels"] == ["MITRE-T1530"]
+        assert event["unmapped"]["bridge_format"] == "cloud-security.environment-graph.v1"
+        assert event["unmapped"]["environment_graph"]["stats"]["total_nodes"] == 3
+
+    def test_static_graph_can_emit_bridge_without_cloud_object(self):
+        graph = EnvironmentGraph(provider="static", discovered_at="2026-04-13T12:00:00+00:00")
+        graph.add_node(GraphNode(id="res:1", entity_type="cloud_resource", label="Static Resource"))
+
+        event = to_ocsf_cloud_resources_inventory(graph)
+
+        assert event["class_uid"] == 5023
+        assert "cloud" not in event
+        assert event["count"] == 1


### PR DESCRIPTION
Summary:
- add optional ocsf cloud inventory output to discover-environment
- map discovered resources into OCSF Discovery class 5023 while preserving the native graph under unmapped
- update README, architecture, OCSF contract, skill docs, and changelog

Validation:
- python3 -m pytest skills/discovery/discover-environment/tests/test_discover.py -q -o addopts=
- python3 -m ruff check skills/discovery/discover-environment/src/discover.py skills/discovery/discover-environment/tests/test_discover.py
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py

Notes:
- native graph JSON remains the default output
- uv run validation could not be used locally because sandbox network access is blocked for package resolution