### PR TITLE
feat: pilot native and OCSF Workspace login path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is loosely based on Keep a Changelog.
 - Extended the native/OCSF pilot to `ingest-k8s-audit-ocsf` and `detect-sensitive-secret-read-k8s`, so Kubernetes audit ingestion and one Kubernetes detector now support the same dual-mode rollout pattern as the earlier CloudTrail / VPC / lateral-movement pilots.
 - Extended the native/OCSF pilot to `detect-privilege-escalation-k8s`, so the main windowed Kubernetes privilege-escalation detector now accepts native or OCSF input and can emit native or OCSF findings.
 - Extended the native/OCSF pilot to `ingest-mcp-proxy-ocsf` and `detect-mcp-tool-drift`, so the MCP application-activity ingestion and tool-drift detection path now supports native or OCSF input/output without changing the core drift logic.
+- Extended the native/OCSF pilot to `ingest-google-workspace-login-ocsf` and `detect-google-workspace-suspicious-login`, so the Workspace login ingestion and suspicious-login detection path now supports native or OCSF input/output without changing the underlying detection semantics.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
   - `ingest-vpc-flow-logs-ocsf`
   - `ingest-k8s-audit-ocsf`
   - `ingest-mcp-proxy-ocsf`
+  - `ingest-google-workspace-login-ocsf`
   - `detect-lateral-movement`
   - `detect-privilege-escalation-k8s`
   - `detect-sensitive-secret-read-k8s`
   - `detect-mcp-tool-drift`
+  - `detect-google-workspace-suspicious-login`
 - native-first with optional bridge:
   - `discover-environment`
   - `discover-control-evidence`

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -137,10 +137,12 @@ Implemented dual-mode skills today:
 - `ingest-vpc-flow-logs-ocsf`
 - `ingest-k8s-audit-ocsf`
 - `ingest-mcp-proxy-ocsf`
+- `ingest-google-workspace-login-ocsf`
 - `detect-lateral-movement`
 - `detect-privilege-escalation-k8s`
 - `detect-sensitive-secret-read-k8s`
 - `detect-mcp-tool-drift`
+- `detect-google-workspace-suspicious-login`
 
 Implemented native-first with bridge skills today:
 

--- a/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
+++ b/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
@@ -2,7 +2,8 @@
 name: detect-google-workspace-suspicious-login
 description: >-
   Detect suspicious Google Workspace login bursts from OCSF 1.8 Authentication
-  (3002) events produced by ingest-google-workspace-login-ocsf. The first
+  (3002) events or the native authentication projection produced by
+  ingest-google-workspace-login-ocsf. The first
   slice stays narrow and verified: it fires when Google Workspace already marks
   a login event as suspicious, or when the same user shows a short burst of
   repeated login failures followed by a successful login from the same source
@@ -17,8 +18,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
-input_formats: ocsf
-output_formats: ocsf
+input_formats: canonical, native, ocsf
+output_formats: native, ocsf
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-google-workspace-suspicious-login
@@ -47,8 +48,9 @@ travel, geovelocity, or every login anomaly in the catalog.
 
 ## Detection logic
 
-One pass over OCSF Authentication (3002) events from
-`ingest-google-workspace-login-ocsf`:
+One pass over Google Workspace authentication events from
+`ingest-google-workspace-login-ocsf`, whether they arrive as OCSF Authentication
+records or the native authentication projection:
 
 1. Keep only Workspace auth events from the Workspace ingester
 2. Group by `user.uid` and `src_endpoint.ip`
@@ -61,7 +63,10 @@ One pass over OCSF Authentication (3002) events from
 
 ## Output contract
 
-Emits OCSF 1.8 Detection Finding (class `2004`) with:
+Emits OCSF 1.8 Detection Finding (class `2004`) by default. With
+`--output-format native`, emits the repo-owned native finding projection.
+
+OCSF output includes:
 
 - deterministic `metadata.uid` and `finding_info.uid`
 - `finding_info.types[] = ["google-workspace-suspicious-login"]`
@@ -77,6 +82,10 @@ Emits OCSF 1.8 Detection Finding (class `2004`) with:
 python ../ingest-google-workspace-login-ocsf/src/ingest.py workspace-login.json \
   | python src/detect.py \
   > workspace-suspicious-login-findings.ocsf.jsonl
