### PR TITLE
feat: deepen AI service inventory and evidence coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is loosely based on Keep a Changelog.
 - First discovery-layer technical evidence skill, `discover-control-evidence`, which turns discovery artifacts into deterministic PCI / SOC 2 evidence JSON.
 - `discover-cloud-control-evidence`, which turns AWS, GCP, and Azure inventory snapshots into deterministic PCI / SOC 2 technical evidence JSON.
 - `discover-environment --output-format ocsf-cloud-resources-inventory`, which emits an OCSF Discovery / Cloud Resources Inventory Info `[5023]` bridge event while preserving the native environment graph under `unmapped`.
+- deeper AI provider inventory and evidence coverage across AWS Bedrock / SageMaker, Google Vertex AI, Azure ML, and Azure AI Foundry in the discovery layer.
 
 ### Changed
 - Removed the redirect-only `skills/ai-infra-security/` and `skills/compliance-cis-mitre/` stubs after the layered skill reshape settled.

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -69,9 +69,13 @@ ATLAS is present today, but coverage is narrower than ATT&CK.
 | `discover-control-evidence` | evidence package that preserves ATLAS / AI RMF context from discovery artifacts |
 | `discover-cloud-control-evidence` | cross-cloud evidence package that preserves ATT&CK / ATLAS / AI RMF inventory context |
 
+Current provider depth in discovery:
+- AWS Bedrock / SageMaker
+- Google Vertex AI
+- Azure ML / Azure AI Foundry
+
 Recommended expansion:
 - make ATLAS mappings more explicit in `gpu-cluster-security`
-- use ATLAS in future AI BOM / discovery / inventory skills
 - add a shared table of ATLAS techniques used by AI-oriented skills
 
 ## Kubernetes and containers
@@ -102,7 +106,7 @@ uniform than classic cloud posture.
 
 Recommended next step:
 - make ATLAS coverage first-class for GPU and model-serving paths
-- connect future AI BOM discovery/inventory outputs to ATLAS and AI RMF
+- connect AI BOM and discovery outputs more directly to ATLAS and AI RMF evidence views
 
 ## Compliance and control frameworks
 

--- a/skills/discovery/discover-ai-bom/REFERENCES.md
+++ b/skills/discovery/discover-ai-bom/REFERENCES.md
@@ -9,9 +9,16 @@ Only official sources are allowed here. This skill relies on:
 - NIST AI Risk Management Framework: https://www.nist.gov/itl/ai-risk-management-framework
 - AWS SageMaker model package inventory (`ListModelPackages`): https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/list_model_packages.html
 - AWS SageMaker endpoint inventory (`ListEndpoints`): https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/list_endpoints.html
+- AWS SageMaker training job inventory (`ListTrainingJobs`): https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/list_training_jobs.html
 - AWS Bedrock custom model inventory (`ListCustomModels`): https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/list_custom_models.html
+- AWS Bedrock guardrails: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+- AWS Bedrock knowledge bases: https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html
 - Google Vertex AI Python client reference (`Model`, `Endpoint` resources): https://cloud.google.com/python/docs/reference/aiplatform/latest
+- Google Vertex AI datasets: https://cloud.google.com/vertex-ai/docs/datasets/overview
+- Google Vertex AI vector search: https://cloud.google.com/vertex-ai/docs/vector-search/overview
 - Azure Machine Learning inference endpoints (official concepts + SDK surface): https://learn.microsoft.com/en-us/azure/machine-learning/concept-endpoints
+- Azure Machine Learning data assets: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-data-assets
+- Azure AI Foundry overview: https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-ai-foundry
 - PCI DSS official site: https://www.pcisecuritystandards.org/
 - AICPA / SOC 2 overview: https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2
 - MITRE ATLAS: https://atlas.mitre.org/

--- a/skills/discovery/discover-ai-bom/SKILL.md
+++ b/skills/discovery/discover-ai-bom/SKILL.md
@@ -80,9 +80,9 @@ The skill accepts one JSON document, either:
 
 2. **Provider-shaped snapshots**
 
