### PR TITLE
feat: pilot native and ocsf network ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is loosely based on Keep a Changelog.
 - Expanded `ingest-okta-system-log-ocsf` to cover the verified Okta Verify push and denial event families needed for narrow MFA fatigue detection.
 - Reframed the repo contract so OCSF remains a first-class interoperability option, but not a mandatory storage or execution model; the stable internal contract is now explicitly source truth -> canonical model -> `native` / `ocsf` / `bridge` output.
 - Made the OCSF metadata validator format-aware so native-mode support does not weaken the OCSF path contract.
+- Extended the native/OCSF pilot to `ingest-vpc-flow-logs-ocsf`, so AWS flow logs can now emit either OCSF Network Activity or the repo's canonical native network-flow shape while preserving a compatible end-to-end lateral-movement path.
 
 ### Added
 - Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
@@ -16,11 +16,13 @@ description: >-
   (use ingest-cloudtrail-ocsf). Do NOT use as a
   detection skill — this only normalises network flows.
 license: Apache-2.0
+input_formats: raw
+output_formats: ocsf, native
 ---
 
 # ingest-vpc-flow-logs-ocsf
 
-Thin ingestion skill: raw AWS VPC Flow Log records in → OCSF 1.8 Network Activity JSONL out. No detection logic, no AWS API calls, no side effects.
+Thin ingestion skill: raw AWS VPC Flow Log records in → canonical network-flow projection → OCSF 1.8 Network Activity JSONL or native enriched network-flow JSONL out. No detection logic, no AWS API calls, no side effects.
 
 ## Wire contract
 
@@ -32,7 +34,9 @@ version account-id interface-id srcaddr dstaddr srcport dstport protocol packets
 
 The skill also understands the v5 extended fields if they are declared in the header: `vpc-id subnet-id instance-id tcp-flags type pkt-srcaddr pkt-dstaddr region az-id sublocation-type sublocation-id pkt-src-aws-service pkt-dst-aws-service flow-direction traffic-path`.
 
-Writes OCSF 1.8 **Network Activity** (`class_uid: 4001`, `category_uid: 4`). See [`../OCSF_CONTRACT.md`](../OCSF_CONTRACT.md).
+By default it writes OCSF 1.8 **Network Activity** (`class_uid: 4001`, `category_uid: 4`). See [`../OCSF_CONTRACT.md`](../OCSF_CONTRACT.md).
+
+When `--output-format native` is selected, it emits the same flow in the repo's native enriched shape with stable `event_uid`, normalized source/destination, byte counters, protocol/direction, and AWS scope fields, but without the OCSF envelope.
 
 ## activity_id mapping
 
