### PR TITLE
feat: pilot native and OCSF skill modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ The format is loosely based on Keep a Changelog.
 - `ingest-entra-directory-audit-ocsf` as the Microsoft Entra / Graph identity-audit ingestion skill, mapping verified `directoryAudit` application, service-principal, app-role-assignment, and federated-credential events into OCSF API Activity (6003).
 - `ingest-google-workspace-login-ocsf` as the Google Workspace identity-audit ingestion skill, mapping verified Admin SDK Reports login audit events into OCSF Authentication (3002) and Account Change (3001) while preserving Workspace natural IDs and event parameters.
 - `detect-google-workspace-suspicious-login` as the first Google Workspace-native detection skill, emitting OCSF Detection Finding (2004) for provider-marked suspicious logins and repeated Workspace login failures followed by success, aligned to MITRE ATT&CK T1110 and T1078.
+- a phased native/OCSF pilot for `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, including explicit `--output-format {ocsf,native}` support, native/canonical-friendly test coverage, and MCP output-format selection for supported skills.
 
 ### Changed
 
 - Expanded the coverage registry and framework mapping docs to track Okta, Entra / Graph, and Google Workspace as first-class OCSF identity-ingestion sources and detections.
 - Expanded `ingest-okta-system-log-ocsf` to cover the verified Okta Verify push and denial event families needed for narrow MFA fatigue detection.
 - Reframed the repo contract so OCSF remains a first-class interoperability option, but not a mandatory storage or execution model; the stable internal contract is now explicitly source truth -> canonical model -> `native` / `ocsf` / `bridge` output.
+- Made the OCSF metadata validator format-aware so native-mode support does not weaken the OCSF path contract.
 
 ### Added
 - Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -71,6 +71,14 @@ def _validate_input(raw_input: Any) -> str:
     return raw_input
 
 
+def _validate_output_format(raw_output_format: Any) -> str | None:
+    if raw_output_format is None:
+        return None
+    if not isinstance(raw_output_format, str):
+        raise ValueError("`output_format` must be a string")
+    return raw_output_format
+
+
 def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     tools = tool_map()
     if name not in tools:
@@ -79,6 +87,7 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     skill = tools[name]
     args = _validate_args((arguments or {}).get("args"))
     stdin_text = _validate_input((arguments or {}).get("input"))
+    output_format = _validate_output_format((arguments or {}).get("output_format"))
 
     if not skill.read_only and "--dry-run" not in args:
         raise ValueError("write-capable tools must be called with `--dry-run`")
@@ -87,7 +96,7 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     env.setdefault("PYTHONUNBUFFERED", "1")
     timeout_seconds = int(env.get("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
     completed = subprocess.run(
-        build_command(skill, args),
+        build_command(skill, args, output_format=output_format),
         input=stdin_text,
         text=True,
         capture_output=True,
@@ -104,6 +113,7 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
             "skill": skill.name,
             "category": skill.category,
             "capability": skill.capability,
+            "output_format": output_format or "default",
             "stdout": completed.stdout,
             "stderr": completed.stderr,
             "exit_code": completed.returncode,

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -24,6 +24,8 @@ class SkillSpec:
     capability: str
     skill_dir: Path
     entrypoint: Path | None
+    input_formats: tuple[str, ...]
+    output_formats: tuple[str, ...]
 
     @property
     def supported(self) -> bool:
@@ -107,6 +109,12 @@ def _derive_capability(skill_dir: Path, metadata: dict[str, str]) -> str:
     return "read-only"
 
 
+def _parse_modes(raw_value: str | None) -> tuple[str, ...]:
+    if not raw_value:
+        return ()
+    return tuple(part.strip() for part in raw_value.split(",") if part.strip())
+
+
 def _resolve_entrypoint(skill_dir: Path) -> Path | None:
     for candidate in ENTRYPOINT_CANDIDATES:
         path = skill_dir / candidate
@@ -128,6 +136,8 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 capability=_derive_capability(skill_dir, metadata),
                 skill_dir=skill_dir,
                 entrypoint=_resolve_entrypoint(skill_dir),
+                input_formats=_parse_modes(metadata.get("input_formats")),
+                output_formats=_parse_modes(metadata.get("output_formats")),
             )
         )
     return specs
@@ -141,19 +151,26 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
     description = "Inline stdin payload for the skill. Use this for JSON or JSONL filters."
     if skill.entrypoint and skill.entrypoint.name == "checks.py":
         description = "Optional stdin payload. Most benchmark/check skills use explicit CLI args instead."
+    properties: dict[str, object] = {
+        "input": {
+            "type": "string",
+            "description": description,
+        },
+        "args": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Explicit CLI arguments forwarded to the fixed skill entrypoint.",
+        },
+    }
+    if skill.output_formats:
+        properties["output_format"] = {
+            "type": "string",
+            "enum": list(skill.output_formats),
+            "description": "Optional output rendering mode supported by this skill.",
+        }
     return {
         "type": "object",
-        "properties": {
-            "input": {
-                "type": "string",
-                "description": description,
-            },
-            "args": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Explicit CLI arguments forwarded to the fixed skill entrypoint.",
-            },
-        },
+        "properties": properties,
         "additionalProperties": False,
     }
 
@@ -176,7 +193,13 @@ def tool_map(root: Path | None = None) -> dict[str, SkillSpec]:
     return {skill.name: skill for skill in supported_skills(root)}
 
 
-def build_command(skill: SkillSpec, args: list[str]) -> list[str]:
+def build_command(skill: SkillSpec, args: list[str], output_format: str | None = None) -> list[str]:
     if not skill.entrypoint:
         raise ValueError(f"skill {skill.name} has no supported entrypoint")
-    return [sys.executable, str(skill.entrypoint), *args]
+    command = [sys.executable, str(skill.entrypoint), *args]
+    if output_format:
+        if output_format not in skill.output_formats:
+            raise ValueError(f"skill `{skill.name}` does not support output_format `{output_format}`")
+        if "--output-format" not in args:
+            command.extend(["--output-format", output_format])
+    return command

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -176,3 +176,35 @@ class TestMcpServer:
         finally:
             proc.terminate()
             proc.wait(timeout=5)
+
+    def test_can_request_native_output_for_supported_tools(self):
+        proc = _start_server()
+        try:
+            _initialize(proc)
+
+            raw_cloudtrail = (GOLDEN_DIR / "cloudtrail_raw_sample.jsonl").read_text()
+            _send_message(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "ingest-cloudtrail-ocsf",
+                        "arguments": {"input": raw_cloudtrail, "output_format": "native"},
+                    },
+                },
+            )
+            ingest_response = _read_message(proc)
+            assert ingest_response["result"]["isError"] is False
+            ingest_lines = [
+                json.loads(line)
+                for line in ingest_response["result"]["structuredContent"]["stdout"].splitlines()
+                if line.strip()
+            ]
+            assert ingest_lines[0]["schema_mode"] == "native"
+            assert "class_uid" not in ingest_lines[0]
+            assert ingest_response["result"]["structuredContent"]["output_format"] == "native"
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -70,9 +70,17 @@ class TestToolDefinition:
         assert "CloudTrail" in tool["description"]
         assert tool["annotations"]["readOnlyHint"] is True
         assert tool["inputSchema"]["properties"]["args"]["type"] == "array"
+        assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["ocsf", "native"]
+        assert skill.input_formats == ("raw",)
+        assert skill.output_formats == ("ocsf", "native")
 
     def test_build_command_uses_fixed_entrypoint(self):
         skill = tool_map(REPO_ROOT)["detect-lateral-movement"]
         command = build_command(skill, ["--output", "findings.jsonl"])
         assert command[1].endswith("skills/detection/detect-lateral-movement/src/detect.py")
         assert command[-2:] == ["--output", "findings.jsonl"]
+
+    def test_build_command_appends_output_format_when_requested(self):
+        skill = tool_map(REPO_ROOT)["ingest-cloudtrail-ocsf"]
+        command = build_command(skill, [], output_format="native")
+        assert command[-2:] == ["--output-format", "native"]

--- a/scripts/validate_ocsf_metadata.py
+++ b/scripts/validate_ocsf_metadata.py
@@ -8,6 +8,12 @@ from skill_validation_common import discover_skill_contracts
 OCSF_LAYERS = {"ingestion", "discovery", "detection"}
 
 
+def _declares_ocsf_output(raw_modes: str) -> bool:
+    if not raw_modes.strip():
+        return True
+    return "ocsf" in {part.strip() for part in raw_modes.split(",") if part.strip()}
+
+
 def _const_str(node: ast.AST) -> str | None:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
@@ -43,6 +49,8 @@ def main() -> int:
 
     for skill in discover_skill_contracts():
         if skill.category not in OCSF_LAYERS or skill.entrypoint is None:
+            continue
+        if not _declares_ocsf_output(skill.frontmatter.get("output_formats", "")):
             continue
 
         tree = ast.parse(skill.entrypoint.read_text(), filename=str(skill.entrypoint))

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -14,10 +14,12 @@ description: >-
   movement, east-west pivot, cloud identity pivot followed by internal
   traffic, or wants to detect attackers moving between cloud resources
   after initial access. Do NOT use on raw logs — pipe audit and network
-  telemetry through their respective ingest-*-ocsf skills first. Do NOT
+  telemetry through their respective ingestion skills first. Do NOT
   use for pre-compromise detection. Do NOT use as an exfiltration
   detector — public internet destinations are deliberately filtered out.
 license: Apache-2.0
+input_formats: canonical, native, ocsf
+output_formats: ocsf, native
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-lateral-movement
@@ -52,7 +54,7 @@ This skill correlates them.
 
 ## Detection logic
 
-One pass over a merged OCSF stream of API Activity (6003) + Network Activity (4001). For each identity-pivot anchor in the API stream:
+One pass over a merged normalized stream of API activity + network activity. The skill accepts OCSF input and the repo's native/canonical event shapes from supported upstream skills. For each identity-pivot anchor in the API stream:
 
 1. Record the `(cloud.provider, cloud.account.uid, actor.session.uid, time)` as an anchor
 2. Within a correlation window (default: 15 minutes), scan the Network Activity stream for flows where:
@@ -100,7 +102,9 @@ The purpose of this rule is **east-west detection**. Egress to the public intern
 
 ## Output contract
 
-OCSF 1.8 Detection Finding (class `2004`) with:
+By default, the skill emits OCSF 1.8 Detection Finding (class `2004`). When `--output-format native` is selected, it emits the repo's native detection-finding shape with the same deterministic IDs and ATT&CK mappings.
+
+The output includes:
 
 - `finding_info.attacks[]` — two techniques populated per MITRE v14:
   - **T1021** Remote Services (Lateral Movement tactic, TA0008)
@@ -119,6 +123,9 @@ OCSF 1.8 Detection Finding (class `2004`) with:
 } > merged.ocsf.jsonl
 
 python src/detect.py < merged.ocsf.jsonl > findings.ocsf.jsonl
+
+# Keep the repo-native finding shape instead of OCSF
+python src/detect.py --output-format native < merged.native.jsonl > findings.native.jsonl
 
 # Or, run the whole pipe and feed into the SARIF converter
 cat merged.ocsf.jsonl \

--- a/skills/detection/detect-lateral-movement/src/detect.py
+++ b/skills/detection/detect-lateral-movement/src/detect.py
@@ -1,10 +1,8 @@
-"""Detect cloud lateral movement by joining OCSF API Activity with Network Activity.
+"""Detect cloud lateral movement by joining API and network telemetry.
 
-Reads a merged OCSF 1.8 JSONL stream containing both:
-  - API Activity (class 6003) from cloud audit ingestors (the identity-pivot
-    anchor events)
-  - Network Activity (class 4001) from cloud flow-log ingestors (the east-west
-    traffic that follows)
+Reads a merged JSONL stream containing either:
+  - OCSF API Activity / Network Activity events, or
+  - native canonical-ish events from supported upstream skills
 
 Emits OCSF 1.8 Detection Finding (class 2004) for each distinct
 (provider, session, internal destination) tuple where a privileged-identity
@@ -65,6 +63,7 @@ CORRELATION_WINDOW_MS = 15 * 60 * 1000
 
 # Byte threshold — filter out scan probes / 3-way handshake noise
 MIN_BYTES = 1024
+OUTPUT_FORMATS = ("ocsf", "native")
 
 # Cloud identity-pivot operations we anchor on
 ASSUME_ROLE_OPERATIONS = {"AssumeRole", "AssumeRoleWithSAML", "AssumeRoleWithWebIdentity"}
@@ -178,60 +177,8 @@ def _now_ms() -> int:
     return int(datetime.now(timezone.utc).timestamp() * 1000)
 
 
-def _event_time(event: dict[str, Any]) -> int:
-    return int(event.get("time") or 0)
-
-
-def _session_uid(event: dict[str, Any]) -> str:
-    return (((event.get("actor") or {}).get("session") or {}).get("uid")) or ""
-
-
-def _actor_name(event: dict[str, Any]) -> str:
-    return (((event.get("actor") or {}).get("user") or {}).get("name")) or ""
-
-
-def _api_operation(event: dict[str, Any]) -> str:
-    return ((event.get("api") or {}).get("operation")) or ""
-
-
-def _api_service(event: dict[str, Any]) -> str:
-    return ((((event.get("api") or {}).get("service")) or {}).get("name")) or ""
-
-
-def _cloud_provider(event: dict[str, Any]) -> str:
-    return (((event.get("cloud") or {}).get("provider")) or "").upper()
-
-
-def _cloud_account(event: dict[str, Any]) -> str:
-    return ((((event.get("cloud") or {}).get("account")) or {}).get("uid")) or ""
-
-
 def _provider_display(provider: str) -> str:
     return {"AWS": "AWS", "GCP": "GCP", "AZURE": "Azure"}.get(provider, provider.title() or "Cloud")
-
-
-def _dst_ip(event: dict[str, Any]) -> str:
-    return (event.get("dst_endpoint") or {}).get("ip") or ""
-
-
-def _dst_port(event: dict[str, Any]) -> int | None:
-    port = (event.get("dst_endpoint") or {}).get("port")
-    return int(port) if port is not None else None
-
-
-def _src_instance(event: dict[str, Any]) -> str:
-    return (event.get("src_endpoint") or {}).get("instance_uid") or ""
-
-
-def _src_ip(event: dict[str, Any]) -> str:
-    return (event.get("src_endpoint") or {}).get("ip") or ""
-
-
-def _bytes(event: dict[str, Any]) -> int:
-    try:
-        return int((event.get("traffic") or {}).get("bytes") or 0)
-    except (TypeError, ValueError):
-        return 0
 
 
 def _normalize_token(value: str) -> str:
@@ -264,14 +211,119 @@ def _is_azure_entra_pivot(service: str, operation: str) -> bool:
     return operation_norm.startswith("POST /APPLICATIONS/") and "FEDERATEDIDENTITYCREDENTIALS" in operation_compact
 
 
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_native_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    record_type = str(event.get("record_type") or event.get("event_kind") or "").strip().lower()
+    if not record_type:
+        if "dst_ip" in event or "traffic_bytes" in event or "bytes" in event:
+            record_type = "network_activity"
+        elif "operation" in event or "service_name" in event:
+            record_type = "api_activity"
+        else:
+            return None
+
+    normalized: dict[str, Any] = {
+        "source_format": "native",
+        "event_kind": record_type,
+        "provider": str(event.get("provider") or event.get("cloud_provider") or "").upper(),
+        "account_uid": str(event.get("account_uid") or event.get("cloud_account_uid") or event.get("account") or ""),
+        "time_ms": _safe_int(event.get("time_ms") or event.get("time") or event.get("event_time")),
+        "session_uid": str(
+            event.get("session_uid")
+            or event.get("session_id")
+            or (((event.get("actor") or {}).get("session") or {}).get("uid"))
+            or ""
+        ),
+        "actor_name": str(
+            event.get("actor_name")
+            or (((event.get("actor") or {}).get("user") or {}).get("name"))
+            or ""
+        ),
+        "operation": str(event.get("operation") or event.get("api_operation") or ""),
+        "service_name": str(event.get("service_name") or event.get("api_service") or ""),
+        "src_ip": str(event.get("src_ip") or ""),
+        "src_instance_uid": str(event.get("src_instance_uid") or event.get("instance_uid") or ""),
+        "dst_ip": str(event.get("dst_ip") or ""),
+        "dst_port": int(event["dst_port"]) if event.get("dst_port") is not None else None,
+        "traffic_bytes": _safe_int(event.get("traffic_bytes") or event.get("bytes")),
+        "activity_id": _safe_int(event.get("activity_id")),
+        "disposition": str(event.get("disposition") or ""),
+        "raw": event,
+    }
+    if record_type == "network_activity" and not normalized["activity_id"]:
+        disposition = normalized["disposition"].upper()
+        if disposition in {"ACCEPT", "ALLOWED", "ALLOW"}:
+            normalized["activity_id"] = NET_ACTIVITY_ACCEPT
+    return normalized
+
+
+def _normalize_ocsf_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    class_uid = event.get("class_uid")
+    if class_uid == API_ACTIVITY_CLASS:
+        return {
+            "source_format": "ocsf",
+            "event_kind": "api_activity",
+            "provider": ((((event.get("cloud") or {}).get("provider")) or "")).upper(),
+            "account_uid": ((((event.get("cloud") or {}).get("account")) or {}).get("uid")) or "",
+            "time_ms": _safe_int(event.get("time")),
+            "session_uid": (((event.get("actor") or {}).get("session") or {}).get("uid")) or "",
+            "actor_name": (((event.get("actor") or {}).get("user") or {}).get("name")) or "",
+            "operation": ((event.get("api") or {}).get("operation")) or "",
+            "service_name": ((((event.get("api") or {}).get("service")) or {}).get("name")) or "",
+            "src_ip": (event.get("src_endpoint") or {}).get("ip") or "",
+            "src_instance_uid": (event.get("src_endpoint") or {}).get("instance_uid") or "",
+            "dst_ip": "",
+            "dst_port": None,
+            "traffic_bytes": 0,
+            "activity_id": _safe_int(event.get("activity_id")),
+            "disposition": "",
+            "raw": event,
+        }
+    if class_uid == NETWORK_ACTIVITY_CLASS:
+        dst_port = (event.get("dst_endpoint") or {}).get("port")
+        return {
+            "source_format": "ocsf",
+            "event_kind": "network_activity",
+            "provider": ((((event.get("cloud") or {}).get("provider")) or "")).upper(),
+            "account_uid": ((((event.get("cloud") or {}).get("account")) or {}).get("uid")) or "",
+            "time_ms": _safe_int(event.get("time")),
+            "session_uid": "",
+            "actor_name": "",
+            "operation": "",
+            "service_name": "",
+            "src_ip": (event.get("src_endpoint") or {}).get("ip") or "",
+            "src_instance_uid": (event.get("src_endpoint") or {}).get("instance_uid") or "",
+            "dst_ip": (event.get("dst_endpoint") or {}).get("ip") or "",
+            "dst_port": int(dst_port) if dst_port is not None else None,
+            "traffic_bytes": _safe_int((event.get("traffic") or {}).get("bytes")),
+            "activity_id": _safe_int(event.get("activity_id")),
+            "disposition": "",
+            "raw": event,
+        }
+    return None
+
+
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    if "class_uid" in event:
+        return _normalize_ocsf_event(event)
+    return _normalize_native_event(event)
+
+
 def is_identity_pivot_anchor(event: dict[str, Any]) -> bool:
-    """Return True when an OCSF API Activity event is a high-signal pivot anchor."""
-    if event.get("class_uid") != API_ACTIVITY_CLASS:
+    """Return True when an API-activity event is a high-signal pivot anchor."""
+    normalized = _normalize_event(event)
+    if normalized is None or normalized["event_kind"] != "api_activity":
         return False
 
-    provider = _cloud_provider(event)
-    operation = _api_operation(event)
-    service = _api_service(event)
+    provider = str(normalized["provider"])
+    operation = str(normalized["operation"])
+    service = str(normalized["service_name"])
 
     if provider == "AWS":
         return operation in ASSUME_ROLE_OPERATIONS
@@ -309,23 +361,23 @@ def coverage_metadata() -> dict[str, object]:
 # ---------------------------------------------------------------------------
 
 
-def _build_finding(
+def _build_native_finding(
     *,
     anchor_event: dict[str, Any],
     flow_event: dict[str, Any],
 ) -> dict[str, Any]:
-    session = _session_uid(anchor_event)
-    principal = _actor_name(anchor_event)
-    provider_code = _cloud_provider(anchor_event)
+    session = str(anchor_event["session_uid"])
+    principal = str(anchor_event["actor_name"])
+    provider_code = str(anchor_event["provider"])
     provider = _provider_display(provider_code)
     provider_key = (provider_code or "cloud").lower()
-    account = _cloud_account(anchor_event)
-    dst_ip = _dst_ip(flow_event)
-    dst_port = _dst_port(flow_event)
-    src_instance = _src_instance(flow_event)
-    src_ip = _src_ip(flow_event)
-    flow_bytes = _bytes(flow_event)
-    operation = _api_operation(anchor_event)
+    account = str(anchor_event["account_uid"])
+    dst_ip = str(flow_event["dst_ip"])
+    dst_port = flow_event["dst_port"]
+    src_instance = str(flow_event["src_instance_uid"])
+    src_ip = str(flow_event["src_ip"])
+    flow_bytes = _safe_int(flow_event["traffic_bytes"])
+    operation = str(anchor_event["operation"])
 
     dst_key = f"{dst_ip}:{dst_port}"
     uid = f"det-lm-{_short(provider_key)}-{_short(session)}-{_short(dst_key)}"
@@ -343,6 +395,59 @@ def _build_finding(
     )
 
     return {
+        "schema_mode": "native",
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": uid,
+        "event_uid": uid,
+        "provider": provider_code,
+        "account_uid": account,
+        "time_ms": int(flow_event["time_ms"]) or _now_ms(),
+        "severity": "high",
+        "severity_id": SEVERITY_HIGH,
+        "status": "success",
+        "status_id": 1,
+        "title": f"{provider} lateral movement: identity pivot followed by east-west traffic",
+        "description": desc,
+        "finding_types": ["cloud-lateral-movement"],
+        "first_seen_time_ms": int(anchor_event["time_ms"]),
+        "last_seen_time_ms": int(flow_event["time_ms"]),
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": T1021_TACTIC_UID,
+                "tactic_name": T1021_TACTIC_NAME,
+                "technique_uid": T1021_TECH_UID,
+                "technique_name": T1021_TECH_NAME,
+            },
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": T1078_TACTIC_UID,
+                "tactic_name": T1078_TACTIC_NAME,
+                "technique_uid": T1078_TECH_UID,
+                "technique_name": T1078_TECH_NAME,
+                "sub_technique_uid": T1078_SUB_UID,
+                "sub_technique_name": T1078_SUB_NAME,
+            },
+        ],
+        "session_uid": session,
+        "actor_name": principal,
+        "anchor_operation": operation,
+        "src_instance_uid": src_instance,
+        "src_ip": src_ip,
+        "dst_ip": dst_ip,
+        "dst_port": dst_port,
+        "traffic_bytes": flow_bytes,
+        "window_seconds": CORRELATION_WINDOW_MS // 1000,
+        "rule_name": "cloud-lateral-movement",
+    }
+
+
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    provider_code = str(native_finding["provider"])
+    provider = _provider_display(provider_code)
+    return {
         "activity_id": FINDING_ACTIVITY_CREATE,
         "category_uid": FINDING_CATEGORY_UID,
         "category_name": FINDING_CATEGORY_NAME,
@@ -351,24 +456,24 @@ def _build_finding(
         "type_uid": FINDING_TYPE_UID,
         "severity_id": SEVERITY_HIGH,
         "status_id": 1,
-        "time": _event_time(flow_event) or _now_ms(),
+        "time": int(native_finding["time_ms"]) or _now_ms(),
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": uid,
+            "uid": native_finding["event_uid"],
             "product": {
                 "name": REPO_NAME,
                 "vendor_name": REPO_VENDOR,
                 "feature": {"name": SKILL_NAME},
             },
-            "labels": ["detection-engineering", provider_key, "lateral-movement", "multi-source"],
+            "labels": ["detection-engineering", provider_code.lower(), "lateral-movement", "multi-source"],
         },
         "finding_info": {
-            "uid": uid,
-            "title": f"{provider} lateral movement: identity pivot followed by east-west traffic",
-            "desc": desc,
-            "types": ["cloud-lateral-movement"],
-            "first_seen_time": _event_time(anchor_event),
-            "last_seen_time": _event_time(flow_event),
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "first_seen_time": int(native_finding["first_seen_time_ms"]),
+            "last_seen_time": int(native_finding["last_seen_time_ms"]),
             "attacks": [
                 {
                     "version": MITRE_VERSION,
@@ -385,22 +490,22 @@ def _build_finding(
         },
         "observables": [
             {"name": "cloud.provider", "type": "Other", "value": provider},
-            {"name": "cloud.account", "type": "Other", "value": account},
-            {"name": "session.uid", "type": "Other", "value": session},
-            {"name": "actor.name", "type": "Other", "value": principal},
-            {"name": "anchor.operation", "type": "Other", "value": operation},
-            {"name": "src.instance_uid", "type": "Other", "value": src_instance},
-            {"name": "src.ip", "type": "Other", "value": src_ip},
-            {"name": "dst.ip", "type": "Other", "value": dst_ip},
-            {"name": "dst.port", "type": "Other", "value": str(dst_port) if dst_port is not None else ""},
-            {"name": "traffic.bytes", "type": "Other", "value": str(flow_bytes)},
-            {"name": "window.seconds", "type": "Other", "value": str(CORRELATION_WINDOW_MS // 1000)},
-            {"name": "rule", "type": "Other", "value": "cloud-lateral-movement"},
+            {"name": "cloud.account", "type": "Other", "value": native_finding["account_uid"]},
+            {"name": "session.uid", "type": "Other", "value": native_finding["session_uid"]},
+            {"name": "actor.name", "type": "Other", "value": native_finding["actor_name"]},
+            {"name": "anchor.operation", "type": "Other", "value": native_finding["anchor_operation"]},
+            {"name": "src.instance_uid", "type": "Other", "value": native_finding["src_instance_uid"]},
+            {"name": "src.ip", "type": "Other", "value": native_finding["src_ip"]},
+            {"name": "dst.ip", "type": "Other", "value": native_finding["dst_ip"]},
+            {"name": "dst.port", "type": "Other", "value": str(native_finding["dst_port"] or "")},
+            {"name": "traffic.bytes", "type": "Other", "value": str(native_finding["traffic_bytes"])},
+            {"name": "window.seconds", "type": "Other", "value": str(native_finding["window_seconds"])},
+            {"name": "rule", "type": "Other", "value": native_finding["rule_name"]},
         ],
         "evidence": {
             "events_observed": 2,
-            "first_seen_time": _event_time(anchor_event),
-            "last_seen_time": _event_time(flow_event),
+            "first_seen_time": int(native_finding["first_seen_time_ms"]),
+            "last_seen_time": int(native_finding["last_seen_time_ms"]),
             "raw_events": [],
         },
     }
@@ -411,67 +516,67 @@ def _build_finding(
 # ---------------------------------------------------------------------------
 
 
-def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
-    """Walk a merged OCSF stream. Yield one finding per (session, dst) pair.
+def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    """Walk a merged stream. Yield one finding per (session, dst) pair.
 
     Deterministic output order: findings are yielded in anchor-event-time
     order (then by dst IP and port as tiebreaker).
     """
-    events_list = list(events)
+    events_list = [normalized for event in events if (normalized := _normalize_event(event)) is not None]
     # Partition the stream
     identity_anchors: list[dict[str, Any]] = []
     flows: list[dict[str, Any]] = []
     for ev in events_list:
-        cls = ev.get("class_uid")
         if is_identity_pivot_anchor(ev):
             identity_anchors.append(ev)
-        elif cls == NETWORK_ACTIVITY_CLASS and ev.get("activity_id") == NET_ACTIVITY_ACCEPT:
+        elif ev["event_kind"] == "network_activity" and int(ev["activity_id"]) == NET_ACTIVITY_ACCEPT:
             flows.append(ev)
 
     # Sort for deterministic iteration
-    identity_anchors.sort(key=_event_time)
-    flows.sort(key=_event_time)
+    identity_anchors.sort(key=lambda event: int(event["time_ms"]))
+    flows.sort(key=lambda event: int(event["time_ms"]))
 
     seen: set[str] = set()
     findings: list[dict[str, Any]] = []
 
     for anchor in identity_anchors:
-        anchor_time = _event_time(anchor)
+        anchor_time = int(anchor["time_ms"])
         window_end = anchor_time + CORRELATION_WINDOW_MS
-        anchor_provider = _cloud_provider(anchor)
-        anchor_account = _cloud_account(anchor)
+        anchor_provider = str(anchor["provider"])
+        anchor_account = str(anchor["account_uid"])
 
         for flow in flows:
-            ft = _event_time(flow)
+            ft = int(flow["time_ms"])
             if ft < anchor_time or ft > window_end:
                 continue
-            if anchor_provider and _cloud_provider(flow) != anchor_provider:
+            if anchor_provider and str(flow["provider"]) != anchor_provider:
                 continue
-            flow_account = _cloud_account(flow)
+            flow_account = str(flow["account_uid"])
             if anchor_account and flow_account and flow_account != anchor_account:
                 continue
-            if _bytes(flow) < MIN_BYTES:
+            if _safe_int(flow["traffic_bytes"]) < MIN_BYTES:
                 continue
-            dst = _dst_ip(flow)
+            dst = str(flow["dst_ip"])
             if not is_rfc1918(dst):
                 continue
 
-            session = _session_uid(anchor)
-            dst_port = _dst_port(flow)
+            session = str(anchor["session_uid"])
+            dst_port = flow["dst_port"]
             dedup_key = f"{anchor_provider}|{session}|{dst}|{dst_port}"
             if dedup_key in seen:
                 continue
             seen.add(dedup_key)
 
-            findings.append(_build_finding(anchor_event=anchor, flow_event=flow))
+            native_finding = _build_native_finding(anchor_event=anchor, flow_event=flow)
+            findings.append(_render_ocsf_finding(native_finding) if output_format == "ocsf" else native_finding)
 
     # Final deterministic ordering by anchor time, dst ip, dst port
     findings.sort(
         key=lambda f: (
-            next((o["value"] for o in f["observables"] if o["name"] == "cloud.provider"), ""),
-            next((o["value"] for o in f["observables"] if o["name"] == "session.uid"), ""),
-            next((o["value"] for o in f["observables"] if o["name"] == "dst.ip"), ""),
-            next((o["value"] for o in f["observables"] if o["name"] == "dst.port"), ""),
+            str(f.get("provider") or next((o["value"] for o in f.get("observables", []) if o["name"] == "cloud.provider"), "")),
+            str(f.get("session_uid") or next((o["value"] for o in f.get("observables", []) if o["name"] == "session.uid"), "")),
+            str(f.get("dst_ip") or next((o["value"] for o in f.get("observables", []) if o["name"] == "dst.ip"), "")),
+            str(f.get("dst_port") or next((o["value"] for o in f.get("observables", []) if o["name"] == "dst.port"), "")),
         )
     )
     yield from findings
@@ -500,8 +605,9 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Detect cloud lateral movement (API Activity + Network Activity join).")
-    parser.add_argument("input", nargs="?", help="Merged OCSF JSONL input. Defaults to stdin.")
-    parser.add_argument("--output", "-o", help="OCSF Detection Finding JSONL output. Defaults to stdout.")
+    parser.add_argument("input", nargs="?", help="Merged native or OCSF JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="Detection Finding JSONL output. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="ocsf", help="Render OCSF detection findings or the native detection-finding shape.")
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
@@ -509,7 +615,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         events = list(load_jsonl(in_stream))
-        for finding in detect(events):
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/detection/detect-lateral-movement/tests/test_detect.py
+++ b/skills/detection/detect-lateral-movement/tests/test_detect.py
@@ -88,6 +88,56 @@ def _flow(
     }
 
 
+def _native_anchor(
+    *,
+    provider: str = "AWS",
+    operation: str = "AssumeRole",
+    account_uid: str = "111122223333",
+    session_uid: str = "ASIASESSION001",
+    time_ms: int = 1775797200000,
+    actor_name: str = "alice",
+    service_name: str = "sts.amazonaws.com",
+) -> dict:
+    return {
+        "schema_mode": "native",
+        "record_type": "api_activity",
+        "provider": provider,
+        "account_uid": account_uid,
+        "session_uid": session_uid,
+        "actor_name": actor_name,
+        "operation": operation,
+        "service_name": service_name,
+        "time_ms": time_ms,
+    }
+
+
+def _native_flow(
+    *,
+    provider: str = "AWS",
+    account_uid: str = "111122223333",
+    src_ip: str = "10.0.1.100",
+    dst_ip: str = "10.0.3.75",
+    dst_port: int = 3306,
+    bytes_: int = 450000,
+    disposition: str = "ACCEPT",
+    time_ms: int = 1775797320000,
+    src_instance_uid: str = "i-0web01",
+) -> dict:
+    return {
+        "schema_mode": "native",
+        "record_type": "network_activity",
+        "provider": provider,
+        "account_uid": account_uid,
+        "src_ip": src_ip,
+        "dst_ip": dst_ip,
+        "dst_port": dst_port,
+        "traffic_bytes": bytes_,
+        "disposition": disposition,
+        "time_ms": time_ms,
+        "src_instance_uid": src_instance_uid,
+    }
+
+
 # ── RFC1918 helper ───────────────────────────────────────────────
 
 
@@ -230,6 +280,29 @@ class TestPositiveCases:
             for finding in findings
         }
         assert sessions == {"session-a", "session-b"}
+
+    def test_native_input_can_emit_native_finding(self):
+        events = [
+            _native_anchor(time_ms=1000),
+            _native_flow(time_ms=60000, dst_ip="10.0.3.75", bytes_=450000),
+        ]
+        findings = list(detect(events, output_format="native"))
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["schema_mode"] == "native"
+        assert finding["record_type"] == "detection_finding"
+        assert finding["provider"] == "AWS"
+        assert finding["session_uid"] == "ASIASESSION001"
+        assert "class_uid" not in finding
+
+    def test_mixed_native_and_ocsf_input_still_correlates(self):
+        events = [
+            _anchor_event(time_ms=1000),
+            _native_flow(time_ms=60000, dst_ip="10.0.3.75", bytes_=450000),
+        ]
+        findings = list(detect(events))
+        assert len(findings) == 1
+        assert findings[0]["class_uid"] == FINDING_CLASS_UID
 
 
 # ── Negative controls ───────────────────────────────────────────

--- a/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
@@ -14,11 +14,13 @@ description: >-
   ingest-k8s-audit-ocsf). Do NOT use as a detection skill — this skill only
   normalises events, it does not flag anything.
 license: Apache-2.0
+input_formats: raw
+output_formats: ocsf, native
 ---
 
 # ingest-cloudtrail-ocsf
 
-Thin, single-purpose ingestion skill: raw CloudTrail JSON in → OCSF 1.8 API Activity JSONL out. No detection logic, no side effects, no AWS API calls. Reads files or stdin; writes JSONL or stdout.
+Thin, single-purpose ingestion skill: raw CloudTrail JSON in → canonical event projection → OCSF 1.8 API Activity JSONL or native enriched JSONL out. No detection logic, no side effects, no AWS API calls. Reads files or stdin; writes JSONL or stdout.
 
 ## Wire contract
 
@@ -29,7 +31,9 @@ Reads either of the two CloudTrail layouts that are emitted by the AWS service:
 
 The skill auto-detects which shape it's looking at and unwraps `Records` if present.
 
-Writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid: 6`). See [`../OCSF_CONTRACT.md`](../OCSF_CONTRACT.md) for the field-level pinning that every event matches.
+By default it writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid: 6`). See [`../OCSF_CONTRACT.md`](../OCSF_CONTRACT.md) for the field-level pinning that every OCSF event matches.
+
+When `--output-format native` is selected, it emits the same event in the repo's native enriched shape with stable `event_uid`, normalized provider/account/operation/status fields, and preserved actor/session/source context, but without the OCSF envelope fields.
 
 ## activity_id inference
 
@@ -56,6 +60,9 @@ CloudTrail records a top-level `errorCode` field when an API call fails. The ski
 ```bash
 # Single file
 python src/ingest.py cloudtrail.json > cloudtrail.ocsf.jsonl
