### PR TITLE
feat: add native mode to k8s privilege escalation detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is loosely based on Keep a Changelog.
 - Made the OCSF metadata validator format-aware so native-mode support does not weaken the OCSF path contract.
 - Extended the native/OCSF pilot to `ingest-vpc-flow-logs-ocsf`, so AWS flow logs can now emit either OCSF Network Activity or the repo's canonical native network-flow shape while preserving a compatible end-to-end lateral-movement path.
 - Extended the native/OCSF pilot to `ingest-k8s-audit-ocsf` and `detect-sensitive-secret-read-k8s`, so Kubernetes audit ingestion and one Kubernetes detector now support the same dual-mode rollout pattern as the earlier CloudTrail / VPC / lateral-movement pilots.
+- Extended the native/OCSF pilot to `detect-privilege-escalation-k8s`, so the main windowed Kubernetes privilege-escalation detector now accepts native or OCSF input and can emit native or OCSF findings.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
   - `ingest-vpc-flow-logs-ocsf`
   - `ingest-k8s-audit-ocsf`
   - `detect-lateral-movement`
+  - `detect-privilege-escalation-k8s`
   - `detect-sensitive-secret-read-k8s`
 - native-first with optional bridge:
   - `discover-environment`

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -137,6 +137,7 @@ Implemented dual-mode skills today:
 - `ingest-vpc-flow-logs-ocsf`
 - `ingest-k8s-audit-ocsf`
 - `detect-lateral-movement`
+- `detect-privilege-escalation-k8s`
 - `detect-sensitive-secret-read-k8s`
 
 Implemented native-first with bridge skills today:

--- a/skills/detection/detect-privilege-escalation-k8s/SKILL.md
+++ b/skills/detection/detect-privilege-escalation-k8s/SKILL.md
@@ -2,12 +2,13 @@
 name: detect-privilege-escalation-k8s
 description: >-
   Detect Kubernetes privilege escalation patterns in OCSF 1.8 API Activity
-  events (class 6003) produced by ingest-k8s-audit-ocsf. Reads normalised
-  kube-apiserver audit events, groups them by actor (service account or user)
-  over a sliding window, and fires OCSF 1.8 Detection Finding (class 2004)
-  events for four patterns: (1) service-account secret enumeration followed
-  by get (MITRE T1552.007 Container API), (2) service-account exec into a pod
-  (MITRE T1611 Escape to Host), (3) creation of a ClusterRoleBinding or
+  events (class 6003) or the native enriched Kubernetes activity shape
+  produced by ingest-k8s-audit-ocsf. Reads normalised kube-apiserver audit
+  events, groups them by actor (service account or user) over a sliding
+  window, and fires OCSF 1.8 Detection Finding (class 2004) events by
+  default for four patterns: (1) service-account secret enumeration followed
+  by get (MITRE T1552.007 Container API), (2) service-account exec into a
+  pod (MITRE T1611 Escape to Host), (3) creation of a ClusterRoleBinding or
   RoleBinding by a non-admin principal (MITRE T1098 Account Manipulation),
   and (4) token-review or token-request self-grant by a service account
   (MITRE T1550.001 Application Access Token). Use when the user mentions
@@ -21,8 +22,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
-input_formats: ocsf
-output_formats: ocsf
+input_formats: canonical, native, ocsf
+output_formats: native, ocsf
 ---
 
 # detect-privilege-escalation-k8s
@@ -69,7 +70,7 @@ A service account calling `create` on the `tokenrequests` or `tokenreviews` subr
 
 ## Output contract
 
-Each finding is a full OCSF 1.8 Detection Finding matching [`../OCSF_CONTRACT.md`](../OCSF_CONTRACT.md). Deterministic `finding_info.uid` of the form `det-k8s-<rule>-<actor-hash>-<target-hash>` so re-running on the same input is idempotent.
+Each finding is a full OCSF 1.8 Detection Finding matching [`../OCSF_CONTRACT.md`](../OCSF_CONTRACT.md) by default. Deterministic `finding_info.uid` of the form `det-k8s-<rule>-<actor-hash>-<target-hash>` so re-running on the same input is idempotent.
 
 `finding_info.attacks[]` always carries:
 - `version: "v14"`
@@ -83,11 +84,47 @@ Rule 1 uses a time window because it requires two events to correlate. The windo
 
 ## Usage
 
