### PR TITLE
feat: deepen NIST AI RMF traceability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on Keep a Changelog.
 - Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.
 - Added [`docs/SIEM_INDEX_GUIDE.md`](docs/SIEM_INDEX_GUIDE.md) covering index fields, timestamps, dedupe keys, and just-in-time vs persistent ingestion guidance.
 - Added Azure Entra / Microsoft Graph credential-pivot coverage to `detect-lateral-movement`, including application and service-principal password-key changes, app-role grants, and federated identity credential creation.
+- Added explicit NIST AI RMF traceability to `model-serving-security` and `discover-cloud-control-evidence`, including machine-readable benchmark metadata and an opt-in `ai-rmf` evidence mode.
 
 ### Added
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -29,7 +29,7 @@ from individual `SKILL.md` files.
 | **SOC 2 TSC** | partial | evaluation and remediation mappings |
 | **ISO 27001:2022** | partial | CSPM/evaluation mappings |
 | **PCI DSS 4.0** | partial | AWS posture mappings today |
-| **NIST AI RMF** | emerging | model-serving security and roadmap items |
+| **NIST AI RMF** | real and growing | model-serving security, cloud control evidence, AI BOM, and roadmap items |
 
 ## By layer
 
@@ -69,10 +69,10 @@ ATLAS is present today, but coverage is narrower than ATT&CK.
 | Skill | Coverage |
 |---|---|
 | `discover-environment` | graph overlay for AI/ML resources and adversarial ML techniques |
-| `model-serving-security` | explicit ATLAS coverage in skill docs and checks |
+| `model-serving-security` | explicit ATLAS coverage plus machine-readable NIST AI RMF section scope in the benchmark metadata |
 | `discover-ai-bom` | inventory artifact for future ATLAS / AI RMF evidence joins |
 | `discover-control-evidence` | evidence package that preserves ATLAS / AI RMF context from discovery artifacts |
-| `discover-cloud-control-evidence` | cross-cloud evidence package that preserves ATT&CK / ATLAS / AI RMF inventory context |
+| `discover-cloud-control-evidence` | cross-cloud evidence package with explicit NIST AI RMF evidence mode and ATT&CK / ATLAS / AI RMF inventory context |
 
 Current provider depth in discovery:
 - AWS Bedrock / SageMaker
@@ -105,7 +105,7 @@ uniform than classic cloud posture.
 | `discover-ai-bom` | CycloneDX ML-BOM, NIST AI RMF, MITRE ATLAS, PCI, SOC 2 |
 | `discover-control-evidence` | PCI DSS 4.0, SOC 2 TSC, CycloneDX ML-BOM, MITRE ATLAS |
 | `discover-cloud-control-evidence` | PCI DSS 4.0, SOC 2 TSC, NIST AI RMF, MITRE ATT&CK, MITRE ATLAS |
-| `model-serving-security` | MITRE ATLAS, NIST CSF, OWASP LLM Top 10, SOC 2, provider-specific AI endpoint controls |
+| `model-serving-security` | MITRE ATLAS, NIST CSF, NIST AI RMF, OWASP LLM Top 10, SOC 2, provider-specific AI endpoint controls |
 | `gpu-cluster-security` | MITRE ATT&CK, MITRE ATLAS, NIST CSF, NIST AI RMF, CIS Controls, CIS Kubernetes |
 | `discover-environment` | MITRE ATT&CK, MITRE ATLAS, NIST CSF |
 

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -3,8 +3,8 @@ name: discover-cloud-control-evidence
 description: >-
   Generate deterministic technical-control evidence from raw cross-cloud
   inventory snapshots. Supports AWS, GCP, and Azure inventory inputs and
-  produces a machine-readable evidence package for PCI DSS 4.0 and SOC 2
-  security reviews without claiming attestation. Use when the user mentions
+  produces a machine-readable evidence package for PCI DSS 4.0, SOC 2, and
+  NIST AI RMF 1.0 reviews without claiming attestation. Use when the user mentions
   PCI evidence, SOC 2 evidence, cloud inventory evidence, audit evidence, or
   wants a reviewable JSON package showing identity surface, externally exposed
   assets, encryption coverage, logging coverage, and key-management coverage
@@ -74,6 +74,7 @@ The skill emits one deterministic JSON document:
 - `frameworks[]` with the requested evidence families
 - `inventory_summary` with providers, services, asset counts, and control-surface counts
 - `controls[]` with `evidence-ready` / `partial` / `missing` status per control domain