+
+# Same input, native enriched output
+python src/ingest.py cloudtrail.json --output-format native > cloudtrail.native.jsonl
 
 # Piped from S3 sync
 aws s3 cp s3://my-cloudtrail-bucket/AWSLogs/.../recent.json.gz - | gunzip | python src/ingest.py

--- a/skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
@@ -2,7 +2,8 @@
 
 Input:  CloudTrail JSON — either single events one-per-line (NDJSON) or the
         digest format ({"Records": [...]}). Auto-detected.
-Output: JSONL of OCSF 1.8 API Activity events.
+Output: JSONL of OCSF 1.8 API Activity events by default, or a documented
+        native enriched event shape when --output-format native is selected.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -18,6 +19,7 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-cloudtrail-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 
 # OCSF 1.8 API Activity (6003)
 CLASS_UID = 6003
@@ -224,14 +226,14 @@ def _build_cloud(event: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def convert_event(raw: dict[str, Any]) -> dict[str, Any]:
-    """Convert one raw CloudTrail event into one OCSF API Activity event."""
+def _build_canonical_event(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert one raw CloudTrail event into the repo's canonical event shape."""
     event_name = raw.get("eventName", "")
     activity_id = infer_activity_id(event_name)
     error_code = raw.get("errorCode")
     status_id = STATUS_FAILURE if error_code else STATUS_SUCCESS
 
-    metadata_uid = str(raw.get("eventID") or "").strip() or hashlib.sha256(
+    event_uid = str(raw.get("eventID") or "").strip() or hashlib.sha256(
         json.dumps(
             {
                 "eventSource": raw.get("eventSource", ""),
@@ -245,6 +247,41 @@ def convert_event(raw: dict[str, Any]) -> dict[str, Any]:
         ).encode("utf-8")
     ).hexdigest()
 
+    canonical: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "api_activity",
+        "event_uid": event_uid,
+        "provider": "AWS",
+        "account_uid": raw.get("recipientAccountId", ""),
+        "region": raw.get("awsRegion", ""),
+        "time_ms": parse_ts_ms(raw.get("eventTime")),
+        "event_name": event_name,
+        "operation": event_name,
+        "service_name": raw.get("eventSource", ""),
+        "activity_id": activity_id,
+        "activity_name": {1: "create", 2: "read", 3: "update", 4: "delete", 99: "other"}.get(activity_id, "unknown"),
+        "status_id": status_id,
+        "status": "failure" if error_code else "success",
+        "actor": _build_actor(raw.get("userIdentity") or {}),
+        "src": _build_src_endpoint(raw),
+        "resources": _project_resources(raw.get("requestParameters")),
+        "source": {
+            "kind": "aws.cloudtrail",
+            "request_id": raw.get("requestID", ""),
+            "event_id": raw.get("eventID", ""),
+            "event_category": raw.get("eventCategory", ""),
+        },
+    }
+    if error_code:
+        canonical["status_detail"] = f"{error_code}: {raw.get('errorMessage', '')}".strip(": ").strip()
+    return canonical
+
+
+def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    """Render the canonical CloudTrail event as OCSF API Activity."""
+    activity_id = int(canonical["activity_id"])
+    status_id = int(canonical["status_id"])
     event: dict[str, Any] = {
         "activity_id": activity_id,
         "category_uid": CATEGORY_UID,
@@ -254,10 +291,10 @@ def convert_event(raw: dict[str, Any]) -> dict[str, Any]:
         "type_uid": CLASS_UID * 100 + activity_id,
         "severity_id": SEVERITY_INFORMATIONAL,
         "status_id": status_id,
-        "time": parse_ts_ms(raw.get("eventTime")),
+        "time": canonical["time_ms"],
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": metadata_uid,
+            "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
                 "vendor_name": "msaad00/cloud-ai-security-skills",
@@ -265,17 +302,47 @@ def convert_event(raw: dict[str, Any]) -> dict[str, Any]:
             },
             "labels": ["detection-engineering", "aws", "cloudtrail", "ingest"],
         },
-        "actor": _build_actor(raw.get("userIdentity") or {}),
-        "src_endpoint": _build_src_endpoint(raw),
-        "api": _build_api(raw),
-        "resources": _project_resources(raw.get("requestParameters")),
-        "cloud": _build_cloud(raw),
+        "actor": canonical["actor"],
+        "src_endpoint": canonical["src"],
+        "api": {
+            "operation": canonical["operation"],
+            "service": {"name": canonical["service_name"]},
+            "request": {"uid": canonical["event_uid"]},
+        },
+        "resources": canonical["resources"],
+        "cloud": {
+            "provider": canonical["provider"],
+            "account": {"uid": canonical["account_uid"]} if canonical["account_uid"] else {},
+            "region": canonical["region"],
+        },
     }
 
-    if error_code:
-        event["status_detail"] = f"{error_code}: {raw.get('errorMessage', '')}".strip(": ").strip()
+    cloud = event["cloud"]
+    if not cloud.get("account"):
+        cloud.pop("account")
+    if canonical.get("status_detail"):
+        event["status_detail"] = canonical["status_detail"]
 
     return event
+
+
+def _render_native_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    """Render the canonical CloudTrail event as the repo's native enriched shape."""
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["source_skill"] = SKILL_NAME
+    native["output_format"] = "native"
+    return native
+
+
+def convert_event(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert one raw CloudTrail event into one OCSF API Activity event."""
+    return _render_ocsf_event(_build_canonical_event(raw))
+
+
+def convert_event_native(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert one raw CloudTrail event into the native enriched event shape."""
+    return _render_native_event(_build_canonical_event(raw))
 
 
 # ---------------------------------------------------------------------------
@@ -345,10 +412,14 @@ def iter_raw_events(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object or Records wrapper", file=sys.stderr)
 
 
-def ingest(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     for raw in iter_raw_events(stream):
         try:
-            yield convert_event(raw)
+            canonical = _build_canonical_event(raw)
+            if output_format == "native":
+                yield _render_native_event(canonical)
+            else:
+                yield _render_ocsf_event(canonical)
         except Exception as e:  # defence-in-depth — never crash the pipeline
             print(f"[{SKILL_NAME}] skipping event: convert error: {e}", file=sys.stderr)
             continue
@@ -358,13 +429,14 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Convert raw CloudTrail JSON to OCSF 1.8 API Activity JSONL.")
     parser.add_argument("input", nargs="?", help="Input JSON/JSONL file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=("ocsf", "native"), default="ocsf", help="Render OCSF events or the native enriched event shape.")
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
     try:
-        for event in ingest(in_stream):
+        for event in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(event, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py
@@ -28,6 +28,7 @@ from ingest import (  # type: ignore[import-not-found]
     STATUS_FAILURE,
     STATUS_SUCCESS,
     convert_event,
+    convert_event_native,
     infer_activity_id,
     ingest,
     iter_raw_events,
@@ -192,6 +193,16 @@ class TestConvertEvent:
         assert len(e["resources"]) == 1
         assert e["resources"][0]["name"] == "bob"
 
+    def test_native_output_keeps_canonical_fields_without_ocsf_envelope(self):
+        e = convert_event_native(self._base_event())
+        assert e["schema_mode"] == "native"
+        assert e["record_type"] == "api_activity"
+        assert e["provider"] == "AWS"
+        assert e["operation"] == "CreateAccessKey"
+        assert e["event_uid"] == "abc-123"
+        assert "class_uid" not in e
+        assert "metadata" not in e
+
 
 # ── iter_raw_events: format auto-detect ─────────────────────────────────
 
@@ -263,3 +274,13 @@ class TestGoldenFixture:
         # principalId becomes the name when userName is missing (assumed-role events)
         assert "AROAEXAMPLEID:alice" in names or "alice" in names
         assert "bob" in names
+
+    def test_native_output_mode_emits_enriched_events(self):
+        produced = list(ingest(RAW_FIXTURE.read_text().splitlines(), output_format="native"))
+        assert len(produced) == 4
+        first = produced[0]
+        assert first["schema_mode"] == "native"
+        assert first["record_type"] == "api_activity"
+        assert first["provider"] == "AWS"
+        assert "class_uid" not in first
+        assert "metadata" not in first


### PR DESCRIPTION
## Summary
- add a phased native/OCSF pilot to ingest-cloudtrail-ocsf and detect-lateral-movement
- keep OCSF as the default output while adding explicit native output support
- add MCP output-format selection and make the OCSF metadata validator format-aware
- harden the pilot with native-path and mixed-mode tests

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_framework_coverage.py
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py skills/detection/detect-lateral-movement/tests/test_detect.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run ruff check skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py skills/detection/detect-lateral-movement/src/detect.py skills/detection/detect-lateral-movement/tests/test_detect.py mcp-server/src/tool_registry.py mcp-server/src/server.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py scripts/validate_ocsf_metadata.py --config pyproject.toml