-- AWS: `sagemaker.model_packages[]`, `sagemaker.endpoints[]`, `bedrock.custom_models[]`, `bedrock.guardrails[]`
-- GCP: `vertex_ai.models[]`, `vertex_ai.endpoints[]`
-- Azure: `azure_ml.models[]`, `azure_ml.online_endpoints[]`, `azure_ml.deployments[]`
+- AWS: `sagemaker.model_packages[]`, `sagemaker.endpoints[]`, `sagemaker.training_jobs[]`, `sagemaker.datasets[]`, `bedrock.custom_models[]`, `bedrock.guardrails[]`, `bedrock.knowledge_bases[]`
+- GCP: `vertex_ai.models[]`, `vertex_ai.endpoints[]`, `vertex_ai.datasets[]`, `vertex_ai.training_pipelines[]`, `vertex_ai.indexes[]`, `vertex_ai.index_endpoints[]`
+- Azure: `azure_ml.models[]`, `azure_ml.online_endpoints[]`, `azure_ml.deployments[]`, `azure_ml.data_assets[]`, `azure_ml.compute_clusters[]`, `ai_foundry.deployments[]`, `ai_foundry.projects[]`
 
 ## Output contract
 

--- a/skills/discovery/discover-ai-bom/src/discover.py
+++ b/skills/discovery/discover-ai-bom/src/discover.py
@@ -40,10 +40,21 @@ COMPONENT_TYPES = {
 }
 KIND_ALIASES = {
     "guardrails": "guardrail",
+    "datasets": "dataset",
+    "data-assets": "dataset",
+    "data_assets": "dataset",
+    "index": "vector-index",
+    "indexes": "vector-index",
+    "index-endpoint": "endpoint",
+    "index_endpoints": "endpoint",
+    "knowledge-base": "vector-store",
+    "knowledge_bases": "vector-store",
     "model-package": "model-package",
     "model-packages": "model-package",
     "online-endpoint": "endpoint",
     "online-endpoints": "endpoint",
+    "training-jobs": "training-job",
+    "training_pipelines": "training-job",
 }
 
 
@@ -182,6 +193,32 @@ def _normalize_aws(document: dict[str, Any]) -> list[dict[str, Any]]:
             )
         )
 
+    for job in sagemaker.get("training_jobs", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="sagemaker",
+                kind="training-job",
+                id=job.get("TrainingJobArn") or job.get("TrainingJobName"),
+                name=job.get("TrainingJobName"),
+                status=job.get("TrainingJobStatus"),
+                region=job.get("Region"),
+            )
+        )
+
+    for dataset in sagemaker.get("datasets", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="sagemaker",
+                kind="dataset",
+                id=dataset.get("DatasetArn") or dataset.get("DatasetName"),
+                name=dataset.get("DatasetName"),
+                version=dataset.get("DatasetVersion"),
+                region=dataset.get("Region"),
+            )
+        )
+
     for model in bedrock.get("custom_models", []):
         assets.append(
             _make_asset(
@@ -206,6 +243,18 @@ def _normalize_aws(document: dict[str, Any]) -> list[dict[str, Any]]:
                 name=guardrail.get("name"),
                 version=guardrail.get("version"),
                 status=guardrail.get("status"),
+            )
+        )
+
+    for knowledge_base in bedrock.get("knowledge_bases", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="bedrock",
+                kind="vector-store",
+                id=knowledge_base.get("knowledgeBaseId") or knowledge_base.get("knowledgeBaseArn"),
+                name=knowledge_base.get("name"),
+                status=knowledge_base.get("status"),
             )
         )
 
@@ -247,6 +296,60 @@ def _normalize_gcp(document: dict[str, Any]) -> list[dict[str, Any]]:
             )
         )
 
+    for dataset in vertex.get("datasets", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="vertex-ai",
+                kind="dataset",
+                id=dataset.get("name"),
+                name=dataset.get("displayName") or dataset.get("name"),
+                region=dataset.get("region"),
+                labels=dataset.get("labels"),
+            )
+        )
+
+    for pipeline in vertex.get("training_pipelines", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="vertex-ai",
+                kind="training-job",
+                id=pipeline.get("name"),
+                name=pipeline.get("displayName") or pipeline.get("name"),
+                status=pipeline.get("state"),
+                region=pipeline.get("region"),
+                labels=pipeline.get("labels"),
+            )
+        )
+
+    for index in vertex.get("indexes", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="vertex-ai",
+                kind="vector-index",
+                id=index.get("name"),
+                name=index.get("displayName") or index.get("name"),
+                region=index.get("region"),
+                labels=index.get("labels"),
+            )
+        )
+
+    for index_endpoint in vertex.get("index_endpoints", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="vertex-ai",
+                kind="endpoint",
+                id=index_endpoint.get("name"),
+                name=index_endpoint.get("displayName") or index_endpoint.get("name"),
+                region=index_endpoint.get("region"),
+                dependencies=[item.get("index") for item in index_endpoint.get("deployedIndexes", []) if item.get("index")],
+                labels=index_endpoint.get("labels"),
+            )
+        )
+
     return assets
 
 