@@ -113,6 +117,9 @@ So `tcp-flags=18` means `SYN|ACK`. The skill decodes this into a comma-joined st
 ```bash
 # Single file from S3 (after sync / gunzip)
 python src/ingest.py vpc-flow.log > vpc-flow.ocsf.jsonl
+
+# Same input, native enriched output
+python src/ingest.py vpc-flow.log --output-format native > vpc-flow.native.jsonl
 
 # Piped from CloudWatch Logs Insights query output (JSON format)
 aws logs start-query --log-group-name "/aws/vpc/flow" ... \

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/src/ingest.py
@@ -3,7 +3,9 @@
 Input:  VPC Flow Log records in v5 space-delimited format. Optional header
         line declaring the field order; when absent, falls back to the
         canonical v5 default.
-Output: JSONL of OCSF 1.8 Network Activity events, one per flow record.
+Output: JSONL of OCSF 1.8 Network Activity events by default, or the repo's
+        native enriched network-activity shape when --output-format native is
+        selected.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -18,6 +20,7 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-vpc-flow-logs-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 
 # OCSF Network Activity (4001)
 CLASS_UID = 4001
@@ -272,8 +275,8 @@ def _cloud(record: dict[str, str]) -> dict[str, Any]:
     return cloud
 
 
-def convert_record(record: dict[str, str]) -> dict[str, Any] | None:
-    """Convert one parsed VPC Flow record into one OCSF Network Activity event.
+def _build_canonical_record(record: dict[str, str]) -> dict[str, Any] | None:
+    """Convert one parsed VPC Flow record into the repo's canonical event shape.
 
     Returns None if the record is a NODATA / SKIPDATA entry (no real flow data).
     """
@@ -310,6 +313,44 @@ def convert_record(record: dict[str, str]) -> dict[str, Any] | None:
     # the most useful because it's when the accumulated counters were flushed.
     event_time = end_ms or start_ms or 0
 
+    canonical: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "network_activity",
+        "event_uid": metadata_uid,
+        "provider": "AWS",
+        "account_uid": _str_or_skip(record.get("account-id")) or "",
+        "region": _str_or_skip(record.get("region")) or "",
+        "time_ms": event_time,
+        "start_time_ms": start_ms,
+        "end_time_ms": end_ms,
+        "activity_id": activity_id,
+        "activity_name": {ACTIVITY_TRAFFIC: "traffic", ACTIVITY_DENIED: "denied", ACTIVITY_UNKNOWN: "unknown"}.get(
+            activity_id, "unknown"
+        ),
+        "status_id": STATUS_SUCCESS,
+        "status": "success",
+        "src": _src_endpoint(record),
+        "dst": _dst_endpoint(record),
+        "traffic": _traffic(record),
+        "connection": _connection_info(record),
+        "cloud": _cloud(record),
+        "disposition": (record.get("action") or "").upper() or "UNKNOWN",
+        "source": {
+            "kind": "aws.vpc-flow-logs",
+            "interface_id": _str_or_skip(record.get("interface-id")) or "",
+            "vpc_id": _str_or_skip(record.get("vpc-id")) or "",
+            "subnet_id": _str_or_skip(record.get("subnet-id")) or "",
+            "instance_id": _str_or_skip(record.get("instance-id")) or "",
+            "flow_direction": _str_or_skip(record.get("flow-direction")) or "",
+            "log_status": status,
+        },
+    }
+    return canonical
+
+
+def _render_ocsf_record(canonical: dict[str, Any]) -> dict[str, Any]:
+    activity_id = int(canonical["activity_id"])
     event: dict[str, Any] = {
         "activity_id": activity_id,
         "category_uid": CATEGORY_UID,
@@ -319,10 +360,10 @@ def convert_record(record: dict[str, str]) -> dict[str, Any] | None:
         "type_uid": CLASS_UID * 100 + activity_id,
         "severity_id": SEVERITY_INFORMATIONAL,
         "status_id": STATUS_SUCCESS,
-        "time": event_time,
+        "time": canonical["time_ms"],
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": metadata_uid,
+            "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
                 "vendor_name": "msaad00/cloud-ai-security-skills",
@@ -330,18 +371,42 @@ def convert_record(record: dict[str, str]) -> dict[str, Any] | None:
             },
             "labels": ["detection-engineering", "aws", "vpc-flow-logs", "ingest"],
         },
-        "src_endpoint": _src_endpoint(record),
-        "dst_endpoint": _dst_endpoint(record),
-        "traffic": _traffic(record),
-        "connection_info": _connection_info(record),
-        "cloud": _cloud(record),
+        "src_endpoint": canonical["src"],
+        "dst_endpoint": canonical["dst"],
+        "traffic": canonical["traffic"],
+        "connection_info": canonical["connection"],
+        "cloud": canonical["cloud"],
     }
-    if start_ms is not None:
-        event["start_time"] = start_ms
-    if end_ms is not None:
-        event["end_time"] = end_ms
+    if canonical.get("start_time_ms") is not None:
+        event["start_time"] = canonical["start_time_ms"]
+    if canonical.get("end_time_ms") is not None:
+        event["end_time"] = canonical["end_time_ms"]
 
     return event
+
+
+def _render_native_record(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["source_skill"] = SKILL_NAME
+    native["output_format"] = "native"
+    return native
+
+
+def convert_record(record: dict[str, str]) -> dict[str, Any] | None:
+    """Convert one parsed VPC Flow record into one OCSF Network Activity event."""
+    canonical = _build_canonical_record(record)
+    if canonical is None:
+        return None
+    return _render_ocsf_record(canonical)
+
+
+def convert_record_native(record: dict[str, str]) -> dict[str, Any] | None:
+    """Convert one parsed VPC Flow record into the native enriched flow shape."""
+    canonical = _build_canonical_record(record)
+    if canonical is None:
+        return None
+    return _render_native_record(canonical)
 
 
 # ---------------------------------------------------------------------------
@@ -349,8 +414,8 @@ def convert_record(record: dict[str, str]) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
-def ingest(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
-    """Yield OCSF events for a stream of VPC Flow Log lines.
+def ingest(lines: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    """Yield events for a stream of VPC Flow Log lines.
 
     The first non-blank line is inspected: if it's a header, it sets the field
     order for every subsequent line. Otherwise, the canonical v5 default order
@@ -381,30 +446,34 @@ def ingest(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
             continue
 
         try:
-            event = convert_record(record)
+            canonical = _build_canonical_record(record)
         except Exception as e:
             print(f"[{SKILL_NAME}] skipping line {lineno}: convert error: {e}", file=sys.stderr)
             continue
 
-        if event is None:
+        if canonical is None:
             # NODATA / SKIPDATA — silently skip, those are legitimate
             # flow-log entries that carry no real flow data
             continue
 
-        yield event
+        if output_format == "native":
+            yield _render_native_record(canonical)
+        else:
+            yield _render_ocsf_record(canonical)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Convert AWS VPC Flow Logs (v5) to OCSF 1.8 Network Activity JSONL.")
     parser.add_argument("input", nargs="?", help="Input flow log file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=("ocsf", "native"), default="ocsf", help="Render OCSF network activity or the native enriched network-flow shape.")
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
     try:
-        for event in ingest(in_stream):
+        for event in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(event, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py
@@ -21,6 +21,7 @@ OCSF_VERSION = _INGEST.OCSF_VERSION
 SKILL_NAME = _INGEST.SKILL_NAME
 activity_id_for_action = _INGEST.activity_id_for_action
 convert_record = _INGEST.convert_record
+convert_record_native = _INGEST.convert_record_native
 decode_tcp_flags = _INGEST.decode_tcp_flags
 ingest = _INGEST.ingest
 parse_header = _INGEST.parse_header
@@ -275,6 +276,18 @@ class TestConvertRecord:
         assert e["start_time"] == 1775797200000
         assert e["end_time"] == 1775797260000
 
+    def test_native_output_keeps_enriched_flow_fields_without_ocsf_envelope(self):
+        e = convert_record_native(self._base())
+        assert e is not None
+        assert e["schema_mode"] == "native"
+        assert e["record_type"] == "network_activity"
+        assert e["provider"] == "AWS"
+        assert e["event_uid"]
+        assert e["src"]["ip"] == "10.0.0.1"
+        assert e["dst"]["ip"] == "10.0.0.2"
+        assert "class_uid" not in e
+        assert "metadata" not in e
+
 
 # ── Stream ingestion w/ header ───────────────────────────────────
 
@@ -312,6 +325,15 @@ class TestIngestStream:
         assert len(out) == 1
         assert "skipping line 1" in capsys.readouterr().err
 
+    def test_native_output_mode_emits_enriched_flows(self):
+        lines = ["5 111122223333 eni-abc 10.0.0.1 10.0.0.2 48123 22 6 12 1680 1775797200 1775797260 ACCEPT OK"]
+        out = list(ingest(lines, output_format="native"))
+        assert len(out) == 1
+        assert out[0]["schema_mode"] == "native"
+        assert out[0]["record_type"] == "network_activity"
+        assert out[0]["provider"] == "AWS"
+        assert "class_uid" not in out[0]
+
 
 # ── Golden fixture parity ────────────────────────────────────────
 
@@ -345,3 +367,8 @@ class TestGoldenFixture:
         events = _load_jsonl(OCSF)
         with_flags = [e for e in events if e["connection_info"].get("tcp_flags") == "SYN,ACK"]
         assert len(with_flags) >= 1
+
+    def test_native_golden_mode_keeps_expected_count(self):
+        produced = list(ingest(RAW.read_text().splitlines(), output_format="native"))
+        assert len(produced) == 5
+        assert all(event["schema_mode"] == "native" for event in produced)


### PR DESCRIPTION
## Summary
- add --output-format {ocsf,native} to ingest-vpc-flow-logs-ocsf
- route VPC flow conversion through a canonical internal model before rendering OCSF or native output
- extend the VPC flow skill contract and tests to prove native mode works cleanly with the existing lateral-movement pilot path

## Validation
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/ingestion/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py skills/detection/detect-lateral-movement/tests/test_detect.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py tests/integration/test_skill_validation_scripts.py -q -o addopts='\
- uv run ruff check skills/ingestion/ingest-vpc-flow-logs-ocsf/src/ingest.py skills/ingestion/ingest-vpc-flow-logs-ocsf/tests/test_ingest.py --config pyproject.toml
