### PR TITLE
feat: add Azure Entra credential pivot coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on Keep a Changelog.
 ### Added
 - Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.
 - Added [`docs/SIEM_INDEX_GUIDE.md`](docs/SIEM_INDEX_GUIDE.md) covering index fields, timestamps, dedupe keys, and just-in-time vs persistent ingestion guidance.
+- Added Azure Entra / Microsoft Graph credential-pivot coverage to `detect-lateral-movement`, including application and service-principal password-key changes, app-role grants, and federated identity credential creation.
 
 ### Added
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -48,7 +48,7 @@ Strongest current ATT&CK coverage:
 
 | Skill | Coverage |
 |---|---|
-| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots, and Azure role/service-principal identity pivots |
+| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots |
 | `detect-mcp-tool-drift` | T1195.001 |
 | `detect-privilege-escalation-k8s` | T1552.007, T1611, T1098, T1550.001 |
 | `detect-sensitive-secret-read-k8s` | T1552, T1552.007 |
@@ -60,7 +60,7 @@ Strongest current ATT&CK coverage:
 Notes:
 - ATT&CK is pinned in the shared OCSF contract.
 - ATT&CK mappings belong inside `finding_info.attacks[]` for OCSF 1.8 outputs, not as loose side metadata.
-- Current cross-cloud identity depth is strongest in `detect-lateral-movement`; follow-up gaps now break down into provider-native identity families instead of one generic "identity coverage" bucket.
+- Current cross-cloud identity depth is strongest in `detect-lateral-movement`; the Azure slice now distinguishes Azure Activity control-plane pivots from Entra / Graph application-service-principal credential pivots.
 
 ## MITRE ATLAS
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,7 +131,7 @@ Open roadmap issues should be:
 
 Good examples:
 
-- `ATT&CK gap: Azure identity and service principal detections`
+- `ATT&CK gap: Azure Entra and service principal credential detections`
 - `ATT&CK gap: AWS IAM user and access-key identity pivots`
 - `ATT&CK gap: GCP service-account and workload-identity abuse detections`
 - `ATLAS gap: AI endpoint and model registry evaluation coverage`

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -170,7 +170,7 @@
       "path": "skills/detection/detect-lateral-movement",
       "layer": "detection",
       "providers": ["aws", "azure", "gcp", "multi"],
-      "asset_classes": ["identities", "service-accounts", "service-principals", "managed-identities", "sessions", "api", "network"],
+      "asset_classes": ["identities", "applications", "service-accounts", "service-principals", "managed-identities", "federated-credentials", "app-role-assignments", "sessions", "api", "network"],
       "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
       "coverage_status": "validated",
       "execution_modes": ["cli", "ci", "mcp", "persistent"]

--- a/skills/detection/detect-lateral-movement/REFERENCES.md
+++ b/skills/detection/detect-lateral-movement/REFERENCES.md
@@ -13,6 +13,10 @@
 - **Azure role assignments** — https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments
 - **Azure elevate access** — https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin
 - **Azure user-assigned managed identities** — https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities
+- **Microsoft Graph application addPassword** — https://learn.microsoft.com/en-us/graph/api/application-addpassword?view=graph-rest-1.0
+- **Microsoft Graph servicePrincipal addPassword** — https://learn.microsoft.com/en-us/graph/api/serviceprincipal-addpassword?view=graph-rest-1.0
+- **Microsoft Graph servicePrincipal appRoleAssignments** — https://learn.microsoft.com/en-us/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0
+- **Microsoft Graph federatedIdentityCredential resource** — https://learn.microsoft.com/en-us/graph/api/resources/federatedidentitycredential?view=graph-rest-beta
 - **Azure NSG Flow Logs overview** — https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-nsg-flow-logging-overview
 - **OCSF schema** — https://schema.ocsf.io/1.8.0/
 

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -42,6 +42,7 @@ The canonical cloud lateral-movement sequence after initial access:
    - AWS `AssumeRole*`
    - GCP service-account impersonation / key generation
    - Azure role assignment / access elevation / managed-identity assignment
