### PR TITLE
docs: add measurable framework coverage roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - run: python scripts/validate_skill_contract.py
       - run: python scripts/validate_skill_integrity.py
       - run: python scripts/validate_dependency_consistency.py
+      - run: python scripts/validate_framework_coverage.py
 
   safe-skill-bar:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is loosely based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+- `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
+- `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.
+
 ## 0.4.0 - 2026-04-13
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ metadata:
 8. Document whether the skill is read-only, dry-run capable, HITL-gated, or side-effectful
 9. Add tests for malformed input, provider quirks, and any deprecated API shape you are intentionally supporting during migration
 10. Add your skill to the catalog in `README.md` and `skills/README.md`
+11. Add or update the skill entry in `docs/framework-coverage.json` when the change affects framework, provider, or asset coverage
 
 ## Code standards
 
@@ -49,6 +50,7 @@ metadata:
 - Prefer only official vendor docs, schemas, and APIs in `REFERENCES.md`
 - Put structured results on `stdout`, debug/warning detail on `stderr`, and fail closed on invalid input
 - Follow [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) for the minimum shipped-skill bar
+- Keep framework claims measurable and machine-readable via [`docs/COVERAGE_MODEL.md`](docs/COVERAGE_MODEL.md) and [`docs/framework-coverage.json`](docs/framework-coverage.json)
 - Design for all execution modes up front: CLI, CI, MCP, and persistent/serverless wrappers should not require different skill code
 - If the skill can write state, require dry-run-first behavior and document the approval/audit model
 
@@ -58,7 +60,7 @@ metadata:
 2. Add or modify skills following the structure above
 3. Ensure tests pass: `pytest skills/<layer>/your-skill/tests/ -v`
 4. Ensure linting passes: `ruff check .`
-5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, `python scripts/validate_dependency_consistency.py`, and `python scripts/validate_safe_skill_bar.py`
+5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, `python scripts/validate_dependency_consistency.py`, `python scripts/validate_framework_coverage.py`, and `python scripts/validate_safe_skill_bar.py`
 6. Open a PR against `main` with a clear description
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Claude Code memory: [CLAUDE.md](CLAUDE.md)
 - MCP usage: [docs/agent-integrations.md](docs/agent-integrations.md) and [`.mcp.json`](.mcp.json)
 - Architecture and visuals: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/DIAGRAMS.md](docs/DIAGRAMS.md)
+- Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), and [docs/ROADMAP.md](docs/ROADMAP.md)
 
 ![Repo architecture](docs/images/repo-architecture.svg)
 
@@ -131,7 +132,7 @@ skills/
 │   ├── cspm-azure-cis-benchmark    (CIS Azure Foundations v2.1 — 6 checks)
 │   ├── k8s-security-benchmark      (CIS Kubernetes — 10 checks)
 │   ├── container-security          (CIS Docker — 8 checks)
-│   ├── model-serving-security      (16 checks — auth / rate limit / egress / safety)
+│   ├── model-serving-security      (20 checks — auth / rate limit / egress / network / safety)
 │   └── gpu-cluster-security        (13 checks — runtime / driver / tenant isolation)
 │
 ├── view/                           "OCSF → reviewable output"
@@ -193,7 +194,10 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | [`DIAGRAMS.md`](docs/DIAGRAMS.md) | Architecture map, IAM departures flow, and detection pipeline visuals |
 | [`CI_WORKFLOW.md`](docs/CI_WORKFLOW.md) | CI lane layout, dedupe rules, and follow-up simplification plan |
 | [`CHANGELOG.md`](CHANGELOG.md) | Repo-level release notes and material skill changes |
+| [`COVERAGE_MODEL.md`](docs/COVERAGE_MODEL.md) | What framework coverage means and how it is measured |
+| [`framework-coverage.json`](docs/framework-coverage.json) | Machine-readable framework, provider, and asset coverage registry |
 | [`FRAMEWORK_MAPPINGS.md`](docs/FRAMEWORK_MAPPINGS.md) | Where ATT&CK, ATLAS, CIS, NIST, OWASP, SOC 2, ISO, and PCI coverage lives today |