@@ -254,6 +357,7 @@ def _normalize_azure(document: dict[str, Any]) -> list[dict[str, Any]]:
     assets: list[dict[str, Any]] = []
     provider = (document.get("provider") or "azure").lower()
     aml = document.get("azure_ml", {}) or {}
+    ai_foundry = document.get("ai_foundry", {}) or {}
 
     for model in aml.get("models", []):
         assets.append(
@@ -292,6 +396,56 @@ def _normalize_azure(document: dict[str, Any]) -> list[dict[str, Any]]:
                 name=deployment.get("name"),
                 version=deployment.get("version"),
                 dependencies=[deployment.get("model"), deployment.get("endpoint_name")],
+            )
+        )
+
+    for dataset in aml.get("data_assets", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="azure-ml",
+                kind="dataset",
+                id=dataset.get("id") or dataset.get("name"),
+                name=dataset.get("name"),
+                version=dataset.get("version"),
+            )
+        )
+
+    for compute in aml.get("compute_clusters", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="azure-ml",
+                kind="runtime",
+                id=compute.get("id") or compute.get("name"),
+                name=compute.get("name"),
+                version=compute.get("size") or compute.get("vmSize"),
+                status=compute.get("state"),
+            )
+        )
+
+    for deployment in ai_foundry.get("deployments", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="ai-foundry",
+                kind="endpoint",
+                id=deployment.get("id") or deployment.get("name"),
+                name=deployment.get("name"),
+                status=deployment.get("provisioning_state") or deployment.get("status"),
+                dependencies=[deployment.get("model"), deployment.get("project_id")],
+            )
+        )
+
+    for project in ai_foundry.get("projects", []):
+        assets.append(
+            _make_asset(
+                provider=provider,
+                service="ai-foundry",
+                kind="runtime",
+                id=project.get("id") or project.get("name"),
+                name=project.get("name"),
+                status=project.get("status"),
             )
         )
 

--- a/skills/discovery/discover-ai-bom/tests/test_discover.py
+++ b/skills/discovery/discover-ai-bom/tests/test_discover.py
@@ -95,6 +95,19 @@ class TestProviderSnapshots:
                             "ModelPackageArn": "arn:aws:sagemaker:us-east-1:123:model-package/fraud/5",
                         }
                     ],
+                    "training_jobs": [
+                        {
+                            "TrainingJobArn": "arn:aws:sagemaker:us-east-1:123:training-job/fraud-train",
+                            "TrainingJobName": "fraud-train",
+                            "TrainingJobStatus": "Completed",
+                        }
+                    ],
+                    "datasets": [
+                        {
+                            "DatasetArn": "arn:aws:sagemaker:us-east-1:123:dataset/fraud",
+                            "DatasetName": "fraud-dataset",
+                        }
+                    ],
                 },
                 "bedrock": {
                     "custom_models": [
@@ -103,11 +116,26 @@ class TestProviderSnapshots:
                             "modelName": "fraud-custom",
                             "foundationModelArn": "arn:aws:bedrock:::foundation-model/anthropic.claude",
                         }
-                    ]
+                    ],
+                    "knowledge_bases": [
+                        {
+                            "knowledgeBaseId": "kb-1",
+                            "name": "fraud-kb",
+                            "status": "ACTIVE",
+                            "storageConfiguration": {"type": "OPENSEARCH_SERVERLESS"},
+                        }
+                    ],
                 },
             }
         )
-        assert [asset["kind"] for asset in assets] == ["model", "endpoint", "model-package"]
+        assert [asset["kind"] for asset in assets] == [
+            "model",
+            "vector-store",
+            "dataset",
+            "endpoint",
+            "model-package",
+            "training-job",
+        ]
 
     def test_gcp_snapshot_normalization(self):
         assets = _normalize_assets(
@@ -122,10 +150,27 @@ class TestProviderSnapshots:
                             "deployedModels": [{"model": "projects/p/locations/us/models/1"}],
                         }
                     ],
+                    "datasets": [{"name": "projects/p/locations/us/datasets/1", "displayName": "fraud-dataset"}],
+                    "training_pipelines": [{"name": "projects/p/locations/us/trainingPipelines/1", "displayName": "fraud-train"}],
+                    "indexes": [{"name": "projects/p/locations/us/indexes/1", "displayName": "fraud-index"}],
+                    "index_endpoints": [
+                        {
+                            "name": "projects/p/locations/us/indexEndpoints/1",
+                            "displayName": "fraud-index-endpoint",
+                            "deployedIndexes": [{"index": "projects/p/locations/us/indexes/1"}],
+                        }
+                    ],
                 },
             }
         )
