### PR TITLE
docs: tighten schema contract and rollout guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is loosely based on Keep a Changelog.
 - `detect-google-workspace-suspicious-login` as the first Google Workspace-native detection skill, emitting OCSF Detection Finding (2004) for provider-marked suspicious logins and repeated Workspace login failures followed by success, aligned to MITRE ATT&CK T1110 and T1078.
 - a phased native/OCSF pilot for `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, including explicit `--output-format {ocsf,native}` support, native/canonical-friendly test coverage, and MCP output-format selection for supported skills.
 - repo-wide skill frontmatter for `approval_model`, `execution_modes`, and `side_effects`, plus CI enforcement and MCP tool-surface hints so human-in-the-loop expectations are explicit instead of inferred.
+- `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed
 
@@ -29,6 +30,7 @@ The format is loosely based on Keep a Changelog.
 - Reframed the repo contract so OCSF remains a first-class interoperability option, but not a mandatory storage or execution model; the stable internal contract is now explicitly source truth -> canonical model -> `native` / `ocsf` / `bridge` output.
 - Made the OCSF metadata validator format-aware so native-mode support does not weaken the OCSF path contract.
 - Extended the native/OCSF pilot to `ingest-vpc-flow-logs-ocsf`, so AWS flow logs can now emit either OCSF Network Activity or the repo's canonical native network-flow shape while preserving a compatible end-to-end lateral-movement path.
+- Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
 ### Added
 - Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - Runtime isolation and trust boundaries: [docs/RUNTIME_ISOLATION.md](docs/RUNTIME_ISOLATION.md)
 - SIEM indexing and dedupe: [docs/SIEM_INDEX_GUIDE.md](docs/SIEM_INDEX_GUIDE.md)
 - Schema modes and interoperability: [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md)
+- Canonical schema and data flow: [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md) and [docs/DATA_FLOW.md](docs/DATA_FLOW.md)
 - Historical state and timeline handling: [docs/STATE_AND_TIMELINE_MODEL.md](docs/STATE_AND_TIMELINE_MODEL.md)
 - Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), and [docs/ROADMAP.md](docs/ROADMAP.md)
 
@@ -72,14 +73,27 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
 Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide): `SKILL.md`, `src/`, `tests/`, `REFERENCES.md`, explicit `Use when...`, and explicit `Do NOT use...`.
 
 **Schema mode note**
-- the repo supports `native`, `canonical`, `ocsf`, and `bridge` modes
-- `ingest`, `detect`, `evaluate`, and `view` remain OCSF-friendly, but OCSF is optional rather than mandatory
-- `discovery` prefers native OCSF inventory/evidence classes and profiles when they fit, and otherwise uses deterministic native or bridge artifacts
-- `discover-environment` supports an `ocsf-cloud-resources-inventory` bridge mode
-- discovery evidence skills support an `ocsf-live-evidence` bridge mode for Discovery-category OCSF workflows
-- the stable repo contract is now: preserve source truth, normalize into a canonical internal model, then emit `native`, `ocsf`, or `bridge` output as appropriate
+- the repo contract supports `native`, `canonical`, `ocsf`, and `bridge` modes
+- OCSF is a first-class interoperability option, not a mandatory storage format
+- the stable repo contract is: preserve source truth, normalize into a canonical internal model, then emit `native`, `ocsf`, or `bridge` as appropriate
 
