### PR TITLE
docs: rebrand repo surface and agent quickstart

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "cloud-security": {
+    "cloud-ai-security-skills": {
       "command": "python3",
       "args": ["mcp-server/src/server.py"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `cloud-security` should be recorded here.
+All notable changes to `cloud-ai-security-skills` should be recorded here.
 
 This changelog is intentionally **repo-level**, not per-skill semver. The repo
 is released as one trust boundary: one CI bar, one MCP wrapper, one validation
@@ -17,6 +17,7 @@ The format is loosely based on Keep a Changelog.
 
 ### Changed
 - Promoted the IAM departures cross-cloud workflow visual in `README.md` and made the CI badge explicitly track the `main` branch.
+- Rebranded the public repo/docs surface to `cloud-ai-security-skills`, updated the MCP server name and project-scoped `.mcp.json`, and added a concise agent quick-start matrix for Claude Code, Codex, Cursor, Windsurf, and Cortex Code CLI.
 
 ## 0.4.0 - 2026-04-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code Project Memory
 
-This file is Claude Code project memory for `cloud-security`. It is repo-wide
+This file is Claude Code project memory for `cloud-ai-security-skills`. It is repo-wide
 and universal for Claude within this repository. It is **not** the place for
 individual skill behavior; per-skill rules belong in `skills/<layer>/<skill>/SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cloud-security
+# cloud-ai-security-skills
 
-[![CI](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/msaad00/cloud-security/actions/workflows/ci.yml?query=branch%3Amain)
+[![CI](https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain)
 [![Version](https://img.shields.io/badge/version-0.4.0-0ea5e9)](CHANGELOG.md)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
@@ -14,12 +14,28 @@
 - Read-only by default, least-privilege, zero-trust
 - Deterministic, auditable, and grounded in official vendor docs
 
+## Quick start
+
 **Start here**
 - Agents: [AGENTS.md](AGENTS.md)
 - Claude Code memory: [CLAUDE.md](CLAUDE.md)
 - MCP usage: [docs/agent-integrations.md](docs/agent-integrations.md) and [`.mcp.json`](.mcp.json)
 - Architecture and visuals: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/DIAGRAMS.md](docs/DIAGRAMS.md)
 - Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), and [docs/ROADMAP.md](docs/ROADMAP.md)
+
+| Tool | Best integration path | What to rely on |
+|---|---|---|
+| **Claude Code** | `CLAUDE.md` + `AGENTS.md` + MCP | project memory + agent rules + tools |
+| **Codex** | `AGENTS.md` + MCP | repo rules + tool calling |
+| **Cursor** | `AGENTS.md` or `.cursor/rules` + MCP | repo rules + tool calling |
+| **Windsurf** | `AGENTS.md` + MCP | directory-scoped agent rules + tools |
+| **Cortex Code CLI** | `SKILL.md` / `.cortex/skills` + MCP | native skills + tool calling |
+
+The repo keeps one source of truth:
+- `AGENTS.md` for universal agent instructions
+- `CLAUDE.md` for Claude-specific project memory
+- `SKILL.md` for each skill contract
+- MCP as the access layer, not a second implementation
 
 ## Flagship workflow
 
@@ -195,7 +211,7 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | Document | Purpose |
 |---|---|
 | [`ARCHITECTURE.md`](docs/ARCHITECTURE.md) | 9-layer design, two execution modes (stateless + persistent), 10 guardrails |
-| [`DIAGRAMS.md`](docs/DIAGRAMS.md) | Architecture map, IAM departures flow, and detection pipeline visuals |
+| [`DIAGRAMS.md`](docs/DIAGRAMS.md) | Architecture map, IAM departures workflow/data flow, and detection pipeline visuals |
 | [`CI_WORKFLOW.md`](docs/CI_WORKFLOW.md) | CI lane layout, dedupe rules, and follow-up simplification plan |
 | [`CHANGELOG.md`](CHANGELOG.md) | Repo-level release notes and material skill changes |
 | [`COVERAGE_MODEL.md`](docs/COVERAGE_MODEL.md) | What framework coverage means and how it is measured |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document is the load-bearing design contract for `cloud-security`. Every future PR is reviewed against it. If you need to deviate, update this doc *in the same PR* — the contract drifts by design, never by accident.
+This document is the load-bearing design contract for `cloud-ai-security-skills`. Every future PR is reviewed against it. If you need to deviate, update this doc *in the same PR* — the contract drifts by design, never by accident.
 
 - **Wire format contract** — see [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
 - **Sink / persistence contract** — see [`./SINK_CONTRACT.md`](./SINK_CONTRACT.md) *(lands with PR T)*
@@ -9,7 +9,7 @@ This document is the load-bearing design contract for `cloud-security`. Every fu
 
 ## 1. Purpose and scope
 
-`cloud-security` is a library of **composable, OCSF-native security skills** that normalize, enrich, detect on, evaluate, remediate, and deliver findings across cloud providers and SaaS products. The repository is designed to be driven by agentic tools (Claude Code, Snowflake Cortex Code CLI, Claude Agent SDK, any MCP client) *and* by traditional CI / serverless pipelines — with no code changes between the two modes.
+`cloud-ai-security-skills` is a library of **composable, OCSF-native security skills** that normalize, enrich, detect on, evaluate, remediate, and deliver findings across cloud providers and SaaS products. The repository is designed to be driven by agentic tools (Claude Code, Snowflake Cortex Code CLI, Claude Agent SDK, any MCP client) *and* by traditional CI / serverless pipelines — with no code changes between the two modes.
 
 **In scope**
 - Normalising raw vendor telemetry into OCSF 1.8 wire format
@@ -172,7 +172,7 @@ An AI BOM capability belongs in the **discovery / inventory path**, not as the i
 - **Enrichment** belongs in L2 when joining model inventory, framework metadata, package provenance, and control coverage into a usable graph.
 - **Evaluation** belongs in L4 when mapping that inventory to MITRE ATLAS, NIST AI RMF, OWASP LLM Top 10, or other AI-security frameworks.
 
-That keeps AI BOM as one valuable skill family inside `cloud-security`, instead of pulling the whole repo away from its broader cloud + AI security scope.
+That keeps AI BOM as one valuable skill family inside `cloud-ai-security-skills`, instead of pulling the whole repo away from its broader cloud + AI security scope.
 
 ### Why this works: idempotency
 
@@ -188,7 +188,7 @@ Sinks exploit this: `MERGE INTO ocsf_findings USING input ON input.finding_info.
 ### Current layered tree
 
 ```
-cloud-security/
+cloud-ai-security-skills/
 ├── skills/
 │   ├── ingestion/               # L1
 │   ├── discovery/               # L2 discovery / inventory
@@ -206,7 +206,7 @@ cloud-security/
 ### Near-term target
 
 ```
-cloud-security/
+cloud-ai-security-skills/
 ├── skills/
 │   ├── ingestion/            # L1
 │   ├── discovery/            # L2

--- a/docs/COVERAGE_MODEL.md
+++ b/docs/COVERAGE_MODEL.md
@@ -1,6 +1,6 @@
 # Coverage Model
 
-`cloud-security` does not use vague framework claims. Coverage is measured
+`cloud-ai-security-skills` does not use vague framework claims. Coverage is measured
 against an explicit scope:
 
 - framework version

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -1,6 +1,6 @@
 # Framework Mappings
 
-This document shows which frameworks are represented in `cloud-security`, where
+This document shows which frameworks are represented in `cloud-ai-security-skills`, where
 they appear today, and where coverage is still partial.
 
 For machine-readable source of truth, see

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-This roadmap turns `cloud-security` into a measurable, cross-cloud security
+This roadmap turns `cloud-ai-security-skills` into a measurable, cross-cloud security
 skills repo for cloud and AI systems.
 
 The operating model is:

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -1,6 +1,6 @@
 # Skill Contract
 
-This document defines the minimum contract for a shipped skill in `cloud-security`.
+This document defines the minimum contract for a shipped skill in `cloud-ai-security-skills`.
 
 The goal is to keep skills:
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -1,9 +1,11 @@
 # Agent Integrations
 
 This repo is a good fit for coding agents because each skill is already packaged
-as a compact contract: `SKILL.md`, implementation code, tests, and infrastructure.
-This document explains how to use that structure with Claude-oriented tooling,
-Codex CLI, and generic AGENTS.md-aware agents.
+as a compact contract: `SKILL.md`, implementation code, tests, and
+infrastructure. This document explains how to use that structure with Claude
+Code, Codex, Cursor, Windsurf, Cortex Code CLI, and other AGENTS.md-aware
+clients without duplicating the repo contract into tool-specific top-level
+files.
 
 ## Source of truth
 
@@ -22,6 +24,20 @@ Use the docs in this order:
 - JSON, console, and SARIF outputs that are easy for agents and CI systems to consume
 - A native local MCP server under [`mcp-server/`](../mcp-server/README.md)
 - Project-scoped MCP config in [`.mcp.json`](../.mcp.json) for Claude Code and similar clients
+
+## Client quick map
+
+| Tool | Best integration path | What to rely on |
+|---|---|---|
+| **Claude Code** | `CLAUDE.md` + `AGENTS.md` + MCP | project memory + repo rules + tools |
+| **Codex** | `AGENTS.md` + MCP | repo rules + tool calling |
+| **Cursor** | `AGENTS.md` or `.cursor/rules` + MCP | repo rules + tool calling |
+| **Windsurf** | `AGENTS.md` + MCP | directory-scoped agent rules + tools |
+| **Cortex Code CLI** | `SKILL.md` / `.cortex/skills` + MCP | native skills + tool calling |
+
+We intentionally do **not** ship separate `CODEX.md`, `CURSOR.md`, or
+`WINDSURF.md` files. `AGENTS.md` stays universal, `CLAUDE.md` stays
+Claude-specific, and `SKILL.md` stays the per-skill source of truth.
 
 ## Execution modes
 
@@ -83,7 +99,7 @@ This repo now ships a project-scoped MCP config:
 ```json
 {
   "mcpServers": {
-    "cloud-security": {
+    "cloud-ai-security-skills": {
       "command": "python3",
       "args": ["mcp-server/src/server.py"]
     }

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" role="img" aria-labelledby="title desc">
-  <title id="title">cloud-security repository architecture</title>
+  <title id="title">cloud-ai-security-skills repository architecture</title>
   <desc id="desc">Skill families feed shared contracts and CI lanes.</desc>
   <rect width="1200" height="640" fill="#0b1220"/>
   <rect x="40" y="40" width="1120" height="560" rx="24" fill="#111827" stroke="#334155"/>
-  <text x="70" y="90" fill="#f8fafc" font-size="32" font-family="Arial, sans-serif" font-weight="700">cloud-security</text>
+  <text x="70" y="90" fill="#f8fafc" font-size="32" font-family="Arial, sans-serif" font-weight="700">cloud-ai-security-skills</text>
   <text x="70" y="122" fill="#94a3b8" font-size="16" font-family="Arial, sans-serif">Skill families, shared contracts, and CI lanes</text>
 
   <rect x="70" y="160" width="230" height="120" rx="18" fill="#172554" stroke="#60a5fa"/>

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-Thin stdio MCP wrapper for `cloud-security`.
+Thin stdio MCP wrapper for `cloud-ai-security-skills`.
 
 This server does not replace the existing skills model. It auto-discovers
 `skills/*/*/SKILL.md`, resolves each supported skill to its existing Python

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -13,7 +13,7 @@ if str(CURRENT_DIR) not in sys.path:
 
 from tool_registry import build_command, repo_root, tool_definition, tool_map  # noqa: E402
 
-SERVER_NAME = "cloud-security"
+SERVER_NAME = "cloud-ai-security-skills"
 SERVER_VERSION = "0.1.0"
 PROTOCOL_VERSION = "2025-06-18"
 DEFAULT_TIMEOUT_SECONDS = 60

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -43,7 +43,7 @@ def _start_server() -> subprocess.Popen[bytes]:
 def _initialize(proc: subprocess.Popen[bytes]) -> None:
     _send_message(proc, {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
     response = _read_message(proc)
-    assert response["result"]["serverInfo"]["name"] == "cloud-security"
+    assert response["result"]["serverInfo"]["name"] == "cloud-ai-security-skills"
     _send_message(proc, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "cloud-security"
+name = "cloud-ai-security-skills"
 version = "0.4.0"
 description = "OCSF-native security skills for cloud and AI systems."
 readme = "README.md"

--- a/skills/README.md
+++ b/skills/README.md
@@ -67,7 +67,7 @@ Read-only posture and benchmark evaluation skills.
 | [`cspm-azure-cis-benchmark`](evaluation/cspm-azure-cis-benchmark/) | Azure | 6 |
 | [`k8s-security-benchmark`](evaluation/k8s-security-benchmark/) | Kubernetes | 10 |
 | [`container-security`](evaluation/container-security/) | Containers | 8 |
-| [`model-serving-security`](evaluation/model-serving-security/) | AI model serving | 16 |
+| [`model-serving-security`](evaluation/model-serving-security/) | AI model serving | 20 |
 | [`gpu-cluster-security`](evaluation/gpu-cluster-security/) | GPU clusters | 13 |
 
 ## view/


### PR DESCRIPTION
## Summary
- rebrand the public repo/docs surface to `cloud-ai-security-skills`
- add a concise agent integration matrix for Claude, Codex, Cursor, Windsurf, and Cortex Code CLI
- surface the IAM departures cross-cloud workflow visual and fix the README badges/version display

## Validation
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `uv run pytest mcp-server/tests/test_server.py tests/integration/test_skill_validation_scripts.py -q -o addopts=''`
- `uv run ruff check mcp-server/src/server.py mcp-server/tests/test_server.py --config pyproject.toml`