-        assert [asset["kind"] for asset in assets] == ["endpoint", "model"]
+        assert [asset["kind"] for asset in assets] == [
+            "dataset",
+            "endpoint",
+            "endpoint",
+            "model",
+            "training-job",
+            "vector-index",
+        ]
 
     def test_azure_snapshot_normalization(self):
         assets = _normalize_assets(
@@ -140,10 +185,24 @@ class TestProviderSnapshots:
                             "deployments": [{"id": "/deployments/fraud-blue"}],
                         }
                     ],
+                    "data_assets": [{"id": "/data/fraud", "name": "fraud-data", "version": "1"}],
+                    "compute_clusters": [{"id": "/compute/gpu", "name": "gpu", "vmSize": "Standard_NC6s_v3"}],
+                },
+                "ai_foundry": {
+                    "deployments": [{"id": "/foundry/deployments/chat", "name": "chat-prod", "model": "/models/fraud"}],
+                    "projects": [{"id": "/foundry/projects/ai-sec", "name": "ai-sec"}],
                 },
             }
         )
-        assert [asset["kind"] for asset in assets] == ["deployment", "endpoint", "model"]
+        assert [asset["kind"] for asset in assets] == [
+            "endpoint",
+            "runtime",
+            "dataset",
+            "deployment",
+            "endpoint",
+            "model",
+            "runtime",
+        ]
 
 
 class TestErrors:

--- a/skills/discovery/discover-cloud-control-evidence/REFERENCES.md
+++ b/skills/discovery/discover-cloud-control-evidence/REFERENCES.md
@@ -6,10 +6,15 @@ Only official sources are allowed here. This skill relies on:
 - AICPA / SOC reporting overview: https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2
 - AWS Security Best Practices and IAM docs: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail user guide: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html
+- AWS Bedrock guardrails: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+- AWS SageMaker endpoint security and IAM: https://docs.aws.amazon.com/sagemaker/latest/dg/security-iam.html
 - Google Cloud IAM overview: https://cloud.google.com/iam/docs/overview
 - Google Cloud Audit Logs overview: https://cloud.google.com/logging/docs/audit
+- Google Vertex AI overview: https://cloud.google.com/vertex-ai/docs/start/introduction-unified-platform
 - Azure identity and access management overview: https://learn.microsoft.com/en-us/azure/security/fundamentals/identity-management-overview
 - Azure Monitor diagnostic settings: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/diagnostic-settings
+- Azure AI Foundry overview: https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-ai-foundry
+- Azure Machine Learning online endpoint concepts: https://learn.microsoft.com/en-us/azure/machine-learning/concept-endpoints-online
 - NIST AI Risk Management Framework: https://www.nist.gov/itl/ai-risk-management-framework
 - MITRE ATT&CK: https://attack.mitre.org/
 - MITRE ATLAS: https://atlas.mitre.org/

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -62,8 +62,9 @@ The skill accepts one JSON document with any mix of these provider snapshots:
 
 Each provider section may include relevant inventory such as identities,
 storage, logging, encryption, key management, network policies, public IPs,
-endpoints, or AI service inventory. The skill only processes the providers and
-services present in the supplied input.
+endpoints, or AI service inventory. AI-specific inputs can include Bedrock,
+SageMaker, Vertex AI, Azure ML, and Azure AI Foundry snapshots. The skill only
+processes the providers and services present in the supplied input.
 
 ## Output contract
 
@@ -74,6 +75,7 @@ The skill emits one deterministic JSON document:
 - `inventory_summary` with providers, services, asset counts, and control-surface counts
 - `controls[]` with `evidence-ready` / `partial` / `missing` status per control domain
 - `gaps[]` only when the source artifact cannot support a given evidence domain
+- AI-oriented evidence domains for endpoint surface and governance inventory when AI service assets are present
 
 By default this is native evidence JSON, not an attestation. When `--output-format ocsf-live-evidence` is used, the skill emits a Discovery-category OCSF bridge event for `Live Evidence Info [5040]` and carries the deterministic evidence payload under `unmapped.cloud_security_technical_evidence`.
 

--- a/skills/discovery/discover-cloud-control-evidence/src/discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/src/discover.py
@@ -31,6 +31,9 @@ SECRET_KEYWORDS = (
     "access_key",
 )
 PUBLIC_CIDRS = {"0.0.0.0/0", "::/0", "*", "internet", "any"}