+   - Azure Entra / Microsoft Graph application or service-principal credential changes
 3. From a compute resource inside the cloud network, attacker initiates east-west traffic to an internal service the original principal never accessed
 4. Data transfer starts
 
@@ -73,7 +74,7 @@ observable in the repo's shipped audit ingestors:
 |---|---|---|
 | AWS | IAM roles, federated role sessions | `AssumeRole`, `AssumeRoleWithSAML`, `AssumeRoleWithWebIdentity` |
 | GCP | Service accounts | IAM Credentials API token generation, ID token generation, JWT/blob signing, service-account key creation |
-| Azure | Service principals, managed identities | role assignments, elevate access, user-assigned managed identity attach |
+| Azure | Applications, service principals, managed identities | Azure Activity role assignments / elevate access / managed-identity attach, plus Entra / Graph password-key adds, app-role grants, and federated identity credential creation |
 
 This keeps the detector explicit and measurable for ATT&CK `T1021` and
 `T1078.004` without pretending it already covers every provider-native identity
@@ -81,9 +82,9 @@ event family.
 
 ## Current limits
 
-- Azure Entra / Microsoft Graph application credential events are **not**
-  covered here yet because they are not part of the current Azure Activity
-  ingest path.
+- Azure Entra / Microsoft Graph coverage here is limited to high-signal
+  application and service-principal credential changes plus app-role grants. It
+  is **not** a complete Entra administrative drift detector.
 - AWS IAM user access-key creation and policy-document drift are roadmap work,
   not current detector anchors.
 - GCP workload-identity federation abuse beyond the current IAM Credentials

--- a/skills/detection/detect-lateral-movement/src/detect.py
+++ b/skills/detection/detect-lateral-movement/src/detect.py
@@ -75,15 +75,39 @@ GCP_IDENTITY_PIVOT_SUFFIXES = (
     "SignBlob",
     "CreateServiceAccountKey",
 )
