### PR TITLE
docs: clarify persistent mode contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design, 
 
 The important rule is that the **skill code does not change between modes**. `SKILL.md + src/ + tests/` stays the product; the runner, pipeline, or MCP wrapper is only the access path.
 
+`execution_modes: persistent` means the skill is safe to embed in a persistent runner or serverless loop. It does **not** mean this repo already ships a dedicated daemon, queue worker, or sink for that skill. Today the only fully shipped persistent workflow is `iam-departures-remediation`; the broader runner and sink layer remains an explicit roadmap item.
+
 ## Safety model
 
 | Skill type | Default posture | Required controls |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,11 @@ The repo operates across four schema modes:
 
 Most current ingest, detect, evaluate, view, and sink paths are still **OCSF-friendly JSONL**, but OCSF is no longer the only valid operating mode. Discovery and evidence paths may emit deterministic native or canonical artifacts, plus OCSF bridge events where that improves interoperability. The current discovery set already supports explicit bridge modes for `Cloud Resources Inventory Info [5023]` and `Live Evidence Info [5040]`.
 
+Execution-mode note:
+- `execution_modes: persistent` means a skill is safe to embed in a persistent runner, queue consumer, scheduler, or serverless loop without changing the skill logic
+- it does **not** mean the repo already ships that runner, daemon, or sink for every skill
+- today, the broad runner/sink layer is still planned work; `iam-departures-remediation` is the main shipped exception with repo-owned event-driven infrastructure
+
 For the detailed contract, see:
 
 - [`NATIVE_VS_OCSF.md`](./NATIVE_VS_OCSF.md)

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -15,6 +15,11 @@ Each shipped `SKILL.md` now declares:
 
 Agents and wrappers should treat those fields as part of the runtime contract, not optional documentation.
 
+Important meaning:
+- `execution_modes: persistent` means the skill is compatible with a persistent runner or serverless loop
+- it does **not** mean the repo already ships a dedicated daemon, queue worker, sink, or Lambda wrapper for that skill
+- today, most skills are persistent-compatible but still run as stateless CLI tools; only a small number of workflows ship repo-owned persistent code paths
+
 ## Modes
 
 | Mode | Best for | Isolation posture | Human approval |
@@ -23,6 +28,11 @@ Agents and wrappers should treat those fields as part of the runtime contract, n
 | CI | regression testing, policy checks, snapshots | ephemeral runner, short-lived creds, no write skills in normal PR lanes | never for read-only skills |
 | MCP | local agent tool calling | stdio-only wrapper, fixed tool surface, timeouts, no generic shell tool | inherited from the wrapped skill |
 | Persistent / serverless | continuous detection, sinks, remediation | isolated runner or cloud service boundary, checkpointing, egress controls, idempotent writes | required for destructive actions |
+
+Persistent mode should be read as:
+- the skill stays stateless and deterministic
+- a separate runner or serverless wrapper owns checkpoints, retries, queue offsets, and sink writes
+- operators still need to provide the surrounding runtime unless the skill explicitly ships one
 
 ## Read-only skills
 
@@ -47,6 +57,9 @@ These are the only places where side effects should happen:
 - `remediation/`
 - future `sinks/`
 - future `runners/`
+
+Current shipped exception:
+- `iam-departures-remediation` includes repo-owned Lambda handlers and infrastructure for its event-driven persistent path
 
 Required controls:
 - `--dry-run` support

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -52,6 +52,9 @@ Rules:
   - `ci`
   - `mcp`
   - `persistent`
+- `execution_modes: persistent` means the skill can be embedded unchanged in a long-lived runner, queue consumer, scheduler, or serverless loop.
+- `persistent` does **not** imply that this repo already ships a dedicated runner, daemon, Lambda wrapper, or sink for that skill.
+- if a skill is the exception and does ship a repo-owned persistent entrypoint, document that explicitly in `SKILL.md`
 - `side_effects` must be a comma-separated subset of:
   - `none`
   - `writes-cloud`

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -47,10 +47,15 @@ The same skill should be usable in all of these modes without code changes:
 |---|---|---|
 | **CLI / just-in-time** | user or agent invokes the script directly | one-off analysis, triage, conversion, local debugging |
 | **CI** | GitHub Actions or another build system | regression tests, compliance snapshots, SARIF generation |
-| **Persistent / serverless** | queue, runner, EventBridge, Step Functions, scheduled jobs | continuous detection or remediation pipelines |
+| **Persistent / serverless** | queue, runner, EventBridge, Step Functions, scheduled jobs | continuous detection or remediation pipelines; in most cases this means the skill is runner-compatible, not that the repo already ships a dedicated runtime |
 | **MCP** | local `mcp-server/` wrapper | Claude, Codex, Cursor, Windsurf, Cortex Code CLI |
 
 MCP is the access layer, not a separate implementation model.
+
+Important nuance:
+- `execution_modes: persistent` in a skill contract means the skill can be embedded in a long-lived runner or serverless loop without changing the skill code
+- it does **not** automatically mean the repo already ships that runner, daemon, or sink
+- today, most skills are persistent-compatible; only a smaller set of workflows ship repo-owned persistent wrappers
 
 ## What Does Not Exist Yet
 


### PR DESCRIPTION
## Summary
- define persistent execution mode as runner-compatible by default instead of implying a repo-shipped daemon for every skill
- align the public README, architecture contract, runtime isolation doc, and agent integration guide with that meaning
- keep iam-departures-remediation documented as the main shipped persistent-path exception today

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py