+AI_SERVICES = {"ai-foundry", "azure-ml", "bedrock", "sagemaker", "vertex-ai"}
+AI_ENDPOINT_KINDS = {"deployment", "endpoint", "inference-endpoint"}
+AI_GOVERNANCE_KINDS = {"ai-guardrail", "dataset", "guardrail", "model", "model-package", "training-job", "vector-index", "vector-store"}
 
 
 def _load_json(path: str | None) -> dict[str, Any]:
@@ -239,6 +242,60 @@ def _aws_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 name=model.get("modelName"),
             )
         )
+    for guardrail in bedrock.get("guardrails", []):
+        assets.append(
+            _asset(
+                "aws",
+                "bedrock",
+                "ai-guardrail",
+                guardrail.get("id") or guardrail.get("guardrailArn"),
+                name=guardrail.get("name"),
+            )
+        )
+    for knowledge_base in bedrock.get("knowledge_bases", []):
+        assets.append(
+            _asset(
+                "aws",
+                "bedrock",
+                "vector-store",
+                knowledge_base.get("knowledgeBaseId") or knowledge_base.get("knowledgeBaseArn"),
+                name=knowledge_base.get("name"),
+                encrypted=_bool(knowledge_base.get("encrypted")),
+            )
+        )
+    for package in sagemaker.get("model_packages", []):
+        assets.append(
+            _asset(
+                "aws",
+                "sagemaker",
+                "model-package",
+                package.get("ModelPackageArn") or package.get("ModelPackageName"),
+                name=package.get("ModelPackageName") or package.get("ModelPackageGroupName"),
+            )
+        )
+    for job in sagemaker.get("training_jobs", []):
+        assets.append(
+            _asset(
+                "aws",
+                "sagemaker",
+                "training-job",
+                job.get("TrainingJobArn") or job.get("TrainingJobName"),
+                name=job.get("TrainingJobName"),
+                encrypted=_bool(job.get("VolumeKmsKeyId")) or _bool(job.get("OutputDataConfig", {}).get("KmsKeyId")),
+                logged=_bool(job.get("EnableNetworkIsolation")) or _bool(job.get("EnableInterContainerTrafficEncryption")),
+            )
+        )
+    for dataset in sagemaker.get("datasets", []):
+        assets.append(
+            _asset(
+                "aws",
+                "sagemaker",
+                "dataset",
+                dataset.get("DatasetArn") or dataset.get("DatasetName"),
+                name=dataset.get("DatasetName"),
+                encrypted=_bool(dataset.get("KmsKeyId")),
+            )
+        )
     for endpoint in sagemaker.get("endpoints", []):
         assets.append(
             _asset(
@@ -248,6 +305,8 @@ def _aws_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 endpoint.get("EndpointArn") or endpoint.get("EndpointName"),
                 name=endpoint.get("EndpointName"),
                 public=_bool(endpoint.get("public")),
+                encrypted=_bool(endpoint.get("KmsKeyId")) or _bool(endpoint.get("DataCaptureConfig", {}).get("KmsKeyId")),
+                logged=_bool(endpoint.get("DataCaptureConfig", {}).get("EnableCapture")),
             )
         )
     return assets
@@ -347,6 +406,40 @@ def _gcp_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 name=model.get("displayName") or model.get("name"),
             )
         )
+    for dataset in vertex.get("datasets", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "vertex-ai",
+                "dataset",
+                dataset.get("name"),
+                name=dataset.get("displayName") or dataset.get("name"),
+                encrypted=bool(dataset.get("encryptionSpec", {}).get("kmsKeyName")),
+            )
+        )
+    for pipeline in vertex.get("training_pipelines", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "vertex-ai",
+                "training-job",
+                pipeline.get("name"),
+                name=pipeline.get("displayName") or pipeline.get("name"),
+                encrypted=bool(pipeline.get("encryptionSpec", {}).get("kmsKeyName")),
+                logged=_bool(pipeline.get("enableContainerLogging")),
+            )
+        )
+    for index in vertex.get("indexes", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "vertex-ai",
+                "vector-index",
+                index.get("name"),
+                name=index.get("displayName") or index.get("name"),
+                encrypted=bool(index.get("encryptionSpec", {}).get("kmsKeyName")),
+            )
+        )
     for endpoint in vertex.get("endpoints", []):
         assets.append(
             _asset(
@@ -356,6 +449,19 @@ def _gcp_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 endpoint.get("name"),
                 name=endpoint.get("displayName") or endpoint.get("name"),
                 public=_bool(endpoint.get("public")),
+                encrypted=bool(endpoint.get("encryptionSpec", {}).get("kmsKeyName")),
+            )
+        )
+    for index_endpoint in vertex.get("index_endpoints", []):
+        assets.append(
+            _asset(
+                "gcp",
+                "vertex-ai",
+                "endpoint",
+                index_endpoint.get("name"),
+                name=index_endpoint.get("displayName") or index_endpoint.get("name"),
+                public=_bool(index_endpoint.get("public")),
+                encrypted=bool(index_endpoint.get("encryptionSpec", {}).get("kmsKeyName")),
             )
         )
     return assets
