### PR TITLE
feat: add gpu cluster atlas and ai-rmf coverage depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on Keep a Changelog.
 ### Added
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
 - `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.
+- explicit MITRE ATLAS and NIST AI RMF declarations for `gpu-cluster-security`, including machine-readable benchmark metadata for wrappers and coverage tests.
 
 ### Changed
 - Promoted the IAM departures cross-cloud workflow visual in `README.md` and made the CI badge explicitly track the `main` branch.

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -79,8 +79,8 @@ Current provider depth in discovery:
 - Azure ML / Azure AI Foundry
 
 Recommended expansion:
-- make ATLAS mappings more explicit in `gpu-cluster-security`
 - add a shared table of ATLAS techniques used by AI-oriented skills
+- deepen provider-shaped GPU and accelerator evidence beyond the current benchmark input model
 
 ## Kubernetes and containers
 
@@ -105,7 +105,7 @@ uniform than classic cloud posture.
 | `discover-control-evidence` | PCI DSS 4.0, SOC 2 TSC, CycloneDX ML-BOM, MITRE ATLAS |
 | `discover-cloud-control-evidence` | PCI DSS 4.0, SOC 2 TSC, NIST AI RMF, MITRE ATT&CK, MITRE ATLAS |
 | `model-serving-security` | MITRE ATLAS, NIST CSF, OWASP LLM Top 10, SOC 2, provider-specific AI endpoint controls |
-| `gpu-cluster-security` | MITRE ATT&CK, NIST CSF, CIS Controls, CIS Kubernetes |
+| `gpu-cluster-security` | MITRE ATT&CK, MITRE ATLAS, NIST CSF, NIST AI RMF, CIS Controls, CIS Kubernetes |
 | `discover-environment` | MITRE ATT&CK, MITRE ATLAS, NIST CSF |
 
 Recommended next step:

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -261,7 +261,7 @@
       "layer": "evaluation",
       "providers": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
       "asset_classes": ["gpu-fleets", "clusters", "containers", "runtime", "tenancy"],
-      "frameworks": ["mitre-attack-v14", "nist-csf-2.0", "cis-controls-v8", "cis-k8s"],
+      "frameworks": ["mitre-attack-v14", "mitre-atlas", "nist-csf-2.0", "nist-ai-rmf", "cis-controls-v8", "cis-k8s"],
       "coverage_status": "validated",
       "execution_modes": ["cli", "ci", "mcp", "persistent"]
     },

--- a/skills/evaluation/gpu-cluster-security/REFERENCES.md
+++ b/skills/evaluation/gpu-cluster-security/REFERENCES.md
@@ -5,8 +5,10 @@
 - **MITRE ATT&CK** — T1610 Deploy Container, T1611 Escape to Host, T1078.004 Cloud Accounts
   https://attack.mitre.org/techniques/T1610/
   https://attack.mitre.org/techniques/T1611/
+- **MITRE ATLAS** — https://atlas.mitre.org/
 - **CIS Kubernetes Benchmark** — https://www.cisecurity.org/benchmark/kubernetes
 - **NIST CSF 2.0** — PR.AC-3, PR.AC-4, PR.PT-3 — https://www.nist.gov/cyberframework
+- **NIST AI Risk Management Framework (AI RMF 1.0)** — https://www.nist.gov/itl/ai-risk-management-framework
 - **NVIDIA Container Toolkit security guidance** — https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/
 
 ## Inputs

--- a/skills/evaluation/gpu-cluster-security/SKILL.md
+++ b/skills/evaluation/gpu-cluster-security/SKILL.md
@@ -19,12 +19,14 @@ compatibility: >-
   no API calls, no network access required.
 metadata:
   author: msaad00
-  homepage: https://github.com/msaad00/cloud-security
-  source: https://github.com/msaad00/cloud-security/tree/main/skills/evaluation/gpu-cluster-security
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/evaluation/gpu-cluster-security
   version: 0.1.0
   frameworks:
     - MITRE ATT&CK
+    - MITRE ATLAS
     - NIST CSF 2.0
+    - NIST AI RMF 1.0
     - CIS Controls v8
     - CIS Kubernetes Benchmark
   cloud: any
@@ -36,7 +38,9 @@ metadata:
 # GPU Cluster Security Benchmark
 
 13 automated checks across 6 domains, auditing the security posture of GPU
-compute infrastructure. Each check mapped to MITRE ATT&CK and NIST CSF 2.0.
+compute infrastructure. Each check mapped to MITRE ATT&CK and NIST CSF 2.0,
+with explicit MITRE ATLAS and NIST AI RMF coverage for AI infrastructure
+runtime, tenancy, storage, and observability safeguards.
 
 No CIS GPU benchmark exists today. This skill fills that gap.
 
@@ -221,6 +225,24 @@ logging:
 | Valid Accounts | T1078 | Checks namespace isolation per tenant |
 | Impair Defenses: Logging | T1562.002 | Checks GPU workload audit logging |
 | Data from Storage | T1530 | Checks model weight encryption |
+
+## MITRE ATLAS and NIST AI RMF Coverage
+
+This skill does **not** invent fake per-check ATLAS technique IDs where the fit
+is weak. Instead, it declares explicit framework depth for the AI
+infrastructure domains the benchmark covers today:
+
+| Domain | MITRE ATLAS focus | NIST AI RMF focus |
+|---|---|---|
+| Runtime isolation | hardening AI workload execution on GPU clusters | MANAGE, GOVERN |
+| Driver security | vulnerable GPU dependency and compute integrity exposure | MEASURE, MANAGE |
+| Network segmentation | tenant boundary protection for AI infrastructure traffic | MAP, MANAGE |
+| Storage and model artifacts | model/artifact protection against unauthorized access | MAP, MANAGE |
+| Tenant isolation and quotas | controls against account and cost abuse on shared GPU fleets | GOVERN, MANAGE |
+| Observability | detection and investigation support for AI infrastructure misuse | MEASURE, MANAGE |
+
+That keeps the framework claims explicit and testable today while leaving
+technique-by-technique ATLAS expansion as a roadmap item.
 
 ## Known Vulnerable NVIDIA Drivers
 

--- a/skills/evaluation/gpu-cluster-security/src/checks.py
+++ b/skills/evaluation/gpu-cluster-security/src/checks.py
@@ -25,6 +25,45 @@ import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+FRAMEWORKS = (
+    "MITRE ATT&CK v14",
+    "MITRE ATLAS",
+    "NIST CSF 2.0",
+    "NIST AI RMF 1.0",
+    "CIS Controls v8",
+    "CIS Kubernetes Benchmark",
+)
+
+PROVIDERS = ("aws", "azure", "gcp", "kubernetes", "containers", "multi")
+ASSET_CLASSES = ("gpu-fleets", "clusters", "containers", "runtime", "tenancy")
+
+AI_FRAMEWORK_FOCUS = {
+    "runtime": {
+        "mitre_atlas": "AI platform runtime hardening for GPU workloads",
+        "nist_ai_rmf": "MANAGE, GOVERN",
+    },
+    "driver": {
+        "mitre_atlas": "GPU compute integrity and vulnerable dependency exposure",
+        "nist_ai_rmf": "MEASURE, MANAGE",
+    },
+    "network": {
+        "mitre_atlas": "Tenant boundary protection for AI infrastructure traffic",
+        "nist_ai_rmf": "MAP, MANAGE",
+    },
+    "storage": {
+        "mitre_atlas": "Model and artifact protection against unauthorized access",
+        "nist_ai_rmf": "MAP, MANAGE",
+    },
+    "tenant": {
+        "mitre_atlas": "GPU tenancy controls against account and cost abuse",
+        "nist_ai_rmf": "GOVERN, MANAGE",
+    },
+    "observability": {
+        "mitre_atlas": "Detection and investigation support for AI infrastructure misuse",
+        "nist_ai_rmf": "MEASURE, MANAGE",
+    },
+}
+
 
 @dataclass
 class Finding:
@@ -39,6 +78,18 @@ class Finding:
     nist_csf: str = ""
     cis_control: str = ""
     resources: list[str] = field(default_factory=list)
+
+
+def benchmark_metadata() -> dict[str, object]:
+    """Return machine-readable benchmark metadata for wrappers and docs."""
+    return {
+        "frameworks": list(FRAMEWORKS),
+        "providers": list(PROVIDERS),
+        "asset_classes": list(ASSET_CLASSES),
+        "ai_framework_focus": AI_FRAMEWORK_FOCUS,
+        "check_count": sum(len(checks) for checks in ALL_CHECKS.values()),
+        "sections": {name: len(checks) for name, checks in ALL_CHECKS.items()},
+    }
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/skills/evaluation/gpu-cluster-security/tests/test_checks.py
+++ b/skills/evaluation/gpu-cluster-security/tests/test_checks.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from checks import (
     Finding,
+    benchmark_metadata,
     check_1_1_no_privileged_gpu_pods,
     check_1_2_gpu_device_plugin,
     check_1_3_no_host_ipc,
@@ -201,3 +202,11 @@ class TestBenchmarkRunner:
         findings = run_benchmark(config, section="runtime")
         for f in findings:
             assert f.nist_csf, f"{f.check_id} missing NIST CSF"
+
+    def test_benchmark_metadata_declares_ai_frameworks(self):
+        metadata = benchmark_metadata()
+        assert "MITRE ATLAS" in metadata["frameworks"]
+        assert "NIST AI RMF 1.0" in metadata["frameworks"]
+        assert metadata["check_count"] == 13
+        assert metadata["sections"]["tenant"] == 2
+        assert metadata["ai_framework_focus"]["tenant"]["mitre_atlas"]

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -84,3 +85,9 @@ class TestValidationScripts:
 
     def test_framework_coverage_validator_passes(self):
         assert COVERAGE.main() == 0
+
+    def test_gpu_skill_ai_framework_depth_is_registered(self):
+        registry = json.loads((ROOT / "docs" / "framework-coverage.json").read_text())
+        gpu = next(item for item in registry["skills"] if item["path"] == "skills/evaluation/gpu-cluster-security")
+        assert "mitre-atlas" in gpu["frameworks"]
+        assert "nist-ai-rmf" in gpu["frameworks"]


### PR DESCRIPTION
## Summary
- add explicit MITRE ATLAS and NIST AI RMF depth to gpu-cluster-security
- expose machine-readable benchmark metadata for wrappers, docs, and coverage validation
- update coverage docs and changelog so the framework registry matches the shipped skill

## Validation
- python scripts/validate_framework_coverage.py
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- uv run pytest skills/evaluation/gpu-cluster-security/tests/test_checks.py tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run ruff check skills/evaluation/gpu-cluster-security/src/checks.py skills/evaluation/gpu-cluster-security/tests/test_checks.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml

## Notes
- implements the first concrete slice of the framework-gap roadmap opened in #91 and aligns the repo coverage registry to current code
