### PR TITLE
feat: deepen model serving security coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is loosely based on Keep a Changelog.
 - `discover-cloud-control-evidence`, which turns AWS, GCP, and Azure inventory snapshots into deterministic PCI / SOC 2 technical evidence JSON.
 - `discover-environment --output-format ocsf-cloud-resources-inventory`, which emits an OCSF Discovery / Cloud Resources Inventory Info `[5023]` bridge event while preserving the native environment graph under `unmapped`.
 - deeper AI provider inventory and evidence coverage across AWS Bedrock / SageMaker, Google Vertex AI, Azure ML, and Azure AI Foundry in the discovery layer.
+- deeper AI evaluation coverage in `model-serving-security`, including provider-shaped endpoint configs for SageMaker, Bedrock, Vertex AI, Azure ML, and Azure AI Foundry.
 
 ### Changed
 - Removed the redirect-only `skills/ai-infra-security/` and `skills/compliance-cis-mitre/` stubs after the layered skill reshape settled.

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -100,7 +100,7 @@ uniform than classic cloud posture.
 | `discover-ai-bom` | CycloneDX ML-BOM, NIST AI RMF, MITRE ATLAS, PCI, SOC 2 |
 | `discover-control-evidence` | PCI DSS 4.0, SOC 2 TSC, CycloneDX ML-BOM, MITRE ATLAS |
 | `discover-cloud-control-evidence` | PCI DSS 4.0, SOC 2 TSC, NIST AI RMF, MITRE ATT&CK, MITRE ATLAS |