@@ -481,6 +587,75 @@ def _azure_assets(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 deployment.get("id") or deployment.get("name"),
                 name=deployment.get("name"),
                 public=_bool(deployment.get("public")),
+                encrypted=_bool(deployment.get("cmk_enabled")) or _bool(deployment.get("encrypted")),
+                logged=_bool(deployment.get("diagnostic_logging")) or _bool(deployment.get("logging_enabled")),
+            )
+        )
+    for project in ai_foundry.get("projects", []):
+        assets.append(
+            _asset(
+                "azure",
+                "ai-foundry",
+                "runtime",
+                project.get("id") or project.get("name"),
+                name=project.get("name"),
+                logged=_bool(project.get("diagnostic_logging")) or _bool(project.get("logging_enabled")),
+            )
+        )
+    for model in ai_foundry.get("models", []):
+        assets.append(
+            _asset(
+                "azure",
+                "ai-foundry",
+                "model",
+                model.get("id") or model.get("name"),
+                name=model.get("name"),
+            )
+        )
+    azure_ml = snapshot.get("azure_ml", {}) or {}
+    for model in azure_ml.get("models", []):
+        assets.append(
+            _asset(
+                "azure",
+                "azure-ml",
+                "model",
+                model.get("id") or model.get("name"),
+                name=model.get("name"),
+            )
+        )
+    for dataset in azure_ml.get("data_assets", []):
+        assets.append(
+            _asset(
+                "azure",
+                "azure-ml",
+                "dataset",
+                dataset.get("id") or dataset.get("name"),
+                name=dataset.get("name"),
+                encrypted=_bool(dataset.get("cmk_enabled")) or _bool(dataset.get("encrypted")),
+            )
+        )
+    for endpoint in azure_ml.get("online_endpoints", []):
+        assets.append(
+            _asset(
+                "azure",
+                "azure-ml",
+                "endpoint",
+                endpoint.get("id") or endpoint.get("name"),
+                name=endpoint.get("name"),
+                public=_bool(endpoint.get("public")) or _bool(endpoint.get("public_network_access")),
+                encrypted=_bool(endpoint.get("cmk_enabled")) or _bool(endpoint.get("encrypted")),
+                logged=_bool(endpoint.get("app_insights_enabled")) or _bool(endpoint.get("logging_enabled")),
+            )
+        )
+    for deployment in azure_ml.get("deployments", []):
+        assets.append(
+            _asset(
+                "azure",
+                "azure-ml",
+                "deployment",
+                deployment.get("id") or deployment.get("name"),
+                name=deployment.get("name"),
+                logged=_bool(deployment.get("logging_enabled")),
             )
         )
     return assets
@@ -531,6 +706,10 @@ def _summaries(normalized: dict[str, Any]) -> dict[str, Any]:
     encrypted_assets = [asset for asset in assets if _bool(asset.get("encrypted"))]
     logging_assets = [asset for asset in assets if _bool(asset.get("logged"))]
     key_assets = [asset for asset in assets if asset["kind"] in {"key", "key-vault"}]
+    ai_assets = [asset for asset in assets if asset["service"] in AI_SERVICES]
+    ai_endpoint_assets = [asset for asset in ai_assets if asset["kind"] in AI_ENDPOINT_KINDS]
+    ai_public_assets = [asset for asset in ai_endpoint_assets if _bool(asset.get("public"))]
+    ai_governance_assets = [asset for asset in ai_assets if asset["kind"] in AI_GOVERNANCE_KINDS]
 
     return {
         "providers": normalized["providers"],
@@ -543,6 +722,10 @@ def _summaries(normalized: dict[str, Any]) -> dict[str, Any]:
             "encrypted_assets": len(encrypted_assets),
             "logging_assets": len(logging_assets),
             "key_assets": len(key_assets),
+            "ai_assets": len(ai_assets),
+            "ai_endpoint_assets": len(ai_endpoint_assets),
+            "ai_public_assets": len(ai_public_assets),
+            "ai_governance_assets": len(ai_governance_assets),
         },
     }
 
