### PR TITLE
docs: align schema docs and test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,15 @@ The format is loosely based on Keep a Changelog.
 - Extended the native/OCSF pilot to `ingest-k8s-audit-ocsf` and `detect-sensitive-secret-read-k8s`, so Kubernetes audit ingestion and one Kubernetes detector now support the same dual-mode rollout pattern as the earlier CloudTrail / VPC / lateral-movement pilots.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
-### Added
-- Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.
-- Added [`docs/SIEM_INDEX_GUIDE.md`](docs/SIEM_INDEX_GUIDE.md) covering index fields, timestamps, dedupe keys, and just-in-time vs persistent ingestion guidance.
-- Added Azure Entra / Microsoft Graph credential-pivot coverage to `detect-lateral-movement`, including application and service-principal password-key changes, app-role grants, and federated identity credential creation.
-- Added explicit NIST AI RMF traceability to `model-serving-security` and `discover-cloud-control-evidence`, including machine-readable benchmark metadata and an opt-in `ai-rmf` evidence mode.
-
-### Added
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
 - `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.
 - explicit cross-cloud ATT&CK identity coverage metadata for `detect-lateral-movement`, covering AWS role pivots, GCP service-account pivots, and Azure role / managed-identity pivot anchors.
 - explicit MITRE ATLAS and NIST AI RMF declarations for `gpu-cluster-security`, including machine-readable benchmark metadata for wrappers and coverage tests.
 - `docs/RUNTIME_ISOLATION.md` to document sandboxing, credential scope, transport protections, integrity controls, and approval rules across CLI, CI, MCP, and persistent/serverless runs.
+- Added deterministic `metadata.uid` to OCSF emitters and discovery bridge events for replay-safe SIEM dedupe.
+- Added [`docs/SIEM_INDEX_GUIDE.md`](docs/SIEM_INDEX_GUIDE.md) covering index fields, timestamps, dedupe keys, and just-in-time vs persistent ingestion guidance.
+- Added Azure Entra / Microsoft Graph credential-pivot coverage to `detect-lateral-movement`, including application and service-principal password-key changes, app-role grants, and federated identity credential creation.
+- Added explicit NIST AI RMF traceability to `model-serving-security` and `discover-cloud-control-evidence`, including machine-readable benchmark metadata and an opt-in `ai-rmf` evidence mode.
 
 ### Changed
 - Promoted the IAM departures cross-cloud workflow visual in `README.md` and made the CI badge explicitly track the `main` branch.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | 3 | **Least privilege** | Each skill documents the EXACT IAM / RBAC permissions it needs in `REFERENCES.md`. Minimal set only. |
 | 4 | **Defense in depth** | Posture + detection + remediation + audit + re-verify all run in parallel and back each other up. |
 | 5 | **Closed loop** | Every workflow has a verification step: detect → finding → action → audit → re-verify. Drift is itself a detection. |
-| 6 | **OCSF on the wire** | All ingest + detect skills speak OCSF 1.8 JSONL. MITRE ATT&CK lives inside `finding_info.attacks[]`. |
+| 6 | **OCSF as default wire format** | Ingest and detect skills default to OCSF 1.8 JSONL; native and bridge modes are first-class alternatives declared in each skill's `output_formats`. MITRE ATT&CK lives inside `finding_info.attacks[]` when OCSF is emitted. |
 | 7 | **Secure by design** | Security is a first-class input to the skill's architecture, not a bolt-on. |
 | 8 | **Secure code** | Defensive parsing on every input boundary. No `eval`/`exec`/`pickle.loads` on untrusted data. Parameterised SQL only. `bandit` in CI. |
 | 9 | **Secure secrets & tokens** | No hardcoded creds. Secrets from cloud secret stores. Short-lived tokens. Logs scrub creds. CI greps for `AKIA` / `sk-` / `ghp_` patterns. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,12 +16,12 @@ This document is the load-bearing design contract for `cloud-ai-security-skills`
 `cloud-ai-security-skills` is a library of **composable security skills for cloud and AI systems** that can operate in native, canonical, OCSF, or bridge modes. The repository is designed to be driven by agentic tools (Claude Code, Snowflake Cortex Code CLI, Claude Agent SDK, any MCP client) *and* by traditional CI / serverless pipelines — with no code changes between the two modes.
 
 **In scope**
-- Normalising raw vendor telemetry into OCSF 1.8 wire format
-- Running deterministic detection rules on OCSF streams
-- Evaluating OCSF streams against compliance benchmarks (CIS, NIST, PCI)
+- Normalising raw vendor telemetry into canonical or OCSF wire formats
+- Running deterministic detection rules on canonical or OCSF streams
+- Evaluating raw, canonical, or OCSF telemetry against compliance benchmarks (CIS, NIST, PCI)
 - Producing remediation proposals (and, when explicitly authorised, executing them)
 - Converting OCSF into downstream wire formats (SARIF, Sigma, Jira, Mermaid)
-- Persisting OCSF into columnar / lakehouse stores (Snowflake, AWS Security Lake, ClickHouse, BigQuery)
+- Persisting canonical or OCSF records into columnar / lakehouse stores (Snowflake, AWS Security Lake, ClickHouse, BigQuery)
 - Exposing every skill as an MCP tool so the same logic runs in every agent
 
 **Out of scope (explicit non-goals)**
@@ -64,7 +64,7 @@ This is how the repo stays secure and reliable without turning every skill into 
  │ L0  SOURCES         raw vendor formats (CloudTrail, VPC Flow,     │
  │                     Okta, Ramp, Snowflake audit, K8s audit, ...)  │
  ├───────────────────────────────────────────────────────────────────┤
- │ L1  INGEST          raw → OCSF 1.8 wire format                    │
+ │ L1  INGEST          raw → canonical → native / OCSF / bridge      │
  │                     ingest-cloudtrail-ocsf, ingest-ramp-ocsf, ... │
  ├───────────────────────────────────────────────────────────────────┤
 │ L2  DISCOVER /      inventory + context                           │
@@ -74,10 +74,10 @@ This is how the repo stays secure and reliable without turning every skill into 
 │                     enrich-asset-inventory, enrich-geoip,         │
 │                     enrich-mitre-navigator, enrich-pii-redact     │
  ├───────────────────────────────────────────────────────────────────┤
- │ L3  DETECT          OCSF → OCSF Detection Finding (2004)          │
+ │ L3  DETECT          canonical / OCSF → native / OCSF findings     │
  │                     detect-lateral-movement, detect-*             │
  ├───────────────────────────────────────────────────────────────────┤
- │ L4  EVALUATE        OCSF → compliance pass/fail + evidence        │
+ │ L4  EVALUATE        raw / canonical → compliance result + evidence│
  │                     cspm-*-cis-benchmark, evaluate-nist-ai-rmf    │
  ├───────────────────────────────────────────────────────────────────┤
  │ L5  REMEDIATE       Finding → IaC patch / SOAR action             │

--- a/docs/CANONICAL_SCHEMA.md
+++ b/docs/CANONICAL_SCHEMA.md
@@ -159,6 +159,58 @@ Persistent stores should prefer canonical fields for:
 
 That avoids breaking DB schemas every time an output format changes.
 
+## Projection example
+
+The same logical event can exist in three wire shapes while preserving one
+canonical contract:
+
+```json
+{
+  "canonical": {
+    "schema_mode": "canonical",
+    "canonical_schema_version": "2026-04",
+    "record_type": "api_activity",
+    "event_uid": "evt-123",
+    "provider": "AWS",
+    "account_uid": "111122223333",
+    "time_ms": 1775797200000,
+    "operation": "AssumeRole"
+  },
+  "native": {
+    "schema_mode": "native",
+    "record_type": "api_activity",
+    "event_uid": "evt-123",
+    "provider": "AWS",
+    "account_uid": "111122223333",
+    "time_ms": 1775797200000,
+    "operation": "AssumeRole"
+  },
+  "ocsf": {
+    "class_uid": 6003,
+    "category_uid": 6,
+    "activity_id": 99,
+    "time": 1775797200000,
+    "metadata": {"uid": "evt-123"},
+    "cloud": {"provider": "AWS", "account": {"uid": "111122223333"}},
+    "api": {"operation": "AssumeRole"}
+  },
+  "bridge": {
+    "class_uid": 5040,
+    "metadata": {"uid": "evt-123"},
+    "unmapped": {
+      "canonical": {
+        "record_type": "api_activity",
+        "provider": "AWS",
+        "operation": "AssumeRole"
+      }
+    }
+  }
+}
+```
+
+The exact projected fields differ by layer, but the rule does not: one
+canonical truth, multiple wire formats.
+
 ## Current implementation note
 
 The canonical model is fully piloted today in:

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -9,7 +9,7 @@ That is not a soft preference. It is the repo contract.
 | Mode | Purpose | When to use it |
 |---|---|---|
 | **native** | Preserve the source payload shape and natural identifiers | source fidelity matters most, the vendor schema is the contract, or OCSF would be lossy |
-| **canonical** | Normalize into the repo's stable internal model | storage, joins, entity state, metrics, views, and cross-skill behavior must stay stable even if the output format changes |
+| **canonical** | Normalize into the repo's stable internal model | internal-only storage and join model; not emitted directly today. `native`, `ocsf`, and `bridge` are projections of canonical |
 | **ocsf** | Emit native OCSF classes, profiles, or extensions | SIEM interoperability, cross-vendor correlation, downstream OCSF consumers, or shared wire contracts between skills |
 | **bridge** | Emit an OCSF-friendly event while preserving the native or canonical artifact under `unmapped` or an explicit sidecar field | OCSF helps transport/search, but the source or evidence shape still carries important detail |
 

--- a/docs/images/detection-pipeline.svg
+++ b/docs/images/detection-pipeline.svg
@@ -11,7 +11,7 @@
 
     <rect x="260" y="132" width="190" height="86" rx="18" fill="#1d4ed8" stroke="#93c5fd"/>
     <text x="318" y="170" fill="#eff6ff" font-size="22" font-weight="700">Ingest</text>
-    <text x="289" y="194" fill="#dbeafe" font-size="14">normalize to OCSF 1.8</text>
+    <text x="273" y="194" fill="#dbeafe" font-size="14">normalize to canonical → native / OCSF</text>
 
     <rect x="500" y="132" width="190" height="86" rx="18" fill="#0f766e" stroke="#5eead4"/>
     <text x="560" y="170" fill="#ecfeff" font-size="22" font-weight="700">Detect</text>
@@ -35,5 +35,5 @@
     <path d="M930 175 L980 175" stroke="#c4b5fd"/>
   </g>
 
-  <text x="40" y="304" fill="#cbd5e1" font-size="18" font-family="Arial, sans-serif">Contract rule: every intermediate handoff stays OCSF-native; only the final delivery edge converts to other formats.</text>
+  <text x="40" y="304" fill="#cbd5e1" font-size="18" font-family="Arial, sans-serif">Contract rule: canonical is the stable internal model; intermediate handoffs may be native or OCSF, and the final edge converts to the delivery format.</text>
 </svg>

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -14,7 +14,7 @@
   <rect x="330" y="160" width="230" height="120" rx="18" fill="#1e3a5f" stroke="#38bdf8"/>
   <text x="352" y="196" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">Detection</text>
   <text x="352" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Ingest → detect → convert</text>
-  <text x="352" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">OCSF 1.8 on the wire</text>
+  <text x="352" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">OCSF 1.8 by default, native available</text>
 
   <rect x="590" y="160" width="230" height="120" rx="18" fill="#1f2937" stroke="#2dd4bf"/>
   <text x="612" y="196" fill="#dcfce7" font-size="22" font-family="Arial, sans-serif" font-weight="700">Remediation</text>

--- a/skills/detection/detect-google-workspace-suspicious-login/tests/conftest.py
+++ b/skills/detection/detect-google-workspace-suspicious-login/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/detection/detect-okta-mfa-fatigue/tests/conftest.py
+++ b/skills/detection/detect-okta-mfa-fatigue/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/ingestion/ingest-entra-directory-audit-ocsf/tests/conftest.py
+++ b/skills/ingestion/ingest-entra-directory-audit-ocsf/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/tests/conftest.py
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/ingestion/ingest-okta-system-log-ocsf/tests/conftest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))


### PR DESCRIPTION
## Summary
- fix remaining OCSF-only wording in README, architecture docs, and SVG visuals
- clarify that canonical is internal-only and show native, OCSF, and bridge projections concretely
- add the missing per-skill test isolation conftest files so repo-configured root pytest stays clean

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest
- uv run ruff check scripts/skill_validation_common.py scripts/validate_skill_contract.py scripts/validate_skill_integrity.py scripts/validate_safe_skill_bar.py scripts/validate_ocsf_metadata.py skills/detection/detect-okta-mfa-fatigue/tests/conftest.py skills/detection/detect-google-workspace-suspicious-login/tests/conftest.py skills/ingestion/ingest-okta-system-log-ocsf/tests/conftest.py skills/ingestion/ingest-entra-directory-audit-ocsf/tests/conftest.py skills/ingestion/ingest-google-workspace-login-ocsf/tests/conftest.py --config pyproject.toml