-AZURE_IDENTITY_PIVOT_OPERATIONS = {
+AZURE_ACTIVITY_IDENTITY_PIVOT_OPERATIONS = {
     "MICROSOFT.AUTHORIZATION/ROLEASSIGNMENTS/WRITE",
     "MICROSOFT.AUTHORIZATION/ELEVATEACCESS/ACTION",
     "MICROSOFT.MANAGEDIDENTITY/USERASSIGNEDIDENTITIES/ASSIGN/ACTION",
 }
+AZURE_ENTRA_SERVICE_NAMES = {
+    "GRAPH.MICROSOFT.COM",
+    "MICROSOFT GRAPH",
+    "MICROSOFT ENTRA ID",
+    "CORE DIRECTORY",
+}
+AZURE_ENTRA_EXACT_OPERATIONS = {
+    "ADD SERVICE PRINCIPAL CREDENTIALS",
+    "UPDATE APPLICATION - CERTIFICATES AND SECRETS MANAGEMENT",
+    "ADD APP ROLE ASSIGNMENT TO SERVICE PRINCIPAL",
+    "CREATE FEDERATED IDENTITY CREDENTIAL",
+    "ADD FEDERATED IDENTITY CREDENTIAL",
+}
 
 FRAMEWORKS = ("OCSF 1.8.0", "MITRE ATT&CK v14")
 PROVIDERS = ("aws", "azure", "gcp", "multi")
-ASSET_CLASSES = ("identities", "service-accounts", "managed-identities", "sessions", "api", "network")
+ASSET_CLASSES = (
+    "identities",
+    "applications",
+    "service-accounts",
+    "service-principals",
+    "managed-identities",
+    "federated-credentials",
+    "app-role-assignments",
+    "sessions",
+    "api",
+    "network",
+)
 ATTACK_COVERAGE = {
     "aws": {
         "principal_types": ["iam-roles", "federated-role-sessions"],
@@ -96,8 +120,32 @@ ATTACK_COVERAGE = {
         "techniques": ["T1021", "T1078.004"],
     },
     "azure": {
-        "principal_types": ["service-principals", "managed-identities"],
-        "anchor_operations": sorted(AZURE_IDENTITY_PIVOT_OPERATIONS),
+        "principal_types": ["applications", "service-principals", "managed-identities"],
+        "operation_families": {
+            "azure-activity": sorted(AZURE_ACTIVITY_IDENTITY_PIVOT_OPERATIONS),
+            "entra-graph": [
+                "Add service principal credentials",
+                "Update application - Certificates and secrets management",
+                "Add app role assignment to service principal",
+                "Create federated identity credential",
+                "POST /applications/{id}/addPassword",
+                "POST /applications/{id}/addKey",
+                "POST /servicePrincipals/{id}/addPassword",
+                "POST /servicePrincipals/{id}/addKey",
+                "POST /servicePrincipals/{id}/appRoleAssignments",
+                "POST /servicePrincipals/{id}/appRoleAssignedTo",
+                "POST /applications/{id}/federatedIdentityCredentials",
+            ],
+        },
+        "anchor_operations": sorted(
+            list(AZURE_ACTIVITY_IDENTITY_PIVOT_OPERATIONS)
+            + [
+                "Add service principal credentials",
+                "Update application - Certificates and secrets management",
+                "Add app role assignment to service principal",
+                "Create federated identity credential",
+            ]
+        ),
         "techniques": ["T1021", "T1078.004"],
     },
 }
@@ -186,6 +234,36 @@ def _bytes(event: dict[str, Any]) -> int:
         return 0
 
 
+def _normalize_token(value: str) -> str:
+    return " ".join((value or "").upper().replace("_", " ").split())
+
+
+def _compact_token(value: str) -> str:
+    return _normalize_token(value).replace(" ", "")
+
+
+def _is_azure_entra_pivot(service: str, operation: str) -> bool:
+    service_norm = _normalize_token(service)
+    operation_norm = _normalize_token(operation)
+    operation_compact = operation_norm.replace(" ", "")
+
+    if service_norm not in AZURE_ENTRA_SERVICE_NAMES:
+        return False
+
+    if operation_norm in AZURE_ENTRA_EXACT_OPERATIONS:
+        return True
+
+    if any(marker in operation_compact for marker in ("ADDPASSWORD", "ADDKEY")):
+        return True
+
+    if operation_norm.startswith("POST /") and any(
+        marker in operation_compact for marker in ("APPROLEASSIGNMENTS", "APPROLEASSIGNEDTO")
+    ):
+        return True
+
+    return operation_norm.startswith("POST /APPLICATIONS/") and "FEDERATEDIDENTITYCREDENTIALS" in operation_compact
+
+
 def is_identity_pivot_anchor(event: dict[str, Any]) -> bool:
     """Return True when an OCSF API Activity event is a high-signal pivot anchor."""
     if event.get("class_uid") != API_ACTIVITY_CLASS:
@@ -205,7 +283,11 @@ def is_identity_pivot_anchor(event: dict[str, Any]) -> bool:
         return any(last.endswith(suffix) for suffix in GCP_IDENTITY_PIVOT_SUFFIXES)
 
     if provider == "AZURE":
-        return operation.upper() in AZURE_IDENTITY_PIVOT_OPERATIONS
+        service_norm = _normalize_token(service)
+        operation_norm = _normalize_token(operation)
+        if operation_norm in AZURE_ACTIVITY_IDENTITY_PIVOT_OPERATIONS:
+            return True
+        return _is_azure_entra_pivot(service_norm, operation_norm)
 
     return False
 

--- a/skills/detection/detect-lateral-movement/tests/test_detect.py
+++ b/skills/detection/detect-lateral-movement/tests/test_detect.py
@@ -308,6 +308,40 @@ class TestCrossCloudAnchors:
         assert findings[0]["finding_info"]["title"].startswith("Azure lateral movement")
         assert "canonical Azure lateral movement pattern" in findings[0]["finding_info"]["desc"]
 
+    def test_azure_entra_service_principal_credential_pivot_fires(self):
+        anchor = _anchor_event(
+            provider="Azure",
+            service="graph.microsoft.com",
+            operation="POST /servicePrincipals/{id}/addPassword",
+            account="00000000-0000-0000-0000-000000000000",
+            session_uid="entra-session-1",
+        )
+        flow = _flow(
+            provider="Azure",
+            account="00000000-0000-0000-0000-000000000000",
+            dst_ip="10.1.2.7",
+        )
+        findings = list(detect([anchor, flow]))
+        assert len(findings) == 1
+        assert findings[0]["observables"][0]["value"] == "Azure"
+
+    def test_azure_entra_federated_identity_credential_pivot_fires(self):
+        anchor = _anchor_event(
+            provider="Azure",
+            service="Microsoft Graph",
+            operation="Create federated identity credential",
+            account="00000000-0000-0000-0000-000000000000",
+            session_uid="entra-session-2",
+        )
+        flow = _flow(
+            provider="Azure",
+            account="00000000-0000-0000-0000-000000000000",
+            dst_ip="10.1.3.9",
+        )
+        findings = list(detect([anchor, flow]))
+        assert len(findings) == 1
+        assert findings[0]["observables"][0]["value"] == "Azure"
+
     def test_provider_mismatch_does_not_fire(self):
         anchor = _anchor_event(provider="AWS", session_uid="aws-session-1")
         flow = _flow(provider="GCP", account="my-project", dst_ip="10.128.0.8")
@@ -338,13 +372,30 @@ class TestCrossCloudAnchors:
                 operation="MICROSOFT.AUTHORIZATION/ROLEASSIGNMENTS/WRITE",
             )
         )