+| [`ROADMAP.md`](docs/ROADMAP.md) | Coverage and execution roadmap for cloud, AI, and framework depth |
 | [`mcp-server/README.md`](mcp-server/README.md) | Thin local MCP wrapper for auto-discovered skills |
 | [`DEPENDENCY_HYGIENE_SKILL.md`](docs/DEPENDENCY_HYGIENE_SKILL.md) | Proposed safe dependency-update skill contract |
 | [`SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) | Minimum files, metadata, and guardrails for shipped skills |

--- a/docs/COVERAGE_MODEL.md
+++ b/docs/COVERAGE_MODEL.md
@@ -1,0 +1,91 @@
+# Coverage Model
+
+`cloud-security` does not use vague framework claims. Coverage is measured
+against an explicit scope:
+
+- framework version
+- provider scope
+- asset-class scope
+- layer scope
+- implementation status
+- test status
+- validation status
+
+The source of truth for current coverage is
+[`docs/framework-coverage.json`](framework-coverage.json).
+
+## What "coverage" means
+
+Coverage is tracked across four levels:
+
+| Level | Meaning |
+|---|---|
+| **mapped** | the skill explicitly maps to the framework or control family |
+| **implemented** | the code emits or evaluates that mapping today |
+| **tested** | the mapping is exercised by automated tests or golden fixtures |
+| **validated** | shared repo validators enforce the contract, references, and safety bar |
+
+The repo should only claim broad framework coverage when the relevant scope is
+both **implemented** and **tested**.
+
+## Coverage dimensions
+
+Every material coverage statement should be measurable across these dimensions:
+
+| Dimension | Examples |
+|---|---|
+| **Layer** | ingest, discover, detect, evaluate, view, remediate |
+| **Provider** | AWS, Azure, GCP, Kubernetes, containers, MCP, multi |
+| **Asset class** | identities, compute, storage, network, logging, clusters, AI endpoints, models, datasets, GPUs, evidence |
+| **Framework** | OCSF, MITRE ATT&CK, MITRE ATLAS, CIS, NIST CSF, NIST AI RMF, PCI DSS, SOC 2, ISO 27001, OWASP LLM |
+| **Execution mode** | CLI, CI, MCP, persistent/serverless |
+| **Approval model** | read-only, dry-run first, HITL, side-effectful edge |
+
+## Coverage policy
+
+The repo follows these rules:
+
+1. Use native **OCSF** classes, profiles, or extensions when they fit.
+2. If OCSF does not fit cleanly, use a deterministic bridge artifact and
+   document the mapping path back to OCSF.
+3. Use only official vendor, schema, benchmark, or framework docs in
+   `REFERENCES.md`.
+4. Do not claim "100% coverage" without naming:
+   - framework version
+   - providers in scope
+   - asset classes in scope
+   - implementation and test status
+5. Keep coverage machine-readable so CI can validate it.
+
+## Target language
+
+The strongest safe claim format is:
+
+> `mapped coverage` target: 100% across the declared provider and asset scope
+> for framework version `X`, with implementation/test status tracked in the
+> coverage registry.
+
+This is better than claiming universal completeness without scope.
+
+## Progress model
+
+Use these progress states in roadmap and reviews:
+
+| State | Meaning |
+|---|---|
+| **gap** | no meaningful support yet |
+| **mapped** | documented and scoped, but not fully implemented |
+| **implemented** | code exists |
+| **tested** | implementation has automated coverage |
+| **validated** | implementation is also enforced by repo validators and CI |
+
+## Why this exists
+
+Security teams and engineers need to know:
+
+- what the repo actually covers today
+- which skills can be trusted for which frameworks
+- where the gaps still are
+- which layers are ready for just-in-time use, CI, MCP, or continuous runs
+
+This model keeps that story explicit, versioned, and auditable.

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -3,6 +3,10 @@
 This document shows which frameworks are represented in `cloud-security`, where
 they appear today, and where coverage is still partial.
 
+For machine-readable source of truth, see
+[`docs/framework-coverage.json`](framework-coverage.json). For the policy behind
+that file, see [`docs/COVERAGE_MODEL.md`](COVERAGE_MODEL.md).
+
 The repo uses two mapping styles:
 
 - **Event / finding mappings** inside OCSF output, especially `finding_info.attacks[]`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,152 @@
+# Roadmap
+
+This roadmap turns `cloud-security` into a measurable, cross-cloud security
+skills repo for cloud and AI systems.
+
+The operating model is:
+
+- **OCSF-first** where the schema fits
+- **deterministic bridge artifacts** where it does not
+- **read-only by default**
+- **least privilege and zero trust**
+- **same skill code across CLI, CI, MCP, and persistent/serverless execution**
+
+## Current focus
+
+The current north star is not "more skills" by itself. It is:
+
+- broader framework coverage
+- deeper provider and asset coverage
+- stronger test and validation coverage
+- cleaner interoperability for agents and security teams
+
+## Phase 1 — Measured coverage and auditability
+
+Goal: make framework claims measurable instead of implicit.
+
+- ship and maintain [`docs/framework-coverage.json`](framework-coverage.json)
+- validate every shipped skill against the coverage registry
+- keep framework and asset scope versioned in docs
+- expose gaps clearly in docs and issue planning
+
+Exit criteria:
+
+- every shipped skill is present in the coverage registry
+- every framework claim in docs is traceable to a concrete skill
+- CI validates the registry on every PR
+
+## Phase 2 — ATT&CK and ATLAS depth
+
+Goal: drive toward full mapped coverage for the declared scope.
+
+Priority areas:
+
+- MITRE ATT&CK across AWS, Azure, GCP, Kubernetes, containers, MCP, and identity flows
+- MITRE ATLAS across AI endpoints, model serving, datasets, model registries, GPUs, and AI control evidence
+- explicit ATT&CK / ATLAS tables per skill family
+
+Exit criteria:
+
+- ATT&CK and ATLAS mappings are explicit in the registry and docs
+- AI-oriented skills consistently declare ATLAS coverage where applicable
+- detection and evaluation layers show clear ATT&CK / ATLAS traceability
+
+## Phase 3 — Compliance and control framework depth
+
+Goal: increase real technical coverage for control frameworks.
+
+Priority frameworks:
+
+- CIS Benchmarks
+- NIST CSF 2.0
+- NIST AI RMF
+- PCI DSS 4.0
+- SOC 2 TSC
+- ISO 27001:2022
+- OWASP LLM / GenAI guidance where supported by primary sources
+
+Priority work:
+
+- broaden evidence discovery and evaluation coverage
+- make provider and asset-class gaps explicit
+- keep "mapped", "implemented", and "tested" separate in the registry
+
+## Phase 4 — Provider and asset expansion
+
+Goal: deepen useful coverage across cloud and AI surfaces.
+
+Priority providers and surfaces:
+
+- AWS: IAM, VPC, EKS, Security Hub, GuardDuty, Bedrock, SageMaker
+- GCP: IAM, VPC, GKE, SCC, Vertex AI
+- Azure: Entra, NSG, Defender, AKS, Azure ML, AI Foundry
+- shared asset classes:
+  - identities
+  - compute
+  - storage
+  - network
+  - logging
+  - clusters
+  - AI endpoints
+  - model registries
+  - datasets
+  - vector stores
+  - GPU fleets
+  - evidence and inventory artifacts
+
+## Phase 5 — Operational execution paths
+
+Goal: keep the same skills usable in multiple modes without rewriting them.
+
+Supported modes:
+
+- **CLI / just-in-time**
+- **CI**
+- **MCP**
+- **persistent / serverless**
+
+Guardrails:
+
+- read-only skills never silently write
+- remediation stays dry-run first
+- destructive actions stay HITL-gated
+- persistent runners remain explicit edge components, not hidden behavior in core skills
+
+## Near-term delivery order
+
+1. coverage registry and validator
+2. framework gap audit against ATT&CK, ATLAS, CIS, NIST, PCI, SOC 2, ISO
+3. targeted issues for the biggest framework/provider/asset gaps
+4. continued AI service evaluation and detection depth
+5. final CI/workflow polish after the coverage program is stable
+
+## Issue design guidance
+
+Open roadmap issues should be:
+
+- provider-scoped
+- framework-scoped
+- asset-scoped
+- measurable
+
+Good examples:
+
+- `ATT&CK gap: Azure identity and service principal detections`
+- `ATLAS gap: AI endpoint and model registry evaluation coverage`
+- `PCI gap: logging and segmentation evidence for cross-cloud discovery`
+- `NIST AI RMF gap: provider-native AI control evidence expansion`
+
+Avoid vague issues like:
+
+- `add more coverage`
+- `support AI security better`
+
+## What success looks like
+
+Security teams and engineers should be able to:
+
+- plug the repo into Claude, Codex, Cursor, Windsurf, or Cortex Code CLI
+- know which skills are safe to expose to agents
+- know which frameworks and providers are covered today
+- run the same skill just-in-time or continuously
+- submit issues and PRs against explicit gaps instead of implied ones

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -1,0 +1,328 @@
+{
+  "schema_version": "1",
+  "updated": "2026-04-13",
+  "repo_version": "0.4.0",
+  "frameworks": [
+    { "id": "ocsf-1.8", "name": "OCSF", "version": "1.8.0", "scope": "wire-contract" },
+    { "id": "mitre-attack-v14", "name": "MITRE ATT&CK", "version": "v14", "scope": "threat-mapping" },
+    { "id": "mitre-atlas", "name": "MITRE ATLAS", "version": "current", "scope": "ai-threat-mapping" },
+    { "id": "cis-aws-v3", "name": "CIS AWS Foundations", "version": "v3.0", "scope": "benchmark" },
+    { "id": "cis-gcp-v3", "name": "CIS GCP Foundations", "version": "v3.0", "scope": "benchmark" },
+    { "id": "cis-azure-v2.1", "name": "CIS Azure Foundations", "version": "v2.1", "scope": "benchmark" },
+    { "id": "cis-k8s", "name": "CIS Kubernetes Benchmark", "version": "current", "scope": "benchmark" },
+    { "id": "cis-docker", "name": "CIS Docker Benchmark", "version": "current", "scope": "benchmark" },
+    { "id": "cis-controls-v8", "name": "CIS Controls", "version": "v8", "scope": "control-framework" },
+    { "id": "nist-csf-2.0", "name": "NIST CSF", "version": "2.0", "scope": "control-framework" },
+    { "id": "nist-ai-rmf", "name": "NIST AI RMF", "version": "current", "scope": "ai-control-framework" },
+    { "id": "soc2-tsc", "name": "SOC 2 TSC", "version": "current", "scope": "control-framework" },
+    { "id": "pci-dss-4.0", "name": "PCI DSS", "version": "4.0", "scope": "control-framework" },
+    { "id": "iso-27001-2022", "name": "ISO 27001", "version": "2022", "scope": "control-framework" },
+    { "id": "owasp-llm-top-10", "name": "OWASP LLM Top 10", "version": "current", "scope": "ai-control-framework" },
+    { "id": "owasp-mcp-top-10", "name": "OWASP MCP Top 10", "version": "current", "scope": "agent-control-framework" },
+    { "id": "cyclonedx-ml-bom", "name": "CycloneDX ML-BOM", "version": "current", "scope": "inventory-artifact" }
+  ],
+  "skills": [
+    {
+      "path": "skills/ingestion/ingest-cloudtrail-ocsf",
+      "layer": "ingestion",
+      "providers": ["aws"],
+      "asset_classes": ["iam", "api", "audit-logs"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-vpc-flow-logs-ocsf",
+      "layer": "ingestion",
+      "providers": ["aws"],
+      "asset_classes": ["network", "flow-logs"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf",
+      "layer": "ingestion",
+      "providers": ["gcp"],
+      "asset_classes": ["network", "flow-logs"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-nsg-flow-logs-azure-ocsf",
+      "layer": "ingestion",
+      "providers": ["azure"],
+      "asset_classes": ["network", "flow-logs"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-guardduty-ocsf",
+      "layer": "ingestion",
+      "providers": ["aws"],
+      "asset_classes": ["findings", "threat-detections"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-security-hub-ocsf",
+      "layer": "ingestion",
+      "providers": ["aws"],
+      "asset_classes": ["findings", "security-posture"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-gcp-scc-ocsf",
+      "layer": "ingestion",
+      "providers": ["gcp"],
+      "asset_classes": ["findings", "security-posture"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-azure-defender-for-cloud-ocsf",
+      "layer": "ingestion",
+      "providers": ["azure"],
+      "asset_classes": ["findings", "security-posture"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-gcp-audit-ocsf",
+      "layer": "ingestion",
+      "providers": ["gcp"],
+      "asset_classes": ["api", "audit-logs"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-azure-activity-ocsf",
+      "layer": "ingestion",
+      "providers": ["azure"],
+      "asset_classes": ["api", "audit-logs"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-k8s-audit-ocsf",
+      "layer": "ingestion",
+      "providers": ["kubernetes"],
+      "asset_classes": ["clusters", "audit-logs", "identities"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/ingestion/ingest-mcp-proxy-ocsf",
+      "layer": "ingestion",
+      "providers": ["mcp", "multi"],
+      "asset_classes": ["agent-tools", "application-activity"],
+      "frameworks": ["ocsf-1.8", "owasp-mcp-top-10"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/discovery/discover-environment",
+      "layer": "discovery",
+      "providers": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
+      "asset_classes": ["inventory", "compute", "storage", "network", "logging", "clusters", "ai-endpoints"],
+      "frameworks": ["mitre-attack-v14", "mitre-atlas", "nist-csf-2.0", "ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/discovery/discover-ai-bom",
+      "layer": "discovery",
+      "providers": ["aws", "azure", "gcp", "multi"],
+      "asset_classes": ["inventory", "ai-endpoints", "models", "datasets", "vector-stores", "gpu-fleets"],
+      "frameworks": ["cyclonedx-ml-bom", "nist-ai-rmf", "mitre-atlas", "pci-dss-4.0", "soc2-tsc"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp"]
+    },
+    {
+      "path": "skills/discovery/discover-control-evidence",
+      "layer": "discovery",
+      "providers": ["multi"],
+      "asset_classes": ["evidence", "inventory", "ai-endpoints"],
+      "frameworks": ["pci-dss-4.0", "soc2-tsc", "cyclonedx-ml-bom", "mitre-atlas", "ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp"]
+    },
+    {
+      "path": "skills/discovery/discover-cloud-control-evidence",
+      "layer": "discovery",
+      "providers": ["aws", "azure", "gcp", "multi"],
+      "asset_classes": ["evidence", "inventory", "network", "logging", "encryption", "ai-endpoints"],
+      "frameworks": ["pci-dss-4.0", "soc2-tsc", "nist-ai-rmf", "mitre-attack-v14", "mitre-atlas", "ocsf-1.8"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp"]
+    },
+    {
+      "path": "skills/detection/detect-lateral-movement",
+      "layer": "detection",
+      "providers": ["aws", "azure", "gcp", "multi"],
+      "asset_classes": ["identities", "sessions", "api", "network"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/detection/detect-mcp-tool-drift",
+      "layer": "detection",
+      "providers": ["mcp", "multi"],
+      "asset_classes": ["agent-tools", "supply-chain", "tool-metadata"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14", "owasp-mcp-top-10"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp"]
+    },
+    {
+      "path": "skills/detection/detect-privilege-escalation-k8s",
+      "layer": "detection",
+      "providers": ["kubernetes"],
+      "asset_classes": ["clusters", "containers", "identities", "secrets"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/detection/detect-sensitive-secret-read-k8s",
+      "layer": "detection",
+      "providers": ["kubernetes"],
+      "asset_classes": ["clusters", "secrets", "identities"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/cspm-aws-cis-benchmark",
+      "layer": "evaluation",
+      "providers": ["aws"],
+      "asset_classes": ["identities", "storage", "logging", "network"],
+      "frameworks": ["cis-aws-v3", "nist-csf-2.0", "iso-27001-2022", "soc2-tsc", "pci-dss-4.0"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/cspm-gcp-cis-benchmark",
+      "layer": "evaluation",
+      "providers": ["gcp"],
+      "asset_classes": ["identities", "storage", "logging", "network"],
+      "frameworks": ["cis-gcp-v3", "nist-csf-2.0", "iso-27001-2022"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/cspm-azure-cis-benchmark",
+      "layer": "evaluation",
+      "providers": ["azure"],
+      "asset_classes": ["identities", "storage", "logging", "network"],
+      "frameworks": ["cis-azure-v2.1", "nist-csf-2.0", "iso-27001-2022"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/k8s-security-benchmark",
+      "layer": "evaluation",
+      "providers": ["kubernetes"],
+      "asset_classes": ["clusters", "identities", "network", "logging"],
+      "frameworks": ["cis-k8s", "nist-csf-2.0"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/container-security",
+      "layer": "evaluation",
+      "providers": ["containers"],
+      "asset_classes": ["containers", "runtime", "images"],
+      "frameworks": ["cis-docker", "nist-csf-2.0"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/model-serving-security",
+      "layer": "evaluation",
+      "providers": ["aws", "azure", "gcp", "multi"],
+      "asset_classes": ["ai-endpoints", "models", "identities", "network", "logging", "guardrails"],
+      "frameworks": ["mitre-atlas", "nist-csf-2.0", "owasp-llm-top-10", "soc2-tsc", "nist-ai-rmf"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/evaluation/gpu-cluster-security",
+      "layer": "evaluation",
+      "providers": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
+      "asset_classes": ["gpu-fleets", "clusters", "containers", "runtime", "tenancy"],
+      "frameworks": ["mitre-attack-v14", "nist-csf-2.0", "cis-controls-v8", "cis-k8s"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/view/convert-ocsf-to-sarif",
+      "layer": "view",
+      "providers": ["multi"],
+      "asset_classes": ["findings", "review-output"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp"]
+    },
+    {
+      "path": "skills/view/convert-ocsf-to-mermaid-attack-flow",
+      "layer": "view",
+      "providers": ["multi"],
+      "asset_classes": ["findings", "review-output", "graphs"],
+      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp"]
+    },
+    {
+      "path": "skills/remediation/iam-departures-remediation",
+      "layer": "remediation",
+      "providers": ["aws", "snowflake", "databricks", "clickhouse"],
+      "asset_classes": ["identities", "access", "audit", "hr-events"],
+      "frameworks": ["mitre-attack-v14", "nist-csf-2.0", "cis-controls-v8", "soc2-tsc"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+    }
+  ],
+  "coverage_targets": [
+    {
+      "framework": "mitre-attack-v14",
+      "target": "100% mapped coverage",
+      "providers_in_scope": ["aws", "azure", "gcp", "kubernetes", "containers", "mcp"],
+      "asset_classes_in_scope": ["identities", "api", "network", "clusters", "containers", "findings"]
+    },
+    {
+      "framework": "mitre-atlas",
+      "target": "100% mapped coverage",
+      "providers_in_scope": ["aws", "azure", "gcp"],
+      "asset_classes_in_scope": ["ai-endpoints", "models", "datasets", "vector-stores", "gpu-fleets", "evidence"]
+    },
+    {
+      "framework": "nist-csf-2.0",
+      "target": "100% mapped coverage",
+      "providers_in_scope": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
+      "asset_classes_in_scope": ["identities", "storage", "logging", "network", "clusters", "runtime", "evidence"]
+    },
+    {
+      "framework": "pci-dss-4.0",
+      "target": "100% mapped coverage",
+      "providers_in_scope": ["aws", "azure", "gcp", "multi"],
+      "asset_classes_in_scope": ["network", "logging", "encryption", "evidence", "inventory"]
+    },
+    {
+      "framework": "soc2-tsc",
+      "target": "100% mapped coverage",
+      "providers_in_scope": ["aws", "azure", "gcp", "multi"],
+      "asset_classes_in_scope": ["access", "logging", "change", "evidence", "inventory", "ai-endpoints"]
+    }
+  ]
+}

--- a/scripts/validate_framework_coverage.py
+++ b/scripts/validate_framework_coverage.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from skill_validation_common import ROOT, discover_skill_contracts
+
+ALLOWED_LAYERS = {"ingestion", "discovery", "detection", "evaluation", "view", "remediation"}
+ALLOWED_STATUSES = {"gap", "mapped", "implemented", "tested", "validated"}
+ALLOWED_EXECUTION_MODES = {"cli", "ci", "mcp", "persistent"}
+
+
+def load_registry() -> dict:
+    path = ROOT / "docs" / "framework-coverage.json"
+    return json.loads(path.read_text())
+
+
+def main() -> int:
+    registry = load_registry()
+    errors: list[str] = []
+
+    frameworks = {item["id"] for item in registry.get("frameworks", [])}
+    if not frameworks:
+        errors.append("docs/framework-coverage.json: no framework ids declared")
+
+    expected_paths = {
+        str(skill.skill_dir.relative_to(ROOT)): skill for skill in discover_skill_contracts()
+    }
+    registered_paths: dict[str, dict] = {}
+
+    for entry in registry.get("skills", []):
+        path = entry.get("path", "")
+        if not path:
+            errors.append("docs/framework-coverage.json: skill entry missing `path`")
+            continue
+        if path in registered_paths:
+            errors.append(f"docs/framework-coverage.json: duplicate skill entry `{path}`")
+            continue
+        registered_paths[path] = entry
+
+        skill = expected_paths.get(path)
+        if skill is None:
+            errors.append(f"docs/framework-coverage.json: unknown skill path `{path}`")
+            continue
+
+        layer = entry.get("layer")
+        if layer not in ALLOWED_LAYERS:
+            errors.append(f"{path}: invalid layer `{layer}`")
+        elif layer != skill.category:
+            errors.append(f"{path}: registry layer `{layer}` does not match skill layer `{skill.category}`")
+
+        status = entry.get("coverage_status")
+        if status not in ALLOWED_STATUSES:
+            errors.append(f"{path}: invalid coverage_status `{status}`")
+
+        providers = entry.get("providers", [])
+        if not isinstance(providers, list) or not providers:
+            errors.append(f"{path}: providers must be a non-empty list")
+
+        asset_classes = entry.get("asset_classes", [])
+        if not isinstance(asset_classes, list) or not asset_classes:
+            errors.append(f"{path}: asset_classes must be a non-empty list")
+
+        modes = entry.get("execution_modes", [])
+        if not isinstance(modes, list) or not modes:
+            errors.append(f"{path}: execution_modes must be a non-empty list")
+        else:
+            for mode in modes:
+                if mode not in ALLOWED_EXECUTION_MODES:
+                    errors.append(f"{path}: invalid execution mode `{mode}`")
+
+        entry_frameworks = entry.get("frameworks", [])
+        if not isinstance(entry_frameworks, list) or not entry_frameworks:
+            errors.append(f"{path}: frameworks must be a non-empty list")
+        else:
+            for framework_id in entry_frameworks:
+                if framework_id not in frameworks:
+                    errors.append(f"{path}: unknown framework id `{framework_id}`")
+
+    missing = sorted(set(expected_paths) - set(registered_paths))
+    extra = sorted(set(registered_paths) - set(expected_paths))
+
+    for path in missing:
+        errors.append(f"docs/framework-coverage.json: missing registry entry for `{path}`")
+    for path in extra:
+        errors.append(f"docs/framework-coverage.json: registry entry without shipped skill `{path}`")
+
+    for target in registry.get("coverage_targets", []):
+        framework = target.get("framework")
+        if framework not in frameworks:
+            errors.append(f"coverage_targets: unknown framework `{framework}`")
+
+    if errors:
+        print("Framework coverage validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Framework coverage validation passed for {len(registered_paths)} skills and "
+        f"{len(frameworks)} frameworks."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -39,6 +39,10 @@ DEPENDENCIES = _load_module(
     "cloud_security_validate_dependency_consistency_test",
     SCRIPTS / "validate_dependency_consistency.py",
 )
+COVERAGE = _load_module(
+    "cloud_security_validate_framework_coverage_test",
+    SCRIPTS / "validate_framework_coverage.py",
+)
 
 
 class TestSkillValidationCommon:
@@ -77,3 +81,6 @@ class TestValidationScripts:
 
     def test_dependency_consistency_validator_passes(self):
         assert DEPENDENCIES.main() == 0
+
+    def test_framework_coverage_validator_passes(self):
+        assert COVERAGE.main() == 0


### PR DESCRIPTION
## Summary
- add a measurable coverage model, machine-readable registry, and roadmap for framework/provider/asset coverage
- validate the registry in CI and integration tests so framework claims stay auditable
- link the new coverage artifacts from README, contributing docs, and framework mapping docs

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_dependency_consistency.py
- python scripts/validate_framework_coverage.py
- python scripts/validate_safe_skill_bar.py
- python3 -m pytest tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- python3 -m ruff check scripts/validate_framework_coverage.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml
