### PR TITLE
feat: pilot native and OCSF MCP activity path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is loosely based on Keep a Changelog.
 - Extended the native/OCSF pilot to `ingest-vpc-flow-logs-ocsf`, so AWS flow logs can now emit either OCSF Network Activity or the repo's canonical native network-flow shape while preserving a compatible end-to-end lateral-movement path.
 - Extended the native/OCSF pilot to `ingest-k8s-audit-ocsf` and `detect-sensitive-secret-read-k8s`, so Kubernetes audit ingestion and one Kubernetes detector now support the same dual-mode rollout pattern as the earlier CloudTrail / VPC / lateral-movement pilots.
 - Extended the native/OCSF pilot to `detect-privilege-escalation-k8s`, so the main windowed Kubernetes privilege-escalation detector now accepts native or OCSF input and can emit native or OCSF findings.
+- Extended the native/OCSF pilot to `ingest-mcp-proxy-ocsf` and `detect-mcp-tool-drift`, so the MCP application-activity ingestion and tool-drift detection path now supports native or OCSF input/output without changing the core drift logic.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
   - `ingest-cloudtrail-ocsf`
   - `ingest-vpc-flow-logs-ocsf`
   - `ingest-k8s-audit-ocsf`
+  - `ingest-mcp-proxy-ocsf`
   - `detect-lateral-movement`
   - `detect-privilege-escalation-k8s`
   - `detect-sensitive-secret-read-k8s`
+  - `detect-mcp-tool-drift`
 - native-first with optional bridge:
   - `discover-environment`
   - `discover-control-evidence`

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -136,9 +136,11 @@ Implemented dual-mode skills today:
 - `ingest-cloudtrail-ocsf`
 - `ingest-vpc-flow-logs-ocsf`
 - `ingest-k8s-audit-ocsf`
+- `ingest-mcp-proxy-ocsf`
 - `detect-lateral-movement`
 - `detect-privilege-escalation-k8s`
 - `detect-sensitive-secret-read-k8s`
+- `detect-mcp-tool-drift`
 
 Implemented native-first with bridge skills today:
 

--- a/skills/detection/detect-mcp-tool-drift/SKILL.md
+++ b/skills/detection/detect-mcp-tool-drift/SKILL.md
@@ -2,8 +2,9 @@
 name: detect-mcp-tool-drift
 description: >-
   Detect MCP tool schema drift mid-session — the MCP tool-poisoning / rug-pull
