### PR TITLE
feat: pilot native and ocsf k8s skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is loosely based on Keep a Changelog.
 - Reframed the repo contract so OCSF remains a first-class interoperability option, but not a mandatory storage or execution model; the stable internal contract is now explicitly source truth -> canonical model -> `native` / `ocsf` / `bridge` output.
 - Made the OCSF metadata validator format-aware so native-mode support does not weaken the OCSF path contract.
 - Extended the native/OCSF pilot to `ingest-vpc-flow-logs-ocsf`, so AWS flow logs can now emit either OCSF Network Activity or the repo's canonical native network-flow shape while preserving a compatible end-to-end lateral-movement path.
+- Extended the native/OCSF pilot to `ingest-k8s-audit-ocsf` and `detect-sensitive-secret-read-k8s`, so Kubernetes audit ingestion and one Kubernetes detector now support the same dual-mode rollout pattern as the earlier CloudTrail / VPC / lateral-movement pilots.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
 - dual-mode (`--output-format ocsf,native`):
   - `ingest-cloudtrail-ocsf`
   - `ingest-vpc-flow-logs-ocsf`
+  - `ingest-k8s-audit-ocsf`
   - `detect-lateral-movement`
+  - `detect-sensitive-secret-read-k8s`
 - native-first with optional bridge:
   - `discover-environment`
   - `discover-control-evidence`

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -135,7 +135,9 @@ Implemented dual-mode skills today:
 
 - `ingest-cloudtrail-ocsf`
 - `ingest-vpc-flow-logs-ocsf`
+- `ingest-k8s-audit-ocsf`
 - `detect-lateral-movement`
+- `detect-sensitive-secret-read-k8s`
 
 Implemented native-first with bridge skills today:
 

--- a/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
+++ b/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
@@ -21,8 +21,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
-input_formats: ocsf
-output_formats: ocsf
+input_formats: native, ocsf
+output_formats: native, ocsf
 ---
 
 # detect-sensitive-secret-read-k8s
@@ -68,13 +68,40 @@ The full pattern list lives in `src/detect.py` as the `SENSITIVE_NAME_PATTERNS` 
 
 ## Output contract
 
-One OCSF Detection Finding (class `2004`) per `(actor, namespace, secret_name)` match. Populates:
+One OCSF Detection Finding (class `2004`) per `(actor, namespace, secret_name)` match by default. Populates:
 
 - `finding_info.attacks[]` — MITRE ATT&CK v14, tactic TA0006 (Credential Access), technique T1552 (Unsecured Credentials), sub-technique T1552.007 (Container API)
 - `finding_info.types[]` — `["k8s-sensitive-secret-read"]`
 - `finding_info.uid` — deterministic (`det-k8s-secret-read-<actor-hash>-<secret-hash>`)
 - `observables[]` — actor.name, namespace, secret.name, matched_patterns
 - `severity_id` — 4 (High)
+
+## Native output format
+
+`--output-format native` emits one native detection-finding record per match with:
+
+- `schema_mode`
+- `record_type`
+- `finding_uid`
+- `event_uid`
+- `provider`
+- `time_ms`
+- `severity`
+- `severity_id`
+- `status`
+- `status_id`
+- `title`
+- `description`
+- `finding_types`
+- `first_seen_time_ms`
+- `last_seen_time_ms`
+- `mitre_attacks`
+- `actor_name`
+- `namespace`
+- `secret_name`
+- `matched_patterns`
+- `verb`
+- `rule_name`
 
 ## Usage
 
@@ -83,6 +110,11 @@ One OCSF Detection Finding (class `2004`) per `(actor, namespace, secret_name)` 
 python ../ingest-k8s-audit-ocsf/src/ingest.py audit.log \
   | python src/detect.py \
   > findings.ocsf.jsonl
+
+# Native end-to-end path
+python ../ingest-k8s-audit-ocsf/src/ingest.py --output-format native audit.log \
+  | python src/detect.py --output-format native \
+  > findings.native.jsonl
 
 # With custom patterns
 python ../ingest-k8s-audit-ocsf/src/ingest.py audit.log \