+- `framework_mappings` per control when the selected framework carries explicit mappings such as NIST AI RMF
 - `gaps[]` only when the source artifact cannot support a given evidence domain
 - AI-oriented evidence domains for endpoint surface and governance inventory when AI service assets are present
 
@@ -87,6 +88,9 @@ python src/discover.py inventory.json > cloud-evidence.json
 
 # Limit to PCI-focused evidence
 python src/discover.py inventory.json --framework pci --pretty > pci-evidence.json
+
+# Emit NIST AI RMF evidence from the same inventory
+python src/discover.py inventory.json --framework ai-rmf --pretty > ai-rmf-evidence.json
 
 # Emit an OCSF Discovery bridge event
 python src/discover.py inventory.json --output-format ocsf-live-evidence > evidence.ocsf.json

--- a/skills/discovery/discover-cloud-control-evidence/src/discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/src/discover.py
@@ -12,11 +12,12 @@ from pathlib import Path
 from typing import Any
 
 SKILL_NAME = "discover-cloud-control-evidence"
-SUPPORTED_FRAMEWORKS = ("pci", "soc2")
+SUPPORTED_FRAMEWORKS = ("pci", "soc2", "ai-rmf")
 SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-live-evidence")
 FRAMEWORK_LABELS = {
     "pci": "PCI DSS 4.0",
     "soc2": "SOC 2 Security",
+    "ai-rmf": "NIST AI RMF 1.0",
 }
 SECRET_KEYWORDS = (
     "authorization",
@@ -34,6 +35,12 @@ PUBLIC_CIDRS = {"0.0.0.0/0", "::/0", "*", "internet", "any"}
 AI_SERVICES = {"ai-foundry", "azure-ml", "bedrock", "sagemaker", "vertex-ai"}
 AI_ENDPOINT_KINDS = {"deployment", "endpoint", "inference-endpoint"}
 AI_GOVERNANCE_KINDS = {"ai-guardrail", "dataset", "guardrail", "model", "model-package", "training-job", "vector-index", "vector-store"}
+AI_RMF_CONTROL_FOCUS = {
+    "ai-rmf.govern.ai-service-governance": "GOVERN",
+    "ai-rmf.map.ai-system-inventory": "MAP",
+    "ai-rmf.measure.ai-logging-and-monitoring": "MEASURE",
+    "ai-rmf.manage.ai-safeguards-and-network-boundaries": "MANAGE",
+}
 
 
 def _load_json(path: str | None) -> dict[str, Any]:
@@ -91,7 +98,7 @@ def _sanitize(value: Any) -> Any:
 
 def _normalize_frameworks(frameworks: list[str] | None) -> list[str]:
     if not frameworks:
-        return list(SUPPORTED_FRAMEWORKS)
+        return ["pci", "soc2"]
     normalized = []
     for item in frameworks:
         key = item.strip().lower()
@@ -745,6 +752,7 @@ def _control(
     description: str,
     evidence: list[dict[str, Any]],
     gaps: list[str],
+    framework_mappings: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     status = _status(not gaps and bool(evidence), bool(evidence))
     return {
@@ -755,6 +763,7 @@ def _control(
         "description": description,
         "evidence": evidence,
         "gaps": gaps,
+        "framework_mappings": framework_mappings or {},
     }
 
 
@@ -839,6 +848,52 @@ def _controls_for(framework: str, normalized: dict[str, Any]) -> list[dict[str, 
                 "Inventory-backed evidence for models, datasets, vector stores, training jobs, and guardrails associated with AI services.",
                 _sample(ai_governance_assets),
                 [] if ai_governance_assets else ["No AI governance inventory was present in the supplied snapshot."],
+            ),
+        ]
+
+    if framework == "ai-rmf":
+        return [
+            _control(
+                framework,
+                "ai-rmf.govern.ai-service-governance",
+                "AI governance surface evidence",
+                "Inventory-backed evidence for guardrails, models, datasets, vector stores, and training paths that contribute to AI governance scope.",
+                _sample(ai_governance_assets),
+                [] if ai_governance_assets else ["No AI governance inventory was present in the supplied snapshot."],
+                framework_mappings={"nist_ai_rmf": AI_RMF_CONTROL_FOCUS["ai-rmf.govern.ai-service-governance"]},
+            ),
+            _control(
+                framework,
+                "ai-rmf.map.ai-system-inventory",
+                "AI system inventory evidence",
+                "Inventory-backed evidence for AI endpoints, deployments, models, datasets, and supporting cloud providers.",
+                _sample(ai_assets),
+                [] if ai_assets else ["No AI system inventory was present in the supplied snapshot."],
+                framework_mappings={"nist_ai_rmf": AI_RMF_CONTROL_FOCUS["ai-rmf.map.ai-system-inventory"]},
+            ),
+            _control(
+                framework,
+                "ai-rmf.measure.ai-logging-and-monitoring",
+                "AI logging and monitoring evidence",
+                "Inventory-backed evidence for endpoint logging, audit trails, and diagnostic surfaces supporting AI monitoring.",
+                _sample(logging_assets + [asset for asset in ai_endpoint_assets if _bool(asset.get("logged"))]),
+                [] if logging_assets else ["No logging inventory was present in the supplied snapshot."],
+                framework_mappings={"nist_ai_rmf": AI_RMF_CONTROL_FOCUS["ai-rmf.measure.ai-logging-and-monitoring"]},
+            ),
+            _control(
+                framework,
+                "ai-rmf.manage.ai-safeguards-and-network-boundaries",
+                "AI safeguards and network boundary evidence",
+                "Inventory-backed evidence for private AI endpoints, encryption, and guardrail surfaces that support AI risk treatment.",
+                _sample(
+                    [asset for asset in ai_endpoint_assets if not _bool(asset.get("public"))]
+                    + [asset for asset in ai_governance_assets if asset.get("kind") in {"ai-guardrail", "guardrail"}]
+                    + encrypted_assets
+                ),
+                [] if ai_endpoint_assets or ai_governance_assets or encrypted_assets else [
+                    "No AI safeguard, private endpoint, or encryption inventory was present in the supplied snapshot."
+                ],
+                framework_mappings={"nist_ai_rmf": AI_RMF_CONTROL_FOCUS["ai-rmf.manage.ai-safeguards-and-network-boundaries"]},
             ),
         ]
 

--- a/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/tests/test_discover.py
@@ -123,6 +123,13 @@ class TestBuildEvidence:
         assert {control["framework"] for control in evidence["controls"]} == {"SOC 2 Security"}
         assert any(control["control_id"] == "cc6.ai-service-surface" for control in evidence["controls"])
 
+    def test_ai_rmf_filter(self):
+        evidence = build_evidence(_multi_cloud_snapshot(), ["ai-rmf"])
+        assert evidence["frameworks"] == ["NIST AI RMF 1.0"]
+        assert {control["framework"] for control in evidence["controls"]} == {"NIST AI RMF 1.0"}
+        assert any(control["control_id"] == "ai-rmf.map.ai-system-inventory" for control in evidence["controls"])
+        assert any(control["framework_mappings"]["nist_ai_rmf"] == "GOVERN" for control in evidence["controls"])
+
     def test_inventory_summary_includes_ai_surface_counts(self):
         evidence = build_evidence(_multi_cloud_snapshot())
         counts = evidence["inventory_summary"]["control_surface_counts"]
@@ -153,3 +160,7 @@ class TestBuildEvidence:
         assert event["class_name"] == "Live Evidence Info"
         assert event["metadata"]["version"] == "1.8.0"
         assert event["unmapped"]["cloud_security_technical_evidence"]["frameworks"] == ["PCI DSS 4.0"]
+
+    def test_ai_rmf_bridge_preserves_framework(self):
+        event = to_ocsf_live_evidence(build_evidence(_multi_cloud_snapshot(), ["ai-rmf"]))
+        assert event["unmapped"]["cloud_security_technical_evidence"]["frameworks"] == ["NIST AI RMF 1.0"]

--- a/skills/evaluation/model-serving-security/SKILL.md
+++ b/skills/evaluation/model-serving-security/SKILL.md
@@ -27,6 +27,7 @@ metadata:
   frameworks:
     - MITRE ATLAS
     - NIST CSF 2.0
+    - NIST AI RMF 1.0
     - OWASP LLM Top 10
     - SOC 2 TSC
   cloud: any
@@ -35,7 +36,8 @@ metadata:
 # Model Serving Security Benchmark
 
 20 automated checks across 6 domains, auditing the security posture of AI model
-serving infrastructure. Each check mapped to MITRE ATLAS and NIST CSF 2.0.
+serving infrastructure. Each check is mapped to MITRE ATLAS, NIST CSF 2.0, and
+an explicit NIST AI RMF 1.0 function scope.
 
 ## When to Use
 

--- a/skills/evaluation/model-serving-security/src/checks.py
+++ b/skills/evaluation/model-serving-security/src/checks.py
@@ -25,6 +25,43 @@ import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+FRAMEWORKS = (
+    "MITRE ATLAS",
+    "NIST CSF 2.0",
+    "NIST AI RMF 1.0",
+    "OWASP LLM Top 10",
+    "SOC 2 TSC",
+)
+
+PROVIDERS = ("aws", "azure", "gcp", "multi")
+ASSET_CLASSES = ("ai-endpoints", "models", "identities", "network", "logging", "guardrails")
+AI_FRAMEWORK_FOCUS = {
+    "auth": {
+        "nist_ai_rmf": "GOVERN, MANAGE",
+        "scope": "identity, access, and provider workload identity on AI endpoints",
+    },
+    "abuse_prevention": {
+        "nist_ai_rmf": "MAP, MANAGE",
+        "scope": "rate limiting and input constraints for misuse and cost containment",
+    },
+    "data_egress": {
+        "nist_ai_rmf": "MAP, MEASURE, MANAGE",
+        "scope": "training-data leakage, PII handling, and output filtering",
+    },
+    "runtime": {
+        "nist_ai_rmf": "MANAGE",
+        "scope": "container and runtime isolation on serving infrastructure",
+    },
+    "network": {
+        "nist_ai_rmf": "MAP, MANAGE",
+        "scope": "public exposure, TLS, and private network isolation",
+    },
+    "safety": {
+        "nist_ai_rmf": "GOVERN, MEASURE, MANAGE",
+        "scope": "guardrails, content safety, audit logging, and version traceability",
+    },
+}
+
 
 @dataclass
 class Finding:
@@ -37,7 +74,20 @@ class Finding:
     remediation: str = ""
     mitre_atlas: str = ""
     nist_csf: str = ""
+    nist_ai_rmf: str = ""
     resources: list[str] = field(default_factory=list)
+
+
+def benchmark_metadata() -> dict[str, object]:
+    """Return machine-readable framework and section coverage for wrappers and docs."""
+    return {
+        "frameworks": list(FRAMEWORKS),
+        "providers": list(PROVIDERS),
+        "asset_classes": list(ASSET_CLASSES),
+        "ai_framework_focus": AI_FRAMEWORK_FOCUS,
+        "check_count": sum(len(checks) for checks in ALL_CHECKS.values()),
+        "sections": {name: len(checks) for name, checks in ALL_CHECKS.items()},
+    }
 
 
 def _iter_endpoints(config: dict) -> list[dict]:
@@ -205,6 +255,7 @@ def check_1_1_endpoint_auth_required(config: dict) -> Finding:
         remediation="Enable API key, OAuth2, or mTLS on all model serving endpoints",
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-1",
+        nist_ai_rmf="GOVERN, MANAGE",
         resources=unauthenticated,
     )
 
@@ -253,6 +304,7 @@ def check_1_2_no_hardcoded_api_keys(config: dict, scan_paths: list[str] | None =
         remediation="Use Secrets Manager, Vault, or environment variable references instead of inline secrets",
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-4",
+        nist_ai_rmf="GOVERN, MANAGE",
         resources=found[:10],
     )
 
@@ -276,6 +328,7 @@ def check_1_3_rbac_model_access(config: dict) -> Finding:
         remediation="Configure role-based permissions per endpoint (admin, user, read-only)",
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-4",
+        nist_ai_rmf="GOVERN, MANAGE",
         resources=no_rbac,
     )
 
@@ -299,6 +352,7 @@ def check_1_4_workload_identity_required(config: dict) -> Finding:
         remediation="Use IAM roles, Vertex AI service accounts, Azure managed identity, or equivalent provider-native workload identity.",
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-4",
+        nist_ai_rmf="GOVERN, MANAGE",
         resources=missing_identity,
     )
 