+        assert is_identity_pivot_anchor(
+            _anchor_event(
+                provider="Azure",
+                service="graph.microsoft.com",
+                operation="POST /applications/{id}/addPassword",
+            )
+        )
+        assert not is_identity_pivot_anchor(
+            _anchor_event(
+                provider="Azure",
+                service="graph.microsoft.com",
+                operation="GET /servicePrincipals/{id}/appRoleAssignments",
+            )
+        )
 
     def test_coverage_metadata_declares_identity_scope(self):
         metadata = coverage_metadata()
         assert "MITRE ATT&CK v14" in metadata["frameworks"]
         assert "azure" in metadata["providers"]
         assert "managed-identities" in metadata["asset_classes"]
+        assert "applications" in metadata["asset_classes"]
         assert "service-principals" in metadata["attack_coverage"]["azure"]["principal_types"]
+        assert "entra-graph" in metadata["attack_coverage"]["azure"]["operation_families"]
+        assert "POST /applications/{id}/addPassword" in metadata["attack_coverage"]["azure"]["operation_families"]["entra-graph"]
         assert "CreateServiceAccountKey" in "".join(metadata["attack_coverage"]["gcp"]["anchor_operations"])
 
 


### PR DESCRIPTION
Summary
- extend detect-lateral-movement with a separate Azure Entra and Microsoft Graph identity-pivot family
- cover application and service-principal password and key changes, app role grants, and federated identity credential creation
- update coverage metadata, roadmap, framework mappings, references, and tests so the Azure slice stays measurable

Validation
- python scripts/validate_framework_coverage.py
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- uv run pytest skills/detection/detect-lateral-movement/tests/test_detect.py tests/integration/test_skill_validation_scripts.py -q -o addopts=
- uv run ruff check skills/detection/detect-lateral-movement/src/detect.py skills/detection/detect-lateral-movement/tests/test_detect.py --config pyproject.toml