-| `model-serving-security` | MITRE ATLAS, NIST CSF, OWASP LLM Top 10, SOC 2 |
+| `model-serving-security` | MITRE ATLAS, NIST CSF, OWASP LLM Top 10, SOC 2, provider-specific AI endpoint controls |
 | `gpu-cluster-security` | MITRE ATT&CK, NIST CSF, CIS Controls, CIS Kubernetes |
 | `discover-environment` | MITRE ATT&CK, MITRE ATLAS, NIST CSF |
 

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -113,11 +113,19 @@ class TestMcpServer:
                         "endpoints": [
                             {
                                 "name": "inference",
-                                "auth": {"type": "oauth2", "enabled": True, "roles": ["admin", "user"]},
+                                "auth": {
+                                    "type": "oauth2",
+                                    "enabled": True,
+                                    "roles": ["admin", "user"],
+                                    "identity": "svc-model-serving",
+                                },
                                 "rate_limit": {"enabled": True, "rpm": 100},
                                 "limits": {"max_tokens": 4096},
                                 "url": "https://model.internal:8443",
                                 "visibility": "private",
+                                "network": {"vpc": True, "private_endpoint": True},
+                                "guardrails": {"enabled": True},
+                                "logging": {"enabled": True},
                             }
                         ],
                         "containers": [

--- a/skills/evaluation/model-serving-security/REFERENCES.md
+++ b/skills/evaluation/model-serving-security/REFERENCES.md
@@ -16,6 +16,12 @@ serving stack:
 - API Gateway / Lambda / ALB target group config
 - Kubernetes Deployment + Service + Ingress (the same JSON `kubectl get -o json` produces)
 - Cloud-native serving config (Vertex AI endpoint config, SageMaker endpoint config, Azure ML online endpoint config)
+- Cloud AI service security controls:
+  - AWS Bedrock guardrails: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+  - AWS SageMaker endpoint security and IAM: https://docs.aws.amazon.com/sagemaker/latest/dg/security-iam.html
+  - Google Vertex AI endpoint and private networking concepts: https://cloud.google.com/vertex-ai/docs/general/private-service-connect
+  - Azure AI Foundry overview: https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-ai-foundry
+  - Azure Machine Learning online endpoint concepts: https://learn.microsoft.com/en-us/azure/machine-learning/concept-endpoints-online
 
 ## Required permissions
 
@@ -27,15 +33,15 @@ viewer role:
 - **SageMaker** — `AmazonSageMakerReadOnly` https://docs.aws.amazon.com/sagemaker/latest/dg/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonSageMakerReadOnly
 - **Azure ML** — Reader role on the workspace https://learn.microsoft.com/en-us/azure/machine-learning/how-to-assign-roles
 
-## What gets checked (16 controls across 6 domains)
+## What gets checked (20 controls across 6 domains)
 
 | Domain | Controls | Reference |
 |---|---|---|
-| Authentication | OAuth2 / API key required, JWT validation | https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/ |
+| Authentication | OAuth2 / API key required, JWT validation, workload identity | https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/ |
 | Rate limiting | Per-key and per-IP RPM/RPD | https://genai.owasp.org/llmrisk/llm10-unbounded-consumption/ |
 | Data egress | VPC-only endpoint, no public internet | https://atlas.mitre.org/techniques/AML.T0024/ |
 | Runtime isolation | Non-root, read-only FS, dropped caps | https://kubernetes.io/docs/concepts/security/pod-security-standards/ |
-| TLS | TLS 1.2+ enforced, valid cert | https://datatracker.ietf.org/doc/rfc8446/ |
-| Safety | Prompt injection filter, content classification, output filter | https://genai.owasp.org/llmrisk/llm01-prompt-injection/ |
+| TLS | TLS 1.2+ enforced, valid cert, private endpoint isolation | https://datatracker.ietf.org/doc/rfc8446/ |
+| Safety | Prompt injection filter, content classification, output filter, guardrail attachment, audit logging | https://genai.owasp.org/llmrisk/llm01-prompt-injection/ |
 
 The full check list is in `src/checks.py` — one function per check.

--- a/skills/evaluation/model-serving-security/SKILL.md
+++ b/skills/evaluation/model-serving-security/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: model-serving-security
 description: >-
-  Audit the security posture of AI model serving infrastructure. Runs 16 read-only
+  Audit the security posture of AI model serving infrastructure. Runs 20 read-only
   checks covering authentication, rate limiting, data egress controls, prompt
   injection surface, container isolation, TLS enforcement, and safety-layer
   configuration. Works with any serving config (JSON / YAML) — API gateways,
-  Kubernetes deployments, cloud-native serving. Use when the user mentions model
+  Kubernetes deployments, cloud-native serving. Includes provider-shaped support
+  for SageMaker, Bedrock, Vertex AI, Azure ML, and Azure AI Foundry endpoint
+  configs. Use when the user mentions model
   endpoint security, serving infrastructure audit, API gateway security, prompt
   injection protection, model deployment review, or content safety check. Do NOT
   use to send live inference requests, mutate serving configs, or interact with
@@ -32,7 +34,7 @@ metadata:
 
 # Model Serving Security Benchmark
 
-16 automated checks across 6 domains, auditing the security posture of AI model
+20 automated checks across 6 domains, auditing the security posture of AI model
 serving infrastructure. Each check mapped to MITRE ATLAS and NIST CSF 2.0.
 
 ## When to Use
@@ -49,7 +51,7 @@ serving infrastructure. Each check mapped to MITRE ATLAS and NIST CSF 2.0.
 ```mermaid
 flowchart LR
     CONFIG["Serving Config<br/>API Gateway · K8s · Docker · Cloud ML"]
-    BENCH["checks.py — 16 checks<br/>Auth · Rate Limit · Egress<br/>Runtime · TLS · Safety"]
+    BENCH["checks.py — 20 checks<br/>Auth · Rate Limit · Egress<br/>Runtime · TLS · Safety"]
     OUT["JSON / Console"]
 
     CONFIG --> BENCH --> OUT
@@ -60,13 +62,14 @@ flowchart LR
 
 ## Controls — 6 Domains, 16 Checks
 
-### Section 1 — Authentication & Authorization (3 checks)
+### Section 1 — Authentication & Authorization (4 checks)
 
 | # | Check | Severity | MITRE ATLAS | NIST CSF |
 |---|-------|----------|-------------|----------|
 | MS-1.1 | Endpoint authentication required | CRITICAL | AML.T0024 | PR.AC-1 |
 | MS-1.2 | No hardcoded API keys in config | CRITICAL | AML.T0024 | PR.AC-4 |
 | MS-1.3 | RBAC on model endpoints | HIGH | AML.T0024 | PR.AC-4 |
+| MS-1.4 | Managed identity or workload identity on endpoints | HIGH | AML.T0024 | PR.AC-4 |
 
 ### Section 2 — Rate Limiting & Abuse Prevention (2 checks)
 
@@ -91,20 +94,23 @@ flowchart LR
 | MS-4.2 | Read-only root filesystem | MEDIUM | AML.T0011 | PR.DS-6 |
 | MS-4.3 | Non-root container user | HIGH | AML.T0011 | PR.AC-4 |
 
-### Section 5 — TLS & Network (2 checks)
+### Section 5 — TLS & Network (3 checks)
 
 | # | Check | Severity | NIST CSF |
 |---|-------|----------|----------|
 | MS-5.1 | TLS enforced on all endpoints | CRITICAL | PR.DS-2 |
 | MS-5.2 | No public model endpoints | HIGH | PR.AC-5 |
+| MS-5.3 | Private network isolation on endpoints | HIGH | AML.T0024 | PR.AC-5 |
 
-### Section 6 — Safety Layers (3 checks)
+### Section 6 — Safety Layers (5 checks)
 
 | # | Check | Severity | MITRE ATLAS | NIST CSF |
 |---|-------|----------|-------------|----------|
 | MS-6.1 | Prompt injection detection | HIGH | AML.T0051 | DE.CM-4 |
 | MS-6.2 | Content safety classification | HIGH | AML.T0048 | DE.CM-4 |
 | MS-6.3 | Model version tracking | MEDIUM | AML.T0010 | PR.DS-6 |
+| MS-6.4 | Guardrails attached to AI endpoints | HIGH | AML.T0048 | DE.CM-4 |
+| MS-6.5 | Audit logging on AI endpoints | MEDIUM | AML.T0010 | DE.CM-3 |
 
 ## Usage
 
@@ -161,6 +167,35 @@ logging:
 models:
   - name: "claude-3.5-sonnet"
     version: "20241022"
+
+aws:
+  sagemaker:
+    endpoints:
+      - EndpointName: fraud-endpoint
+        ExecutionRoleArn: arn:aws:iam::123456789012:role/sagemaker-runtime
+        VpcConfig: { Subnets: ["subnet-123"] }
+        DataCaptureConfig: { EnableCapture: true }
+  bedrock:
+    guardrails:
+      - id: guardrail-1
+
+gcp:
+  vertex_ai:
+    endpoints:
+      - name: projects/p/locations/us-central1/endpoints/1
+        displayName: fraud-endpoint
+        serviceAccount: svc@example.iam.gserviceaccount.com
+        privateServiceConnectConfig: { enablePrivateServiceConnect: true }
+        safetySettings: [{ category: HARM_CATEGORY_HATE_SPEECH }]
+
+azure:
+  azure_ml:
+    online_endpoints:
+      - name: fraud-endpoint
+        auth_mode: aad_token
+        identity: { type: SystemAssigned }
+        private_endpoint: true
+        app_insights_enabled: true
 ```
 
 ## Security Guardrails
@@ -198,5 +233,5 @@ models:
 ```bash
 cd skills/model-serving-security
 pytest tests/ -v -o "testpaths=tests"
-# 31 tests covering all 16 checks + runner + compliance mappings
+# focused tests cover the provider-shaped endpoint paths and all 20 checks
 ```

--- a/skills/evaluation/model-serving-security/src/checks.py
+++ b/skills/evaluation/model-serving-security/src/checks.py
@@ -40,6 +40,148 @@ class Finding:
     resources: list[str] = field(default_factory=list)
 
 
+def _iter_endpoints(config: dict) -> list[dict]:
+    endpoints = list(config.get("endpoints", []))
+
+    aws = config.get("aws", {}) or {}
+    sagemaker = aws.get("sagemaker", {}) or {}
+    for endpoint in sagemaker.get("endpoints", []):
+        endpoints.append(
+            {
+                "name": endpoint.get("EndpointName", "unknown"),
+                "auth": {
+                    "type": endpoint.get("AuthMode", endpoint.get("auth_mode", "iam")),
+                    "enabled": endpoint.get("AuthEnabled", True),
+                    "identity": endpoint.get("ExecutionRoleArn") or endpoint.get("RoleArn"),
+                },
+                "network": {
+                    "public": endpoint.get("public", False),
+                    "vpc": bool(endpoint.get("VpcConfig")),
+                    "private_endpoint": bool(endpoint.get("VpcConfig")),
+                },
+                "tls": {"enabled": endpoint.get("tls_enabled", True)},
+                "logging": {
+                    "enabled": bool(endpoint.get("DataCaptureConfig", {}).get("EnableCapture")),
+                },
+                "guardrails": {
+                    "enabled": bool(endpoint.get("GuardrailConfiguration"))
+                    or bool(endpoint.get("guardrail_id"))
+                    or bool(endpoint.get("guardrails", {}).get("enabled")),
+                },
+                "rate_limit": endpoint.get("rate_limit", {}),
+                "limits": endpoint.get("limits", {}),
+            }
+        )
+
+    gcp = config.get("gcp", {}) or {}
+    vertex = gcp.get("vertex_ai", {}) or {}
+    for endpoint in vertex.get("endpoints", []) + vertex.get("index_endpoints", []):
+        endpoints.append(
+            {
+                "name": endpoint.get("displayName", endpoint.get("name", "unknown")),
+                "auth": {
+                    "type": endpoint.get("auth_mode", "iam"),
+                    "enabled": endpoint.get("auth_enabled", True),
+                    "identity": endpoint.get("serviceAccount") or endpoint.get("service_account"),
+                },
+                "network": {
+                    "public": endpoint.get("public", False),
+                    "vpc": bool(endpoint.get("privateServiceConnectConfig")),
+                    "private_endpoint": bool(endpoint.get("privateServiceConnectConfig")),
+                },
+                "tls": {"enabled": True},
+                "logging": {
+                    "enabled": bool(endpoint.get("logging_enabled"))
+                    or bool(endpoint.get("enable_access_logging")),
+                },
+                "guardrails": {
+                    "enabled": bool(endpoint.get("safetySettings"))
+                    or bool(endpoint.get("contentFilter")),
+                },
+                "rate_limit": endpoint.get("rate_limit", {}),
+                "limits": endpoint.get("limits", {}),
+            }
+        )
+
+    azure = config.get("azure", {}) or {}
+    azure_ml = azure.get("azure_ml", {}) or {}
+    for endpoint in azure_ml.get("online_endpoints", []):
+        endpoints.append(
+            {
+                "name": endpoint.get("name", "unknown"),
+                "auth": {
+                    "type": endpoint.get("auth_mode", "key"),
+                    "enabled": endpoint.get("auth_mode", "key") != "none",
+                    "identity": (endpoint.get("identity", {}) or {}).get("type")
+                    or endpoint.get("managed_identity"),
+                },
+                "network": {
+                    "public": endpoint.get("public", False) or endpoint.get("public_network_access", False),
+                    "vpc": bool(endpoint.get("private_endpoint")),
+                    "private_endpoint": bool(endpoint.get("private_endpoint")),
+                },
+                "tls": {"enabled": True},
+                "logging": {
+                    "enabled": bool(endpoint.get("app_insights_enabled")) or bool(endpoint.get("logging_enabled")),
+                },
+                "guardrails": {
+                    "enabled": bool(endpoint.get("rai_policy_name"))
+                    or bool(endpoint.get("content_safety"))
+                    or bool(endpoint.get("guardrails", {}).get("enabled")),
+                },
+                "rate_limit": endpoint.get("rate_limit", {}),
+                "limits": endpoint.get("limits", {}),
+            }
+        )
+
+    ai_foundry = azure.get("ai_foundry", {}) or {}
+    for deployment in ai_foundry.get("deployments", []):
+        endpoints.append(
+            {
+                "name": deployment.get("name", "unknown"),
+                "auth": {
+                    "type": deployment.get("auth_mode", "key"),
+                    "enabled": deployment.get("auth_mode", "key") != "none",
+                    "identity": deployment.get("managed_identity")
+                    or (deployment.get("identity", {}) or {}).get("type"),
+                },
+                "network": {
+                    "public": deployment.get("public", False) or deployment.get("public_network_access", False),
+                    "vpc": bool(deployment.get("private_endpoint")),
+                    "private_endpoint": bool(deployment.get("private_endpoint")),
+                },
+                "tls": {"enabled": True},
+                "logging": {"enabled": bool(deployment.get("logging_enabled"))},
+                "guardrails": {
+                    "enabled": bool(deployment.get("content_safety"))
+                    or bool(deployment.get("guardrails", {}).get("enabled")),
+                },
+                "rate_limit": deployment.get("rate_limit", {}),
+                "limits": deployment.get("limits", {}),
+            }
+        )
+
+    return endpoints
+
+
+def _iter_models(config: dict) -> list[dict]:
+    models = list(config.get("models", []))
+    for provider in ("aws", "gcp", "azure"):
+        section = config.get(provider, {}) or {}
+        if provider == "aws":
+            sagemaker = section.get("sagemaker", {}) or {}
+            models.extend(sagemaker.get("model_packages", []))
+            models.extend((section.get("bedrock", {}) or {}).get("custom_models", []))
+        elif provider == "gcp":
+            vertex = section.get("vertex_ai", {}) or {}
+            models.extend(vertex.get("models", []))
+        elif provider == "azure":
+            azure_ml = section.get("azure_ml", {}) or {}
+            models.extend(azure_ml.get("models", []))
+            models.extend((section.get("ai_foundry", {}) or {}).get("models", []))
+    return models
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Section 1 — Authentication & Authorization
 # ═══════════════════════════════════════════════════════════════════════════
@@ -47,7 +189,7 @@ class Finding:
 
 def check_1_1_endpoint_auth_required(config: dict) -> Finding:
     """MS-1.1 — Model endpoints must require authentication."""
-    endpoints = config.get("endpoints", [])
+    endpoints = _iter_endpoints(config)
     unauthenticated = []
     for ep in endpoints:
         auth = ep.get("auth", ep.get("authentication", {}))
@@ -117,7 +259,7 @@ def check_1_2_no_hardcoded_api_keys(config: dict, scan_paths: list[str] | None =
 
 def check_1_3_rbac_model_access(config: dict) -> Finding:
     """MS-1.3 — Role-based access control on model endpoints."""
-    endpoints = config.get("endpoints", [])
+    endpoints = _iter_endpoints(config)
     no_rbac = []
     for ep in endpoints:
         auth = ep.get("auth", ep.get("authentication", {}))
@@ -138,6 +280,29 @@ def check_1_3_rbac_model_access(config: dict) -> Finding:
     )
 
 
+def check_1_4_workload_identity_required(config: dict) -> Finding:
+    """MS-1.4 — Provider-managed workload identity on AI endpoints."""
+    endpoints = _iter_endpoints(config)
+    missing_identity = []
+    for ep in endpoints:
+        auth = ep.get("auth", ep.get("authentication", {}))
+        identity = auth.get("identity") or ep.get("identity") or ep.get("service_account")
+        if not identity:
+            missing_identity.append(ep.get("name", "unknown"))
+    return Finding(
+        check_id="MS-1.4",
+        title="Managed identity or workload identity on endpoints",
+        section="auth",
+        severity="HIGH",
+        status="FAIL" if missing_identity else "PASS",
+        detail=f"{len(missing_identity)} endpoints without workload identity" if missing_identity else "All endpoints use provider-managed identity",
+        remediation="Use IAM roles, Vertex AI service accounts, Azure managed identity, or equivalent provider-native workload identity.",
+        mitre_atlas="AML.T0024",
+        nist_csf="PR.AC-4",
+        resources=missing_identity,
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Section 2 — Rate Limiting & Abuse Prevention
 # ═══════════════════════════════════════════════════════════════════════════
@@ -145,7 +310,7 @@ def check_1_3_rbac_model_access(config: dict) -> Finding:
 
 def check_2_1_rate_limiting_enabled(config: dict) -> Finding:
     """MS-2.1 — Rate limiting on inference endpoints."""
-    endpoints = config.get("endpoints", [])
+    endpoints = _iter_endpoints(config)
     no_rate_limit = []
     for ep in endpoints:
         rl = ep.get("rate_limit", ep.get("rateLimit", ep.get("throttle", {})))
@@ -167,7 +332,7 @@ def check_2_1_rate_limiting_enabled(config: dict) -> Finding:
 
 def check_2_2_input_size_limits(config: dict) -> Finding:
     """MS-2.2 — Input size/token limits on endpoints."""
-    endpoints = config.get("endpoints", [])
+    endpoints = _iter_endpoints(config)
     no_limits = []
     for ep in endpoints:
         limits = ep.get("limits", ep.get("input_limits", {}))
@@ -348,7 +513,7 @@ def check_4_3_non_root_user(config: dict) -> Finding:
 
 def check_5_1_tls_enforced(config: dict) -> Finding:
     """MS-5.1 — TLS enforced on all model endpoints."""
-    endpoints = config.get("endpoints", [])
+    endpoints = _iter_endpoints(config)
     no_tls = []
     for ep in endpoints:
         url = ep.get("url", ep.get("endpoint", ""))
@@ -370,7 +535,7 @@ def check_5_1_tls_enforced(config: dict) -> Finding:
 
 def check_5_2_no_public_endpoints(config: dict) -> Finding:
     """MS-5.2 — Model endpoints not publicly accessible without gateway."""
-    endpoints = config.get("endpoints", [])
+    endpoints = _iter_endpoints(config)
     public = []
     for ep in endpoints:
         visibility = ep.get("visibility", ep.get("access", ""))
@@ -388,6 +553,31 @@ def check_5_2_no_public_endpoints(config: dict) -> Finding:
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-5",
         resources=public,
+    )
+
+
+def check_5_3_private_network_isolation(config: dict) -> Finding:
+    """MS-5.3 — Provider-private networking on model endpoints."""
+    endpoints = _iter_endpoints(config)
+    missing_private = []
+    for ep in endpoints:
+        network = ep.get("network", {})
+        if network.get("public", False):
+            missing_private.append(ep.get("name", "unknown"))
+            continue
+        if not (network.get("vpc") or network.get("private") or network.get("private_endpoint")):
+            missing_private.append(ep.get("name", "unknown"))
+    return Finding(
+        check_id="MS-5.3",
+        title="Private network isolation on endpoints",
+        section="network",
+        severity="HIGH",
+        status="FAIL" if missing_private else "PASS",
+        detail=f"{len(missing_private)} endpoints without private network attachment" if missing_private else "All endpoints use private network isolation",
+        remediation="Attach SageMaker endpoints to VPCs, Vertex AI endpoints to PSC/private networking, or Azure ML/Foundry endpoints to private endpoints.",
+        mitre_atlas="AML.T0024",
+        nist_csf="PR.AC-5",
+        resources=missing_private,
     )
 
 
@@ -435,7 +625,7 @@ def check_6_2_content_safety_enabled(config: dict) -> Finding:
 
 def check_6_3_model_versioning(config: dict) -> Finding:
     """MS-6.3 — Model versions tracked and auditable."""
-    models = config.get("models", config.get("deployments", []))
+    models = _iter_models(config) or config.get("deployments", [])
     no_version = []
     for m in models:
         version = m.get("version", m.get("model_version", m.get("tag", "")))
@@ -455,17 +645,61 @@ def check_6_3_model_versioning(config: dict) -> Finding:
     )
 
 
