### PR TITLE
docs: surface release badge and flagship workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is loosely based on Keep a Changelog.
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
 - `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.
 
+### Changed
+- Promoted the IAM departures cross-cloud workflow visual in `README.md` and made the CI badge explicitly track the `main` branch.
+
 ## 0.4.0 - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cloud-security
 
-[![CI](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml/badge.svg)](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml)
+[![CI](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml?query=branch%3Amain)
+[![Version](https://img.shields.io/badge/version-0.4.0-0ea5e9)](CHANGELOG.md)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
@@ -20,9 +21,12 @@
 - Architecture and visuals: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/DIAGRAMS.md](docs/DIAGRAMS.md)
 - Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), and [docs/ROADMAP.md](docs/ROADMAP.md)
 
-![Repo architecture](docs/images/repo-architecture.svg)
+## Flagship workflow
+
+![IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
 
 **Visuals**
+- [IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
 - [Repo architecture](docs/images/repo-architecture.svg)
 - [IAM departures flow](docs/images/iam-departures-data-flow.svg)
 - [Detection pipeline](docs/images/detection-pipeline.svg)

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -4,6 +4,7 @@ Keep the markdown source diagrams lightweight and reviewable, then pair them wit
 
 ## Visual set
 
+- [IAM departures cross-cloud workflow](images/iam-departures-architecture.svg)
 - [Repository architecture](images/repo-architecture.svg)
 - [IAM departures data flow](images/iam-departures-data-flow.svg)
 - [Detection engineering pipeline](images/detection-pipeline.svg)


### PR DESCRIPTION
## Summary
- make the README CI badge explicitly track the main branch
- add the current repo version badge for v0.4.0
- promote the IAM departures cross-cloud workflow visual to the README hero area
- add the same flagship workflow to the diagrams index

## Notes
- the README badge now follows main explicitly instead of the workflow badge default
- the IAM departures architecture SVG already existed; this PR surfaces it where readers will actually see it
