### PR TITLE
feat: require skill approval and execution metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is loosely based on Keep a Changelog.
 - `ingest-google-workspace-login-ocsf` as the Google Workspace identity-audit ingestion skill, mapping verified Admin SDK Reports login audit events into OCSF Authentication (3002) and Account Change (3001) while preserving Workspace natural IDs and event parameters.
 - `detect-google-workspace-suspicious-login` as the first Google Workspace-native detection skill, emitting OCSF Detection Finding (2004) for provider-marked suspicious logins and repeated Workspace login failures followed by success, aligned to MITRE ATT&CK T1110 and T1078.
 - a phased native/OCSF pilot for `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, including explicit `--output-format {ocsf,native}` support, native/canonical-friendly test coverage, and MCP output-format selection for supported skills.
+- repo-wide skill frontmatter for `approval_model`, `execution_modes`, and `side_effects`, plus CI enforcement and MCP tool-surface hints so human-in-the-loop expectations are explicit instead of inferred.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The important rule is that the **skill code does not change between modes**. `SK
 
 For every shipped skill, the contract is:
 - exact input and output format
+- explicit `approval_model`, `execution_modes`, and `side_effects` frontmatter so agents know when to stop for human approval
 - explicit `Use when...` and `Do NOT use...`
 - official vendor docs only in `REFERENCES.md`
 - failure-safe behavior on malformed input and deprecated API shapes

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -8,6 +8,13 @@ The rule is simple:
 - write-capable skills run in tighter, separate execution boundaries
 - transport, storage, and audit controls are explicit, not assumed
 
+Each shipped `SKILL.md` now declares:
+- `approval_model`
+- `execution_modes`
+- `side_effects`
+
+Agents and wrappers should treat those fields as part of the runtime contract, not optional documentation.
+
 ## Modes
 
 | Mode | Best for | Isolation posture | Human approval |

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -31,6 +31,9 @@ Optional:
 - `name`
 - `description`
 - `license`
+- `approval_model`
+- `execution_modes`
+- `side_effects`
 
 Rules:
 
@@ -38,6 +41,29 @@ Rules:
 - `name` must be 64 characters or fewer
 - `description` must clearly state when the skill should be used
 - `description` must clearly state what the skill must not be used for
+- `approval_model` must be one of:
+  - `none`
+  - `dry_run_required`
+  - `human_required`
+- `execution_modes` must be a comma-separated subset of:
+  - `jit`
+  - `ci`
+  - `mcp`
+  - `persistent`
+- `side_effects` must be a comma-separated subset of:
+  - `none`
+  - `writes-cloud`
+  - `writes-identity`
+  - `writes-storage`
+  - `writes-database`
+  - `writes-audit`
+- `side_effects: none` must appear by itself, never combined with write scopes
+- read-only skills must set:
+  - `approval_model: none`
+  - `side_effects: none`
+- write-capable skills must set:
+  - `approval_model: human_required`
+  - one or more explicit write scopes in `side_effects`
 
 ## Required language
 
@@ -67,6 +93,7 @@ Examples:
 - deterministic output where practical
 - explicit input/output shape
 - defensive parsing on untrusted input
+- explicit human-in-the-loop and runtime-mode declaration in frontmatter so agents know when they must stop for approval
 
 ## Required validation and error handling
 
@@ -98,8 +125,10 @@ CI currently validates:
 - required files exist
 - `name` format is valid
 - `Use when` and `Do NOT use` are present
+- `approval_model`, `execution_modes`, and `side_effects` are present and valid
 - read-only skills do not use subprocess/shell execution
 - write-capable skills document and test dry-run behavior
+- write-capable skills explicitly require human approval
 - wildcard IAM / RBAC policy entries carry an explicit `WILDCARD_OK` justification
 
 The contract will expand over time, but new CI rules should only be added when the current tree already satisfies them.

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -24,6 +24,9 @@ class SkillSpec:
     capability: str
     skill_dir: Path
     entrypoint: Path | None
+    approval_model: str
+    execution_modes: tuple[str, ...]
+    side_effects: tuple[str, ...]
     input_formats: tuple[str, ...]
     output_formats: tuple[str, ...]
 
@@ -136,6 +139,9 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 capability=_derive_capability(skill_dir, metadata),
                 skill_dir=skill_dir,
                 entrypoint=_resolve_entrypoint(skill_dir),