-  attack pattern. Reads OCSF 1.8 Application Activity (class 6002) events produced
-  by ingest-mcp-proxy-ocsf, groups them by session, and flags any tool whose
+  attack pattern. Reads OCSF 1.8 Application Activity (class 6002) or the native
+  application-activity projection produced by ingest-mcp-proxy-ocsf, groups them
+  by session, and flags any tool whose
   fingerprint (sha256 over name + description + inputSchema + annotations) changes
   between tools/list responses in the same session. Emits OCSF 1.8 Detection
   Finding (class 2004) with MITRE ATT&CK T1195.001 (Compromise Software Supply
@@ -18,8 +19,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
-input_formats: ocsf
-output_formats: ocsf
+input_formats: canonical, native, ocsf
+output_formats: native, ocsf
 ---
 
 # detect-mcp-tool-drift
@@ -32,7 +33,12 @@ This is the **MCP tool-poisoning** / **rug-pull** pattern. It maps to MITRE ATT&
 
 ## Detection logic
 
-Walk OCSF Application Activity events (emitted by `ingest-mcp-proxy-ocsf`) in timestamp order. For each session and tool name, track the last-seen fingerprint. If a later `tools/list` entry for the same `(session, tool name)` has a different fingerprint, emit **one** Detection Finding per drift event.
+Walk MCP Application Activity events in timestamp order. The detector accepts:
+
+- OCSF Application Activity emitted by `ingest-mcp-proxy-ocsf`
+- the native or canonical activity projection emitted by the same skill when `--output-format native` is selected
+
+For each session and tool name, track the last-seen fingerprint. If a later `tools/list` entry for the same `(session, tool name)` has a different fingerprint, emit **one** Detection Finding per drift event.
 
 ```
 state[(session_uid, tool_name)] = last_fingerprint
@@ -44,7 +50,9 @@ state[(session_uid, tool_name)] = last_fingerprint
 
 ## Output contract
 
-One OCSF 1.8 Detection Finding (class `2004`) per drift event. Populates:
+One Detection Finding per drift event. By default the skill emits OCSF 1.8 Detection Finding (class `2004`). With `--output-format native`, it emits the repo-owned native finding projection.
+
+OCSF output populates:
 
 - `finding_info.attacks[]`: MITRE ATT&CK v14, tactic TA0001 (Initial Access), technique T1195.001 (Compromise Software Supply Chain).
 - `finding_info.types[]`: `["mcp-tool-drift"]` for downstream filtering.
@@ -63,8 +71,45 @@ python ../ingest-mcp-proxy-ocsf/src/ingest.py mcp-proxy.jsonl \
   | python src/detect.py \
   > drift-findings.ocsf.jsonl
 
+# Native input and native output
+python ../ingest-mcp-proxy-ocsf/src/ingest.py mcp-proxy.jsonl --output-format native \
+  | python src/detect.py --output-format native \
+  > drift-findings.native.jsonl
+
 # Standalone file
 python src/detect.py ../golden/mcp_proxy_sample.ocsf.jsonl
+```
+
+## Native output format
+
+When `--output-format native` is selected, the skill emits:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "detection_finding"`
+- `finding_uid` and `event_uid`
+- `provider`
+- `time_ms`
+- `session_uid`
+- `tool_name`
+- `before_fingerprint`
+- `after_fingerprint`
+- `mitre_attacks`
+
+Example:
+
+```json
+{
+  "schema_mode": "native",
+  "canonical_schema_version": "2026-04",
+  "record_type": "detection_finding",
+  "finding_uid": "det-mcp-drift-sess-abc-query_db-9b5f6e3c-7d10a2bf",
+  "provider": "MCP",
+  "session_uid": "sess-abc",
+  "tool_name": "query_db",
+  "before_fingerprint": "sha256:...",
+  "after_fingerprint": "sha256:..."
+}
 ```
 
 ## Tests

--- a/skills/detection/detect-mcp-tool-drift/src/detect.py
+++ b/skills/detection/detect-mcp-tool-drift/src/detect.py
@@ -1,8 +1,9 @@
-"""Detect MCP tool schema drift mid-session (OCSF input → OCSF Detection Finding).
+"""Detect MCP tool schema drift mid-session from OCSF or native activity streams.
 
-Reads OCSF 1.8 Application Activity events (class 6002) produced by the sibling
-ingest-mcp-proxy-ocsf skill, tracks tool fingerprints per (session, tool name),
-and emits one OCSF Detection Finding (class 2004) per drift event.
+Reads OCSF 1.8 Application Activity events (class 6002) or the native MCP
+application-activity projection produced by the sibling ingest skill, tracks
+tool fingerprints per (session, tool name), and emits one Detection Finding per
+drift event.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -10,6 +11,7 @@ Contract: see ../OCSF_CONTRACT.md
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from datetime import datetime, timezone
@@ -17,6 +19,8 @@ from typing import Any, Iterable
 
 SKILL_NAME = "detect-mcp-tool-drift"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 # Detection Finding (2004) — the replacement for the deprecated
 # Security Finding (2001) since OCSF 1.1.0.
@@ -43,15 +47,61 @@ MITRE_TECHNIQUE_NAME = "Supply Chain Compromise: Compromise Software Supply Chai
 # ---------------------------------------------------------------------------
 
 
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _short(value: str) -> str:
+    return hashlib.sha256((value or "").encode("utf-8")).hexdigest()[:8]
+
+
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    if "class_uid" in event:
+        if event.get("class_uid") != 6002:
+            return None
+        mcp = event.get("mcp") or {}
+        tool = mcp.get("tool") or {}
+        return {
+            "source_format": "ocsf",
+            "session_uid": str(mcp.get("session_uid") or "sess-unknown"),
+            "method": str(mcp.get("method") or ""),
+            "direction": str(mcp.get("direction") or ""),
+            "time_ms": _safe_int(event.get("time")),
+            "tool_name": str(tool.get("name") or ""),
+            "fingerprint": str(tool.get("fingerprint") or ""),
+            "raw_event": event,
+        }
+
+    schema_mode = str(event.get("schema_mode") or "").strip().lower()
+    if schema_mode and schema_mode not in {"canonical", "native"}:
+        return None
+    record_type = str(event.get("record_type") or "").strip().lower()
+    if record_type and record_type != "application_activity":
+        return None
+    tool = event.get("tool") or {}
+    return {
+        "source_format": schema_mode or "native",
+        "session_uid": str(event.get("session_uid") or "sess-unknown"),
+        "method": str(event.get("method") or ""),
+        "direction": str(event.get("direction") or ""),
+        "time_ms": _safe_int(event.get("time_ms") or event.get("time")),
+        "tool_name": str(tool.get("name") or event.get("tool_name") or ""),
+        "fingerprint": str(tool.get("fingerprint") or event.get("tool_fingerprint") or ""),
+        "raw_event": event,
+    }
+
+
 def _is_tools_list_response_with_fingerprint(event: dict[str, Any]) -> bool:
     """True iff the event is a tools/list response with a populated tool fingerprint."""
-    if event.get("class_uid") != 6002:
+    normalized = _normalize_event(event)
+    if not normalized:
         return False
-    mcp = event.get("mcp") or {}
-    if mcp.get("method") != "tools/list" or mcp.get("direction") != "response":
+    if normalized["method"] != "tools/list" or normalized["direction"] != "response":
         return False
-    tool = mcp.get("tool") or {}
-    return bool(tool.get("name")) and bool(tool.get("fingerprint"))
+    return bool(normalized["tool_name"]) and bool(normalized["fingerprint"])
 
 
 def _now_ms() -> int:
@@ -69,18 +119,9 @@ def _build_finding(
     before_event: dict[str, Any],
     after_event: dict[str, Any],
 ) -> dict[str, Any]:
-    """Produce one OCSF 1.8 Detection Finding (class 2004) describing a single drift.
-
-    Field layout follows OCSF 1.8:
-      - attacks[] lives INSIDE finding_info (not at event root — that was the
-        pre-1.1 Security Finding layout).
-      - status_id is recommended, not required.
-      - type_uid = class_uid * 100 + activity_id  (200401).
-    """
-    before_tool = before_event["mcp"]["tool"]
-    after_tool = after_event["mcp"]["tool"]
-    before_fp = before_tool["fingerprint"]
-    after_fp = after_tool["fingerprint"]
+    """Produce one native detection finding describing a single drift."""
+    before_fp = before_event["fingerprint"]
+    after_fp = after_event["fingerprint"]
 
     # Deterministic ID so re-running on the same input is idempotent.
     uid = f"det-mcp-drift-{session_uid}-{tool_name}-{before_fp.split(':')[-1][:8]}-{after_fp.split(':')[-1][:8]}"
@@ -94,55 +135,45 @@ def _build_finding(
     )
 
     return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": uid,
+        "event_uid": uid,
+        "provider": "MCP",
+        "time_ms": after_event.get("time_ms") or _now_ms(),
+        "severity": "high",
         "activity_id": FINDING_ACTIVITY_CREATE,
-        "category_uid": FINDING_CATEGORY_UID,
-        "category_name": FINDING_CATEGORY_NAME,
-        "class_uid": FINDING_CLASS_UID,
-        "class_name": FINDING_CLASS_NAME,
-        "type_uid": FINDING_TYPE_UID,
         "severity_id": SEVERITY_HIGH,
-        "status_id": 1,  # 1 Success — recommended field, the detector ran cleanly
-        "time": after_event.get("time") or _now_ms(),
-        "metadata": {
-            "version": OCSF_VERSION,
-            "uid": uid,
-            "product": {
-                "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
-                "feature": {"name": SKILL_NAME},
-            },
-            "labels": ["detection-engineering", "mcp", "supply-chain", "tool-drift"],
-        },
-        "finding_info": {
-            "uid": uid,
-            "title": title,
-            "desc": desc,
-            "types": ["mcp-tool-drift"],
-            "first_seen_time": before_event.get("time"),
-            "last_seen_time": after_event.get("time"),
-            "attacks": [
-                {
-                    "version": MITRE_VERSION,
-                    "tactic": {"name": MITRE_TACTIC_NAME, "uid": MITRE_TACTIC_UID},
-                    "technique": {"name": MITRE_TECHNIQUE_NAME, "uid": MITRE_TECHNIQUE_UID},
-                }
-            ],
-        },
+        "status": "success",
+        "status_id": 1,
+        "title": title,
+        "description": desc,
+        "finding_types": ["mcp-tool-drift"],
+        "first_seen_time_ms": before_event.get("time_ms"),
+        "last_seen_time_ms": after_event.get("time_ms"),
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": MITRE_TACTIC_UID,
+                "tactic_name": MITRE_TACTIC_NAME,
+                "technique_uid": MITRE_TECHNIQUE_UID,
+                "technique_name": MITRE_TECHNIQUE_NAME,
+            }
+        ],
+        "session_uid": session_uid,
+        "tool_name": tool_name,
+        "before_fingerprint": before_fp,
+        "after_fingerprint": after_fp,
         "observables": [
             {"name": "session.uid", "type": "Other", "value": session_uid},
             {"name": "tool.name", "type": "Other", "value": tool_name},
             {"name": "tool.before_fingerprint", "type": "Fingerprint", "value": before_fp},
             {"name": "tool.after_fingerprint", "type": "Fingerprint", "value": after_fp},
         ],
-        "evidence": {
-            "events_observed": 2,
-            "before_event_time": before_event.get("time"),
-            "after_event_time": after_event.get("time"),
-            # Intentionally empty: per the OCSF contract, raw events live in
-            # downstream storage (S3 / ClickHouse), not inside the finding body.
-            # Callers that need the raw events pivot via observables.session.uid.
-            "raw_events": [],
-        },
+        "evidence_count": 2,
     }
 
 
@@ -151,7 +182,54 @@ def _build_finding(
 # ---------------------------------------------------------------------------
 
 
-def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    attack = native_finding["mitre_attacks"][0]
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": native_finding["severity_id"],
+        "status_id": native_finding["status_id"],
+        "time": native_finding["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native_finding["event_uid"],
+            "product": {
+                "name": "cloud-ai-security-skills",
+                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["detection-engineering", "mcp", "supply-chain", "tool-drift"],
+        },
+        "finding_info": {
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "first_seen_time": native_finding["first_seen_time_ms"],
+            "last_seen_time": native_finding["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": attack["version"],
+                    "tactic": {"name": attack["tactic_name"], "uid": attack["tactic_uid"]},
+                    "technique": {"name": attack["technique_name"], "uid": attack["technique_uid"]},
+                }
+            ],
+        },
+        "observables": native_finding["observables"],
+        "evidence": {
+            "events_observed": native_finding["evidence_count"],
+            "before_event_time": native_finding["first_seen_time_ms"],
+            "after_event_time": native_finding["last_seen_time_ms"],
+            "raw_events": [],
+        },
+    }
+
+
+def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     """Walk events in order; yield a finding per (session, tool) drift.
 
     State is minimal: one last-seen fingerprint per (session, tool name). We also
@@ -159,18 +237,25 @@ def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
     exact evidence.
     """
     # (session_uid, tool_name) -> (last_fingerprint, last_event)
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
     state: dict[tuple[str, str], tuple[str, dict[str, Any]]] = {}
 
     # Materialise and stable-sort by time so out-of-order JSONL still works.
-    listed = [e for e in events if _is_tools_list_response_with_fingerprint(e)]
-    listed.sort(key=lambda e: (e.get("mcp", {}).get("session_uid", ""), e.get("time", 0)))
+    listed = []
+    for event in events:
+        if not _is_tools_list_response_with_fingerprint(event):
+            continue
+        normalized = _normalize_event(event)
+        if normalized:
+            listed.append(normalized)
+    listed.sort(key=lambda e: (e.get("session_uid", ""), e.get("time_ms", 0)))
 
     for event in listed:
-        mcp = event["mcp"]
-        session_uid = mcp.get("session_uid", "sess-unknown")
-        tool = mcp["tool"]
-        tool_name = tool["name"]
-        fingerprint = tool["fingerprint"]
+        session_uid = event["session_uid"]
+        tool_name = event["tool_name"]
+        fingerprint = event["fingerprint"]
 
         key = (session_uid, tool_name)
         prior = state.get(key)
@@ -183,7 +268,8 @@ def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
             # Republished with same fingerprint — no drift.
             continue
 
-        yield _build_finding(session_uid, tool_name, prior_event, event)
+        finding = _build_finding(session_uid, tool_name, prior_event, event)
+        yield _render_ocsf_finding(finding) if output_format == "ocsf" else finding
         # Update state so we only raise ONCE per distinct transition.
         # A subsequent re-drift will produce a new finding because the "before"
         # fingerprint has moved forward.
@@ -207,9 +293,15 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Detect MCP tool schema drift from OCSF events.")
-    parser.add_argument("input", nargs="?", help="OCSF JSONL input. Defaults to stdin.")
-    parser.add_argument("--output", "-o", help="OCSF Detection Finding JSONL output. Defaults to stdout.")
+    parser = argparse.ArgumentParser(description="Detect MCP tool schema drift from OCSF or native activity events.")
+    parser.add_argument("input", nargs="?", help="OCSF or native JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="Detection Finding JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=OUTPUT_FORMATS,
+        default="ocsf",
+        help="Render OCSF Detection Finding (default) or the native canonical projection.",
+    )
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
@@ -217,7 +309,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         events = list(load_jsonl(in_stream))
-        for finding in detect(events):
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/detection/detect-mcp-tool-drift/tests/test_detect.py
+++ b/skills/detection/detect-mcp-tool-drift/tests/test_detect.py
@@ -19,14 +19,17 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from detect import (  # type: ignore[import-not-found]
+    CANONICAL_VERSION,
     FINDING_CATEGORY_UID,
     FINDING_CLASS_UID,
     FINDING_TYPE_UID,
     MITRE_TACTIC_UID,
     MITRE_TECHNIQUE_UID,
+    OUTPUT_FORMATS,
     SEVERITY_HIGH,
     SKILL_NAME,
     _is_tools_list_response_with_fingerprint,
+    _normalize_event,
     detect,
     load_jsonl,
 )
@@ -69,6 +72,23 @@ class TestFilter:
         e = {"class_uid": 6002, "mcp": {"method": "tools/list", "direction": "response", "tool": {"name": "x", "fingerprint": "sha256:f"}}}
         assert _is_tools_list_response_with_fingerprint(e)
 
+    def test_accepts_valid_native(self):
+        assert _is_tools_list_response_with_fingerprint(_native_ev("s1", "x", "sha256:f", 100))
+
+
+class TestNormalize:
+    def test_normalizes_ocsf_event(self):
+        normalized = _normalize_event(_ev("s1", "x", "sha256:f", 100))
+        assert normalized is not None
+        assert normalized["source_format"] == "ocsf"
+        assert normalized["tool_name"] == "x"
+
+    def test_normalizes_native_event(self):
+        normalized = _normalize_event(_native_ev("s1", "x", "sha256:f", 100))
+        assert normalized is not None
+        assert normalized["source_format"] == "native"
+        assert normalized["tool_name"] == "x"
+
 
 # ── detect() behaviour ─────────────────────────────────────────────────
 
@@ -83,6 +103,20 @@ def _ev(session: str, tool: str, fp: str, time_ms: int) -> dict:
             "direction": "response",
             "tool": {"name": tool, "fingerprint": fp},
         },
+    }
+
+
+def _native_ev(session: str, tool: str, fp: str, time_ms: int) -> dict:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "application_activity",
+        "provider": "MCP",
+        "time_ms": time_ms,
+        "session_uid": session,
+        "method": "tools/list",
+        "direction": "response",
+        "tool": {"name": tool, "fingerprint": fp},
     }
 
 
@@ -188,6 +222,48 @@ class TestDetect:
         obs = {o["name"]: o["value"] for o in findings[0]["observables"]}
         assert obs["tool.before_fingerprint"] == "sha256:a"
         assert obs["tool.after_fingerprint"] == "sha256:b"
+
+    def test_native_input_can_emit_native_finding(self):
+        findings = list(
+            detect(
+                [
+                    _native_ev("s1", "t1", "sha256:a", 100),
+                    _native_ev("s1", "t1", "sha256:b", 200),
+                ],
+                output_format="native",
+            )
+        )
+        assert OUTPUT_FORMATS == ("ocsf", "native")
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["schema_mode"] == "native"
+        assert finding["record_type"] == "detection_finding"
+        assert finding["provider"] == "MCP"
+        assert finding["session_uid"] == "s1"
+        assert "class_uid" not in finding
+
+    def test_native_input_can_emit_ocsf_finding(self):
+        findings = list(
+            detect(
+                [
+                    _native_ev("s1", "t1", "sha256:a", 100),
+                    _native_ev("s1", "t1", "sha256:b", 200),
+                ],
+                output_format="ocsf",
+            )
+        )
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["class_uid"] == FINDING_CLASS_UID
+        assert finding["finding_info"]["uid"].startswith("det-mcp-drift-")
+
+    def test_rejects_unsupported_output_format(self):
+        try:
+            list(detect([], output_format="bridge"))
+        except ValueError as exc:
+            assert "unsupported output_format" in str(exc)
+        else:
+            raise AssertionError("expected unsupported output_format to raise")
 
 
 # ── load_jsonl robustness ──────────────────────────────────────────────

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
@@ -2,8 +2,9 @@
 name: ingest-mcp-proxy-ocsf
 description: >-
   Convert raw MCP proxy logs (from agent-bom proxy or any MCP JSON-RPC middleware)
-  into OCSF 1.8 Application Activity events (class 6002) with the cloud_security_mcp
-  custom profile. Every event carries session_uid, JSON-RPC method, direction, and
+  into Application Activity records. OCSF 1.8 (class 6002) is the default output,
+  with a native projection available via `--output-format native`. Every event carries
+  session_uid, JSON-RPC method, direction, and
   a stable tool fingerprint (sha256 of name + description + inputSchema + annotations)
   so downstream detection skills can spot schema drift. Use when the user mentions
   MCP proxy logs, OCSF ingestion, detection engineering pipeline, or wants to feed
@@ -16,12 +17,12 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: ocsf
+output_formats: native, ocsf
 ---
 
 # ingest-mcp-proxy-ocsf
 
-Thin, single-purpose ingestion skill: raw MCP proxy JSONL in → OCSF 1.8 Application Activity JSONL out. No detection logic, no side effects, no external calls.
+Thin, single-purpose ingestion skill: raw MCP proxy JSONL in → OCSF 1.8 Application Activity JSONL by default, or the repo-owned native application-activity projection when requested. No detection logic, no side effects, no external calls.
 
 ## Wire contract
 
@@ -42,14 +43,53 @@ Writes OCSF 1.8 Application Activity (class 6002) with the `cloud_security_mcp` 
 ## Usage
 
 ```bash
-# Single file
+# Single file, OCSF default
 python src/ingest.py mcp-proxy.jsonl > mcp-proxy.ocsf.jsonl
+
+# Native projection
+python src/ingest.py mcp-proxy.jsonl --output-format native > mcp-proxy.native.jsonl
 
 # Piped from a running proxy
 agent-bom proxy "<server cmd>" --log-format jsonl \
   | python src/ingest.py \
   | python ../detect-mcp-tool-drift/src/detect.py \
   > findings.ocsf.jsonl
+```
+
+## Native output format
+
+When `--output-format native` is selected, the skill emits the repo-owned
+canonical projection instead of the OCSF envelope. Each record includes:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "application_activity"`
+- `event_uid`
+- `provider`
+- `time_ms`
+- `session_uid`
+- `method`
+- `direction`
+- `tool` when the source event declares a tool
+
+Example:
+
+```json
+{
+  "schema_mode": "native",
+  "canonical_schema_version": "2026-04",
+  "record_type": "application_activity",
+  "event_uid": "7a1c...",
+  "provider": "MCP",
+  "time_ms": 1775797200000,
+  "session_uid": "sess-abc",
+  "method": "tools/list",
+  "direction": "response",
+  "tool": {
+    "name": "query_db",
+    "fingerprint": "sha256:..."
+  }
+}
 ```
 
 ## Fingerprint

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/src/ingest.py
@@ -1,4 +1,4 @@
-"""Convert raw MCP proxy logs to OCSF 1.8 Application Activity (class 6002).
+"""Convert raw MCP proxy logs to canonical or OCSF Application Activity records.
 
 Input:  JSONL as emitted by `agent-bom proxy --log-format jsonl`
 Output: JSONL of OCSF 1.8 Application Activity events with the
@@ -18,7 +18,9 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-mcp-proxy-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 MCP_PROFILE = "cloud_security_mcp"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 # OCSF 1.8 Application Activity (6002) — unchanged from 1.3 for this class.
 CLASS_UID = 6002
@@ -90,9 +92,8 @@ def parse_ts_ms(ts: str | None) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _base_event(raw: dict[str, Any], activity_id: int) -> dict[str, Any]:
-    """Populate every OCSF field pinned in OCSF_CONTRACT.md."""
-    metadata_uid = hashlib.sha256(
+def _event_uid(raw: dict[str, Any]) -> str:
+    return hashlib.sha256(
         json.dumps(
             {
                 "timestamp": raw.get("timestamp", ""),
@@ -106,19 +107,61 @@ def _base_event(raw: dict[str, Any], activity_id: int) -> dict[str, Any]:
             separators=(",", ":"),
         ).encode("utf-8")
     ).hexdigest()
+
+
+def _activity_name(activity_id: int) -> str:
     return {
+        ACTIVITY_CREATE: "create",
+        ACTIVITY_READ: "read",
+        ACTIVITY_UNKNOWN: "unknown",
+    }.get(activity_id, "unknown")
+
+
+def _status_name(status_id: int) -> str:
+    return {1: "success", 0: "unknown"}.get(status_id, "unknown")
+
+
+def _build_canonical_event(raw: dict[str, Any], activity_id: int) -> dict[str, Any]:
+    """Populate the stable repo-owned canonical activity shape."""
+    event_uid = _event_uid(raw)
+    return {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "application_activity",
+        "source_skill": SKILL_NAME,
+        "event_uid": event_uid,
+        "provider": "MCP",
+        "time_ms": parse_ts_ms(raw.get("timestamp")),
         "activity_id": activity_id,
+        "activity_name": _activity_name(activity_id),
+        "severity": "informational",
+        "severity_id": 1,
+        "status": _status_name(1),
+        "status_id": 1,
+        "profile": MCP_PROFILE,
+        "session_uid": raw.get("session_id", "sess-unknown"),
+        "method": raw.get("method", "unknown"),
+        "direction": raw.get("direction", "unknown"),
+        "params": raw.get("params") or {},
+        "body": raw.get("body") or {},
+    }
+
+
+def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    """Project the canonical activity shape into the pinned OCSF envelope."""
+    event = {
+        "activity_id": canonical["activity_id"],
         "category_uid": CATEGORY_UID,
         "category_name": CATEGORY_NAME,
         "class_uid": CLASS_UID,
         "class_name": CLASS_NAME,
-        "type_uid": CLASS_UID * 100 + activity_id,
-        "severity_id": 1,  # Informational — ingestion events are not findings
-        "status_id": 1,  # Success — a bad line is skipped upstream, not emitted as Failure
-        "time": parse_ts_ms(raw.get("timestamp")),
+        "type_uid": CLASS_UID * 100 + canonical["activity_id"],
+        "severity_id": canonical["severity_id"],
+        "status_id": canonical["status_id"],
+        "time": canonical["time_ms"],
         "metadata": {
             "version": OCSF_VERSION,
-            "uid": metadata_uid,
+            "uid": canonical["event_uid"],
             "profiles": [MCP_PROFILE],
             "product": {
                 "name": "cloud-ai-security-skills",
@@ -128,15 +171,26 @@ def _base_event(raw: dict[str, Any], activity_id: int) -> dict[str, Any]:
             "labels": ["detection-engineering", "mcp", "ingest"],
         },
         "mcp": {
-            "session_uid": raw.get("session_id", "sess-unknown"),
-            "method": raw.get("method", "unknown"),
-            "direction": raw.get("direction", "unknown"),
+            "session_uid": canonical["session_uid"],
+            "method": canonical["method"],
+            "direction": canonical["direction"],
         },
     }
+    if canonical.get("tool"):
+        event["mcp"]["tool"] = dict(canonical["tool"])
+    return event
 
 
-def _with_tool(event: dict[str, Any], tool: dict[str, Any]) -> dict[str, Any]:
-    event["mcp"]["tool"] = {
+def _render_native_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["output_format"] = "native"
+    return native
+
+
+def _with_tool(canonical: dict[str, Any], tool: dict[str, Any]) -> dict[str, Any]:
+    event = dict(canonical)
+    event["tool"] = {
         "name": tool.get("name", ""),
         "description": tool.get("description", ""),
         "input_schema_sha256": input_schema_fingerprint(tool),
@@ -145,8 +199,8 @@ def _with_tool(event: dict[str, Any], tool: dict[str, Any]) -> dict[str, Any]:
     return event
 
 
-def convert_event(raw: dict[str, Any]) -> Iterable[dict[str, Any]]:
-    """Convert one raw proxy line into zero or more OCSF events.
+def convert_event(raw: dict[str, Any], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    """Convert one raw proxy line into zero or more application activity events.
 
     - tools/list response -> one OCSF event per tool in the response (Create)
     - tools/call request  -> one OCSF event (Read) carrying the called tool's
@@ -160,26 +214,29 @@ def convert_event(raw: dict[str, Any]) -> Iterable[dict[str, Any]]:
     if method == "tools/list" and direction == "response":
         tools = (raw.get("body") or {}).get("tools") or []
         if not tools:
-            yield _base_event(raw, ACTIVITY_CREATE)
+            canonical = _build_canonical_event(raw, ACTIVITY_CREATE)
+            yield _render_native_event(canonical) if output_format == "native" else _render_ocsf_event(canonical)
             return
         for tool in tools:
-            yield _with_tool(_base_event(raw, ACTIVITY_CREATE), tool)
+            canonical = _with_tool(_build_canonical_event(raw, ACTIVITY_CREATE), tool)
+            yield _render_native_event(canonical) if output_format == "native" else _render_ocsf_event(canonical)
         return
 
     if method == "tools/call" and direction == "request":
         called_name = ((raw.get("params") or {}).get("name")) or ""
-        event = _base_event(raw, ACTIVITY_READ)
+        event = _build_canonical_event(raw, ACTIVITY_READ)
         if called_name:
             # Do NOT populate a fingerprint here — this is a call, not a
             # declaration. The detector pairs the call to the last-seen
             # fingerprint in the same session.
-            event["mcp"]["tool"] = {"name": called_name}
-        yield event
+            event["tool"] = {"name": called_name}
+        yield _render_native_event(event) if output_format == "native" else _render_ocsf_event(event)
         return
 
     # Anything else — emit a base event so the downstream pipeline stays
     # aware of activity on the session.
-    yield _base_event(raw, ACTIVITY_UNKNOWN)
+    canonical = _build_canonical_event(raw, ACTIVITY_UNKNOWN)
+    yield _render_native_event(canonical) if output_format == "native" else _render_ocsf_event(canonical)
 
 
 # ---------------------------------------------------------------------------
@@ -187,8 +244,10 @@ def convert_event(raw: dict[str, Any]) -> Iterable[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def ingest(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
-    """Yield OCSF events for a stream of raw JSONL lines."""
+def ingest(lines: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    """Yield activity records for a stream of raw JSONL lines."""
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
     for lineno, line in enumerate(lines, start=1):
         line = line.strip()
         if not line:
@@ -202,23 +261,31 @@ def ingest(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
             print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
             continue
         try:
-            yield from convert_event(raw)
+            yield from convert_event(raw, output_format=output_format)
         except Exception as e:  # defence-in-depth — never crash the pipeline
             print(f"[{SKILL_NAME}] skipping line {lineno}: convert error: {e}", file=sys.stderr)
             continue
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Convert raw MCP proxy JSONL to OCSF 1.8 Application Activity JSONL.")
+    parser = argparse.ArgumentParser(
+        description="Convert raw MCP proxy JSONL to OCSF or native Application Activity JSONL."
+    )
     parser.add_argument("input", nargs="?", help="Input JSONL file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=OUTPUT_FORMATS,
+        default="ocsf",
+        help="Render OCSF Application Activity (default) or the native canonical projection.",
+    )
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
     try:
-        for event in ingest(in_stream):
+        for event in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(event, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/tests/test_ingest.py
@@ -17,9 +17,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from ingest import (  # type: ignore[import-not-found]
     ACTIVITY_CREATE,
     ACTIVITY_READ,
+    CANONICAL_VERSION,
     CATEGORY_UID,
     CLASS_UID,
     OCSF_VERSION,
+    OUTPUT_FORMATS,
     SKILL_NAME,
     convert_event,
     ingest,
@@ -168,6 +170,26 @@ class TestConvertEvent:
         events = list(convert_event(raw))
         assert all(e["mcp"]["session_uid"] == "sess-unknown" for e in events)
 
+    def test_native_output_has_no_ocsf_envelope(self):
+        raw = {
+            "timestamp": "2026-04-10T05:00:00Z",
+            "session_id": "sess-abc",
+            "method": "tools/list",
+            "direction": "response",
+            "body": {"tools": [{"name": "query_db", "description": "", "inputSchema": {}, "annotations": {}}]},
+        }
+        events = list(convert_event(raw, output_format="native"))
+        assert len(events) == 1
+        event = events[0]
+        assert event["schema_mode"] == "native"
+        assert event["canonical_schema_version"] == CANONICAL_VERSION
+        assert event["record_type"] == "application_activity"
+        assert event["output_format"] == "native"
+        assert event["provider"] == "MCP"
+        assert event["tool"]["name"] == "query_db"
+        assert "class_uid" not in event
+        assert "metadata" not in event
+
 
 # ── ingest (stream) ────────────────────────────────────────────────────
 
@@ -188,6 +210,14 @@ class TestIngest:
         events = list(ingest(lines))
         assert len(events) == 1
         assert "not a JSON object" in capsys.readouterr().err
+
+    def test_rejects_unsupported_output_format(self):
+        try:
+            list(ingest([], output_format="bridge"))
+        except ValueError as exc:
+            assert "unsupported output_format" in str(exc)
+        else:
+            raise AssertionError("expected unsupported output_format to raise")
 
 
 # ── Golden fixture parity ──────────────────────────────────────────────
@@ -225,3 +255,16 @@ class TestGoldenFixture:
         ]
         assert len(fps) == 2
         assert fps[0] == fps[1], "fixture must have stable read_file fingerprint as a negative control"
+
+    def test_native_fixture_projection_preserves_event_uid_and_tool_shape(self):
+        raw_lines = RAW_FIXTURE.read_text().splitlines()
+        native_events = list(ingest(raw_lines, output_format="native"))
+        ocsf_events = list(ingest(raw_lines, output_format="ocsf"))
+        assert OUTPUT_FORMATS == ("ocsf", "native")
+        assert len(native_events) == len(ocsf_events)
+        assert native_events[0]["event_uid"] == ocsf_events[0]["metadata"]["uid"]
+        assert native_events[0]["schema_mode"] == "native"
+        assert native_events[0]["record_type"] == "application_activity"
+        assert "class_uid" not in native_events[0]
+        assert "metadata" not in native_events[0]
+        assert native_events[0]["tool"]["fingerprint"] == ocsf_events[0]["mcp"]["tool"]["fingerprint"]


### PR DESCRIPTION
Summary
- add output-format ocsf/native to ingest-mcp-proxy-ocsf and route MCP activity through a canonical internal record before rendering either projection
- let detect-mcp-tool-drift accept native or OCSF input and emit native or OCSF findings without changing the core drift logic
- update the skill contracts, rollout docs, and tests so the MCP path is documented the same way as the CloudTrail, VPC, and Kubernetes pilots

Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/ingestion/ingest-mcp-proxy-ocsf/tests/test_ingest.py skills/detection/detect-mcp-tool-drift/tests/test_detect.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run pytest skills/ingestion/ingest-mcp-proxy-ocsf/tests/test_ingest.py skills/detection/detect-mcp-tool-drift/tests/test_detect.py -q -o addopts=''
- uv run ruff check skills/ingestion/ingest-mcp-proxy-ocsf/src/ingest.py skills/ingestion/ingest-mcp-proxy-ocsf/tests/test_ingest.py skills/detection/detect-mcp-tool-drift/src/detect.py skills/detection/detect-mcp-tool-drift/tests/test_detect.py README.md docs/NATIVE_VS_OCSF.md CHANGELOG.md --config pyproject.toml