+
+python ../ingest-google-workspace-login-ocsf/src/ingest.py workspace-login.json --output-format native \
+  | python src/detect.py --output-format native \
+  > workspace-suspicious-login-findings.native.jsonl
 ```
 
 ## Do NOT use
@@ -96,3 +105,18 @@ The test suite covers:
 - exact window-boundary behavior
 - duplicate event suppression by `metadata.uid`
 - a frozen golden fixture for detector parity
+
+## Native output format
+
+When `--output-format native` is selected, the skill emits:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "detection_finding"`
+- `finding_uid` and `event_uid`
+- `provider`
+- `time_ms`
+- `user_uid` / `user_name`
+- `src_ip`
+- `mitre_attacks`
+- `evidence`

--- a/skills/detection/detect-google-workspace-suspicious-login/src/detect.py
+++ b/skills/detection/detect-google-workspace-suspicious-login/src/detect.py
@@ -1,4 +1,4 @@
-"""Detect suspicious Google Workspace login patterns from OCSF auth events."""
+"""Detect suspicious Google Workspace login patterns from OCSF or native auth events."""
 
 from __future__ import annotations
 
@@ -11,8 +11,10 @@ from typing import Any, Iterable
 
 SKILL_NAME = "detect-google-workspace-suspicious-login"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
 REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 WORKSPACE_INGEST_SKILL = "ingest-google-workspace-login-ocsf"
 AUTH_CLASS_UID = 3002
@@ -46,16 +48,18 @@ def _now_ms() -> int:
 
 def _event_time(event: dict[str, Any]) -> int:
     try:
-        return int(event.get("time") or 0)
+        return int(event.get("time_ms") or event.get("time") or 0)
     except (TypeError, ValueError):
         return 0
 
 
 def _metadata_uid(event: dict[str, Any]) -> str:
-    return str((event.get("metadata") or {}).get("uid") or "")
+    return str(event.get("event_uid") or (event.get("metadata") or {}).get("uid") or "")
 
 
 def _feature_name(event: dict[str, Any]) -> str:
+    if event.get("source_skill"):
+        return str(event["source_skill"])
     metadata = event.get("metadata") or {}
     product = metadata.get("product") or {}
     feature = product.get("feature") or {}
@@ -63,6 +67,11 @@ def _feature_name(event: dict[str, Any]) -> str:
 
 
 def _workspace_payload(event: dict[str, Any]) -> dict[str, Any]:
+    if event.get("schema_mode") in {"canonical", "native"} or event.get("source_format"):
+        return {
+            "event_name": event.get("event_name"),
+            "parameters": event.get("parameters") or {},
+        }
     return ((event.get("unmapped") or {}).get("google_workspace_login")) or {}
 
 
@@ -84,19 +93,74 @@ def _user_info(event: dict[str, Any]) -> tuple[str, str]:
 
 
 def _source_ip(event: dict[str, Any]) -> str:
-    return str((event.get("src_endpoint") or {}).get("ip") or "")
+    return str(event.get("src_ip") or (event.get("src_endpoint") or {}).get("ip") or "")
 
 
 def _session_uid(event: dict[str, Any]) -> str:
-    return str((event.get("session") or {}).get("uid") or "")
+    return str(event.get("session_uid") or (event.get("session") or {}).get("uid") or "")
+
+
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    if "class_uid" in event:
+        if event.get("class_uid") != AUTH_CLASS_UID:
+            return None
+        return {
+            "source_format": "ocsf",
+            "source_skill": _feature_name(event),
+            "event_uid": _metadata_uid(event),
+            "time_ms": _event_time(event),
+            "user": event.get("user") or {},
+            "src_endpoint": event.get("src_endpoint") or {},
+            "session": event.get("session") or {},
+            "event_name": _workspace_event_name(event),
+            "parameters": _workspace_params(event),
+            "status_id": event.get("status_id"),
+            "status_detail": event.get("status_detail"),
+        }
+
+    source_format = str(event.get("source_format") or "").strip().lower()
+    if source_format in {"ocsf", "native", "canonical"} and event.get("event_name"):
+        return {
+            "source_format": source_format,
+            "source_skill": str(event.get("source_skill") or ""),
+            "event_uid": _metadata_uid(event),
+            "time_ms": _event_time(event),
+            "user": event.get("user") or {},
+            "src_endpoint": event.get("src_endpoint") or {},
+            "session": event.get("session") or {},
+            "event_name": str(event.get("event_name") or ""),
+            "parameters": event.get("parameters") or {},
+            "status_id": event.get("status_id"),
+            "status_detail": event.get("status_detail"),
+        }
+
+    schema_mode = str(event.get("schema_mode") or "").strip().lower()
+    if schema_mode and schema_mode not in {"canonical", "native"}:
+        return None
+    if str(event.get("record_type") or "").strip().lower() != "authentication":
+        return None
+    return {
+        "source_format": schema_mode or "native",
+        "source_skill": str(event.get("source_skill") or ""),
+        "event_uid": _metadata_uid(event),
+        "time_ms": _event_time(event),
+        "user": event.get("user") or {},
+        "src_endpoint": event.get("src_endpoint") or {},
+        "session": event.get("session") or {},
+        "event_name": str(event.get("event_name") or ""),
+        "parameters": event.get("parameters") or {},
+        "status_id": event.get("status_id"),
+        "status_detail": event.get("status_detail"),
+    }
 
 
 def _login_kind(event: dict[str, Any]) -> str | None:
-    if event.get("class_uid") != AUTH_CLASS_UID:
+    normalized = _normalize_event(event)
+    if not normalized:
         return None
-    if _feature_name(event) != WORKSPACE_INGEST_SKILL:
+    if str(normalized.get("source_skill") or "") != WORKSPACE_INGEST_SKILL:
         return None
-    event_name = _workspace_event_name(event)
+    event_name = str(normalized["event_name"])
     if event_name == "login_failure":
         return "failure"
     if event_name == "login_success":
@@ -158,45 +222,44 @@ def _build_finding(
     observables.extend({"name": "session.uid", "type": "Other", "value": uid} for uid in session_uids)
 
     return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": finding_uid,
+        "event_uid": finding_uid,
+        "provider": "Google Workspace",
+        "time_ms": _event_time(last) or _now_ms(),
+        "severity": "high",
+        "status": "success",
         "activity_id": FINDING_ACTIVITY_CREATE,
-        "category_uid": FINDING_CATEGORY_UID,
-        "category_name": FINDING_CATEGORY_NAME,
-        "class_uid": FINDING_CLASS_UID,
-        "class_name": FINDING_CLASS_NAME,
-        "type_uid": FINDING_TYPE_UID,
         "severity_id": severity_id,
         "status_id": STATUS_SUCCESS,
-        "time": _event_time(last) or _now_ms(),
-        "metadata": {
-            "version": OCSF_VERSION,
-            "uid": finding_uid,
-            "product": {
-                "name": REPO_NAME,
-                "vendor_name": REPO_VENDOR,
-                "feature": {"name": SKILL_NAME},
+        "title": title,
+        "description": desc,
+        "finding_types": ["google-workspace-suspicious-login"],
+        "first_seen_time_ms": _event_time(first),
+        "last_seen_time_ms": _event_time(last),
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": TACTIC_UID,
+                "tactic_name": TACTIC_NAME,
+                "technique_uid": BRUTE_FORCE_UID,
+                "technique_name": BRUTE_FORCE_NAME,
             },
-            "labels": ["identity", "google-workspace", "login", "suspicious", "detection"],
-        },
-        "finding_info": {
-            "uid": finding_uid,
-            "title": title,
-            "desc": desc,
-            "types": ["google-workspace-suspicious-login"],
-            "first_seen_time": _event_time(first),
-            "last_seen_time": _event_time(last),
-            "attacks": [
-                {
-                    "version": MITRE_VERSION,
-                    "tactic": {"name": TACTIC_NAME, "uid": TACTIC_UID},
-                    "technique": {"name": BRUTE_FORCE_NAME, "uid": BRUTE_FORCE_UID},
-                },
-                {
-                    "version": MITRE_VERSION,
-                    "tactic": {"name": TACTIC_NAME, "uid": TACTIC_UID},
-                    "technique": {"name": VALID_ACCOUNTS_NAME, "uid": VALID_ACCOUNTS_UID},
-                },
-            ],
-        },
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": TACTIC_UID,
+                "tactic_name": TACTIC_NAME,
+                "technique_uid": VALID_ACCOUNTS_UID,
+                "technique_name": VALID_ACCOUNTS_NAME,
+            },
+        ],
+        "user_uid": user_uid,
+        "user_name": user_name,
+        "src_ip": ip,
         "observables": observables,
         "evidence": {
             "raw_event_uids": raw_event_uids,
@@ -205,6 +268,48 @@ def _build_finding(
             "suspicious_flag_events": suspicious_flags,
             "session_uids": session_uids,
         },
+    }
+
+
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": native_finding["severity_id"],
+        "status_id": native_finding["status_id"],
+        "time": native_finding["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native_finding["event_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["identity", "google-workspace", "login", "suspicious", "detection"],
+        },
+        "finding_info": {
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "first_seen_time": native_finding["first_seen_time_ms"],
+            "last_seen_time": native_finding["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": attack["version"],
+                    "tactic": {"name": attack["tactic_name"], "uid": attack["tactic_uid"]},
+                    "technique": {"name": attack["technique_name"], "uid": attack["technique_uid"]},
+                }
+                for attack in native_finding["mitre_attacks"]
+            ],
+        },
+        "observables": native_finding["observables"],
+        "evidence": native_finding["evidence"],
     }
 
 