--- a/skills/detection/detect-sensitive-secret-read-k8s/src/detect.py
+++ b/skills/detection/detect-sensitive-secret-read-k8s/src/detect.py
@@ -1,9 +1,9 @@
 """Detect reads of Kubernetes Secrets matching sensitive name patterns.
 
-Reads OCSF 1.8 API Activity (class 6003) events produced by
-ingest-k8s-audit-ocsf and emits OCSF 1.8 Detection Finding (class 2004)
-for any `get` or `list` on a secret whose name matches at least one
-sensitive pattern.
+Reads OCSF 1.8 API Activity (class 6003) events or the native enriched
+Kubernetes activity shape produced by ingest-k8s-audit-ocsf and emits OCSF 1.8
+Detection Finding (class 2004) by default for any `get` or `list` on a secret
+whose name matches at least one sensitive pattern.
 
 Stateless pattern matcher — no window, no correlation required. Works on
 Metadata-level audit logs.
@@ -23,6 +23,7 @@ from typing import Any, Iterable
 
 SKILL_NAME = "detect-sensitive-secret-read-k8s"
 OCSF_VERSION = "1.8.0"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 # Detection Finding (2004)
 FINDING_CLASS_UID = 2004
@@ -117,25 +118,51 @@ def matches_sensitive_pattern(name: str, patterns: tuple[str, ...] | list[str]) 
 # ---------------------------------------------------------------------------
 
 
-def _is_api_activity(event: dict[str, Any]) -> bool:
-    return event.get("class_uid") == 6003
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
 
 
-def _verb(event: dict[str, Any]) -> str:
-    return (event.get("api") or {}).get("operation", "")
+def _resource(resources: Any) -> dict[str, Any]:
+    values = resources or []
+    return values[0] if values else {}
 
 
-def _resource(event: dict[str, Any]) -> dict[str, Any]:
-    resources = event.get("resources") or []
-    return resources[0] if resources else {}
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    if "class_uid" in event:
+        if event.get("class_uid") != 6003:
+            return None
+        resource = _resource(event.get("resources"))
+        return {
+            "source_format": "ocsf",
+            "provider": str(((event.get("cloud") or {}).get("provider")) or "Kubernetes"),
+            "time_ms": _safe_int(event.get("time")),
+            "actor_name": str((((event.get("actor") or {}).get("user")) or {}).get("name") or ""),
+            "operation": str(((event.get("api") or {}).get("operation")) or ""),
+            "resource_type": str(resource.get("type") or ""),
+            "resource_name": str(resource.get("name") or ""),
+            "namespace": str(resource.get("namespace") or ""),
+        }
 
+    record_type = str(event.get("record_type") or "").strip().lower()
+    if record_type and record_type != "api_activity":
+        return None
 
-def _actor_name(event: dict[str, Any]) -> str:
-    return ((event.get("actor") or {}).get("user") or {}).get("name", "")
-
-
-def _event_time(event: dict[str, Any]) -> int:
-    return int(event.get("time") or 0)
+    resource = _resource(event.get("resources"))
+    actor = event.get("actor") or {}
+    actor_user = actor.get("user") or {}
+    return {
+        "source_format": "native",
+        "provider": str(event.get("provider") or event.get("cloud_provider") or "Kubernetes"),
+        "time_ms": _safe_int(event.get("time_ms") or event.get("time")),
+        "actor_name": str(event.get("actor_name") or actor_user.get("name") or ""),
+        "operation": str(event.get("operation") or event.get("api_operation") or ""),
+        "resource_type": str(event.get("resource_type") or resource.get("type") or ""),
+        "resource_name": str(event.get("resource_name") or resource.get("name") or ""),
+        "namespace": str(event.get("namespace") or resource.get("namespace") or ""),
+    }
 
 
 def _short(s: str) -> str:
@@ -163,13 +190,53 @@ def _build_finding(
 
     patterns_str = ", ".join(matched_patterns)
     desc = (
-        f"Principal '{actor}' called `{_verb(event)}` on secret '{secret_name}' "
+        f"Principal '{actor}' called `{event['operation']}` on secret '{secret_name}' "
         f"in namespace '{namespace}'. The secret name matches the sensitive "
         f"pattern(s): {patterns_str}. Workloads should mount secret data as "
         f"files — the Kubernetes API is not the intended credential read path "
         f"at runtime. (MITRE T1552.007 Unsecured Credentials: Container API)"
     )
 
+    return {
+        "schema_mode": "native",
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": uid,
+        "event_uid": uid,
+        "provider": str(event["provider"] or "Kubernetes"),
+        "time_ms": int(event["time_ms"]) or _now_ms(),
+        "severity": "high",
+        "severity_id": SEVERITY_HIGH,
+        "status": "success",
+        "status_id": 1,
+        "title": "Kubernetes workload read a sensitive secret by name",
+        "description": desc,
+        "finding_types": ["k8s-sensitive-secret-read"],
+        "first_seen_time_ms": int(event["time_ms"]),
+        "last_seen_time_ms": int(event["time_ms"]),
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": MITRE_TACTIC_UID,
+                "tactic_name": MITRE_TACTIC_NAME,
+                "technique_uid": MITRE_TECH_UID,
+                "technique_name": MITRE_TECH_NAME,
+                "sub_technique_uid": MITRE_SUB_UID,
+                "sub_technique_name": MITRE_SUB_NAME,
+            }
+        ],
+        "actor_name": actor,
+        "namespace": namespace,
+        "secret_name": secret_name,
+        "matched_patterns": matched_patterns,
+        "verb": str(event["operation"]),
+        "rule_name": "k8s-sensitive-secret-read",
+    }
+
+
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    patterns_str = ", ".join(native_finding["matched_patterns"])
     return {
         "activity_id": FINDING_ACTIVITY_CREATE,
         "category_uid": FINDING_CATEGORY_UID,
@@ -179,10 +246,10 @@ def _build_finding(
         "type_uid": FINDING_TYPE_UID,
         "severity_id": SEVERITY_HIGH,
         "status_id": 1,
-        "time": _event_time(event) or _now_ms(),
+        "time": int(native_finding["time_ms"]) or _now_ms(),
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": uid,
+            "uid": native_finding["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
                 "vendor_name": "msaad00/cloud-ai-security-skills",
@@ -191,12 +258,12 @@ def _build_finding(
             "labels": ["detection-engineering", "kubernetes", "credential-access", "secret-read"],
         },
         "finding_info": {
-            "uid": uid,
-            "title": "Kubernetes workload read a sensitive secret by name",
-            "desc": desc,
-            "types": ["k8s-sensitive-secret-read"],
-            "first_seen_time": _event_time(event),
-            "last_seen_time": _event_time(event),
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "first_seen_time": int(native_finding["first_seen_time_ms"]),
+            "last_seen_time": int(native_finding["last_seen_time_ms"]),
             "attacks": [
                 {
                     "version": MITRE_VERSION,
@@ -207,17 +274,17 @@ def _build_finding(
             ],
         },
         "observables": [
-            {"name": "actor.name", "type": "Other", "value": actor},
-            {"name": "namespace", "type": "Other", "value": namespace},
-            {"name": "secret.name", "type": "Other", "value": secret_name},
-            {"name": "verb", "type": "Other", "value": _verb(event)},
+            {"name": "actor.name", "type": "Other", "value": native_finding["actor_name"]},
+            {"name": "namespace", "type": "Other", "value": native_finding["namespace"]},
+            {"name": "secret.name", "type": "Other", "value": native_finding["secret_name"]},
+            {"name": "verb", "type": "Other", "value": native_finding["verb"]},
             {"name": "matched_patterns", "type": "Other", "value": patterns_str},
-            {"name": "rule", "type": "Other", "value": "k8s-sensitive-secret-read"},
+            {"name": "rule", "type": "Other", "value": native_finding["rule_name"]},
         ],
         "evidence": {
             "events_observed": 1,
-            "first_seen_time": _event_time(event),
-            "last_seen_time": _event_time(event),
+            "first_seen_time": int(native_finding["first_seen_time_ms"]),
+            "last_seen_time": int(native_finding["last_seen_time_ms"]),
             "raw_events": [],
         },
     }
@@ -232,8 +299,9 @@ def detect(
     events: Iterable[dict[str, Any]],
     *,
     patterns: tuple[str, ...] | list[str] | None = None,
+    output_format: str = "ocsf",
 ) -> Iterable[dict[str, Any]]:
-    """Walk OCSF API Activity events; yield one finding per sensitive secret read.
+    """Walk native or OCSF API Activity events; yield one finding per match.
 
     Idempotent: the same (actor, namespace, secret_name) tuple produces
     at most one finding per call, even if the actor reads the same secret
@@ -243,15 +311,15 @@ def detect(
     seen: set[str] = set()
 
     for event in events:
-        if not _is_api_activity(event):
+        normalized = _normalize_event(event)
+        if normalized is None:
             continue
-        verb = _verb(event)
+        verb = normalized["operation"]
         if verb not in READ_VERBS:
             continue
-        r = _resource(event)
-        if r.get("type") != "secrets":
+        if normalized["resource_type"] != "secrets":
             continue
-        secret_name = r.get("name") or ""
+        secret_name = normalized["resource_name"] or ""
         if not secret_name:
             # `list` with no specific name — that's enumeration, covered by
             # detect-privilege-escalation-k8s Rule 1 in a different pipeline.
@@ -260,20 +328,21 @@ def detect(
         if not matched:
             continue
 
-        actor = _actor_name(event)
-        namespace = r.get("namespace") or ""
+        actor = normalized["actor_name"]
+        namespace = normalized["namespace"] or ""
         dedup_key = f"{actor}|{namespace}|{secret_name}"
         if dedup_key in seen:
             continue
         seen.add(dedup_key)
 
-        yield _build_finding(
-            event=event,
+        native_finding = _build_finding(
+            event=normalized,
             actor=actor,
             namespace=namespace,
             secret_name=secret_name,
             matched_patterns=matched,
         )
+        yield _render_ocsf_finding(native_finding) if output_format == "ocsf" else native_finding
 
 
 # ---------------------------------------------------------------------------
@@ -299,8 +368,9 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Detect reads of Kubernetes Secrets with sensitive names.")
-    parser.add_argument("input", nargs="?", help="OCSF JSONL input. Defaults to stdin.")
-    parser.add_argument("--output", "-o", help="OCSF Detection Finding JSONL output. Defaults to stdout.")
+    parser.add_argument("input", nargs="?", help="Native or OCSF JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="Detection Finding JSONL output. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="ocsf", help="Render OCSF detection findings or the native detection-finding shape.")
     parser.add_argument(
         "--sensitive-pattern",
         action="append",
@@ -321,7 +391,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         events = list(load_jsonl(in_stream))
-        for finding in detect(events, patterns=patterns):
+        for finding in detect(events, patterns=patterns, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/detection/detect-sensitive-secret-read-k8s/tests/test_detect.py
+++ b/skills/detection/detect-sensitive-secret-read-k8s/tests/test_detect.py
@@ -54,6 +54,25 @@ def _event(
     }
 
 
+def _native_event(
+    *,
+    verb: str = "get",
+    secret_name: str = "aws-access-key",
+    namespace: str = "default",
+    actor: str = "system:serviceaccount:default:app",
+    time_ms: int = 1775797200000,
+) -> dict:
+    return {
+        "schema_mode": "native",
+        "record_type": "api_activity",
+        "provider": "Kubernetes",
+        "time_ms": time_ms,
+        "actor_name": actor,
+        "operation": verb,
+        "resources": [{"type": "secrets", "name": secret_name, "namespace": namespace}],
+    }
+
+
 # ── Pattern matching ─────────────────────────────────────────────────
 
 
@@ -182,6 +201,23 @@ class TestFindingShape:
         b = list(detect(events))[0]["finding_info"]["uid"]
         assert a == b
         assert a.startswith("det-k8s-secret-read-")
+
+    def test_native_input_can_emit_native_finding(self):
+        findings = list(detect([_native_event()], output_format="native"))
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["schema_mode"] == "native"
+        assert finding["record_type"] == "detection_finding"
+        assert finding["provider"] == "Kubernetes"
+        assert finding["rule_name"] == "k8s-sensitive-secret-read"
+        assert "class_uid" not in finding
+
+    def test_native_input_can_emit_ocsf_finding(self):
+        findings = list(detect([_native_event()], output_format="ocsf"))
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["class_uid"] == FINDING_CLASS_UID
+        assert finding["finding_info"]["uid"].startswith("det-k8s-secret-read-")
 
 
 # ── Idempotency / dedup ──────────────────────────────────────────────

--- a/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
@@ -21,12 +21,12 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: ocsf
+output_formats: native, ocsf
 ---
 
 # ingest-k8s-audit-ocsf
 
-Thin, single-purpose ingestion skill: raw Kubernetes audit logs in → OCSF 1.8 API Activity JSONL out. No detection logic, no K8s API calls, no side effects.
+Thin, single-purpose ingestion skill: raw Kubernetes audit logs in → OCSF 1.8 API Activity JSONL out by default, with an optional native enriched event shape when `--output-format native` is selected. No detection logic, no K8s API calls, no side effects.
 
 ## Wire contract
 
@@ -59,7 +59,9 @@ Reads the `audit.k8s.io/v1` `Event` object that `kube-apiserver` writes to its a
 }
 ```
 
-Writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid: 6`).
+Writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid: 6`) by default.
+With `--output-format native`, writes the repo's native enriched API activity
+shape instead of the OCSF envelope.
 
 ## activity_id inference
 
@@ -118,7 +120,35 @@ python src/ingest.py /var/log/k8s-audit.log > k8s-audit.ocsf.jsonl
 # Piped from a dynamic webhook sink
 kubectl logs -n kube-system audit-webhook-receiver \
   | python src/ingest.py
+
+# Native enriched output (same source truth, no OCSF envelope)
+python src/ingest.py --output-format native /var/log/k8s-audit.log > k8s-audit.native.jsonl
 ```
+
+## Native output format
+
+`--output-format native` emits one enriched event per accepted audit entry with:
+
+- `schema_mode`
+- `canonical_schema_version`
+- `record_type`
+- `event_uid`
+- `provider`
+- `account_uid`
+- `region`
+- `time_ms`
+- `activity_id`
+- `activity_name`
+- `status_id`
+- `status`
+- `status_detail` when present
+- `operation`
+- `service_name`
+- `actor`
+- `src`
+- `resources`
+- `source`
+- `k8s.service_account_namespace` when the actor is a service account
 
 ## Tests
 

--- a/skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py
@@ -1,8 +1,9 @@
-"""Convert raw Kubernetes audit logs to OCSF 1.8 API Activity (class 6003).
+"""Convert raw Kubernetes audit logs to API activity events.
 
 Input:  K8s audit.k8s.io/v1 Event objects — either JSONL (one per line) or a
         top-level array. The skill filters for ResponseComplete / Panic stages.
-Output: JSONL of OCSF 1.8 API Activity events.
+Output: JSONL of OCSF 1.8 API Activity events by default, or a documented
+        native enriched event shape when --output-format native is selected.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -18,6 +19,7 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-k8s-audit-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 
 CLASS_UID = 6003
 CLASS_NAME = "API Activity"
@@ -36,6 +38,7 @@ STATUS_SUCCESS = 1
 STATUS_FAILURE = 2
 
 SEVERITY_INFORMATIONAL = 1
+OUTPUT_FORMATS = ("ocsf", "native")
 
 TERMINAL_STAGES = {"ResponseComplete", "Panic"}
 K8S_API_GROUP = "audit.k8s.io/v1"
@@ -232,18 +235,31 @@ def _metadata_labels(entry: dict[str, Any]) -> list[str]:
     return labels
 
 
+def _activity_name(activity_id: int) -> str:
+    return {
+        ACTIVITY_CREATE: "create",
+        ACTIVITY_READ: "read",
+        ACTIVITY_UPDATE: "update",
+        ACTIVITY_DELETE: "delete",
+        ACTIVITY_OTHER: "other",
+    }.get(activity_id, "unknown")
+
+
+def _status_name(status_id: int) -> str:
+    return {
+        STATUS_SUCCESS: "success",
+        STATUS_FAILURE: "failure",
+        STATUS_UNKNOWN: "unknown",
+    }.get(status_id, "unknown")
+
+
 # ---------------------------------------------------------------------------
 # Event builder
 # ---------------------------------------------------------------------------
 
 
-def convert_event(entry: dict[str, Any]) -> dict[str, Any] | None:
-    """Convert one K8s audit Event to one OCSF API Activity event.
-
-    Returns None if the entry is not an audit Event or is not in a terminal
-    stage (i.e. RequestReceived / ResponseStarted — we wait for the full
-    response to land before emitting).
-    """
+def _build_canonical_event(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert one K8s audit Event into the repo's canonical event shape."""
     if entry.get("kind") != "Event":
         return None
     if entry.get("apiVersion") != K8S_API_GROUP:
@@ -270,6 +286,47 @@ def convert_event(entry: dict[str, Any]) -> dict[str, Any] | None:
         ).encode("utf-8")
     ).hexdigest()
 
+    canonical: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "api_activity",
+        "event_uid": metadata_uid,
+        "provider": "Kubernetes",
+        "account_uid": "",
+        "region": "",
+        "time_ms": parse_ts_ms(entry.get("requestReceivedTimestamp")),
+        "activity_id": activity_id,
+        "activity_name": _activity_name(activity_id),
+        "status_id": status_id,
+        "status": _status_name(status_id),
+        "operation": verb.lower(),
+        "service_name": "kubernetes",
+        "actor": _build_actor(entry),
+        "src": _build_src_endpoint(entry),
+        "resources": _build_resources(entry),
+        "source": {
+            "kind": "kubernetes.audit",
+            "audit_id": entry.get("auditID", ""),
+            "stage": entry.get("stage", ""),
+            "request_uri": entry.get("requestURI", ""),
+            "api_version": entry.get("apiVersion", ""),
+        },
+        "metadata_labels": _metadata_labels(entry),
+    }
+
+    if status_detail:
+        canonical["status_detail"] = status_detail
+
+    # Service-account namespace as a custom marker for downstream detectors.
+    sa_ns = service_account_namespace(((entry.get("user") or {}).get("username")) or "")
+    if sa_ns is not None:
+        canonical["k8s"] = {"service_account_namespace": sa_ns}
+
+    return canonical
+
+
+def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    activity_id = int(canonical["activity_id"])
     event: dict[str, Any] = {
         "activity_id": activity_id,
         "category_uid": CATEGORY_UID,
@@ -278,34 +335,58 @@ def convert_event(entry: dict[str, Any]) -> dict[str, Any] | None:
         "class_name": CLASS_NAME,
         "type_uid": CLASS_UID * 100 + activity_id,
         "severity_id": SEVERITY_INFORMATIONAL,
-        "status_id": status_id,
-        "time": parse_ts_ms(entry.get("requestReceivedTimestamp")),
+        "status_id": int(canonical["status_id"]),
+        "time": canonical["time_ms"],
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": metadata_uid,
+            "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
                 "vendor_name": "msaad00/cloud-ai-security-skills",
                 "feature": {"name": SKILL_NAME},
             },