@@ -601,6 +784,9 @@ def _controls_for(framework: str, normalized: dict[str, Any]) -> list[dict[str, 
     encrypted_assets = [asset for asset in assets if _bool(asset.get("encrypted"))]
     logging_assets = [asset for asset in assets if _bool(asset.get("logged"))]
     key_assets = [asset for asset in assets if asset["kind"] in {"key", "key-vault"}]
+    ai_assets = [asset for asset in assets if asset["service"] in AI_SERVICES]
+    ai_endpoint_assets = [asset for asset in ai_assets if asset["kind"] in AI_ENDPOINT_KINDS]
+    ai_governance_assets = [asset for asset in ai_assets if asset["kind"] in AI_GOVERNANCE_KINDS]
 
     if framework == "pci":
         return [
@@ -638,6 +824,22 @@ def _controls_for(framework: str, normalized: dict[str, Any]) -> list[dict[str, 
                 _sample(logging_assets),
                 [] if logging_assets else ["No logging inventory was present in the supplied snapshot."],
             ),
+            _control(
+                framework,
+                "inventory.ai-service-surface",
+                "AI service surface evidence",
+                "Inventory-backed evidence for model endpoints, deployments, and AI-facing service surfaces across AWS, GCP, and Azure.",
+                _sample(ai_endpoint_assets),
+                [] if ai_endpoint_assets else ["No AI endpoint or deployment inventory was present in the supplied snapshot."],
+            ),
+            _control(
+                framework,
+                "inventory.ai-governance",
+                "AI governance and data-path evidence",
+                "Inventory-backed evidence for models, datasets, vector stores, training jobs, and guardrails associated with AI services.",
+                _sample(ai_governance_assets),
+                [] if ai_governance_assets else ["No AI governance inventory was present in the supplied snapshot."],
+            ),
         ]
 
     return [
@@ -674,6 +876,22 @@ def _controls_for(framework: str, normalized: dict[str, Any]) -> list[dict[str, 
             "Inventory-backed evidence for audit logging and diagnostic coverage.",
             _sample(logging_assets),
             [] if logging_assets else ["No logging inventory was present in the supplied snapshot."],
+        ),
+        _control(
+            framework,
+            "cc6.ai-service-surface",
+            "AI service surface evidence",
+            "Inventory-backed evidence for model-serving endpoints, AI deployments, and externally reachable AI service surfaces.",
+            _sample(ai_endpoint_assets),
+            [] if ai_endpoint_assets else ["No AI endpoint or deployment inventory was present in the supplied snapshot."],
+        ),
+        _control(
+            framework,
+            "cc7.ai-governance-and-monitoring",
+            "AI governance and monitoring evidence",
+            "Inventory-backed evidence for models, datasets, vector stores, training jobs, and guardrail surfaces associated with AI services.",
+            _sample(ai_governance_assets),
+            [] if ai_governance_assets else ["No AI governance inventory was present in the supplied snapshot."],
         ),
     ]
 

--- a/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
@@ -51,18 +51,40 @@ def _multi_cloud_snapshot() -> dict:
         "snapshot_id": "multi-1",
         "captured_at": "2026-04-12T03:00:00Z",
         "aws": {
-            "bedrock": {"custom_models": [{"modelArn": "arn:aws:bedrock:model/guard", "modelName": "guard-model"}]}
+            "bedrock": {
+                "custom_models": [{"modelArn": "arn:aws:bedrock:model/guard", "modelName": "guard-model"}],
+                "guardrails": [{"id": "gr-1", "name": "bedrock-guard"}],
+                "knowledge_bases": [{"knowledgeBaseId": "kb-1", "name": "kb-prod", "encrypted": True}],
+            },
+            "sagemaker": {
+                "endpoints": [{"EndpointArn": "arn:aws:sagemaker:endpoint/fraud", "EndpointName": "fraud", "public": False}],
+                "training_jobs": [{"TrainingJobArn": "arn:aws:sagemaker:training-job/fraud", "TrainingJobName": "fraud-train"}],
+            },
         },
         "gcp": {
             "iam": {"service_accounts": [{"email": "svc@example.iam.gserviceaccount.com"}]},
             "logging": {"sinks": [{"name": "org-sink"}]},
             "compute": {"instances": [{"id": "gce-1", "name": "gce-1", "networkInterfaces": [{"accessConfigs": [{}]}]}]},
+            "vertex_ai": {
+                "models": [{"name": "projects/p/locations/us/models/1", "displayName": "fraud-model"}],
+                "endpoints": [{"name": "projects/p/locations/us/endpoints/1", "displayName": "fraud-endpoint", "public": True}],
+                "datasets": [{"name": "projects/p/locations/us/datasets/1", "displayName": "fraud-dataset"}],
+                "indexes": [{"name": "projects/p/locations/us/indexes/1", "displayName": "fraud-index"}],
+            },
         },
         "azure": {
             "entra": {"managed_identities": [{"id": "mi-1", "name": "mi-prod"}]},
             "storage": {"accounts": [{"id": "st-1", "name": "stprod", "encrypted": True}]},
             "monitor": {"diagnostic_settings": [{"id": "diag-1", "name": "diag-prod"}]},
-            "ai_foundry": {"deployments": [{"id": "dep-1", "name": "chat-prod", "public": True}]},
+            "ai_foundry": {
+                "deployments": [{"id": "dep-1", "name": "chat-prod", "public": True, "logging_enabled": True}],
+                "projects": [{"id": "proj-1", "name": "ai-project"}],
+            },
+            "azure_ml": {
+                "models": [{"id": "/models/fraud", "name": "fraud-model"}],
+                "data_assets": [{"id": "/data/fraud", "name": "fraud-data"}],
+                "online_endpoints": [{"id": "/endpoints/fraud", "name": "fraud", "public_network_access": False}],
+            },
         },
     }
 
@@ -79,6 +101,8 @@ class TestNormalizeInventory:
         assert normalized["providers"] == ["aws", "azure", "gcp"]
         assert any(asset["provider"] == "azure" for asset in normalized["assets"])
         assert any(asset["provider"] == "gcp" for asset in normalized["assets"])
+        assert any(asset["service"] == "vertex-ai" for asset in normalized["assets"])
+        assert any(asset["kind"] == "ai-guardrail" for asset in normalized["assets"])
 
 
 class TestBuildEvidence:
@@ -86,7 +110,7 @@ class TestBuildEvidence:
         evidence = build_evidence(_aws_snapshot())
         assert evidence["artifact_type"] == "technical-control-evidence"
         assert evidence["frameworks"] == ["PCI DSS 4.0", "SOC 2 Security"]
-        assert len(evidence["controls"]) == 8
+        assert len(evidence["controls"]) == 12
 
     def test_drops_secret_like_properties(self):
         normalized = normalize_inventory(_aws_snapshot())
@@ -97,6 +121,14 @@ class TestBuildEvidence:
         evidence = build_evidence(_multi_cloud_snapshot(), ["soc2"])
         assert evidence["frameworks"] == ["SOC 2 Security"]
         assert {control["framework"] for control in evidence["controls"]} == {"SOC 2 Security"}
+        assert any(control["control_id"] == "cc6.ai-service-surface" for control in evidence["controls"])
+
+    def test_inventory_summary_includes_ai_surface_counts(self):
+        evidence = build_evidence(_multi_cloud_snapshot())
+        counts = evidence["inventory_summary"]["control_surface_counts"]
+        assert counts["ai_assets"] >= 1
+        assert counts["ai_endpoint_assets"] >= 1
+        assert counts["ai_governance_assets"] >= 1
 
     def test_deterministic_output(self):
         assert build_evidence(_multi_cloud_snapshot()) == build_evidence(_multi_cloud_snapshot())


### PR DESCRIPTION
Summary:
- expand discover-ai-bom normalization across AWS Bedrock and SageMaker, Google Vertex AI, Azure ML, and Azure AI Foundry
- deepen discover-cloud-control-evidence so the same provider snapshots produce AI-specific endpoint and governance evidence
- update skill docs, official references, framework mappings, and changelog to match the new provider depth

Validation:
- python3 -m pytest skills/discovery/discover-ai-bom/tests/test_discover.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py -q -o addopts='--import-mode=importlib'
- python3 -m ruff check skills/discovery/discover-ai-bom/src/discover.py skills/discovery/discover-ai-bom/tests/test_discover.py skills/discovery/discover-cloud-control-evidence/src/discover.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py

Notes:
- this stays modular by extending the existing discovery and evidence skills rather than creating an overlapping AI service skill
- the repo now has broader provider-shaped support for AI endpoints, training jobs, datasets, vector stores, guardrails, and AI control evidence across AWS, GCP, and Azure