-See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design, [`docs/NATIVE_VS_OCSF.md`](docs/NATIVE_VS_OCSF.md) for schema-mode selection, [`docs/STATE_AND_TIMELINE_MODEL.md`](docs/STATE_AND_TIMELINE_MODEL.md) for historical-state handling, and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
+**Currently implemented**
+- dual-mode (`--output-format ocsf,native`):
+  - `ingest-cloudtrail-ocsf`
+  - `ingest-vpc-flow-logs-ocsf`
+  - `detect-lateral-movement`
+- native-first with optional bridge:
+  - `discover-environment`
+  - `discover-control-evidence`
+  - `discover-cloud-control-evidence`
+- OCSF-only today, with format metadata declared for rollout:
+  - the remaining ingestion and detection skills
+- native-only today:
+  - evaluation and view skills
+
+`-ocsf` in a skill name means OCSF is the default wire format, not necessarily the only supported mode.
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design, [`docs/NATIVE_VS_OCSF.md`](docs/NATIVE_VS_OCSF.md) for schema-mode selection, [`docs/CANONICAL_SCHEMA.md`](docs/CANONICAL_SCHEMA.md) for the repo-owned canonical contract, [`docs/DATA_FLOW.md`](docs/DATA_FLOW.md) for the end-to-end projection flow, [`docs/STATE_AND_TIMELINE_MODEL.md`](docs/STATE_AND_TIMELINE_MODEL.md) for historical-state handling, and [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) for the visual set.
 
 ## How it runs
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,8 @@ This document is the load-bearing design contract for `cloud-ai-security-skills`
 - **Runner / streaming contract** — see [`./RUNNER_CONTRACT.md`](./RUNNER_CONTRACT.md) *(lands with PR V)*
 - **Runtime isolation and trust boundaries** — see [`./RUNTIME_ISOLATION.md`](./RUNTIME_ISOLATION.md)
 - **SIEM indexing and dedupe guidance** — see [`./SIEM_INDEX_GUIDE.md`](./SIEM_INDEX_GUIDE.md)
+- **Canonical schema contract** — see [`./CANONICAL_SCHEMA.md`](./CANONICAL_SCHEMA.md)
+- **Raw → canonical → native / OCSF / bridge flow** — see [`./DATA_FLOW.md`](./DATA_FLOW.md)
 - **Visual guide** — see [`./DIAGRAMS.md`](./DIAGRAMS.md) for the architecture and data-flow diagrams in both markdown-native and SVG-friendly form
 
 ## 1. Purpose and scope
@@ -109,6 +111,8 @@ Most current ingest, detect, evaluate, view, and sink paths are still **OCSF-fri
 For the detailed contract, see:
 
 - [`NATIVE_VS_OCSF.md`](./NATIVE_VS_OCSF.md)
