### PR TITLE
release: cut v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ The format is loosely based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.4.0 - 2026-04-13
+
 ### Added
 - Repo-wide `CHANGELOG.md` to make material architecture, security, and skill changes discoverable without reading every PR.
 - [`docs/FRAMEWORK_MAPPINGS.md`](docs/FRAMEWORK_MAPPINGS.md) to consolidate ATT&CK, ATLAS, CIS, NIST, OWASP, SOC 2, ISO, and PCI coverage across the repo.
 - First `discovery/` layer AI BOM skill, `discover-ai-bom`, which turns AI asset inventory snapshots into a deterministic CycloneDX-aligned BOM.
 - First discovery-layer technical evidence skill, `discover-control-evidence`, which turns discovery artifacts into deterministic PCI / SOC 2 evidence JSON.
 - `discover-cloud-control-evidence`, which turns AWS, GCP, and Azure inventory snapshots into deterministic PCI / SOC 2 technical evidence JSON.
+- `discover-cloud-control-evidence --output-format ocsf-live-evidence`, which emits an OCSF Discovery / Live Evidence Info `[5040]` bridge event while preserving the native evidence document under `unmapped`.
 - `discover-environment --output-format ocsf-cloud-resources-inventory`, which emits an OCSF Discovery / Cloud Resources Inventory Info `[5023]` bridge event while preserving the native environment graph under `unmapped`.
 - deeper AI provider inventory and evidence coverage across AWS Bedrock / SageMaker, Google Vertex AI, Azure ML, and Azure AI Foundry in the discovery layer.
 - deeper AI evaluation coverage in `model-serving-security`, including provider-shaped endpoint configs for SageMaker, Bedrock, Vertex AI, Azure ML, and Azure AI Foundry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cloud-security"
-version = "0.3.0"
-description = "Cloud security automations, benchmark checks, and remediation skills."
+version = "0.4.0"
+description = "OCSF-native security skills for cloud and AI systems."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "cloud-security"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- bump the repo version to 0.4.0
- roll current discovery, OCSF bridge, evidence, and AI evaluation work into a named release
- keep the lockfile aligned to the repo version without introducing unrelated dependency churn

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