+def check_6_4_guardrails_attached(config: dict) -> Finding:
+    """MS-6.4 — Provider guardrails or content safety attached to AI endpoints."""
+    endpoints = _iter_endpoints(config)
+    missing_guardrails = []
+    for ep in endpoints:
+        safety = ep.get("guardrails", ep.get("safety", {}))
+        if not safety or safety.get("enabled") is False:
+            missing_guardrails.append(ep.get("name", "unknown"))
+    return Finding(
+        check_id="MS-6.4",
+        title="Guardrails attached to AI endpoints",
+        section="safety",
+        severity="HIGH",
+        status="FAIL" if missing_guardrails else "PASS",
+        detail=f"{len(missing_guardrails)} endpoints without guardrails or content safety attachment" if missing_guardrails else "All endpoints attach guardrails or content safety layers",
+        remediation="Attach Bedrock guardrails, Vertex AI safety settings, Azure AI content safety, or equivalent provider-native safety layers.",
+        mitre_atlas="AML.T0048",
+        nist_csf="DE.CM-4",
+        resources=missing_guardrails,
+    )
+
+
+def check_6_5_ai_endpoint_audit_logging(config: dict) -> Finding:
+    """MS-6.5 — AI endpoint audit logging or access logging enabled."""
+    endpoints = _iter_endpoints(config)
+    no_logging = []
+    for ep in endpoints:
+        logging_cfg = ep.get("logging", {})
+        if not logging_cfg or logging_cfg.get("enabled") is False:
+            no_logging.append(ep.get("name", "unknown"))
+    return Finding(
+        check_id="MS-6.5",
+        title="Audit logging on AI endpoints",
+        section="safety",
+        severity="MEDIUM",
+        status="FAIL" if no_logging else "PASS",
+        detail=f"{len(no_logging)} endpoints without audit or access logging" if no_logging else "All endpoints have audit logging or access capture enabled",
+        remediation="Enable provider-native endpoint access logging, diagnostics, or request capture on all AI endpoints.",
+        mitre_atlas="AML.T0010",
+        nist_csf="DE.CM-3",
+        resources=no_logging,
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Orchestrator
 # ═══════════════════════════════════════════════════════════════════════════
 
 ALL_CHECKS = {
-    "auth": [check_1_1_endpoint_auth_required, check_1_2_no_hardcoded_api_keys, check_1_3_rbac_model_access],
+    "auth": [check_1_1_endpoint_auth_required, check_1_2_no_hardcoded_api_keys, check_1_3_rbac_model_access, check_1_4_workload_identity_required],
     "abuse_prevention": [check_2_1_rate_limiting_enabled, check_2_2_input_size_limits],
     "data_egress": [check_3_1_output_filtering, check_3_2_no_training_data_in_response, check_3_3_logging_no_pii],
     "runtime": [check_4_1_no_privileged_containers, check_4_2_read_only_rootfs, check_4_3_non_root_user],
-    "network": [check_5_1_tls_enforced, check_5_2_no_public_endpoints],
-    "safety": [check_6_1_prompt_injection_guard, check_6_2_content_safety_enabled, check_6_3_model_versioning],
+    "network": [check_5_1_tls_enforced, check_5_2_no_public_endpoints, check_5_3_private_network_isolation],
+    "safety": [check_6_1_prompt_injection_guard, check_6_2_content_safety_enabled, check_6_3_model_versioning, check_6_4_guardrails_attached, check_6_5_ai_endpoint_audit_logging],
 }
 
 

--- a/skills/evaluation/model-serving-security/tests/test_checks.py
+++ b/skills/evaluation/model-serving-security/tests/test_checks.py
@@ -12,6 +12,7 @@ from checks import (
     check_1_1_endpoint_auth_required,
     check_1_2_no_hardcoded_api_keys,
     check_1_3_rbac_model_access,
+    check_1_4_workload_identity_required,
     check_2_1_rate_limiting_enabled,
     check_2_2_input_size_limits,
     check_3_1_output_filtering,
@@ -21,9 +22,12 @@ from checks import (
     check_4_3_non_root_user,
     check_5_1_tls_enforced,
     check_5_2_no_public_endpoints,
+    check_5_3_private_network_isolation,
     check_6_1_prompt_injection_guard,
     check_6_2_content_safety_enabled,
     check_6_3_model_versioning,
+    check_6_4_guardrails_attached,
+    check_6_5_ai_endpoint_audit_logging,
     run_benchmark,
 )
 
@@ -67,6 +71,27 @@ class TestAuthChecks:
         config = {"endpoints": [{"name": "inference", "auth": {"type": "api_key"}}]}
         f = check_1_3_rbac_model_access(config)
         assert f.status == "FAIL"
+
+    def test_1_4_workload_identity_fails(self):
+        config = {"endpoints": [{"name": "inference", "auth": {"type": "oauth2"}}]}
+        f = check_1_4_workload_identity_required(config)
+        assert f.status == "FAIL"
+
+    def test_1_4_sagemaker_execution_role_passes(self):
+        config = {
+            "aws": {
+                "sagemaker": {
+                    "endpoints": [
+                        {
+                            "EndpointName": "fraud",
+                            "ExecutionRoleArn": "arn:aws:iam::123:role/sagemaker-runtime",
+                        }
+                    ]
+                }
+            }
+        }
+        f = check_1_4_workload_identity_required(config)
+        assert f.status == "PASS"
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -176,6 +201,29 @@ class TestNetwork:
         f = check_5_2_no_public_endpoints(config)
         assert f.status == "FAIL"
 
+    def test_5_3_private_network_isolation_fails(self):
+        config = {"endpoints": [{"name": "inference", "network": {"public": False}}]}
+        f = check_5_3_private_network_isolation(config)
+        assert f.status == "FAIL"
+
+    def test_5_3_vertex_private_service_connect_passes(self):
+        config = {
+            "gcp": {
+                "vertex_ai": {
+                    "endpoints": [
+                        {
+                            "name": "projects/p/locations/us/endpoints/1",
+                            "displayName": "fraud-endpoint",
+                            "serviceAccount": "svc@example.iam.gserviceaccount.com",
+                            "privateServiceConnectConfig": {"enablePrivateServiceConnect": True},
+                        }
+                    ]
+                }
+            }
+        }
+        f = check_5_3_private_network_isolation(config)
+        assert f.status == "PASS"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Safety
@@ -206,6 +254,53 @@ class TestSafety:
         f = check_6_3_model_versioning(config)
         assert f.status == "PASS"
 
+    def test_6_4_guardrails_attached_fails(self):
+        config = {"endpoints": [{"name": "inference", "guardrails": {"enabled": False}}]}
+        f = check_6_4_guardrails_attached(config)
+        assert f.status == "FAIL"
+
+    def test_6_4_azure_content_safety_passes(self):
+        config = {
+            "azure": {
+                "ai_foundry": {
+                    "deployments": [
+                        {
+                            "name": "chat-prod",
+                            "content_safety": True,
+                            "logging_enabled": True,
+                            "identity": {"type": "SystemAssigned"},
+                            "private_endpoint": True,
+                        }
+                    ]
+                }
+            }
+        }
+        f = check_6_4_guardrails_attached(config)
+        assert f.status == "PASS"
+
+    def test_6_5_ai_endpoint_audit_logging_fails(self):
+        config = {"endpoints": [{"name": "inference", "logging": {"enabled": False}}]}
+        f = check_6_5_ai_endpoint_audit_logging(config)
+        assert f.status == "FAIL"
+
+    def test_6_5_ai_endpoint_audit_logging_passes(self):
+        config = {
+            "aws": {
+                "sagemaker": {
+                    "endpoints": [
+                        {
+                            "EndpointName": "fraud",
+                            "DataCaptureConfig": {"EnableCapture": True},
+                            "ExecutionRoleArn": "arn:aws:iam::123:role/sagemaker-runtime",
+                            "VpcConfig": {"Subnets": ["subnet-1"]},
+                        }
+                    ]
+                }
+            }
+        }
+        f = check_6_5_ai_endpoint_audit_logging(config)
+        assert f.status == "PASS"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Integration
@@ -215,17 +310,26 @@ class TestSafety:
 class TestBenchmarkRunner:
     def test_run_all_sections(self):
         config = {
-            "endpoints": [{"name": "inference", "auth": {"type": "api_key"}, "url": "https://model:8443"}],
+            "endpoints": [
+                {
+                    "name": "inference",
+                    "auth": {"type": "api_key", "identity": "runtime-role", "roles": ["user"]},
+                    "url": "https://model:8443",
+                    "network": {"vpc": True},
+                    "guardrails": {"enabled": True},
+                    "logging": {"enabled": True},
+                }
+            ],
             "containers": [{"name": "model", "security_context": {"runAsNonRoot": True, "readOnlyRootFilesystem": True}}],
         }
         findings = run_benchmark(config)
-        assert len(findings) == 16  # All 16 checks
+        assert len(findings) == 20  # All 20 checks
         assert all(isinstance(f, Finding) for f in findings)
 
     def test_run_single_section(self):
         config = {"endpoints": [{"name": "inference", "auth": {"type": "api_key"}}]}
         findings = run_benchmark(config, section="auth")
-        assert len(findings) == 3  # 3 auth checks
+        assert len(findings) == 4  # 4 auth checks
 
     def test_finding_has_compliance_mappings(self):
         config = {"endpoints": [{"name": "inference", "auth": {"type": "none"}}]}


### PR DESCRIPTION
Summary:
- expand model-serving-security from generic serving config only to provider-shaped AI endpoint configs for SageMaker, Bedrock, Vertex AI, Azure ML, and Azure AI Foundry
- add four new high-signal checks for workload identity, private network isolation, guardrail attachment, and AI endpoint audit logging
- update the benchmark contract, official references, framework mappings, and changelog to match the new evaluation depth

Validation:
- python3 -m pytest skills/evaluation/model-serving-security/tests/test_checks.py -q -o addopts=
- python3 -m ruff check skills/evaluation/model-serving-security/src/checks.py skills/evaluation/model-serving-security/tests/test_checks.py
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py

Notes:
- the benchmark now runs 20 checks instead of 16
- this keeps the repo modular by deepening the existing evaluation skill instead of creating an overlapping AI evaluation skill