@@ -326,6 +380,7 @@ def check_2_1_rate_limiting_enabled(config: dict) -> Finding:
         remediation="Set per-client RPM/RPD limits to prevent abuse and cost overruns",
         mitre_atlas="AML.T0042",
         nist_csf="PR.DS-4",
+        nist_ai_rmf="MAP, MANAGE",
         resources=no_rate_limit,
     )
 
@@ -350,6 +405,7 @@ def check_2_2_input_size_limits(config: dict) -> Finding:
         remediation="Set max_tokens and max_input_size to prevent resource exhaustion",
         mitre_atlas="AML.T0042",
         nist_csf="PR.DS-4",
+        nist_ai_rmf="MAP, MANAGE",
         resources=no_limits,
     )
 
@@ -374,6 +430,7 @@ def check_3_1_output_filtering(config: dict) -> Finding:
             remediation="Enable content safety filters to prevent PII leakage, harmful content, and prompt injection echoing",
             mitre_atlas="AML.T0048.002",
             nist_csf="PR.DS-5",
+            nist_ai_rmf="MEASURE, MANAGE",
         )
     return Finding(
         check_id="MS-3.1",
@@ -384,6 +441,7 @@ def check_3_1_output_filtering(config: dict) -> Finding:
         detail="Output content filtering is enabled",
         mitre_atlas="AML.T0048.002",
         nist_csf="PR.DS-5",
+        nist_ai_rmf="MEASURE, MANAGE",
     )
 
 