+- [`CANONICAL_SCHEMA.md`](./CANONICAL_SCHEMA.md)
+- [`DATA_FLOW.md`](./DATA_FLOW.md)
 - [`STATE_AND_TIMELINE_MODEL.md`](./STATE_AND_TIMELINE_MODEL.md)
 - [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
 

--- a/docs/CANONICAL_SCHEMA.md
+++ b/docs/CANONICAL_SCHEMA.md
@@ -1,0 +1,170 @@
+# Canonical Schema
+
+The repo must work with or without OCSF.
+
+That means the stable internal contract cannot be "whatever the current OCSF
+projection happens to look like." It must be a repo-owned canonical model.
+
+The canonical model is the layer between:
+
+- raw source payloads
+- native output
+- OCSF output
+- bridge output
+- persistent DB tables, views, indexes, and metrics
+
+## Rules
+
+1. Raw source truth is preserved.
+2. Canonical fields are stable and versioned.
+3. `native`, `ocsf`, and `bridge` are projections of canonical.
+4. Canonical changes are additive first, then deprecated, then removed.
+
+## Versioning
+
+Canonical payloads should carry:
+
+- `schema_mode: "canonical"`
+- `canonical_schema_version`
+
+Current repo-wide canonical schema version:
+
+- `2026-04`
+
+## Shared core fields
+
+These are the minimum fields every canonical record should preserve where the
+source makes them available:
+
+| Field | Meaning |
+|---|---|
+| `record_type` | repo-owned semantic kind such as `api_activity`, `network_activity`, `detection_finding`, `inventory`, `evidence` |
+| `event_uid` or `finding_uid` | deterministic stable identity for replay, dedupe, and joins |
+| `provider` | source provider or vendor |
+| `tenant_uid` / `account_uid` | tenant, org, subscription, or account key |
+| `region` | cloud or locality context when applicable |
+| `event_time_ms` / `time_ms` | primary event timestamp in UTC epoch-ms |
+| `observed_time_ms` | when the source says the record was observed, if different |
+| `ingested_time_ms` | when the repo ingested the record, if materialized later |
+| `actor_uid` / `actor_name` | principal identity |
+| `session_uid` | stable session or correlation identity |
+| `resource_uid` | primary resource identity |
+| `status` / `status_id` | normalized success/failure/unknown or equivalent |
+| `last_seen_time_ms` | materialized state / inventory last-seen time |
+| `is_active` / `presence_state` | current-state and tombstone semantics |
+
+## Layer-specific canonical shapes
+
+### Ingestion
+
+Input:
+- `raw`
+
+Canonical output:
+- stable provider/account/actor/resource/session/time fields
+- source-specific detail preserved under structured canonical keys
+
+Examples:
+- `api_activity`
+- `network_activity`
+- `application_activity`
+- `authentication`
+- `account_change`
+
+### Detection
+
+Input:
+- `canonical`
+- optionally `ocsf`
+- optionally documented `native`
+
+Canonical detection output:
+- `record_type: "detection_finding"`
+- deterministic `finding_uid`
+- ATT&CK / ATLAS mappings
+- severity
+- normalized evidence / observables
+
+### Evaluation
+
+Input:
+- `raw`
+- optionally `canonical`
+- optionally `ocsf`
+
+Canonical evaluation output:
+- `record_type: "evaluation_result"`
+- benchmark/control identifier
+- status
+- evidence references
+
+### Discovery
+
+Input:
+- `raw`
+- `canonical`
+
+Canonical discovery output:
+- `record_type: "inventory"` or `record_type: "evidence"`
+- stable entity keys
+- lifecycle state
+- last-seen / deactivated semantics
+
+### View
+
+Input:
+- usually `ocsf`
+- sometimes `canonical`
+
+Output:
+- repo-native delivery artifact such as SARIF, Mermaid, dashboards, or reports
+
+### Remediation
+
+Input:
+- `raw`
+- `canonical`
+
+Canonical remediation output:
+- action plan or action result
+- stable target IDs
+- approval status
+- audit references
+
+## Relationship to OCSF
+
+OCSF is a projection target, not the canonical storage model.
+
+Use OCSF when:
+
+- a shared wire format is useful
+- a SIEM or lake expects OCSF
+- cross-vendor detection benefits from standard fields
+
+Do not force OCSF when:
+
+- native source fidelity matters more
+- the payload is inventory/evidence/BOM-shaped and OCSF is a poor fit
+- a bridge mode preserves more useful detail
+
+## Relationship to persistence
+
+Persistent stores should prefer canonical fields for:
+
+- tables
+- views
+- indexes
+- metrics
+- lifecycle state
+
+That avoids breaking DB schemas every time an output format changes.
+
+## Current implementation note
+
+The canonical model is fully piloted today in:
+
+- `ingest-cloudtrail-ocsf`
+- `ingest-vpc-flow-logs-ocsf`
+- `detect-lateral-movement`
+
+The rest of the repo is being rolled into the same pattern skill-by-skill.

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1,0 +1,55 @@
+# Data Flow
+
+This repo supports raw-source fidelity, a stable canonical model, and optional
+OCSF interoperability.
+
+```mermaid
+flowchart LR
+    RAW["Raw vendor payload\nCloudTrail / VPC Flow / Okta / Entra / Workspace / K8s"]
+    INGEST["Ingest skill"]
+    CANON["Canonical internal model\nstable, versioned, repo-owned"]
+    NATIVE["native output\nsource-aware enriched JSON"]
+    OCSF["ocsf output\nOCSF 1.8 class/profile/extension"]
+    BRIDGE["bridge output\nOCSF + native detail under unmapped.*"]
+    DETECT["Detect / Evaluate / Discover / View / Remediate"]
+    STORE["DB / lake / views / metrics\nprefer canonical keys"]
+
+    RAW --> INGEST
+    INGEST --> CANON
+    CANON --> NATIVE
+    CANON --> OCSF
+    CANON --> BRIDGE
+    CANON --> DETECT
+    NATIVE --> DETECT
+    OCSF --> DETECT
+    BRIDGE --> DETECT
+    CANON --> STORE
+```
+
+## Layer view
+
+| Layer | Typical input | Canonical role | Typical output |
+|---|---|---|---|
+| Ingestion | raw | normalize source truth | native, ocsf, bridge |
+| Discovery | raw, canonical | inventory / evidence / BOM | native, bridge |
+| Detection | canonical, ocsf, documented native | finding correlation | native or ocsf |
+| Evaluation | raw, canonical, ocsf | control / benchmark result | native |
+| View | canonical or ocsf | delivery conversion | native artifact |
+| Remediation | raw, canonical | action planning / execution state | native audit/result |
+
+## Current rollout
+
+Fully dual-mode today:
+
+- `ingest-cloudtrail-ocsf`
+- `ingest-vpc-flow-logs-ocsf`
+- `detect-lateral-movement`
+
+Native-first with optional bridge today:
+
+- `discover-environment`
+- `discover-control-evidence`
+- `discover-cloud-control-evidence`
+
+Everything else declares its supported formats explicitly and can be rolled into
+the same canonical projection pattern without changing the repo contract.

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -128,3 +128,22 @@ The repo can support all three operational styles:
 - **OCSF-first** for interoperability, SIEMs, and shared pipelines
 
 The correct choice depends on the skill and the downstream consumer, not on ideology.
+
+## Current rollout status
+
+Implemented dual-mode skills today:
+
+- `ingest-cloudtrail-ocsf`
+- `ingest-vpc-flow-logs-ocsf`
+- `detect-lateral-movement`
+
+Implemented native-first with bridge skills today:
+
+- `discover-environment`
+- `discover-control-evidence`
+- `discover-cloud-control-evidence`
+
+The remaining skills now declare their supported `input_formats` and
+`output_formats` explicitly in `SKILL.md`, even where only one format is
+implemented today. That keeps the contract honest while the rollout continues
+skill-by-skill.

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -34,6 +34,8 @@ Optional:
 - `approval_model`
 - `execution_modes`
 - `side_effects`
+- `input_formats`
+- `output_formats`
 
 Rules:
 
@@ -64,6 +66,16 @@ Rules:
 - write-capable skills must set:
   - `approval_model: human_required`
   - one or more explicit write scopes in `side_effects`
+- `input_formats` must be a comma-separated subset of:
+  - `raw`
+  - `canonical`
+  - `native`
+  - `ocsf`
+- `output_formats` must be a comma-separated subset of:
+  - `native`
+  - `ocsf`
+  - `bridge`
+- every skill must declare the formats it supports today, even if only one mode is implemented
 
 ## Required language
 
@@ -126,6 +138,7 @@ CI currently validates:
 - `name` format is valid
 - `Use when` and `Do NOT use` are present
 - `approval_model`, `execution_modes`, and `side_effects` are present and valid
+- `input_formats` and `output_formats` are present and valid
 - read-only skills do not use subprocess/shell execution
 - write-capable skills document and test dry-run behavior
 - write-capable skills explicitly require human approval

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -22,6 +22,8 @@ SIDE_EFFECT_VALUES = {
     "writes-database",
     "writes-audit",
 }
+INPUT_FORMAT_VALUES = {"raw", "canonical", "native", "ocsf"}
+OUTPUT_FORMAT_VALUES = {"native", "ocsf", "bridge"}
 
 ENTRYPOINT_CANDIDATES = (
     "src/ingest.py",

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -5,7 +5,9 @@ import sys
 from skill_validation_common import (
     APPROVAL_MODE_VALUES,
     EXECUTION_MODE_VALUES,
+    INPUT_FORMAT_VALUES,
     NAME_RE,
+    OUTPUT_FORMAT_VALUES,
     ROOT,
     SIDE_EFFECT_VALUES,
     discover_skill_contracts,
@@ -24,7 +26,16 @@ def main() -> int:
             if not (skill.skill_dir / required).exists():
                 errors.append(f"{rel}: missing required path `{required}`")
 
-        for field in ("name", "description", "license", "approval_model", "execution_modes", "side_effects"):
+        for field in (
+            "name",
+            "description",
+            "license",
+            "approval_model",
+            "execution_modes",
+            "side_effects",
+            "input_formats",
+            "output_formats",
+        ):
             if not skill.frontmatter.get(field):
                 errors.append(f"{rel}: frontmatter missing `{field}`")
 
@@ -52,6 +63,28 @@ def main() -> int:
                 errors.append(f"{rel}: side_effects `none` must not be combined with other values")
         elif skill.frontmatter.get("side_effects"):
             errors.append(f"{rel}: side_effects must not be empty")
+
+        input_formats = skill.frontmatter.get("input_formats")
+        parsed_input_formats = tuple(
+            part.strip() for part in input_formats.split(",") if part.strip()
+        ) if input_formats else ()
+        if parsed_input_formats:
+            unknown_input_formats = [mode for mode in parsed_input_formats if mode not in INPUT_FORMAT_VALUES]
+            if unknown_input_formats:
+                errors.append(f"{rel}: invalid input_formats {unknown_input_formats}")
+        elif input_formats:
+            errors.append(f"{rel}: input_formats must not be empty")
+
+        output_formats = skill.frontmatter.get("output_formats")
+        parsed_output_formats = tuple(
+            part.strip() for part in output_formats.split(",") if part.strip()
+        ) if output_formats else ()
+        if parsed_output_formats:
+            unknown_output_formats = [mode for mode in parsed_output_formats if mode not in OUTPUT_FORMAT_VALUES]
+            if unknown_output_formats:
+                errors.append(f"{rel}: invalid output_formats {unknown_output_formats}")
+        elif output_formats:
+            errors.append(f"{rel}: output_formats must not be empty")
 
         if skill.is_write_capable:
             if skill.approval_model != "human_required":

--- a/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
+++ b/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
@@ -17,6 +17,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: ocsf
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-google-workspace-suspicious-login

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -107,6 +107,23 @@ The purpose of this rule is **east-west detection**. Egress to the public intern
 
 By default, the skill emits OCSF 1.8 Detection Finding (class `2004`). When `--output-format native` is selected, it emits the repo's native detection-finding shape with the same deterministic IDs and ATT&CK mappings.
 
+## Native output format
+
+`--output-format native` returns one JSON object per finding with:
+
+- `schema_mode: "native"`
+- `record_type: "detection_finding"`
+- `finding_uid`
+- `rule_id`, `title`, `description`
+- `severity_id`, `severity`
+- `provider`, `account_uid`, `session_uid`
+- `attacks`
+- `observables`
+- `evidence`
+
+The native finding preserves the same correlation result and deterministic
+identity as the OCSF projection while omitting the OCSF 2004 wrapper fields.
+
 The output includes:
 
 - `finding_info.attacks[]` — two techniques populated per MITRE v14:

--- a/skills/detection/detect-mcp-tool-drift/SKILL.md
+++ b/skills/detection/detect-mcp-tool-drift/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: ocsf
 ---
 
 # detect-mcp-tool-drift

--- a/skills/detection/detect-okta-mfa-fatigue/SKILL.md
+++ b/skills/detection/detect-okta-mfa-fatigue/SKILL.md
@@ -15,6 +15,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: ocsf
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-okta-mfa-fatigue

--- a/skills/detection/detect-privilege-escalation-k8s/SKILL.md
+++ b/skills/detection/detect-privilege-escalation-k8s/SKILL.md
@@ -21,6 +21,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: ocsf
 ---
 
 # detect-privilege-escalation-k8s

--- a/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
+++ b/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
@@ -21,6 +21,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: ocsf
 ---
 
 # detect-sensitive-secret-read-k8s

--- a/skills/discovery/discover-ai-bom/SKILL.md
+++ b/skills/discovery/discover-ai-bom/SKILL.md
@@ -15,6 +15,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw, canonical
+output_formats: native
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs required when inventory snapshots are
   already exported. Read-only — validates and normalizes inventory into a

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -15,6 +15,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw, canonical
+output_formats: native, bridge
 compatibility: >-
   Requires Python 3.11+. Read-only. Accepts raw cloud inventory JSON from
   stdin or a file path. Produces deterministic JSON evidence suitable for CLI,

--- a/skills/discovery/discover-control-evidence/SKILL.md
+++ b/skills/discovery/discover-control-evidence/SKILL.md
@@ -16,6 +16,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: canonical
+output_formats: native, bridge
 compatibility: >-
   Requires Python 3.11+. Read-only. Accepts discovery-layer JSON from stdin or
   a file path. Produces deterministic JSON evidence suitable for CLI, CI, MCP,

--- a/skills/discovery/discover-environment/SKILL.md
+++ b/skills/discovery/discover-environment/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native, bridge
 compatibility: >-
   Requires Python 3.11+. Cloud discovery needs respective SDKs (boto3 for AWS,
   google-cloud-* for GCP, azure-* for Azure). Static config mode needs no SDKs.

--- a/skills/evaluation/container-security/SKILL.md
+++ b/skills/evaluation/container-security/SKILL.md
@@ -14,6 +14,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+. No Docker daemon needed — works with config files.
   Optional: PyYAML for YAML parsing. Read-only — no image pulls or execution.

--- a/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
@@ -13,6 +13,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+, boto3, and AWS credentials with SecurityAudit managed policy
   (read-only). No write permissions needed — assessment only.

--- a/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
@@ -12,6 +12,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+, azure-identity, azure-mgmt-storage, azure-mgmt-network.
   Service principal needs Reader role. No write permissions — assessment only.

--- a/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
@@ -12,6 +12,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-compute.
   Service account needs roles/viewer + roles/iam.securityReviewer.

--- a/skills/evaluation/gpu-cluster-security/SKILL.md
+++ b/skills/evaluation/gpu-cluster-security/SKILL.md
@@ -16,6 +16,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files
   (JSON/YAML). Optional: PyYAML for YAML parsing. Read-only — no write permissions,

--- a/skills/evaluation/k8s-security-benchmark/SKILL.md
+++ b/skills/evaluation/k8s-security-benchmark/SKILL.md
@@ -15,6 +15,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with exported JSON/YAML.
   Optional: kubectl for live cluster dumps. Read-only — no write permissions.

--- a/skills/evaluation/model-serving-security/SKILL.md
+++ b/skills/evaluation/model-serving-security/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: native
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files.
   Optional: PyYAML for YAML config parsing. Read-only — no write permissions,

--- a/skills/ingestion/ingest-azure-activity-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-azure-activity-ocsf/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-azure-activity-ocsf

--- a/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/SKILL.md
@@ -13,6 +13,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-azure-defender-for-cloud-ocsf

--- a/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
@@ -38,6 +38,23 @@ By default it writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid
 
 When `--output-format native` is selected, it emits the same event in the repo's native enriched shape with stable `event_uid`, normalized provider/account/operation/status fields, and preserved actor/session/source context, but without the OCSF envelope fields.
 
+## Native output format
+
+`--output-format native` returns one JSON object per event with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "api_activity"`
+- `event_uid`
+- `provider`, `account_uid`, `region`
+- `time_ms`
+- `activity_id`, `activity_name`
+- `status_id`, `status`, `status_detail`
+- `actor`, `api`, `src`, `cloud`, and `resources`
+
+The native shape keeps the same normalized semantics as the OCSF projection,
+but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
+
 ## activity_id inference
 
 CloudTrail doesn't tell you whether an event is a Create / Read / Update / Delete — you have to infer from the verb in `eventName`. The skill uses a deterministic prefix table:

--- a/skills/ingestion/ingest-entra-directory-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-entra-directory-audit-ocsf/SKILL.md
@@ -15,6 +15,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 compatibility: >-
   Requires Python 3.11+. No Graph SDK required when directoryAudit payloads are
   already exported. Read-only — validates raw Entra audit shape and emits OCSF

--- a/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-gcp-audit-ocsf

--- a/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
@@ -13,6 +13,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-gcp-scc-ocsf

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
@@ -16,6 +16,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 compatibility: >-
   Requires Python 3.11+. No Google SDK required when Admin SDK Reports payloads
   are already exported. Read-only — validates raw Workspace audit shape and

--- a/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-guardduty-ocsf

--- a/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
@@ -20,6 +20,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-k8s-audit-ocsf

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
@@ -15,6 +15,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-mcp-proxy-ocsf

--- a/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/SKILL.md
@@ -12,6 +12,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-nsg-flow-logs-azure-ocsf

--- a/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
@@ -17,6 +17,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 compatibility: >-
   Requires Python 3.11+. No Okta SDK required when System Log payloads are
   already exported. Read-only — validates raw Okta event shape and emits OCSF

--- a/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
@@ -21,6 +21,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-security-hub-ocsf

--- a/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/SKILL.md
@@ -13,6 +13,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: raw
+output_formats: ocsf
 ---
 
 # ingest-vpc-flow-logs-gcp-ocsf

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
@@ -41,6 +41,24 @@ By default it writes OCSF 1.8 **Network Activity** (`class_uid: 4001`, `category
 
 When `--output-format native` is selected, it emits the same flow in the repo's native enriched shape with stable `event_uid`, normalized source/destination, byte counters, protocol/direction, and AWS scope fields, but without the OCSF envelope.
 
+## Native output format
+
+`--output-format native` returns one JSON object per flow with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "network_activity"`
+- `event_uid`
+- `provider`, `account_uid`, `region`
+- `time_ms`, `start_time_ms`, `end_time_ms`
+- `activity_id`, `activity_name`
+- `status_id`, `status`
+- `src`, `dst`, `traffic`, `connection`, `cloud`, and `source`
+
+The native shape preserves the same normalized network semantics as the OCSF
+projection while omitting the OCSF envelope fields such as `class_uid`,
+`category_uid`, `type_uid`, and `metadata.product`.
+
 ## activity_id mapping
 
 VPC Flow Logs have an `action` field with two values: `ACCEPT` and `REJECT`. OCSF Network Activity activity ids map as:

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: human_required
 execution_modes: jit, persistent
 side_effects: writes-identity, writes-storage, writes-database, writes-audit
+input_formats: raw, canonical
+output_formats: native
 compatibility: >-
   Requires AWS CLI, Python 3.11+, and boto3. Lambdas deploy to AWS. HR data
   source requires one of: Snowflake connector, Databricks SQL connector,

--- a/skills/view/convert-ocsf-to-mermaid-attack-flow/SKILL.md
+++ b/skills/view/convert-ocsf-to-mermaid-attack-flow/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: native
 ---
 
 # convert-ocsf-to-mermaid-attack-flow

--- a/skills/view/convert-ocsf-to-sarif/SKILL.md
+++ b/skills/view/convert-ocsf-to-sarif/SKILL.md
@@ -18,6 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
+input_formats: ocsf
+output_formats: native
 ---
 
 # convert-ocsf-to-sarif


### PR DESCRIPTION
## Summary
- make the README honest about current dual-mode rollout instead of implying OCSF-optional support is already universal
- add docs/CANONICAL_SCHEMA.md and docs/DATA_FLOW.md to define the repo-owned canonical contract and raw -> canonical -> native/ocsf/bridge flow
- require input_formats and output_formats on every shipped skill and document native output fields for the current dual-mode skills

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_safe_skill_bar.py
- uv run pytest tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py -q -o addopts='\
- uv run ruff check README.md docs/ARCHITECTURE.md docs/NATIVE_VS_OCSF.md docs/CANONICAL_SCHEMA.md docs/DATA_FLOW.md scripts/skill_validation_common.py scripts/validate_skill_contract.py docs/SKILL_CONTRACT.md tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py --config pyproject.toml