+                approval_model=metadata.get("approval_model", ""),
+                execution_modes=_parse_modes(metadata.get("execution_modes")),
+                side_effects=_parse_modes(metadata.get("side_effects")),
                 input_formats=_parse_modes(metadata.get("input_formats")),
                 output_formats=_parse_modes(metadata.get("output_formats")),
             )
@@ -176,9 +182,14 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
 
 
 def tool_definition(skill: SkillSpec) -> dict[str, object]:
+    mode_list = ", ".join(skill.execution_modes) if skill.execution_modes else "unspecified"
+    effect_list = ", ".join(skill.side_effects) if skill.side_effects else "unspecified"
     tool: dict[str, object] = {
         "name": skill.name,
-        "description": skill.description,
+        "description": (
+            f"{skill.description} Approval model: {skill.approval_model or 'unspecified'}. "
+            f"Execution modes: {mode_list}. Side effects: {effect_list}."
+        ),
         "inputSchema": tool_input_schema(skill),
         "annotations": {
             "readOnlyHint": skill.read_only,

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -71,8 +71,14 @@ class TestToolDefinition:
         assert tool["annotations"]["readOnlyHint"] is True
         assert tool["inputSchema"]["properties"]["args"]["type"] == "array"
         assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["ocsf", "native"]
+        assert "Approval model: none." in tool["description"]
+        assert "Execution modes: jit, ci, mcp, persistent." in tool["description"]
+        assert "Side effects: none." in tool["description"]
         assert skill.input_formats == ("raw",)
         assert skill.output_formats == ("ocsf", "native")
+        assert skill.approval_model == "none"
+        assert skill.execution_modes == ("jit", "ci", "mcp", "persistent")
+        assert skill.side_effects == ("none",)
 
     def test_build_command_uses_fixed_entrypoint(self):
         skill = tool_map(REPO_ROOT)["detect-lateral-movement"]

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -12,6 +12,17 @@ NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
 URL_RE = re.compile(r"https://[^\s)>\"]+")
 
+APPROVAL_MODE_VALUES = {"none", "dry_run_required", "human_required"}
+EXECUTION_MODE_VALUES = {"jit", "ci", "mcp", "persistent"}
+SIDE_EFFECT_VALUES = {
+    "none",
+    "writes-cloud",
+    "writes-identity",
+    "writes-storage",
+    "writes-database",
+    "writes-audit",
+}
+
 ENTRYPOINT_CANDIDATES = (
     "src/ingest.py",
     "src/detect.py",
@@ -83,6 +94,18 @@ class SkillContract:
             return True
         return self.category == "remediation" or self.name.startswith(("remediate-", "sink-", "runner-"))
 
+    @property
+    def approval_model(self) -> str:
+        return self.frontmatter.get("approval_model", "")
+
+    @property
+    def execution_modes(self) -> tuple[str, ...]:
+        return parse_modes(self.frontmatter.get("execution_modes"))
+
+    @property
+    def side_effects(self) -> tuple[str, ...]:
+        return parse_modes(self.frontmatter.get("side_effects"))
+
 
 def iter_skill_dirs() -> list[Path]:
     return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
@@ -134,6 +157,12 @@ def parse_frontmatter(frontmatter: str) -> dict[str, str]:
         idx += 1
 
     return data
+
+
+def parse_modes(raw_value: str | None) -> tuple[str, ...]:
+    if not raw_value:
+        return ()
+    return tuple(part.strip() for part in raw_value.split(",") if part.strip())
 
 
 def resolve_entrypoint(skill_dir: Path) -> Path | None:

--- a/scripts/validate_safe_skill_bar.py
+++ b/scripts/validate_safe_skill_bar.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import sys
-from pathlib import Path
 
 from skill_validation_common import ROOT, SKILLS_ROOT, discover_skill_contracts
 
@@ -24,23 +23,12 @@ WILDCARD_PATTERNS = (
 POLICY_SUFFIXES = (".json", ".tf", ".yaml", ".yml")
 
 
-def is_write_skill(skill_dir: Path) -> bool:
-    category = skill_dir.parent.name
-    name = skill_dir.name
-    return (
-        category == "remediation"
-        or name.startswith("remediate-")
-        or name.startswith("sink-")
-        or name.startswith("runner-")
-    )
-
-
-def validate_read_only_no_subprocess(skill_dir: Path) -> list[str]:
+def validate_read_only_no_subprocess(skill) -> list[str]:
     errors: list[str] = []
-    if is_write_skill(skill_dir):
+    if skill.is_write_capable:
         return errors
 
-    for path in sorted((skill_dir / "src").rglob("*.py")):
+    for path in sorted((skill.skill_dir / "src").rglob("*.py")):
         text = path.read_text()
         for pattern in SUBPROCESS_PATTERNS:
             if pattern in text:
@@ -48,22 +36,28 @@ def validate_read_only_no_subprocess(skill_dir: Path) -> list[str]:
                 errors.append(
                     f"{rel}: read-only skill must not use subprocess/shell pattern `{pattern}`"
                 )
+    if skill.approval_model != "none":
+        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: read-only skill must keep approval_model `none`")
+    if skill.side_effects != ("none",):
+        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: read-only skill must keep side_effects `none`")
     return errors
 
 
-def validate_write_skill_dry_run(skill_dir: Path) -> list[str]:
+def validate_write_skill_dry_run(skill) -> list[str]:
     errors: list[str] = []
-    if not is_write_skill(skill_dir):
+    if not skill.is_write_capable:
         return errors
 
-    skill_md = (skill_dir / "SKILL.md").read_text().lower()
+    skill_md = (skill.skill_dir / "SKILL.md").read_text().lower()
     if "dry-run" not in skill_md and "dry_run" not in skill_md:
-        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must document dry-run in SKILL.md")
+        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: write-capable skill must document dry-run in SKILL.md")
 
-    tests_dir = skill_dir / "tests"
+    tests_dir = skill.skill_dir / "tests"
     test_text = "\n".join(path.read_text() for path in sorted(tests_dir.rglob("*.py")))
     if "dry_run" not in test_text and "--dry-run" not in test_text and "dry-run" not in test_text:
-        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must exercise dry-run in tests")
+        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: write-capable skill must exercise dry-run in tests")
+    if skill.approval_model != "human_required":
+        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: write-capable skill must require human approval")
 
     return errors
 
@@ -97,9 +91,8 @@ def validate_wildcards() -> list[str]:
 def main() -> int:
     errors: list[str] = []
     for skill in discover_skill_contracts():
-        skill_dir = skill.skill_dir
-        errors.extend(validate_read_only_no_subprocess(skill_dir))
-        errors.extend(validate_write_skill_dry_run(skill_dir))
+        errors.extend(validate_read_only_no_subprocess(skill))
+        errors.extend(validate_write_skill_dry_run(skill))
     errors.extend(validate_wildcards())
 
     if errors:

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import sys
 
-from skill_validation_common import NAME_RE, ROOT, discover_skill_contracts
+from skill_validation_common import (
+    APPROVAL_MODE_VALUES,
+    EXECUTION_MODE_VALUES,
+    NAME_RE,
+    ROOT,
+    SIDE_EFFECT_VALUES,
+    discover_skill_contracts,
+)
 
 
 def main() -> int:
@@ -17,11 +24,45 @@ def main() -> int:
             if not (skill.skill_dir / required).exists():
                 errors.append(f"{rel}: missing required path `{required}`")
 
+        for field in ("name", "description", "license", "approval_model", "execution_modes", "side_effects"):
+            if not skill.frontmatter.get(field):
+                errors.append(f"{rel}: frontmatter missing `{field}`")
+
         if not skill.name:
             errors.append(f"{rel}: frontmatter missing `name`")
         else:
             if not NAME_RE.fullmatch(skill.name):
                 errors.append(f"{rel}: invalid skill name `{skill.name}`")
+
+        if skill.approval_model and skill.approval_model not in APPROVAL_MODE_VALUES:
+            errors.append(f"{rel}: invalid approval_model `{skill.approval_model}`")
+
+        if skill.execution_modes:
+            unknown_modes = [mode for mode in skill.execution_modes if mode not in EXECUTION_MODE_VALUES]
+            if unknown_modes:
+                errors.append(f"{rel}: invalid execution_modes {unknown_modes}")
+        elif skill.frontmatter.get("execution_modes"):
+            errors.append(f"{rel}: execution_modes must not be empty")
+
+        if skill.side_effects:
+            unknown_effects = [effect for effect in skill.side_effects if effect not in SIDE_EFFECT_VALUES]
+            if unknown_effects:
+                errors.append(f"{rel}: invalid side_effects {unknown_effects}")
+            if "none" in skill.side_effects and skill.side_effects != ("none",):
+                errors.append(f"{rel}: side_effects `none` must not be combined with other values")
+        elif skill.frontmatter.get("side_effects"):
+            errors.append(f"{rel}: side_effects must not be empty")
+
+        if skill.is_write_capable:
+            if skill.approval_model != "human_required":
+                errors.append(f"{rel}: write-capable skills must set approval_model to `human_required`")
+            if not skill.side_effects or skill.side_effects == ("none",):
+                errors.append(f"{rel}: write-capable skills must declare concrete side_effects")
+        else:
+            if skill.approval_model and skill.approval_model != "none":
+                errors.append(f"{rel}: read-only skills must set approval_model to `none`")
+            if skill.side_effects and skill.side_effects != ("none",):
+                errors.append(f"{rel}: read-only skills must set side_effects to `none`")
 
         if "Use when" not in skill.skill_text:
             errors.append(f"{rel}: SKILL.md must include `Use when`")

--- a/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
+++ b/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
@@ -14,6 +14,9 @@ description: >-
   ingest-google-workspace-login-ocsf first. Do NOT use as a generic MFA
   detector or for non-Workspace identity sources.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-google-workspace-suspicious-login

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -18,6 +18,9 @@ description: >-
   use for pre-compromise detection. Do NOT use as an exfiltration
   detector — public internet destinations are deliberately filtered out.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: ocsf, native
 metadata:

--- a/skills/detection/detect-mcp-tool-drift/SKILL.md
+++ b/skills/detection/detect-mcp-tool-drift/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   attack; a separate detector will cover it. Do NOT use as a compliance check;
   this is an active detection skill.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # detect-mcp-tool-drift

--- a/skills/detection/detect-okta-mfa-fatigue/SKILL.md
+++ b/skills/detection/detect-okta-mfa-fatigue/SKILL.md
@@ -12,6 +12,9 @@ description: >-
   through ingest-okta-system-log-ocsf first. Do NOT use as a generic failed-logon
   detector or credential-stuffing rule.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-okta-mfa-fatigue

--- a/skills/detection/detect-privilege-escalation-k8s/SKILL.md
+++ b/skills/detection/detect-privilege-escalation-k8s/SKILL.md
@@ -18,6 +18,9 @@ description: >-
   own detectors — roadmap). Do NOT use as a compliance check; this is an
   active detection skill that emits findings on observed behaviour.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # detect-privilege-escalation-k8s

--- a/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
+++ b/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
@@ -18,6 +18,9 @@ description: >-
   NOT use for cross-namespace analysis — that's a separate detector on the
   roadmap.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # detect-sensitive-secret-read-k8s

--- a/skills/discovery/discover-ai-bom/SKILL.md
+++ b/skills/discovery/discover-ai-bom/SKILL.md
@@ -12,6 +12,9 @@ description: >-
   Do NOT use as a live monitor or to claim compliance by itself — it produces a
   point-in-time inventory artifact and never mutates cloud state.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs required when inventory snapshots are
   already exported. Read-only — validates and normalizes inventory into a

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -12,6 +12,9 @@ description: >-
   certification tool, or remediation planner. Do NOT use on raw logs or OCSF
   findings.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. Read-only. Accepts raw cloud inventory JSON from
   stdin or a file path. Produces deterministic JSON evidence suitable for CLI,

--- a/skills/discovery/discover-control-evidence/SKILL.md
+++ b/skills/discovery/discover-control-evidence/SKILL.md
@@ -13,6 +13,9 @@ description: >-
   benchmark evaluator, or remediation planner. Do NOT use on raw logs or
   findings — this skill expects inventory artifacts, not events.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. Read-only. Accepts discovery-layer JSON from stdin or
   a file path. Produces deterministic JSON evidence suitable for CLI, CI, MCP,

--- a/skills/discovery/discover-environment/SKILL.md
+++ b/skills/discovery/discover-environment/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   ocsf-cloud-resources-inventory` wraps the snapshot as OCSF Discovery / Cloud
   Resources Inventory Info [5023] while preserving the graph under `unmapped`.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. Cloud discovery needs respective SDKs (boto3 for AWS,
   google-cloud-* for GCP, azure-* for Azure). Static config mode needs no SDKs.

--- a/skills/evaluation/container-security/SKILL.md
+++ b/skills/evaluation/container-security/SKILL.md
@@ -11,6 +11,9 @@ description: >-
   for Kubernetes cluster posture (use k8s-security-benchmark) or GPU runtime
   isolation (use gpu-cluster-security).
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No Docker daemon needed — works with config files.
   Optional: PyYAML for YAML parsing. Read-only — no image pulls or execution.

--- a/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
@@ -10,6 +10,9 @@ description: >-
   with iam-departures-remediation for IAM cleanup, or open a ticket in your remediation
   workflow for other findings.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+, boto3, and AWS credentials with SecurityAudit managed policy
   (read-only). No write permissions needed — assessment only.

--- a/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
@@ -9,6 +9,9 @@ description: >-
   claim full CIS Azure coverage — only 6 controls are implemented, see the Roadmap
   section in this file for the gap.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+, azure-identity, azure-mgmt-storage, azure-mgmt-network.
   Service principal needs Reader role. No write permissions — assessment only.

--- a/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
@@ -9,6 +9,9 @@ description: >-
   claim full CIS GCP coverage — only 7 controls are implemented, see the Roadmap
   section in this file for the gap.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-compute.
   Service account needs roles/viewer + roles/iam.securityReviewer.

--- a/skills/evaluation/gpu-cluster-security/SKILL.md
+++ b/skills/evaluation/gpu-cluster-security/SKILL.md
@@ -13,6 +13,9 @@ description: >-
   for general K8s posture (use k8s-security-benchmark) or model serving endpoint
   hardening (use model-serving-security).
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files
   (JSON/YAML). Optional: PyYAML for YAML parsing. Read-only — no write permissions,

--- a/skills/evaluation/k8s-security-benchmark/SKILL.md
+++ b/skills/evaluation/k8s-security-benchmark/SKILL.md
@@ -12,6 +12,9 @@ description: >-
   and never calls write APIs). Do NOT use against a cluster you do not own or
   have explicit authorisation to scan.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with exported JSON/YAML.
   Optional: kubectl for live cluster dumps. Read-only — no write permissions.

--- a/skills/evaluation/model-serving-security/SKILL.md
+++ b/skills/evaluation/model-serving-security/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   of prompt injection inside live traffic (a future detect-prompt-injection skill
   will cover that). Do NOT use for GPU cluster posture (use gpu-cluster-security).
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files.
   Optional: PyYAML for YAML config parsing. Read-only — no write permissions,

--- a/skills/ingestion/ingest-azure-activity-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-azure-activity-ocsf/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   diagnostic / metric logs — those are different pipelines. Do NOT use as a
   detection skill — this only normalises events.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-azure-activity-ocsf

--- a/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/SKILL.md
@@ -10,6 +10,9 @@ description: >-
   detector; Defender already produced the alert and this skill only
   validates and normalizes it.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-azure-defender-for-cloud-ocsf

--- a/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
@@ -14,6 +14,9 @@ description: >-
   ingest-k8s-audit-ocsf). Do NOT use as a detection skill — this skill only
   normalises events, it does not flag anything.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 input_formats: raw
 output_formats: ocsf, native
 ---

--- a/skills/ingestion/ingest-entra-directory-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-entra-directory-audit-ocsf/SKILL.md
@@ -12,6 +12,9 @@ description: >-
   Azure Activity Logs, or as a detector or policy engine — this skill only
   normalizes verified Microsoft Graph directoryAudit payloads.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No Graph SDK required when directoryAudit payloads are
   already exported. Read-only — validates raw Entra audit shape and emits OCSF

--- a/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   or Kubernetes audit logs (use ingest-k8s-audit-ocsf). Do NOT use as a
   detection skill — this only normalises events.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-gcp-audit-ocsf

--- a/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
@@ -10,6 +10,9 @@ description: >-
   benchmark output. Do NOT use as a detector; SCC already produced the
   finding and this skill only validates and normalizes it.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-gcp-scc-ocsf

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
@@ -13,6 +13,9 @@ description: >-
   Cloud Audit Logs, Okta System Log, or as a detector or policy engine — this
   skill only normalizes verified Workspace login audit payloads.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No Google SDK required when Admin SDK Reports payloads
   are already exported. Read-only — validates raw Workspace audit shape and

--- a/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   ingest-vpc-flow-logs-ocsf). Do NOT use as a detection skill — GuardDuty IS
   the detector; this skill is a passthrough normaliser.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-guardduty-ocsf

--- a/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
@@ -17,6 +17,9 @@ description: >-
   matching ingest-* skills). Do NOT use as a detection skill — this only
   normalises events.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-k8s-audit-ocsf

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
@@ -12,6 +12,9 @@ description: >-
   / ingest-azure-activity-ocsf / ingest-k8s-audit-ocsf respectively). Do NOT use as a
   detection skill — this skill only normalises, it does not flag anything.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-mcp-proxy-ocsf

--- a/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/SKILL.md
@@ -9,6 +9,9 @@ description: >-
   for correlation, detection, or storage. Do NOT use on Azure Activity
   Logs or Defender alerts. Do NOT use on AWS or GCP flow-log formats.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-nsg-flow-logs-azure-ocsf

--- a/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
@@ -14,6 +14,9 @@ description: >-
   Google Workspace, or AWS IAM logs. Do NOT use as a detector or policy engine
   — this skill only normalizes verified Okta event payloads into OCSF.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 compatibility: >-
   Requires Python 3.11+. No Okta SDK required when System Log payloads are
   already exported. Read-only — validates raw Okta event shape and emits OCSF

--- a/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
@@ -18,6 +18,9 @@ description: >-
   aggregates detections from upstream products; this skill is a passthrough
   normaliser/validator.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-security-hub-ocsf

--- a/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/SKILL.md
@@ -10,6 +10,9 @@ description: >-
   rendering. Do NOT use on firewall rule logs, packet mirroring, or raw
   pcap. Do NOT use when the source is AWS or Azure network telemetry.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # ingest-vpc-flow-logs-gcp-ocsf

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
@@ -16,6 +16,9 @@ description: >-
   (use ingest-cloudtrail-ocsf). Do NOT use as a
   detection skill — this only normalises network flows.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 input_formats: raw
 output_formats: ocsf, native
 ---

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   are closed-loop guarantees that must not be broken. Do NOT use for access
   provisioning; this skill only deactivates and deletes.
 license: Apache-2.0
+approval_model: human_required
+execution_modes: jit, persistent
+side_effects: writes-identity, writes-storage, writes-database, writes-audit
 compatibility: >-
   Requires AWS CLI, Python 3.11+, and boto3. Lambdas deploy to AWS. HR data
   source requires one of: Snowflake connector, Databricks SQL connector,

--- a/skills/view/convert-ocsf-to-mermaid-attack-flow/SKILL.md
+++ b/skills/view/convert-ocsf-to-mermaid-attack-flow/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   (class_uid != 2004) — those don't have the MITRE / actor / target
   structure this skill expects.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # convert-ocsf-to-mermaid-attack-flow

--- a/skills/view/convert-ocsf-to-sarif/SKILL.md
+++ b/skills/view/convert-ocsf-to-sarif/SKILL.md
@@ -15,6 +15,9 @@ description: >-
   convert-ocsf-compliance-to-sarif will cover those. Do NOT use as a
   detection skill — this only converts.
 license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
 ---
 
 # convert-ocsf-to-sarif

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -70,6 +70,9 @@ class TestSkillValidationCommon:
         ingest = next(skill for skill in skills if skill.name == "ingest-cloudtrail-ocsf")
         assert ingest.entrypoint is not None
         assert ingest.entrypoint.name == "ingest.py"
+        assert ingest.approval_model == "none"
+        assert ingest.execution_modes == ("jit", "ci", "mcp", "persistent")
+        assert ingest.side_effects == ("none",)
 
     def test_reference_policy_accepts_known_official_hosts(self):
         assert COMMON.reference_url_allowed("https://docs.aws.amazon.com/IAM/latest/APIReference/")
@@ -116,3 +119,10 @@ class TestValidationScripts:
         assert "service-accounts" in skill["asset_classes"]
         assert "service-principals" in skill["asset_classes"]
         assert "managed-identities" in skill["asset_classes"]
+
+    def test_remediation_skill_declares_human_approval(self):
+        skills = {skill.name: skill for skill in COMMON.discover_skill_contracts()}
+        remediation = skills["iam-departures-remediation"]
+        assert remediation.approval_model == "human_required"
+        assert remediation.execution_modes == ("jit", "persistent")
+        assert "writes-identity" in remediation.side_effects


### PR DESCRIPTION
## Summary
- require approval_model, execution_modes, and side_effects in every shipped SKILL.md
- enforce those fields in the skill contract and safe-skill validators
- surface approval/runtime metadata in the MCP tool descriptions so agents can see when human approval is required

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_skill_integrity.py
- uv run pytest tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py -q -o addopts='\
- uv run ruff check scripts/skill_validation_common.py scripts/validate_skill_contract.py scripts/validate_safe_skill_bar.py mcp-server/src/tool_registry.py tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py --config pyproject.toml