+## Native output format
+
+`--output-format native` emits one native detection-finding record per match with:
+
+- `schema_mode`
+- `canonical_schema_version`
+- `record_type`
+- `source_skill`
+- `output_format`
+- `finding_uid`
+- `event_uid`
+- `provider`
+- `time_ms`
+- `severity`
+- `severity_id`
+- `status`
+- `status_id`
+- `title`
+- `description`
+- `finding_types`
+- `first_seen_time_ms`
+- `last_seen_time_ms`
+- `mitre_attacks`
+- `actor_name`
+- `target`
+- `rule_name`
+- `observables`
+- `evidence_count`
+
+## Usage
+
 ```bash
-# Piped from the ingest skill
+# Piped from the ingest skill (default OCSF output)
 python ../ingest-k8s-audit-ocsf/src/ingest.py audit.log \
   | python src/detect.py \
   > findings.ocsf.jsonl
+
+# Native end-to-end path
+python ../ingest-k8s-audit-ocsf/src/ingest.py --output-format native audit.log \
+  | python src/detect.py --output-format native \
+  > findings.native.jsonl
 
 # Standalone OCSF file
 python src/detect.py ../golden/k8s_audit_sample.ocsf.jsonl

--- a/skills/detection/detect-privilege-escalation-k8s/src/detect.py
+++ b/skills/detection/detect-privilege-escalation-k8s/src/detect.py
@@ -1,8 +1,9 @@
-"""Detect Kubernetes privilege escalation patterns in OCSF 1.8 API Activity.
+"""Detect Kubernetes privilege escalation patterns in OCSF or native API Activity.
 
-Reads OCSF 1.8 API Activity (class 6003) events produced by
-ingest-k8s-audit-ocsf and emits OCSF 1.8 Detection Findings (class 2004) for
-four K8s priv-esc patterns.
+Reads OCSF 1.8 API Activity (class 6003) events or the native enriched
+Kubernetes activity shape produced by ingest-k8s-audit-ocsf and emits OCSF 1.8
+Detection Findings (class 2004) by default for four K8s privilege-escalation
+patterns.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -18,6 +19,8 @@ from typing import Any, Iterable
 
 SKILL_NAME = "detect-privilege-escalation-k8s"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 # Detection Finding (2004)
 FINDING_CLASS_UID = 2004
@@ -70,55 +73,106 @@ ADMIN_GROUPS = {"system:masters"}
 ADMIN_USERS = {"kubernetes-admin", "kube-admin"}
 
 
-# ---------------------------------------------------------------------------
-# Input helpers
-# ---------------------------------------------------------------------------
-
-
-def _is_api_activity(event: dict[str, Any]) -> bool:
-    return event.get("class_uid") == 6003
-
-
-def _actor_name(event: dict[str, Any]) -> str:
-    return ((event.get("actor") or {}).get("user") or {}).get("name", "")
-
-
-def _actor_is_service_account(event: dict[str, Any]) -> bool:
-    return ((event.get("actor") or {}).get("user") or {}).get("type") == "ServiceAccount"
-
-
-def _actor_groups(event: dict[str, Any]) -> set[str]:
-    groups = ((event.get("actor") or {}).get("user") or {}).get("groups") or []
-    return {g.get("name", "") for g in groups}
-
-
-def _verb(event: dict[str, Any]) -> str:
-    return (event.get("api") or {}).get("operation", "")
-
-
-def _resource(event: dict[str, Any]) -> dict[str, Any]:
-    resources = event.get("resources") or []
-    return resources[0] if resources else {}
-
-
-def _event_time(event: dict[str, Any]) -> int:
-    return int(event.get("time") or 0)
-
-
-def _short(s: str) -> str:
-    return hashlib.sha256((s or "").encode()).hexdigest()[:8]
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _now_ms() -> int:
     return int(datetime.now(timezone.utc).timestamp() * 1000)
 
 
-# ---------------------------------------------------------------------------
-# Finding builder
-# ---------------------------------------------------------------------------
+def _short(s: str) -> str:
+    return hashlib.sha256((s or "").encode()).hexdigest()[:8]
 
 
-def _build_finding(
+def _severity_name(severity_id: int) -> str:
+    if severity_id >= SEVERITY_CRITICAL:
+        return "critical"
+    if severity_id >= SEVERITY_HIGH:
+        return "high"
+    return "unknown"
+
+
+def _resource(resources: Any) -> dict[str, Any]:
+    values = resources or []
+    return values[0] if values else {}
+
+
+def _group_names(groups: Any) -> tuple[str, ...]:
+    names: list[str] = []
+    for group in groups or []:
+        if isinstance(group, dict):
+            name = group.get("name")
+        else:
+            name = group
+        if name:
+            names.append(str(name))
+    return tuple(names)
+
+
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    if "class_uid" in event:
+        if event.get("class_uid") != 6003:
+            return None
+        actor_user = ((event.get("actor") or {}).get("user")) or {}
+        resource = _resource(event.get("resources"))
+        return {
+            "source_format": "ocsf",
+            "provider": str(((event.get("cloud") or {}).get("provider")) or "Kubernetes"),
+            "time_ms": _safe_int(event.get("time")),
+            "actor_name": str(actor_user.get("name") or ""),
+            "actor_type": str(actor_user.get("type") or ""),
+            "actor_groups": _group_names(actor_user.get("groups")),
+            "operation": str(((event.get("api") or {}).get("operation")) or ""),
+            "resource_type": str(resource.get("type") or ""),
+            "resource_name": str(resource.get("name") or ""),
+            "namespace": str(resource.get("namespace") or ""),
+            "subresource": str(resource.get("subresource") or ""),
+        }
+
+    schema_mode = str(event.get("schema_mode") or "").strip().lower()
+    if schema_mode and schema_mode not in {"native", "canonical"}:
+        return None
+
+    record_type = str(event.get("record_type") or "").strip().lower()
+    if record_type and record_type != "api_activity":
+        return None
+
+    actor_user = ((event.get("actor") or {}).get("user")) or {}
+    resource = _resource(event.get("resources"))
+    return {
+        "source_format": schema_mode or "native",
+        "provider": str(event.get("provider") or event.get("cloud_provider") or "Kubernetes"),
+        "time_ms": _safe_int(event.get("time_ms") or event.get("time")),
+        "actor_name": str(event.get("actor_name") or actor_user.get("name") or ""),
+        "actor_type": str(event.get("actor_type") or actor_user.get("type") or ""),
+        "actor_groups": _group_names(event.get("actor_groups") or actor_user.get("groups")),
+        "operation": str(event.get("operation") or event.get("api_operation") or ""),
+        "resource_type": str(event.get("resource_type") or resource.get("type") or ""),
+        "resource_name": str(event.get("resource_name") or resource.get("name") or ""),
+        "namespace": str(event.get("namespace") or resource.get("namespace") or ""),
+        "subresource": str(event.get("subresource") or resource.get("subresource") or ""),
+    }
+
+
+def _normalized_events(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for event in events:
+        item = _normalize_event(event)
+        if item is not None:
+            normalized.append(item)
+    normalized.sort(key=lambda item: item["time_ms"])
+    return normalized
+
+
+def _actor_is_service_account(event: dict[str, Any]) -> bool:
+    return event["actor_type"] == "ServiceAccount"
+
+
+def _build_native_finding(
     *,
     rule_id: str,
     title: str,
@@ -140,11 +194,55 @@ def _build_finding(
     uid = f"det-k8s-{rule_id}-{_short(actor)}-{_short(target)}"
     attack: dict[str, Any] = {
         "version": MITRE_VERSION,
-        "tactic": {"name": tactic_name, "uid": tactic_uid},
-        "technique": {"name": technique_name, "uid": technique_uid},
+        "tactic_uid": tactic_uid,
+        "tactic_name": tactic_name,
+        "technique_uid": technique_uid,
+        "technique_name": technique_name,
     }
     if sub_technique_uid and sub_technique_name:
-        attack["sub_technique"] = {"name": sub_technique_name, "uid": sub_technique_uid}
+        attack["sub_technique_uid"] = sub_technique_uid
+        attack["sub_technique_name"] = sub_technique_name
+
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": uid,
+        "event_uid": uid,
+        "provider": "Kubernetes",
+        "time_ms": last_seen_time or _now_ms(),
+        "severity": _severity_name(severity_id),
+        "severity_id": severity_id,
+        "status": "success",
+        "status_id": 1,
+        "title": title,
+        "description": desc,
+        "finding_types": [f"k8s-{rule_id}"],
+        "first_seen_time_ms": first_seen_time,
+        "last_seen_time_ms": last_seen_time,
+        "mitre_attacks": [attack],
+        "actor_name": actor,
+        "target": target,
+        "rule_name": rule_id,
+        "observables": observables,
+        "evidence_count": evidence_count,
+    }
+
+
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    attack = native_finding["mitre_attacks"][0]
+    rendered_attack: dict[str, Any] = {
+        "version": attack["version"],
+        "tactic": {"name": attack["tactic_name"], "uid": attack["tactic_uid"]},
+        "technique": {"name": attack["technique_name"], "uid": attack["technique_uid"]},
+    }
+    if attack.get("sub_technique_uid") and attack.get("sub_technique_name"):
+        rendered_attack["sub_technique"] = {
+            "name": attack["sub_technique_name"],
+            "uid": attack["sub_technique_uid"],
+        }
 
     return {
         "activity_id": FINDING_ACTIVITY_CREATE,
@@ -153,97 +251,85 @@ def _build_finding(
         "class_uid": FINDING_CLASS_UID,
         "class_name": FINDING_CLASS_NAME,
         "type_uid": FINDING_TYPE_UID,
-        "severity_id": severity_id,
-        "status_id": 1,
-        "time": last_seen_time or _now_ms(),
+        "severity_id": native_finding["severity_id"],
+        "status_id": native_finding["status_id"],
+        "time": native_finding["time_ms"],
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": uid,
+            "uid": native_finding["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
                 "vendor_name": "msaad00/cloud-ai-security-skills",
                 "feature": {"name": SKILL_NAME},
             },
-            "labels": ["detection-engineering", "kubernetes", "privilege-escalation", rule_id],
+            "labels": ["detection-engineering", "kubernetes", "privilege-escalation", native_finding["rule_name"]],
         },
         "finding_info": {
-            "uid": uid,
-            "title": title,
-            "desc": desc,
-            "types": [f"k8s-{rule_id}"],
-            "first_seen_time": first_seen_time,
-            "last_seen_time": last_seen_time,
-            "attacks": [attack],
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "first_seen_time": native_finding["first_seen_time_ms"],
+            "last_seen_time": native_finding["last_seen_time_ms"],
+            "attacks": [rendered_attack],
         },
-        "observables": observables,
+        "observables": native_finding["observables"],
         "evidence": {
-            "events_observed": evidence_count,
-            "first_seen_time": first_seen_time,
-            "last_seen_time": last_seen_time,
+            "events_observed": native_finding["evidence_count"],
+            "first_seen_time": native_finding["first_seen_time_ms"],
+            "last_seen_time": native_finding["last_seen_time_ms"],
             "raw_events": [],
         },
     }
 
 
-# ---------------------------------------------------------------------------
-# Rule 1: Service-account secret enumeration + read (T1552.007)
-# ---------------------------------------------------------------------------
-
-
 def rule1_secret_enumeration(events: list[dict[str, Any]]) -> Iterable[dict[str, Any]]:
     """list(secrets) → get(secrets) in the same namespace, same SA, within window."""
-    # Index: (actor, namespace) → list of (time_ms, event) for list events
-    list_events: dict[tuple[str, str], list[tuple[int, dict]]] = {}
+    normalized = _normalized_events(events)
+    list_events: dict[tuple[str, str], list[tuple[int, dict[str, Any]]]] = {}
 
-    # First pass: collect list events
-    for ev in events:
-        if not _is_api_activity(ev):
+    for event in normalized:
+        if not _actor_is_service_account(event):
             continue
-        if not _actor_is_service_account(ev):
+        if event["operation"] != "list":
             continue
-        if _verb(ev) != "list":
+        if event["resource_type"] != "secrets":
             continue
-        r = _resource(ev)
-        if r.get("type") != "secrets":
-            continue
-        key = (_actor_name(ev), r.get("namespace", ""))
-        list_events.setdefault(key, []).append((_event_time(ev), ev))
+        key = (event["actor_name"], event["namespace"])
+        list_events.setdefault(key, []).append((event["time_ms"], event))
 
-    # Second pass: match get events against list events within the window
     seen_findings: set[str] = set()
-    for ev in events:
-        if not _is_api_activity(ev):
+    for event in normalized:
+        if not _actor_is_service_account(event):
             continue
-        if not _actor_is_service_account(ev):
+        if event["operation"] != "get":
             continue
-        if _verb(ev) != "get":
+        if event["resource_type"] != "secrets":
             continue
-        r = _resource(ev)
-        if r.get("type") != "secrets":
-            continue
-        actor = _actor_name(ev)
-        ns = r.get("namespace", "")
-        get_time = _event_time(ev)
-        secret_name = r.get("name", "")
 
-        candidates = list_events.get((actor, ns), [])
-        matching = [(t, le) for t, le in candidates if 0 < get_time - t <= RULE1_WINDOW_MS]
+        actor = event["actor_name"]
+        namespace = event["namespace"]
+        get_time = event["time_ms"]
+        secret_name = event["resource_name"]
+
+        candidates = list_events.get((actor, namespace), [])
+        matching = [(time_ms, item) for time_ms, item in candidates if 0 < get_time - time_ms <= RULE1_WINDOW_MS]
         if not matching:
             continue
 
-        first_list_time = min(t for t, _ in matching)
-        key = f"r1|{actor}|{ns}|{secret_name}"
+        first_list_time = min(time_ms for time_ms, _ in matching)
+        key = f"r1|{actor}|{namespace}|{secret_name}"
         if key in seen_findings:
             continue
         seen_findings.add(key)
 
-        target = f"{ns}/{secret_name}"
-        yield _build_finding(
+        target = f"{namespace}/{secret_name}"
+        yield _build_native_finding(
             rule_id="r1-secret-enum",
             title="Service account enumerated and read a Kubernetes secret",
             desc=(
                 f"Service account '{actor}' performed `list` on secrets in namespace "
-                f"'{ns}' and then `get` on secret '{secret_name}' within the "
+                f"'{namespace}' and then `get` on secret '{secret_name}' within the "
                 f"{RULE1_WINDOW_MS // 1000}-second correlation window. Workloads that "
                 f"need secret data should mount secrets as files, not call the K8s "
                 f"API for them — this pattern is a strong signal of a compromised "
@@ -262,7 +348,7 @@ def rule1_secret_enumeration(events: list[dict[str, Any]]) -> Iterable[dict[str,
             last_seen_time=get_time,
             observables=[
                 {"name": "actor.name", "type": "Other", "value": actor},
-                {"name": "namespace", "type": "Other", "value": ns},
+                {"name": "namespace", "type": "Other", "value": namespace},
                 {"name": "secret.name", "type": "Other", "value": secret_name},
                 {"name": "rule", "type": "Other", "value": "r1-secret-enum"},
             ],
@@ -270,39 +356,34 @@ def rule1_secret_enumeration(events: list[dict[str, Any]]) -> Iterable[dict[str,
         )
 
 
-# ---------------------------------------------------------------------------
-# Rule 2: Service-account pod exec (T1611)
-# ---------------------------------------------------------------------------
-
-
 def rule2_pod_exec(events: list[dict[str, Any]]) -> Iterable[dict[str, Any]]:
     """create on pods/exec by a service account."""
+    normalized = _normalized_events(events)
     seen: set[str] = set()
-    for ev in events:
-        if not _is_api_activity(ev):
+    for event in normalized:
+        if not _actor_is_service_account(event):
             continue
-        if not _actor_is_service_account(ev):
+        if event["operation"] != "create":
             continue
-        if _verb(ev) != "create":
+        if event["resource_type"] != "pods" or event["subresource"] != "exec":
             continue
-        r = _resource(ev)
-        if r.get("type") != "pods" or r.get("subresource") != "exec":
-            continue
-        actor = _actor_name(ev)
-        pod = r.get("name", "")
-        ns = r.get("namespace", "")
-        target = f"{ns}/{pod}"
+
+        actor = event["actor_name"]
+        pod = event["resource_name"]
+        namespace = event["namespace"]
+        target = f"{namespace}/{pod}"
         key = f"r2|{actor}|{target}"
         if key in seen:
             continue
         seen.add(key)
-        t = _event_time(ev)
-        yield _build_finding(
+
+        time_ms = event["time_ms"]
+        yield _build_native_finding(
             rule_id="r2-pod-exec",
             title="Service account executed a shell inside a pod",
             desc=(
                 f"Service account '{actor}' called `create` on pods/exec for pod "
-                f"'{pod}' in namespace '{ns}'. Workloads (as opposed to human "
+                f"'{pod}' in namespace '{namespace}'. Workloads (as opposed to human "
                 f"operators) should never exec into other pods — this is the "
                 f"precursor to container escape. (MITRE T1611)"
             ),
@@ -315,61 +396,56 @@ def rule2_pod_exec(events: list[dict[str, Any]]) -> Iterable[dict[str, Any]]:
             sub_technique_name=None,
             actor=actor,
             target=target,
-            first_seen_time=t,
-            last_seen_time=t,
+            first_seen_time=time_ms,
+            last_seen_time=time_ms,
             observables=[
                 {"name": "actor.name", "type": "Other", "value": actor},
                 {"name": "pod.name", "type": "Other", "value": pod},
-                {"name": "namespace", "type": "Other", "value": ns},
+                {"name": "namespace", "type": "Other", "value": namespace},
                 {"name": "rule", "type": "Other", "value": "r2-pod-exec"},
             ],
             evidence_count=1,
         )
 
 
-# ---------------------------------------------------------------------------
-# Rule 3: Non-admin creates a RoleBinding / ClusterRoleBinding (T1098)
-# ---------------------------------------------------------------------------
-
-
 def _is_admin(event: dict[str, Any]) -> bool:
-    actor = _actor_name(event)
+    normalized = _normalize_event(event) or event
+    actor = str(normalized.get("actor_name") or "")
     if actor in ADMIN_USERS:
         return True
-    if _actor_groups(event) & ADMIN_GROUPS:
-        return True
-    return False
+    groups = normalized.get("actor_groups") or ()
+    return bool(set(groups) & ADMIN_GROUPS)
 
 
 def rule3_rbac_self_grant(events: list[dict[str, Any]]) -> Iterable[dict[str, Any]]:
     """create on rolebindings or clusterrolebindings by a non-admin."""
+    normalized = _normalized_events(events)
     seen: set[str] = set()
-    for ev in events:
-        if not _is_api_activity(ev):
+    for event in normalized:
+        if event["operation"] != "create":
             continue
-        if _verb(ev) != "create":
+        resource_type = event["resource_type"]
+        if resource_type not in ("rolebindings", "clusterrolebindings"):
             continue
-        r = _resource(ev)
-        rtype = r.get("type", "")
-        if rtype not in ("rolebindings", "clusterrolebindings"):
+        if _is_admin(event):
             continue
-        if _is_admin(ev):
-            continue
-        actor = _actor_name(ev)
-        binding_name = r.get("name", "")
-        ns = r.get("namespace", "")
-        target = f"{rtype}/{ns}/{binding_name}"
+
+        actor = event["actor_name"]
+        binding_name = event["resource_name"]
+        namespace = event["namespace"]
+        target = f"{resource_type}/{namespace}/{binding_name}"
         key = f"r3|{actor}|{target}"
         if key in seen:
             continue
         seen.add(key)
-        t = _event_time(ev)
-        yield _build_finding(
+
+        time_ms = event["time_ms"]
+        yield _build_native_finding(
             rule_id="r3-rbac-self-grant",
-            title=f"Non-admin principal created a {rtype[:-1]}",
+            title=f"Non-admin principal created a {resource_type[:-1]}",
             desc=(
-                f"Principal '{actor}' created {rtype[:-1]} '{binding_name}'"
-                f"{f' in namespace {ns}' if ns else ''}. This principal is not "
+                f"Principal '{actor}' created {resource_type[:-1]} '{binding_name}'"
+                f"{f' in namespace {namespace}' if namespace else ''}. This principal is not "
                 f"in system:masters and is not a recognised admin user — creating "
                 f"a binding is the canonical K8s privilege-escalation move after "
                 f"initial compromise. (MITRE T1098)"
@@ -383,55 +459,50 @@ def rule3_rbac_self_grant(events: list[dict[str, Any]]) -> Iterable[dict[str, An
             sub_technique_name=None,
             actor=actor,
             target=target,
-            first_seen_time=t,
-            last_seen_time=t,
+            first_seen_time=time_ms,
+            last_seen_time=time_ms,
             observables=[
                 {"name": "actor.name", "type": "Other", "value": actor},
-                {"name": "binding.type", "type": "Other", "value": rtype},
+                {"name": "binding.type", "type": "Other", "value": resource_type},
                 {"name": "binding.name", "type": "Other", "value": binding_name},
-                {"name": "namespace", "type": "Other", "value": ns},
+                {"name": "namespace", "type": "Other", "value": namespace},
                 {"name": "rule", "type": "Other", "value": "r3-rbac-self-grant"},
             ],
             evidence_count=1,
         )
 
 
-# ---------------------------------------------------------------------------
-# Rule 4: Service-account token self-grant (T1550.001)
-# ---------------------------------------------------------------------------
-
-
 def rule4_token_self_grant(events: list[dict[str, Any]]) -> Iterable[dict[str, Any]]:
     """create on serviceaccounts/token(request) or tokenreviews by a service account."""
+    normalized = _normalized_events(events)
     seen: set[str] = set()
-    for ev in events:
-        if not _is_api_activity(ev):
+    for event in normalized:
+        if not _actor_is_service_account(event):
             continue
-        if not _actor_is_service_account(ev):
+        if event["operation"] != "create":
             continue
-        if _verb(ev) != "create":
-            continue
-        r = _resource(ev)
-        rtype = r.get("type", "")
-        subres = r.get("subresource", "")
-        hit = (rtype == "serviceaccounts" and subres in ("token", "tokenrequest")) or rtype == "tokenreviews"
+        resource_type = event["resource_type"]
+        subresource = event["subresource"]
+        hit = (resource_type == "serviceaccounts" and subresource in ("token", "tokenrequest")) or resource_type == "tokenreviews"
         if not hit:
             continue
-        actor = _actor_name(ev)
-        target_sa = r.get("name", "")
-        ns = r.get("namespace", "")
-        target = f"{ns}/{target_sa}"
+
+        actor = event["actor_name"]
+        target_sa = event["resource_name"]
+        namespace = event["namespace"]
+        target = f"{namespace}/{target_sa}"
         key = f"r4|{actor}|{target}"
         if key in seen:
             continue
         seen.add(key)
-        t = _event_time(ev)
-        yield _build_finding(
+
+        time_ms = event["time_ms"]
+        yield _build_native_finding(
             rule_id="r4-token-self-grant",
             title="Service account issued itself (or another SA) an API token",
             desc=(
                 f"Service account '{actor}' created a token for '{target_sa or 'tokenreview'}' "
-                f"in namespace '{ns}'. Combined with secret access or RBAC "
+                f"in namespace '{namespace}'. Combined with secret access or RBAC "
                 f"manipulation this is token-theft in progress. (MITRE T1550.001)"
             ),
             severity_id=SEVERITY_HIGH,
@@ -443,38 +514,33 @@ def rule4_token_self_grant(events: list[dict[str, Any]]) -> Iterable[dict[str, A
             sub_technique_name=R4_SUB_NAME,
             actor=actor,
             target=target,
-            first_seen_time=t,
-            last_seen_time=t,
+            first_seen_time=time_ms,
+            last_seen_time=time_ms,
             observables=[
                 {"name": "actor.name", "type": "Other", "value": actor},
                 {"name": "target.serviceaccount", "type": "Other", "value": target_sa},
-                {"name": "namespace", "type": "Other", "value": ns},
+                {"name": "namespace", "type": "Other", "value": namespace},
                 {"name": "rule", "type": "Other", "value": "r4-token-self-grant"},
             ],
             evidence_count=1,
         )
 
 
-# ---------------------------------------------------------------------------
-# Main detect entry point
-# ---------------------------------------------------------------------------
-
-
-def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
-    """Run all four rules over an event stream and yield all findings.
-
-    Events are materialised into a list so rules can make two passes (needed
-    for Rule 1's correlation). Findings are yielded in deterministic order:
-    r1 findings, then r2, then r3, then r4, each in event-time order.
-    """
+def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    """Run all four rules over an event stream and yield all findings."""
     events_list = list(events)
-    # Sort by time for deterministic output
-    events_list.sort(key=_event_time)
+    native_findings: list[dict[str, Any]] = []
+    native_findings.extend(rule1_secret_enumeration(events_list))
+    native_findings.extend(rule2_pod_exec(events_list))
+    native_findings.extend(rule3_rbac_self_grant(events_list))
+    native_findings.extend(rule4_token_self_grant(events_list))
 
-    yield from rule1_secret_enumeration(events_list)
-    yield from rule2_pod_exec(events_list)
-    yield from rule3_rbac_self_grant(events_list)
-    yield from rule4_token_self_grant(events_list)
+    native_findings.sort(key=lambda finding: finding["time_ms"])
+    for native_finding in native_findings:
+        if output_format == "native":
+            yield native_finding
+        else:
+            yield _render_ocsf_finding(native_finding)
 
 
 def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
@@ -484,8 +550,8 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             continue
         try:
             obj = json.loads(line)
-        except json.JSONDecodeError as e:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {e}", file=sys.stderr)
+        except json.JSONDecodeError as exc:
+            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {exc}", file=sys.stderr)
             continue
         if isinstance(obj, dict):
             yield obj
@@ -494,9 +560,17 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Detect K8s privilege escalation from OCSF API Activity events.")
-    parser.add_argument("input", nargs="?", help="OCSF JSONL input. Defaults to stdin.")
-    parser.add_argument("--output", "-o", help="OCSF Detection Finding JSONL output. Defaults to stdout.")
+    parser = argparse.ArgumentParser(
+        description="Detect K8s privilege escalation from OCSF or native API Activity events."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=OUTPUT_FORMATS,
+        default="ocsf",
+        help="Render OCSF findings or the native enriched finding shape.",
+    )
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
@@ -504,7 +578,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         events = list(load_jsonl(in_stream))
-        for finding in detect(events):
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py
+++ b/skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py
@@ -70,6 +70,35 @@ def _sa_event(
     }
 
 
+def _native_sa_event(
+    *,
+    verb: str,
+    resource_type: str,
+    time_ms: int = 1775797200000,
+    name: str = "",
+    namespace: str = "default",
+    subresource: str = "",
+    sa: str = "system:serviceaccount:default:builder",
+    groups: list[str] | None = None,
+) -> dict:
+    r: dict = {"type": resource_type}
+    if name:
+        r["name"] = name
+    if namespace:
+        r["namespace"] = namespace
+    if subresource:
+        r["subresource"] = subresource
+    return {
+        "schema_mode": "native",
+        "record_type": "api_activity",
+        "provider": "Kubernetes",
+        "time_ms": time_ms,
+        "operation": verb,
+        "actor": {"user": {"name": sa, "type": "ServiceAccount", "groups": [{"name": g} for g in (groups or [])]}},
+        "resources": [r],
+    }
+
+
 # ── Rule 1: secret enumeration ────────────────────────────────────────
 
 
@@ -81,7 +110,7 @@ class TestRule1:
         ]
         findings = list(rule1_secret_enumeration(events))
         assert len(findings) == 1
-        assert findings[0]["finding_info"]["attacks"][0]["sub_technique"]["uid"] == R1_SUB_UID
+        assert findings[0]["mitre_attacks"][0]["sub_technique_uid"] == R1_SUB_UID
         assert findings[0]["severity_id"] == SEVERITY_HIGH
 
     def test_get_without_list_does_not_fire(self):
@@ -146,9 +175,18 @@ class TestRule1:
             _sa_event(verb="list", resource_type="secrets", time_ms=1000),
             _sa_event(verb="get", resource_type="secrets", name="db", time_ms=2000),
         ]
-        a = list(rule1_secret_enumeration(events))[0]["finding_info"]["uid"]
-        b = list(rule1_secret_enumeration(events))[0]["finding_info"]["uid"]
+        a = list(rule1_secret_enumeration(events))[0]["finding_uid"]
+        b = list(rule1_secret_enumeration(events))[0]["finding_uid"]
         assert a == b
+
+    def test_native_input_fires(self):
+        events = [
+            _native_sa_event(verb="list", resource_type="secrets", time_ms=1000),
+            _native_sa_event(verb="get", resource_type="secrets", name="db", time_ms=2000),
+        ]
+        findings = list(rule1_secret_enumeration(events))
+        assert len(findings) == 1
+        assert findings[0]["rule_name"] == "r1-secret-enum"
 
 
 # ── Rule 2: pod exec ──────────────────────────────────────────────────
@@ -159,7 +197,7 @@ class TestRule2:
         events = [_sa_event(verb="create", resource_type="pods", name="web", subresource="exec")]
         findings = list(rule2_pod_exec(events))
         assert len(findings) == 1
-        assert findings[0]["finding_info"]["attacks"][0]["technique"]["uid"] == R2_TECH_UID
+        assert findings[0]["mitre_attacks"][0]["technique_uid"] == R2_TECH_UID
         assert findings[0]["severity_id"] == SEVERITY_CRITICAL
 
     def test_pod_create_without_exec_subresource_does_not_fire(self):
@@ -190,6 +228,12 @@ class TestRule2:
         ]
         assert len(list(rule2_pod_exec(events))) == 1
 
+    def test_native_input_fires(self):
+        events = [_native_sa_event(verb="create", resource_type="pods", name="web", subresource="exec")]
+        findings = list(rule2_pod_exec(events))
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "critical"
+
 
 # ── Rule 3: RBAC self-grant ───────────────────────────────────────────
 
@@ -214,7 +258,7 @@ class TestRule3:
         )
         findings = list(rule3_rbac_self_grant([ev]))
         assert len(findings) == 1
-        assert findings[0]["finding_info"]["attacks"][0]["technique"]["uid"] == R3_TECH_UID
+        assert findings[0]["mitre_attacks"][0]["technique_uid"] == R3_TECH_UID
         assert findings[0]["severity_id"] == SEVERITY_CRITICAL
 
     def test_non_admin_rb_fires(self):
@@ -241,6 +285,20 @@ class TestRule3:
         events = [_sa_event(verb="create", resource_type="pods", name="web")]
         assert list(rule3_rbac_self_grant(events)) == []
 
+    def test_native_input_fires(self):
+        event = {
+            "schema_mode": "native",
+            "record_type": "api_activity",
+            "provider": "Kubernetes",
+            "time_ms": 1000,
+            "operation": "create",
+            "actor": {"user": {"name": "user-bob", "type": "User", "groups": []}},
+            "resources": [{"type": "rolebindings", "name": "attacker", "namespace": "default"}],
+        }
+        findings = list(rule3_rbac_self_grant([event]))
+        assert len(findings) == 1
+        assert findings[0]["rule_name"] == "r3-rbac-self-grant"
+
 
 # ── Rule 4: token self-grant ──────────────────────────────────────────
 
@@ -250,7 +308,7 @@ class TestRule4:
         events = [_sa_event(verb="create", resource_type="serviceaccounts", name="target-sa", subresource="token")]
         findings = list(rule4_token_self_grant(events))
         assert len(findings) == 1
-        assert findings[0]["finding_info"]["attacks"][0]["sub_technique"]["uid"] == R4_SUB_UID
+        assert findings[0]["mitre_attacks"][0]["sub_technique_uid"] == R4_SUB_UID
 
     def test_tokenrequest_subresource_fires(self):
         events = [_sa_event(verb="create", resource_type="serviceaccounts", name="target-sa", subresource="tokenrequest")]
@@ -276,6 +334,12 @@ class TestRule4:
         ]
         assert list(rule4_token_self_grant(events)) == []
 
+    def test_native_input_fires(self):
+        events = [_native_sa_event(verb="create", resource_type="serviceaccounts", name="target-sa", subresource="token")]
+        findings = list(rule4_token_self_grant(events))
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+
 
 # ── Finding shape / OCSF compliance ───────────────────────────────────
 
@@ -297,6 +361,22 @@ class TestFindingShape:
         assert "attacks" not in f, "attacks[] must NOT be at event root in OCSF 1.8"
         assert "attacks" in f["finding_info"]
         assert len(f["finding_info"]["attacks"]) == 1
+
+    def test_native_output_has_no_ocsf_envelope(self):
+        events = [_sa_event(verb="create", resource_type="pods", name="web", subresource="exec")]
+        finding = list(detect(events, output_format="native"))[0]
+        assert finding["schema_mode"] == "native"
+        assert finding["record_type"] == "detection_finding"
+        assert finding["output_format"] == "native"
+        assert "class_uid" not in finding
+        assert "finding_info" not in finding
+        assert finding["rule_name"] == "r2-pod-exec"
+
+    def test_native_input_can_still_emit_ocsf(self):
+        events = [_native_sa_event(verb="create", resource_type="pods", name="web", subresource="exec")]
+        finding = list(detect(events))[0]
+        assert finding["class_uid"] == FINDING_CLASS_UID
+        assert finding["finding_info"]["uid"].startswith("det-k8s-r2-pod-exec-")
 
 
 # ── load_jsonl robustness ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add native input and output support to detect-privilege-escalation-k8s while keeping OCSF as the default path
- update the skill contract and rollout docs so the Kubernetes dual-mode pilot now includes both main detectors
- extend the detector test suite with native-input and native-output coverage plus a green K8s integration check

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py -q -o addopts=''
- uv run pytest tests/integration/test_k8s_pipeline.py -q -o addopts=''
- uv run ruff check skills/detection/detect-privilege-escalation-k8s/src/detect.py skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py README.md docs/NATIVE_VS_OCSF.md CHANGELOG.md --config pyproject.toml