@@ -401,6 +459,7 @@ def check_3_2_no_training_data_in_response(config: dict) -> Finding:
         remediation="Enable training data memorization detection to prevent data extraction attacks",
         mitre_atlas="AML.T0025",
         nist_csf="PR.DS-5",
+        nist_ai_rmf="MAP, MEASURE, MANAGE",
     )
 
 
@@ -420,6 +479,7 @@ def check_3_3_logging_no_pii(config: dict) -> Finding:
             remediation="Enable pii_redaction in logging config or disable request body logging",
             mitre_atlas="AML.T0025",
             nist_csf="PR.DS-5",
+            nist_ai_rmf="MEASURE, MANAGE",
         )
     return Finding(
         check_id="MS-3.3",
@@ -430,6 +490,7 @@ def check_3_3_logging_no_pii(config: dict) -> Finding:
         detail="PII redaction enabled or request logging disabled",
         mitre_atlas="AML.T0025",
         nist_csf="PR.DS-5",
+        nist_ai_rmf="MEASURE, MANAGE",
     )
 
 
@@ -456,6 +517,7 @@ def check_4_1_no_privileged_containers(config: dict) -> Finding:
         remediation="Remove privileged: true from all model serving containers. Use specific capabilities instead.",
         mitre_atlas="AML.T0011",
         nist_csf="PR.AC-4",