-            "labels": _metadata_labels(entry),
+            "labels": canonical["metadata_labels"],
         },
-        "actor": _build_actor(entry),
-        "src_endpoint": _build_src_endpoint(entry),
-        "api": _build_api(entry),
-        "resources": _build_resources(entry),
+        "actor": canonical["actor"],
+        "src_endpoint": canonical["src"],
+        "api": {
+            "operation": canonical["operation"],
+            "service": {"name": canonical["service_name"]},
+            "request": {"uid": canonical["source"]["audit_id"]},
+        },
+        "resources": canonical["resources"],
         "cloud": _build_cloud(),
     }
-
-    if status_detail:
-        event["status_detail"] = status_detail
-
-    # Service-account namespace as a custom marker for downstream detectors.
-    sa_ns = service_account_namespace(((entry.get("user") or {}).get("username")) or "")
-    if sa_ns is not None:
-        event["k8s"] = {"service_account_namespace": sa_ns}
-
+    if canonical.get("status_detail"):
+        event["status_detail"] = canonical["status_detail"]
+    if canonical.get("k8s"):
+        event["k8s"] = canonical["k8s"]
     return event
+
+
+def _render_native_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native.pop("metadata_labels", None)
+    native["schema_mode"] = "native"
+    native["source_skill"] = SKILL_NAME
+    native["output_format"] = "native"
+    return native
+
+
+def convert_event(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert one K8s audit Event to one OCSF API Activity event."""
+    canonical = _build_canonical_event(entry)
+    if canonical is None:
+        return None
+    return _render_ocsf_event(canonical)
+
+
+def convert_event_native(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert one K8s audit Event to the repo's native enriched event shape."""
+    canonical = _build_canonical_event(entry)
+    if canonical is None:
+        return None
+    return _render_native_event(canonical)
 
 
 # ---------------------------------------------------------------------------
@@ -351,29 +432,33 @@ def iter_raw_entries(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
 
 
-def ingest(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     for raw in iter_raw_entries(stream):
         try:
-            event = convert_event(raw)
+            canonical = _build_canonical_event(raw)
         except Exception as e:
             print(f"[{SKILL_NAME}] skipping entry: convert error: {e}", file=sys.stderr)
             continue
-        if event is None:
+        if canonical is None:
             continue
-        yield event
+        if output_format == "native":
+            yield _render_native_event(canonical)
+        else:
+            yield _render_ocsf_event(canonical)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Convert raw K8s audit logs to OCSF 1.8 API Activity JSONL.")
     parser.add_argument("input", nargs="?", help="Input JSON/JSONL file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="ocsf", help="Render OCSF events or the native enriched event shape.")
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
     try:
-        for event in ingest(in_stream):
+        for event in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(event, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py
@@ -24,6 +24,7 @@ from ingest import (  # type: ignore[import-not-found]
     STATUS_UNKNOWN,
     _status_id_and_detail,
     convert_event,
+    convert_event_native,
     infer_activity_id,
     ingest,
     is_service_account,
@@ -241,6 +242,16 @@ class TestConvertEvent:
         e = convert_event(self._event(annotations={"authorization.k8s.io/decision": "forbid"}))
         assert "authz-deny" in e["metadata"]["labels"]
 
+    def test_native_output_keeps_canonical_fields_without_ocsf_envelope(self):
+        e = convert_event_native(self._event())
+        assert e["schema_mode"] == "native"
+        assert e["record_type"] == "api_activity"
+        assert e["provider"] == "Kubernetes"
+        assert e["service_name"] == "kubernetes"
+        assert e["output_format"] == "native"
+        assert "class_uid" not in e
+        assert "metadata" not in e
+
 
 # ── Golden fixture parity ──────────────────────────────────────────────
 
@@ -250,6 +261,15 @@ class TestGoldenFixture:
         # Fixture has 6 entries but 1 is RequestReceived (must be skipped)
         produced = list(ingest(RAW_FIXTURE.read_text().splitlines()))
         assert len(produced) == 5
+
+    def test_native_output_mode_emits_enriched_events(self):
+        produced = list(ingest(RAW_FIXTURE.read_text().splitlines(), output_format="native"))
+        assert len(produced) == 5
+        first = produced[0]
+        assert first["schema_mode"] == "native"
+        assert first["record_type"] == "api_activity"
+        assert "class_uid" not in first
+        assert "metadata" not in first
 
     def test_deep_equality(self):
         produced = list(ingest(RAW_FIXTURE.read_text().splitlines()))


### PR DESCRIPTION
## Summary
- add --output-format {ocsf,native} to ingest-k8s-audit-ocsf
- let detect-sensitive-secret-read-k8s consume native or OCSF input and emit native or OCSF findings
- document the expanded K8s pilot in the skill contracts, README rollout note, and schema-mode docs

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py skills/detection/detect-sensitive-secret-read-k8s/tests/test_detect.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py tests/integration/test_skill_validation_scripts.py -q -o addopts= 
- uv run ruff check skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py skills/detection/detect-sensitive-secret-read-k8s/src/detect.py skills/detection/detect-sensitive-secret-read-k8s/tests/test_detect.py scripts/validate_skill_contract.py scripts/validate_safe_skill_bar.py scripts/validate_ocsf_metadata.py --config pyproject.toml