@@ -225,32 +330,37 @@ def coverage_metadata() -> dict[str, Any]:
     }
 
 
-def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
     dedupe: set[str] = set()
     relevant: list[dict[str, Any]] = []
     findings: list[dict[str, Any]] = []
 
     for event in events:
+        normalized = _normalize_event(event)
+        if not normalized:
+            continue
         kind = _login_kind(event)
         if kind is None:
             continue
-        metadata_uid = _metadata_uid(event)
+        metadata_uid = str(normalized["event_uid"])
         if metadata_uid and metadata_uid in dedupe:
             continue
         if metadata_uid:
             dedupe.add(metadata_uid)
 
-        user_uid, user_name = _user_info(event)
+        user_uid, user_name = _user_info(normalized)
         if not user_uid:
             continue
 
         relevant.append(
             {
-                "event": event,
+                "event": normalized,
                 "kind": kind,
                 "user_uid": user_uid,
                 "user_name": user_name,
-                "ip": _source_ip(event),
+                "ip": _source_ip(normalized),
             }
         )
 
@@ -276,11 +386,12 @@ def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
             related=[item["event"]],
             finding_kind="workspace-suspicious-flag",
         )
-        uid = finding["metadata"]["uid"]
+        uid = finding["event_uid"]
+        uid = finding["event_uid"]
         if uid in seen_findings:
             continue
         seen_findings.add(uid)
-        findings.append(finding)
+        findings.append(_render_ocsf_finding(finding) if output_format == "ocsf" else finding)
 
     # Failure burst followed by success path.
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
@@ -319,14 +430,14 @@ def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
                 related=related,
                 finding_kind="workspace-failure-burst",
             )
-            uid = finding["metadata"]["uid"]
+            uid = finding["event_uid"]
             if uid in seen_findings:
                 continue
             seen_findings.add(uid)
-            findings.append(finding)
+            findings.append(_render_ocsf_finding(finding) if output_format == "ocsf" else finding)
             failures = []
 
-    findings.sort(key=lambda item: (int(item.get("time") or 0), str((item.get("metadata") or {}).get("uid") or "")))
+    findings.sort(key=lambda item: (_event_time(item), _metadata_uid(item)))
     yield from findings
 
 
@@ -357,9 +468,15 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Detect suspicious Google Workspace login patterns.")
     parser.add_argument("paths", nargs="*", help="Input OCSF JSONL files. Reads stdin when omitted.")
     parser.add_argument("--output", help="Optional file path to write JSONL findings.")
+    parser.add_argument(
+        "--output-format",
+        choices=OUTPUT_FORMATS,
+        default="ocsf",
+        help="Render OCSF Detection Findings (default) or the native canonical projection.",
+    )
     args = parser.parse_args(argv)
 
-    findings = list(detect(load_jsonl(_iter_input(args.paths))))
+    findings = list(detect(load_jsonl(_iter_input(args.paths)), output_format=args.output_format))
     rendered = "\n".join(json.dumps(finding, sort_keys=True, separators=(",", ":")) for finding in findings)
     if rendered:
         rendered += "\n"

--- a/skills/detection/detect-google-workspace-suspicious-login/tests/test_detect.py
+++ b/skills/detection/detect-google-workspace-suspicious-login/tests/test_detect.py
@@ -12,9 +12,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from detect import (  # type: ignore[import-not-found]
     AUTH_CLASS_UID,
     BRUTE_FORCE_UID,
+    CANONICAL_VERSION,
     FINDING_CLASS_UID,
     FINDING_TYPE_UID,
     MIN_FAILURES,
+    OUTPUT_FORMATS,
     REPO_NAME,
     REPO_VENDOR,
     SKILL_NAME,
@@ -87,6 +89,42 @@ def _event(
     return event
 
 
+def _native_event(
+    *,
+    uid: str,
+    event_name: str,
+    time_ms: int,
+    user_uid: str = "workspace-user-1",
+    user_name: str = "alice@example.com",
+    ip: str = "198.51.100.21",
+    session_uid: str = "workspace-login-1",
+    suspicious: bool = False,
+    status_id: int = 1,
+    status_detail: str | None = None,
+) -> dict:
+    params: dict[str, object] = {"login_type": "google_password"}
+    if suspicious:
+        params["is_suspicious"] = True
+    event = {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "authentication",
+        "source_skill": "ingest-google-workspace-login-ocsf",
+        "event_uid": uid,
+        "provider": "Google Workspace",
+        "time_ms": time_ms,
+        "status_id": status_id,
+        "user": {"uid": user_uid, "name": user_name, "email_addr": user_name},
+        "src_endpoint": {"ip": ip},
+        "session": {"uid": session_uid},
+        "event_name": event_name,
+        "parameters": params,
+    }
+    if status_detail:
+        event["status_detail"] = status_detail
+    return event
+
+
 class TestDetection:
     def test_suspicious_flag_fires(self):
         events = [_event(uid="evt-1", event_name="login_success", time_ms=1000, suspicious=True)]
@@ -153,6 +191,31 @@ class TestDetection:
     def test_golden_fixture_matches(self):
         findings = list(detect(_load(INPUT)))
         assert findings == _load(EXPECTED)
+
+    def test_native_input_can_emit_native_finding(self):
+        events = [_native_event(uid="evt-1", event_name="login_success", time_ms=1000, suspicious=True)]
+        findings = list(detect(events, output_format="native"))
+        assert OUTPUT_FORMATS == ("ocsf", "native")
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["schema_mode"] == "native"
+        assert finding["record_type"] == "detection_finding"
+        assert finding["provider"] == "Google Workspace"
+        assert "class_uid" not in finding
+
+    def test_native_input_can_emit_ocsf_finding(self):
+        events = [_native_event(uid="evt-1", event_name="login_success", time_ms=1000, suspicious=True)]
+        findings = list(detect(events, output_format="ocsf"))
+        assert len(findings) == 1
+        assert findings[0]["class_uid"] == FINDING_CLASS_UID
+
+    def test_rejects_unsupported_output_format(self):
+        try:
+            list(detect([], output_format="bridge"))
+        except ValueError as exc:
+            assert "unsupported output_format" in str(exc)
+        else:
+            raise AssertionError("expected unsupported output_format to raise")
 
 
 class TestMetadata:

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
@@ -17,11 +17,11 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: ocsf
+output_formats: native, ocsf
 compatibility: >-
   Requires Python 3.11+. No Google SDK required when Admin SDK Reports payloads
   are already exported. Read-only — validates raw Workspace audit shape and
-  emits OCSF JSONL only. Never calls write APIs.
+  emits OCSF or native JSONL. Never calls write APIs.
 metadata:
   author: msaad00
   homepage: https://github.com/msaad00/cloud-ai-security-skills
@@ -36,7 +36,8 @@ metadata:
 # ingest-google-workspace-login-ocsf
 
 Convert verified Google Workspace Admin SDK Reports login audit payloads into
-OCSF 1.8 IAM records with deterministic IDs and source-preserving parameters.
+OCSF 1.8 IAM records by default, or the repo-owned native IAM projection when
+`--output-format native` is selected.
 
 ## Use when
 
@@ -120,7 +121,7 @@ Emits OCSF 1.8 JSONL with verified class mappings:
 - **Authentication (3002)** for `login_success`, `login_failure`, and `logout`
 - **Account Change (3001)** for `2sv_enroll` and `2sv_disable`
 
-Each output record includes:
+Each OCSF output record includes:
 
 - deterministic `metadata.uid` based on `applicationName`, `time`, `uniqueQualifier`, and event name
 - UTC epoch-millisecond `time` from `id.time`
@@ -130,15 +131,33 @@ Each output record includes:
 ## Usage
 
 ```bash
-# activities.list export
+# activities.list export, OCSF default
 python src/ingest.py workspace-login.json > workspace-login.ocsf.jsonl
 
 # JSONL stream from stdin
 cat workspace-login.jsonl | python src/ingest.py > workspace-login.ocsf.jsonl
 
+# Native projection
+python src/ingest.py workspace-login.json --output-format native > workspace-login.native.jsonl
+
 # explicit output file
 python src/ingest.py workspace-login.json --output workspace-login.ocsf.jsonl
 ```
+
+## Native output format
+
+When `--output-format native` is selected, the skill emits the canonical
+projection with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "authentication"` or `"account_change"`
+- `event_uid`
+- `provider`
+- `time_ms`
+- `event_name`
+- `parameters`
+- preserved `actor`, `user`, `src_endpoint`, and `session` blocks
 
 ## Security guardrails
 

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/src/ingest.py
@@ -1,4 +1,4 @@
-"""Convert Google Workspace login audit activities to OCSF 1.8 IAM events.
+"""Convert Google Workspace login audit activities to native or OCSF IAM events.
 
 Input:  Admin SDK Reports API activities.list JSON objects for applicationName=login.
         Supports top-level {"items": [...]}, arrays, single activities, or JSONL.
@@ -20,6 +20,8 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-google-workspace-login-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 CATEGORY_UID = 3
 CATEGORY_NAME = "Identity & Access Management"
@@ -189,6 +191,21 @@ def _metadata_uid(activity: dict[str, Any], event_name: str) -> str:
     return hashlib.sha256(json.dumps(stable, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
+def _status_name(status_id: int) -> str:
+    return {
+        STATUS_SUCCESS: "success",
+        STATUS_FAILURE: "failure",
+        STATUS_UNKNOWN: "unknown",
+    }.get(status_id, "unknown")
+
+
+def _record_type(class_uid: int) -> str:
+    return {
+        AUTH_CLASS_UID: "authentication",
+        ACCOUNT_CHANGE_CLASS_UID: "account_change",
+    }.get(class_uid, "iam_activity")
+
+
 def validate_activity(activity: dict[str, Any]) -> tuple[bool, str]:
     if not isinstance(activity, dict):
         return False, "not a dict"
@@ -215,7 +232,7 @@ def _supported_events(activity: dict[str, Any]) -> Iterable[dict[str, Any]]:
         yield event
 
 
-def convert_activity_event(activity: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]:
+def _build_canonical_event(activity: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]:
     event_name = str(event.get("name") or "")
     class_uid, class_name, activity_id = _classify(event_name)
     status_id, severity_id = _status_and_severity(event_name)
@@ -227,35 +244,25 @@ def convert_activity_event(activity: dict[str, Any], event: dict[str, Any]) -> d
     message = _message(activity, event_name)
 
     out: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": _record_type(class_uid),
+        "source_skill": SKILL_NAME,
+        "event_uid": _metadata_uid(activity, event_name),
+        "provider": "Google Workspace",
         "activity_id": activity_id,
-        "category_uid": CATEGORY_UID,
-        "category_name": CATEGORY_NAME,
-        "class_uid": class_uid,
-        "class_name": class_name,
-        "type_uid": class_uid * 100 + activity_id,
+        "activity_name": event_name,
         "severity_id": severity_id,
+        "severity": "low" if severity_id == SEVERITY_LOW else "informational" if severity_id == SEVERITY_INFORMATIONAL else "unknown",
         "status_id": status_id,
-        "time": parse_ts_ms((activity.get("id") or {}).get("time")),
-        "metadata": {
-            "version": OCSF_VERSION,
-            "uid": _metadata_uid(activity, event_name),
-            "product": {
-                "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
-                "feature": {"name": SKILL_NAME},
-            },
-            "labels": ["identity", "google-workspace", "login-audit", "ingest"],
-        },
-        "unmapped": {
-            "google_workspace_login": {
-                "application_name": ((activity.get("id") or {}).get("applicationName") or "login"),
-                "customer_id": (activity.get("id") or {}).get("customerId"),
-                "event_type": event.get("type"),
-                "event_name": event_name,
-                "owner_domain": activity.get("ownerDomain"),
-                "parameters": params,
-            }
-        },
+        "status": _status_name(status_id),
+        "time_ms": parse_ts_ms((activity.get("id") or {}).get("time")),
+        "application_name": ((activity.get("id") or {}).get("applicationName") or "login"),
+        "customer_id": (activity.get("id") or {}).get("customerId"),
+        "event_type": event.get("type"),
+        "event_name": event_name,
+        "owner_domain": activity.get("ownerDomain"),
+        "parameters": params,
     }
     if actor:
         out["actor"] = actor
@@ -272,6 +279,58 @@ def convert_activity_event(activity: dict[str, Any], event: dict[str, Any]) -> d
         if failure:
             out["status_detail"] = str(failure)
     return out
+
+
+def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "activity_id": canonical["activity_id"],
+        "category_uid": CATEGORY_UID,
+        "category_name": CATEGORY_NAME,
+        "class_uid": AUTH_CLASS_UID if canonical["record_type"] == "authentication" else ACCOUNT_CHANGE_CLASS_UID,
+        "class_name": "Authentication" if canonical["record_type"] == "authentication" else "Account Change",
+        "type_uid": (AUTH_CLASS_UID if canonical["record_type"] == "authentication" else ACCOUNT_CHANGE_CLASS_UID) * 100 + canonical["activity_id"],
+        "severity_id": canonical["severity_id"],
+        "status_id": canonical["status_id"],
+        "time": canonical["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": canonical["event_uid"],
+            "product": {
+                "name": "cloud-ai-security-skills",
+                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["identity", "google-workspace", "login-audit", "ingest"],
+        },
+        "unmapped": {
+            "google_workspace_login": {
+                "application_name": canonical["application_name"],
+                "customer_id": canonical.get("customer_id"),
+                "event_type": canonical.get("event_type"),
+                "event_name": canonical["event_name"],
+                "owner_domain": canonical.get("owner_domain"),
+                "parameters": canonical.get("parameters") or {},
+            }
+        },
+    }
+    for field in ("actor", "user", "src_endpoint", "session", "message", "status_detail"):
+        if canonical.get(field):
+            out[field] = canonical[field]
+    return out
+
+
+def _render_native_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["output_format"] = "native"
+    return native
+
+
+def convert_activity_event(activity: dict[str, Any], event: dict[str, Any], output_format: str = "ocsf") -> dict[str, Any]:
+    canonical = _build_canonical_event(activity, event)
+    if output_format == "native":
+        return _render_native_event(canonical)
+    return _render_ocsf_event(canonical)
 
 
 def iter_raw_activities(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
@@ -321,7 +380,9 @@ def iter_raw_activities(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
 
 
-def ingest(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
     for activity in iter_raw_activities(stream):
         ok, reason = validate_activity(activity)
         if not ok:
@@ -329,23 +390,29 @@ def ingest(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             continue
         for event in _supported_events(activity):
             try:
-                yield convert_activity_event(activity, event)
+                yield convert_activity_event(activity, event, output_format=output_format)
             except Exception as exc:
                 print(f"[{SKILL_NAME}] skipping event: convert error: {exc}", file=sys.stderr)
                 continue
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Convert raw Google Workspace login audit JSON to OCSF 1.8 IAM JSONL.")
+    parser = argparse.ArgumentParser(description="Convert raw Google Workspace login audit JSON to OCSF or native IAM JSONL.")
     parser.add_argument("input", nargs="?", help="Input JSON/JSONL file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=OUTPUT_FORMATS,
+        default="ocsf",
+        help="Render OCSF IAM events (default) or the native canonical projection.",
+    )
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
     try:
-        for record in ingest(in_stream):
+        for record in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/tests/test_ingest.py
@@ -20,7 +20,9 @@ ACCOUNT_CHANGE_MFA_ENABLE = _INGEST.ACCOUNT_CHANGE_MFA_ENABLE
 AUTH_ACTIVITY_LOGOFF = _INGEST.AUTH_ACTIVITY_LOGOFF
 AUTH_ACTIVITY_LOGON = _INGEST.AUTH_ACTIVITY_LOGON
 AUTH_CLASS_UID = _INGEST.AUTH_CLASS_UID
+CANONICAL_VERSION = _INGEST.CANONICAL_VERSION
 OCSF_VERSION = _INGEST.OCSF_VERSION
+OUTPUT_FORMATS = _INGEST.OUTPUT_FORMATS
 SKILL_NAME = _INGEST.SKILL_NAME
 STATUS_FAILURE = _INGEST.STATUS_FAILURE
 STATUS_SUCCESS = _INGEST.STATUS_SUCCESS
@@ -158,6 +160,18 @@ class TestConvert:
         assert event["class_uid"] == ACCOUNT_CHANGE_CLASS_UID
         assert event["activity_id"] == ACCOUNT_CHANGE_MFA_DISABLE
 
+    def test_native_output_has_no_ocsf_envelope(self):
+        activity = _activity()
+        event = convert_activity_event(activity, activity["events"][0], output_format="native")
+        assert event["schema_mode"] == "native"
+        assert event["canonical_schema_version"] == CANONICAL_VERSION
+        assert event["record_type"] == "authentication"
+        assert event["provider"] == "Google Workspace"
+        assert event["event_name"] == "login_success"
+        assert event["event_uid"]
+        assert "class_uid" not in event
+        assert "metadata" not in event
+
 
 class TestIterRawActivities:
     def test_items_wrapper(self):
@@ -181,3 +195,12 @@ class TestGoldenFixture:
         produced = list(ingest([RAW_FIXTURE.read_text()]))
         expected = _load_jsonl(OCSF_FIXTURE)
         assert produced == expected
+
+    def test_native_projection_preserves_event_uid(self):
+        native = list(ingest([RAW_FIXTURE.read_text()], output_format="native"))
+        ocsf = list(ingest([RAW_FIXTURE.read_text()], output_format="ocsf"))
+        assert OUTPUT_FORMATS == ("ocsf", "native")
+        assert len(native) == len(ocsf)
+        assert native[0]["event_uid"] == ocsf[0]["metadata"]["uid"]
+        assert native[0]["schema_mode"] == "native"
+        assert "class_uid" not in native[0]


### PR DESCRIPTION
Summary
- add --output-format {ocsf,native} to ingest-google-workspace-login-ocsf
- let detect-google-workspace-suspicious-login accept native or OCSF input and emit native or OCSF findings
- update the skill contracts, rollout docs, and changelog for the Workspace dual-mode pilot

Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/ingestion/ingest-google-workspace-login-ocsf/tests/test_ingest.py skills/detection/detect-google-workspace-suspicious-login/tests/test_detect.py -q -o addopts=''
- uv run ruff check skills/ingestion/ingest-google-workspace-login-ocsf/src/ingest.py skills/ingestion/ingest-google-workspace-login-ocsf/tests/test_ingest.py skills/detection/detect-google-workspace-suspicious-login/src/detect.py skills/detection/detect-google-workspace-suspicious-login/tests/test_detect.py README.md docs/NATIVE_VS_OCSF.md CHANGELOG.md --config pyproject.toml