+        nist_ai_rmf="MANAGE",
         resources=privileged,
     )
 
@@ -478,6 +540,7 @@ def check_4_2_read_only_rootfs(config: dict) -> Finding:
         remediation="Set readOnlyRootFilesystem: true and use emptyDir volumes for temp data",
         mitre_atlas="AML.T0011",
         nist_csf="PR.DS-6",
+        nist_ai_rmf="MANAGE",
         resources=writable,
     )
 
@@ -502,6 +565,7 @@ def check_4_3_non_root_user(config: dict) -> Finding:
         remediation="Set runAsNonRoot: true and runAsUser to a non-zero UID",
         mitre_atlas="AML.T0011",
         nist_csf="PR.AC-4",
+        nist_ai_rmf="MANAGE",
         resources=root_containers,
     )
 
@@ -529,6 +593,7 @@ def check_5_1_tls_enforced(config: dict) -> Finding:
         detail=f"{len(no_tls)} endpoints without TLS" if no_tls else "All endpoints enforce TLS",
         remediation="Enable TLS 1.2+ on all model serving endpoints. Redirect HTTP to HTTPS.",
         nist_csf="PR.DS-2",
+        nist_ai_rmf="MAP, MANAGE",
         resources=no_tls,
     )
 
@@ -552,6 +617,7 @@ def check_5_2_no_public_endpoints(config: dict) -> Finding:
         remediation="Place model endpoints behind API gateway or VPC. No direct public access.",
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-5",
+        nist_ai_rmf="MAP, MANAGE",
         resources=public,
     )
 
@@ -577,6 +643,7 @@ def check_5_3_private_network_isolation(config: dict) -> Finding:
         remediation="Attach SageMaker endpoints to VPCs, Vertex AI endpoints to PSC/private networking, or Azure ML/Foundry endpoints to private endpoints.",
         mitre_atlas="AML.T0024",
         nist_csf="PR.AC-5",
+        nist_ai_rmf="MAP, MANAGE",
         resources=missing_private,
     )
 
@@ -600,6 +667,7 @@ def check_6_1_prompt_injection_guard(config: dict) -> Finding:
         remediation="Enable prompt injection detection to prevent adversarial input attacks",
         mitre_atlas="AML.T0051",
         nist_csf="DE.CM-4",
+        nist_ai_rmf="MEASURE, MANAGE",
     )
 
 
@@ -620,6 +688,7 @@ def check_6_2_content_safety_enabled(config: dict) -> Finding:
         remediation="Enable content safety with blocked categories (violence, hate, self-harm, sexual)",
         mitre_atlas="AML.T0048",
         nist_csf="DE.CM-4",
+        nist_ai_rmf="GOVERN, MEASURE, MANAGE",
     )
 
 
@@ -641,6 +710,7 @@ def check_6_3_model_versioning(config: dict) -> Finding:
         remediation="Pin model versions (never use 'latest'). Enable model registry with immutable tags.",
         mitre_atlas="AML.T0010",
         nist_csf="PR.DS-6",
+        nist_ai_rmf="GOVERN, MEASURE",
         resources=no_version,
     )
 
@@ -663,6 +733,7 @@ def check_6_4_guardrails_attached(config: dict) -> Finding:
         remediation="Attach Bedrock guardrails, Vertex AI safety settings, Azure AI content safety, or equivalent provider-native safety layers.",
         mitre_atlas="AML.T0048",
         nist_csf="DE.CM-4",
+        nist_ai_rmf="GOVERN, MEASURE, MANAGE",
         resources=missing_guardrails,
     )
 
@@ -685,6 +756,7 @@ def check_6_5_ai_endpoint_audit_logging(config: dict) -> Finding:
         remediation="Enable provider-native endpoint access logging, diagnostics, or request capture on all AI endpoints.",
         mitre_atlas="AML.T0010",
         nist_csf="DE.CM-3",
+        nist_ai_rmf="MEASURE, MANAGE",
         resources=no_logging,
     )
 

--- a/skills/evaluation/model-serving-security/tests/test_checks.py
+++ b/skills/evaluation/model-serving-security/tests/test_checks.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from checks import (
     Finding,
+    benchmark_metadata,
     check_1_1_endpoint_auth_required,
     check_1_2_no_hardcoded_api_keys,
     check_1_3_rbac_model_access,
@@ -92,6 +93,7 @@ class TestAuthChecks:
         }
         f = check_1_4_workload_identity_required(config)
         assert f.status == "PASS"
+        assert f.nist_ai_rmf == "GOVERN, MANAGE"
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -258,6 +260,11 @@ class TestSafety:
         config = {"endpoints": [{"name": "inference", "guardrails": {"enabled": False}}]}
         f = check_6_4_guardrails_attached(config)
         assert f.status == "FAIL"
+
+    def test_benchmark_metadata_declares_ai_rmf_scope(self):
+        metadata = benchmark_metadata()
+        assert "NIST AI RMF 1.0" in metadata["frameworks"]
+        assert metadata["ai_framework_focus"]["safety"]["nist_ai_rmf"] == "GOVERN, MEASURE, MANAGE"
 
     def test_6_4_azure_content_safety_passes(self):
         config = {

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -99,6 +99,12 @@ class TestValidationScripts:
         assert "mitre-atlas" in gpu["frameworks"]
         assert "nist-ai-rmf" in gpu["frameworks"]
 
+    def test_model_serving_ai_framework_depth_is_registered(self):
+        registry = json.loads((ROOT / "docs" / "framework-coverage.json").read_text())
+        model_serving = next(item for item in registry["skills"] if item["path"] == "skills/evaluation/model-serving-security")
+        assert "mitre-atlas" in model_serving["frameworks"]
+        assert "nist-ai-rmf" in model_serving["frameworks"]
+
     def test_lateral_movement_identity_assets_are_registered(self):
         registry = json.loads((ROOT / "docs" / "framework-coverage.json").read_text())
         skill = next(item for item in registry["skills"] if item["path"] == "skills/detection/detect-lateral-movement")


### PR DESCRIPTION
Summary
- add machine-readable NIST AI RMF scope to model-serving-security benchmark metadata and findings
- add an opt-in ai-rmf evidence mode to discover-cloud-control-evidence
- align tests, changelog, and framework mappings so AI RMF coverage is explicit and validated

Validation
- python scripts/validate_framework_coverage.py
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- uv run pytest skills/evaluation/model-serving-security/tests/test_checks.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py tests/integration/test_skill_validation_scripts.py -q -o addopts=
- uv run ruff check skills/evaluation/model-serving-security/src/checks.py skills/evaluation/model-serving-security/tests/test_checks.py skills/discovery/discover-cloud-control-evidence/src/discover.py skills/discovery/discover-cloud-control-evidence/tests/test_discover.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml