### PR TITLE
feat: pilot native and OCSF Okta path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is loosely based on Keep a Changelog.
 - Extended the native/OCSF pilot to `ingest-mcp-proxy-ocsf` and `detect-mcp-tool-drift`, so the MCP application-activity ingestion and tool-drift detection path now supports native or OCSF input/output without changing the core drift logic.
 - Extended the native/OCSF pilot to `ingest-google-workspace-login-ocsf` and `detect-google-workspace-suspicious-login`, so the Workspace login ingestion and suspicious-login detection path now supports native or OCSF input/output without changing the underlying detection semantics.
 - Extended the native/OCSF pilot to `ingest-entra-directory-audit-ocsf` and `detect-entra-credential-addition`, so Entra directory-audit ingestion and credential-addition detection now support native or OCSF input/output without changing the underlying detection semantics.
+- Extended the native/OCSF pilot to `ingest-okta-system-log-ocsf` and `detect-okta-mfa-fatigue`, so the Okta System Log ingestion and MFA-fatigue detection path now supports native or OCSF input/output without changing the underlying detection semantics.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Each skill is a standalone Python bundle following [Anthropic's skill spec](http
   - `ingest-mcp-proxy-ocsf`
   - `ingest-entra-directory-audit-ocsf`
   - `ingest-google-workspace-login-ocsf`
+  - `ingest-okta-system-log-ocsf`
   - `detect-lateral-movement`
+  - `detect-okta-mfa-fatigue`
   - `detect-privilege-escalation-k8s`
   - `detect-sensitive-secret-read-k8s`
   - `detect-mcp-tool-drift`

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -139,7 +139,9 @@ Implemented dual-mode skills today:
 - `ingest-mcp-proxy-ocsf`
 - `ingest-entra-directory-audit-ocsf`
 - `ingest-google-workspace-login-ocsf`
+- `ingest-okta-system-log-ocsf`
 - `detect-lateral-movement`
+- `detect-okta-mfa-fatigue`
 - `detect-privilege-escalation-k8s`
 - `detect-sensitive-secret-read-k8s`
 - `detect-mcp-tool-drift`

--- a/skills/detection/detect-okta-mfa-fatigue/SKILL.md
+++ b/skills/detection/detect-okta-mfa-fatigue/SKILL.md
@@ -2,7 +2,8 @@
 name: detect-okta-mfa-fatigue
 description: >-
   Detect repeated Okta Verify push-challenge and denial bursts from OCSF 1.8
-  Authentication (3002) events produced by ingest-okta-system-log-ocsf. Tracks
+  Authentication (3002) events or the native authentication projection
+  produced by ingest-okta-system-log-ocsf. Tracks
   one user at a time, looks for multiple Okta Verify push sends plus at least
   one explicit deny or MFA verification failure inside a short time window, and
   emits OCSF 1.8 Detection Finding (class 2004) with MITRE ATT&CK T1621
@@ -15,8 +16,8 @@ license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
-input_formats: ocsf
-output_formats: ocsf
+input_formats: canonical, native, ocsf
+output_formats: native, ocsf
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-okta-mfa-fatigue
@@ -48,8 +49,9 @@ guess at every MFA-related event type in the catalog.
 
 ## Detection logic
 
-One pass over OCSF Authentication (3002) events from
-`ingest-okta-system-log-ocsf`:
+One pass over Okta authentication events from `ingest-okta-system-log-ocsf`,
+whether they arrive as OCSF Authentication records or the native
+authentication projection:
 
 1. Group by `user.uid`
 2. Sort by `time`
@@ -64,7 +66,10 @@ there is a quiet period longer than the correlation window.
 
 ## Output contract
 
-Emits OCSF 1.8 Detection Finding (class `2004`) with:
+Emits OCSF 1.8 Detection Finding (class `2004`) by default. With
+`--output-format native`, emits the repo-owned native finding projection.
+
+OCSF output includes:
 
 - deterministic `metadata.uid` and `finding_info.uid`
 - `finding_info.types[] = ["okta-mfa-fatigue", "mfa-request-generation"]`
@@ -78,6 +83,10 @@ Emits OCSF 1.8 Detection Finding (class `2004`) with:
 python ../ingest-okta-system-log-ocsf/src/ingest.py okta-system-log.json \
   | python src/detect.py \
   > okta-mfa-fatigue-findings.ocsf.jsonl
+
+python ../ingest-okta-system-log-ocsf/src/ingest.py okta-system-log.json --output-format native \
+  | python src/detect.py --output-format native \
+  > okta-mfa-fatigue-findings.native.jsonl
 ```
 
 ## Do NOT use
@@ -91,8 +100,22 @@ python ../ingest-okta-system-log-ocsf/src/ingest.py okta-system-log.json \
 
 The test suite covers:
 
-- out-of-order OCSF auth input
+- out-of-order OCSF and native auth input
 - exact window-boundary behavior
 - duplicate event suppression by `metadata.uid`
 - classic `deny_push` and OIE `auth_via_mfa` failure paths
 - a frozen golden fixture for detector output parity
+
+## Native output format
+
+When `--output-format native` is selected, the skill emits:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "detection_finding"`
+- `finding_uid` and `event_uid`
+- `provider`
+- `time_ms`
+- `mitre_attacks`
+- `observables`
+- `evidence`

--- a/skills/detection/detect-okta-mfa-fatigue/src/detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/src/detect.py
@@ -1,9 +1,10 @@
-"""Detect repeated Okta Verify push-denial bursts from OCSF Authentication events.
+"""Detect repeated Okta Verify push-denial bursts from Okta authentication events.
 
-Reads OCSF 1.8 Authentication (class 3002) events produced by
-ingest-okta-system-log-ocsf and emits OCSF 1.8 Detection Finding (class 2004)
-when a single user receives repeated Okta Verify push challenges and denies or
-generic MFA verification failures inside a short time window.
+Reads OCSF 1.8 Authentication (class 3002) events or the native authentication
+projection produced by ingest-okta-system-log-ocsf and emits OCSF 1.8 Detection
+Finding (class 2004) by default when a single user receives repeated Okta
+Verify push challenges and denies or generic MFA verification failures inside a
+short time window.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -19,8 +20,10 @@ from typing import Any, Iterable
 
 SKILL_NAME = "detect-okta-mfa-fatigue"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
 REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 AUTH_CLASS_UID = 3002
 FINDING_CLASS_UID = 2004
@@ -61,20 +64,20 @@ def _now_ms() -> int:
 
 def _event_time(event: dict[str, Any]) -> int:
     try:
-        return int(event.get("time") or 0)
+        return int(event.get("time_ms") or event.get("time") or 0)
     except (TypeError, ValueError):
         return 0
 
 
 def _metadata_uid(event: dict[str, Any]) -> str:
-    return str((event.get("metadata") or {}).get("uid") or "")
-
+    return str(event.get("event_uid") or (event.get("metadata") or {}).get("uid") or "")
 
 def _okta_event_type(event: dict[str, Any]) -> str:
-    return str((((event.get("unmapped") or {}).get("okta")) or {}).get("event_type") or "")
+    return str(event.get("event_type") or (((event.get("unmapped") or {}).get("okta")) or {}).get("event_type") or "")
 
-
-def _product_feature_name(event: dict[str, Any]) -> str:
+def _source_skill(event: dict[str, Any]) -> str:
+    if event.get("source_skill"):
+        return str(event["source_skill"])
     metadata = event.get("metadata") or {}
     product = metadata.get("product") or {}
     feature = product.get("feature") or {}
@@ -115,21 +118,62 @@ def _is_okta_verify_factor(event: dict[str, Any]) -> bool:
     return any(marker in normalized for marker in OKTA_VERIFY_RESOURCE_MARKERS)
 
 
-def _classify_relevant_event(event: dict[str, Any]) -> str | None:
-    if event.get("class_uid") != AUTH_CLASS_UID:
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    if "class_uid" in event:
+        if event.get("class_uid") != AUTH_CLASS_UID:
+            return None
+        return {
+            "source_format": "ocsf",
+            "source_skill": _source_skill(event),
+            "event_uid": _metadata_uid(event),
+            "time_ms": _event_time(event),
+            "status_id": int(event.get("status_id") or 0),
+            "status_detail": str(event.get("status_detail") or ""),
+            "user": event.get("user") or {},
+            "src_endpoint": event.get("src_endpoint") or {},
+            "session": event.get("session") or {},
+            "resources": event.get("resources") or [],
+            "service": event.get("service") or {},
+            "event_type": _okta_event_type(event),
+        }
+
+    schema_mode = str(event.get("schema_mode") or "").strip().lower()
+    if schema_mode and schema_mode not in {"canonical", "native"}:
         return None
-    if _product_feature_name(event) != OKTA_INGEST_SKILL:
+    if str(event.get("record_type") or "").strip().lower() not in {"", "authentication"}:
+        return None
+    return {
+        "source_format": schema_mode or "native",
+        "source_skill": _source_skill(event),
+        "event_uid": _metadata_uid(event),
+        "time_ms": _event_time(event),
+        "status_id": int(event.get("status_id") or 0),
+        "status_detail": str(event.get("status_detail") or ""),
+        "user": event.get("user") or {},
+        "src_endpoint": event.get("src_endpoint") or {},
+        "session": event.get("session") or {},
+        "resources": event.get("resources") or [],
+        "service": event.get("service") or {},
+        "event_type": _okta_event_type(event),
+    }
+
+
+def _classify_relevant_event(event: dict[str, Any]) -> str | None:
+    normalized = _normalize_event(event)
+    if normalized is None:
+        return None
+    if normalized["source_skill"] != OKTA_INGEST_SKILL:
         return None
 
-    event_type = _okta_event_type(event)
+    event_type = normalized["event_type"]
     if event_type in CHALLENGE_EVENT_TYPES:
         return "challenge"
     if event_type in DENY_EVENT_TYPES:
         return "deny"
     if (
         event_type == GENERIC_MFA_EVENT_TYPE
-        and int(event.get("status_id") or 0) == STATUS_FAILURE
-        and _is_okta_verify_factor(event)
+        and normalized["status_id"] == STATUS_FAILURE
+        and _is_okta_verify_factor(normalized)
     ):
         return "deny"
     return None
@@ -140,18 +184,18 @@ def _finding_uid(user_uid: str, first_uid: str, last_uid: str) -> str:
     return f"det-okta-mfa-fatigue-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
 
 
-def _build_finding(user_uid: str, user_name: str, burst: list[dict[str, Any]]) -> dict[str, Any]:
+def _build_native_finding(user_uid: str, user_name: str, burst: list[dict[str, Any]]) -> dict[str, Any]:
     first = burst[0]
     last = burst[-1]
-    first_uid = _metadata_uid(first["event"])
-    last_uid = _metadata_uid(last["event"])
+    first_uid = first["event_uid"]
+    last_uid = last["event_uid"]
     finding_uid = _finding_uid(user_uid, first_uid, last_uid)
 
     challenge_count = sum(1 for item in burst if item["kind"] == "challenge")
     denial_count = sum(1 for item in burst if item["kind"] == "deny")
-    source_ips = sorted({_source_ip(item["event"]) for item in burst if _source_ip(item["event"])})
-    session_uids = sorted({_session_uid(item["event"]) for item in burst if _session_uid(item["event"])})
-    event_uids = [_metadata_uid(item["event"]) for item in burst]
+    source_ips = sorted({str((item["src_endpoint"] or {}).get("ip") or "") for item in burst if (item["src_endpoint"] or {}).get("ip")})
+    session_uids = sorted({str((item["session"] or {}).get("uid") or "") for item in burst if (item["session"] or {}).get("uid")})
+    event_uids = [item["event_uid"] for item in burst]
 
     description = (
         f"User '{user_name or user_uid}' received {challenge_count} Okta Verify push challenge events and "
@@ -169,40 +213,33 @@ def _build_finding(user_uid: str, user_name: str, burst: list[dict[str, Any]]) -
     observables.extend({"name": "session.uid", "type": "Other", "value": uid} for uid in session_uids)
 
     return {
-        "activity_id": FINDING_ACTIVITY_CREATE,
-        "category_uid": FINDING_CATEGORY_UID,
-        "category_name": FINDING_CATEGORY_NAME,
-        "class_uid": FINDING_CLASS_UID,
-        "class_name": FINDING_CLASS_NAME,
-        "type_uid": FINDING_TYPE_UID,
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": finding_uid,
+        "event_uid": finding_uid,
+        "provider": "Okta",
+        "time_ms": last["time_ms"] or _now_ms(),
+        "severity": "high",
         "severity_id": SEVERITY_HIGH,
+        "status": "success",
         "status_id": 1,
-        "time": _event_time(last["event"]) or _now_ms(),
-        "metadata": {
-            "version": OCSF_VERSION,
-            "uid": finding_uid,
-            "product": {
-                "name": REPO_NAME,
-                "vendor_name": REPO_VENDOR,
-                "feature": {"name": SKILL_NAME},
-            },
-            "labels": ["identity", "okta", "mfa", "fatigue", "detection"],
-        },
-        "finding_info": {
-            "uid": finding_uid,
-            "title": "Repeated Okta Verify MFA push denials for one user",
-            "desc": description,
-            "types": ["okta-mfa-fatigue", "mfa-request-generation"],
-            "first_seen_time": _event_time(first["event"]),
-            "last_seen_time": _event_time(last["event"]),
-            "attacks": [
-                {
-                    "version": MITRE_VERSION,
-                    "tactic": {"name": MITRE_TACTIC_NAME, "uid": MITRE_TACTIC_UID},
-                    "technique": {"name": MITRE_TECHNIQUE_NAME, "uid": MITRE_TECHNIQUE_UID},
-                }
-            ],
-        },
+        "title": "Repeated Okta Verify MFA push denials for one user",
+        "description": description,
+        "finding_types": ["okta-mfa-fatigue", "mfa-request-generation"],
+        "first_seen_time_ms": first["time_ms"],
+        "last_seen_time_ms": last["time_ms"],
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": MITRE_TACTIC_UID,
+                "tactic_name": MITRE_TACTIC_NAME,
+                "technique_uid": MITRE_TECHNIQUE_UID,
+                "technique_name": MITRE_TECHNIQUE_NAME,
+            }
+        ],
         "observables": observables,
         "evidence": {
             "events_observed": len(burst),
@@ -212,6 +249,48 @@ def _build_finding(user_uid: str, user_name: str, burst: list[dict[str, Any]]) -
             "session_uids": session_uids,
             "raw_event_uids": event_uids,
         },
+    }
+
+
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    attack = native_finding["mitre_attacks"][0]
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": native_finding["severity_id"],
+        "status_id": native_finding["status_id"],
+        "time": native_finding["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native_finding["event_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["identity", "okta", "mfa", "fatigue", "detection"],
+        },
+        "finding_info": {
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "first_seen_time": native_finding["first_seen_time_ms"],
+            "last_seen_time": native_finding["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": attack["version"],
+                    "tactic": {"name": attack["tactic_name"], "uid": attack["tactic_uid"]},
+                    "technique": {"name": attack["technique_name"], "uid": attack["technique_uid"]},
+                }
+            ],
+        },
+        "observables": native_finding["observables"],
+        "evidence": native_finding["evidence"],
     }
 
 
@@ -236,7 +315,9 @@ def coverage_metadata() -> dict[str, Any]:
     }
 
 
-def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format: {output_format}")
     dedupe: set[str] = set()
     states: dict[str, list[dict[str, Any]]] = {}
     active_bursts: set[str] = set()
@@ -246,29 +327,35 @@ def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
         kind = _classify_relevant_event(event)
         if kind is None:
             continue
-        metadata_uid = _metadata_uid(event)
+        normalized = _normalize_event(event)
+        if normalized is None:
+            continue
+        metadata_uid = normalized["event_uid"]
         if metadata_uid and metadata_uid in dedupe:
             continue
         if metadata_uid:
             dedupe.add(metadata_uid)
-        user_uid, user_name = _user_info(event)
+        user_uid, user_name = _user_info(normalized)
         if not user_uid:
             continue
-        relevant.append({"kind": kind, "event": event, "user_uid": user_uid, "user_name": user_name})
+        normalized["kind"] = kind
+        normalized["user_uid"] = user_uid
+        normalized["user_name"] = user_name
+        relevant.append(normalized)
 
-    relevant.sort(key=lambda item: (item["user_uid"], _event_time(item["event"]), _metadata_uid(item["event"])))
+    relevant.sort(key=lambda item: (item["user_uid"], item["time_ms"], item["event_uid"]))
 
     for item in relevant:
         user_uid = item["user_uid"]
-        current_time = _event_time(item["event"])
+        current_time = item["time_ms"]
         burst = states.setdefault(user_uid, [])
 
-        if burst and current_time - _event_time(burst[-1]["event"]) > WINDOW_MS:
+        if burst and current_time - burst[-1]["time_ms"] > WINDOW_MS:
             burst.clear()
             active_bursts.discard(user_uid)
 
         cutoff = current_time - WINDOW_MS
-        burst[:] = [entry for entry in burst if _event_time(entry["event"]) >= cutoff]
+        burst[:] = [entry for entry in burst if entry["time_ms"] >= cutoff]
         burst.append(item)
 
         challenge_count = sum(1 for entry in burst if entry["kind"] == "challenge")
@@ -280,7 +367,11 @@ def detect(events: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
             and challenge_count >= MIN_CHALLENGES
             and denial_count >= MIN_DENIALS
         ):
-            yield _build_finding(user_uid, item["user_name"], burst)
+            native_finding = _build_native_finding(user_uid, item["user_name"], burst)
+            if output_format == "native":
+                yield native_finding
+            else:
+                yield _render_ocsf_finding(native_finding)
             active_bursts.add(user_uid)
 
 
@@ -301,9 +392,10 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Detect repeated Okta Verify MFA push-denial bursts from OCSF.")
-    parser.add_argument("input", nargs="?", help="OCSF JSONL input. Defaults to stdin.")
+    parser = argparse.ArgumentParser(description="Detect repeated Okta Verify MFA push-denial bursts from native or OCSF input.")
+    parser.add_argument("input", nargs="?", help="Authentication JSONL input. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Detection Finding JSONL output. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="ocsf", help="Output format.")
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
@@ -311,7 +403,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         events = list(load_jsonl(in_stream))
-        for finding in detect(events):
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from detect import (  # type: ignore[import-not-found]
     AUTH_CLASS_UID,
+    CANONICAL_VERSION,
     CHALLENGE_EVENT_TYPES,
     FINDING_CLASS_UID,
     FINDING_TYPE_UID,
@@ -20,6 +21,7 @@ from detect import (  # type: ignore[import-not-found]
     MIN_RELEVANT_EVENTS,
     MITRE_TECHNIQUE_UID,
     OKTA_INGEST_SKILL,
+    OUTPUT_FORMATS,
     REPO_NAME,
     REPO_VENDOR,
     SEVERITY_HIGH,
@@ -77,6 +79,42 @@ def _event(
         "src_endpoint": {"ip": ip},
         "user": {"uid": user_uid, "name": user_name, "email_addr": user_name},
         "session": {"uid": session_uid},
+        "unmapped": {"okta": {"event_type": event_type}},
+    }
+    if status_detail:
+        event["status_detail"] = status_detail
+    if resource_name:
+        event["resources"] = [{"name": resource_name, "type": "AuthenticatorEnrollment"}]
+        event["service"] = {"name": resource_name}
+    return event
+
+
+def _native_event(
+    *,
+    uid: str,
+    event_type: str,
+    time_ms: int,
+    user_uid: str = "00u-alice",
+    user_name: str = "alice@example.com",
+    status_id: int = 1,
+    status_detail: str | None = None,
+    ip: str = "198.51.100.25",
+    session_uid: str = "sess-okta-1",
+    resource_name: str = "Okta Verify",
+) -> dict:
+    event = {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "authentication",
+        "source_skill": OKTA_INGEST_SKILL,
+        "event_uid": uid,
+        "provider": "Okta",
+        "time_ms": time_ms,
+        "status_id": status_id,
+        "user": {"uid": user_uid, "name": user_name, "email_addr": user_name},
+        "src_endpoint": {"ip": ip},
+        "session": {"uid": session_uid},
+        "event_type": event_type,
         "unmapped": {"okta": {"event_type": event_type}},
     }
     if status_detail:
@@ -215,6 +253,51 @@ class TestDetection:
     def test_golden_fixture_matches(self):
         findings = list(detect(_load(INPUT)))
         assert findings == _load(EXPECTED)
+
+    def test_native_input_can_emit_native_finding(self):
+        events = [
+            _native_event(uid="evt-1", event_type="system.push.send_factor_verify_push", time_ms=1000),
+            _native_event(uid="evt-2", event_type="system.push.send_factor_verify_push", time_ms=2000),
+            _native_event(
+                uid="evt-3",
+                event_type="user.mfa.okta_verify.deny_push",
+                time_ms=3000,
+                status_id=STATUS_FAILURE,
+                status_detail="INVALID_CREDENTIALS",
+            ),
+        ]
+        findings = list(detect(events, output_format="native"))
+        assert OUTPUT_FORMATS == ("ocsf", "native")
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding["schema_mode"] == "native"
+        assert finding["record_type"] == "detection_finding"
+        assert finding["provider"] == "Okta"
+        assert "class_uid" not in finding
+
+    def test_native_input_can_emit_ocsf_finding(self):
+        events = [
+            _native_event(uid="evt-1", event_type="system.push.send_factor_verify_push", time_ms=1000),
+            _native_event(uid="evt-2", event_type="system.push.send_factor_verify_push", time_ms=2000),
+            _native_event(
+                uid="evt-3",
+                event_type="user.mfa.okta_verify.deny_push",
+                time_ms=3000,
+                status_id=STATUS_FAILURE,
+                status_detail="INVALID_CREDENTIALS",
+            ),
+        ]
+        findings = list(detect(events, output_format="ocsf"))
+        assert len(findings) == 1
+        assert findings[0]["class_uid"] == FINDING_CLASS_UID
+
+    def test_rejects_unsupported_output_format(self):
+        try:
+            list(detect([], output_format="bridge"))
+        except ValueError as exc:
+            assert "unsupported output_format" in str(exc)
+        else:
+            raise AssertionError("expected unsupported output_format to raise")
 
 
 class TestMetadata:

--- a/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ingest-okta-system-log-ocsf
 description: >-
-  Convert verified Okta System Log events into OCSF 1.8 Identity & Access
-  Management events. The first slice maps session and SSO events to
+  Convert verified Okta System Log events into OCSF 1.8 or native Identity &
+  Access Management records. The first slice maps session and SSO events to
   Authentication (3002), user lifecycle and account-control changes to Account
   Change (3001), app/group membership updates to User Access Management (3005),
   and a narrow verified set of Okta Verify MFA challenge and denial events to
@@ -10,19 +10,19 @@ description: >-
   transaction.id, and authenticationContext.externalSessionId for SIEM-friendly
   dedupe and correlation. Use when the user mentions Okta System Log ingestion,
   Okta audit log normalization, cross-vendor identity telemetry, or feeding
-  Okta identity events into an OCSF pipeline. Do NOT use for raw Azure Entra,
+  Okta identity events into an OCSF pipeline or native canonical-first flow. Do NOT use for raw Azure Entra,
   Google Workspace, or AWS IAM logs. Do NOT use as a detector or policy engine
-  — this skill only normalizes verified Okta event payloads into OCSF.
+  — this skill only normalizes verified Okta event payloads into OCSF or native output.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: ocsf
+output_formats: native, ocsf
 compatibility: >-
   Requires Python 3.11+. No Okta SDK required when System Log payloads are
   already exported. Read-only — validates raw Okta event shape and emits OCSF
-  JSONL only. Never calls write APIs.
+  or native JSONL. Never calls write APIs.
 metadata:
   author: msaad00
   homepage: https://github.com/msaad00/cloud-ai-security-skills
@@ -36,7 +36,7 @@ metadata:
 
 # ingest-okta-system-log-ocsf
 
-Convert raw Okta System Log payloads into OCSF 1.8 IAM events with
+Convert raw Okta System Log payloads into OCSF 1.8 or native IAM events with
 deterministic IDs and verified field mappings.
 
 ## Use when
@@ -127,7 +127,10 @@ Unsupported event types are skipped with a warning to `stderr`.
 
 ## Output contract
 
-Emits OCSF 1.8 JSONL with verified class mappings:
+Emits OCSF 1.8 JSONL by default, with `--output-format native` available for
+the repo-owned canonical projection.
+
+OCSF output uses these verified class mappings:
 
 - **Authentication (3002)** for session, SSO, and verified Okta Verify MFA verification events
 - **Account Change (3001)** for user lifecycle and account-control events
@@ -151,6 +154,9 @@ cat event-hook.json | python src/ingest.py > okta.ocsf.jsonl
 
 # pretty output file
 python src/ingest.py okta.json --output okta.ocsf.jsonl
+
+# native projection for non-OCSF consumers
+python src/ingest.py okta.json --output-format native > okta.native.jsonl
 ```
 
 ## Security guardrails
@@ -159,6 +165,23 @@ python src/ingest.py okta.json --output okta.ocsf.jsonl
 - Keeps vendor-native IDs for dedupe and correlation instead of inventing new random IDs.
 - Uses verified raw fields from official Okta docs only; unsupported event types are skipped rather than guessed.
 - Normalizes into OCSF only where the class fit is explicit. Unmapped vendor-specific detail stays under `unmapped`.
+
+## Native output format
+
+When `--output-format native` is selected, the skill emits:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type`
+- `event_uid`
+- `provider`
+- `activity_id`
+- `event_type`
+- `severity` / `severity_id`
+- `status` / `status_id`
+- `time_ms`
+- `actor`, `user`, `src_endpoint`, `session`, `resources`, and `privileges` where present
+- `unmapped.okta.*` vendor-specific detail for transaction and root-session correlation
 
 ## See also
 

--- a/skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py
@@ -1,11 +1,11 @@
-"""Convert raw Okta System Log events to OCSF 1.8 IAM events.
+"""Convert raw Okta System Log events to native or OCSF IAM events.
 
 Input:  Okta System Log API arrays, single-event JSON, event hook wrappers,
         or NDJSON.
-Output: JSONL of OCSF Identity & Access Management events across:
-        - Authentication (3002)
-        - Account Change (3001)
-        - User Access Management (3005)
+Output: JSONL of either:
+        - OCSF Identity & Access Management events across Authentication (3002),
+          Account Change (3001), and User Access Management (3005), or
+        - repo-owned native IAM activity records.
 
 Contract: see ../OCSF_CONTRACT.md
 """
@@ -21,6 +21,8 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-okta-system-log-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
+OUTPUT_FORMATS = ("ocsf", "native")
 
 CATEGORY_UID = 3
 CATEGORY_NAME = "Identity & Access Management"
@@ -255,29 +257,50 @@ def _metadata_uid(event: dict[str, Any]) -> str:
     return hashlib.sha256(json.dumps(stable, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
-def _base_event(event: dict[str, Any], class_uid: int, class_name: str, activity_id: int) -> dict[str, Any]:
+def _status_name(status_id: int) -> str:
+    return {
+        STATUS_SUCCESS: "success",
+        STATUS_FAILURE: "failure",
+        STATUS_UNKNOWN: "unknown",
+    }.get(status_id, "unknown")
+
+
+def _severity_name(severity_id: int) -> str:
+    return {
+        SEVERITY_INFORMATIONAL: "informational",
+        SEVERITY_LOW: "low",
+        SEVERITY_MEDIUM: "medium",
+        SEVERITY_HIGH: "high",
+        SEVERITY_UNKNOWN: "unknown",
+    }.get(severity_id, "unknown")
+
+
+def _record_type(class_uid: int) -> str:
+    return {
+        AUTH_CLASS_UID: "authentication",
+        ACCOUNT_CHANGE_CLASS_UID: "account_change",
+        USER_ACCESS_CLASS_UID: "user_access_management",
+    }.get(class_uid, "iam_activity")
+
+
+def _build_canonical_event(event: dict[str, Any], class_uid: int, activity_id: int) -> dict[str, Any]:
     status_id, status_detail = status_from_outcome(event.get("outcome") or {})
-    base: dict[str, Any] = {
+    severity_id = severity_to_id(event.get("severity"))
+    canonical: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": _record_type(class_uid),
+        "source_skill": SKILL_NAME,
+        "event_uid": _metadata_uid(event),
+        "provider": "Okta",
         "activity_id": activity_id,
-        "category_uid": CATEGORY_UID,
-        "category_name": CATEGORY_NAME,
-        "class_uid": class_uid,
-        "class_name": class_name,
-        "type_uid": class_uid * 100 + activity_id,
-        "severity_id": severity_to_id(event.get("severity")),
+        "event_type": str(event.get("eventType") or ""),
+        "severity_id": severity_id,
+        "severity": _severity_name(severity_id),
         "status_id": status_id,
-        "time": parse_ts_ms(event.get("published")),
-        "message": str(event.get("displayMessage") or event.get("eventType") or class_name),
-        "metadata": {
-            "version": OCSF_VERSION,
-            "uid": _metadata_uid(event),
-            "product": {
-                "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
-                "feature": {"name": SKILL_NAME},
-            },
-            "labels": ["identity", "okta", "system-log", "ingest"],
-        },
+        "status": _status_name(status_id),
+        "time_ms": parse_ts_ms(event.get("published")),
+        "message": str(event.get("displayMessage") or event.get("eventType") or _record_type(class_uid)),
         "actor": _actor(event),
         "src_endpoint": _src_endpoint(event),
         "unmapped": {
@@ -290,12 +313,12 @@ def _base_event(event: dict[str, Any], class_uid: int, class_name: str, activity
         },
     }
     if status_detail:
-        base["status_detail"] = status_detail
-    return base
+        canonical["status_detail"] = status_detail
+    return canonical
 
 
 def _build_authentication_event(event: dict[str, Any], activity_id: int) -> dict[str, Any]:
-    out = _base_event(event, AUTH_CLASS_UID, AUTH_CLASS_NAME, activity_id)
+    out = _build_canonical_event(event, AUTH_CLASS_UID, activity_id)
     user = _subject_user(event)
     if user:
         out["user"] = user
@@ -310,7 +333,7 @@ def _build_authentication_event(event: dict[str, Any], activity_id: int) -> dict
 
 
 def _build_account_change_event(event: dict[str, Any], activity_id: int) -> dict[str, Any]:
-    out = _base_event(event, ACCOUNT_CHANGE_CLASS_UID, ACCOUNT_CHANGE_CLASS_NAME, activity_id)
+    out = _build_canonical_event(event, ACCOUNT_CHANGE_CLASS_UID, activity_id)
     out["user"] = _subject_user(event)
     resources = _resources(event)
     if resources:
@@ -319,11 +342,58 @@ def _build_account_change_event(event: dict[str, Any], activity_id: int) -> dict
 
 
 def _build_user_access_event(event: dict[str, Any], activity_id: int) -> dict[str, Any]:
-    out = _base_event(event, USER_ACCESS_CLASS_UID, USER_ACCESS_CLASS_NAME, activity_id)
+    out = _build_canonical_event(event, USER_ACCESS_CLASS_UID, activity_id)
     out["user"] = _subject_user(event)
     out["resources"] = _resources(event)
     out["privileges"] = _privileges(event)
     return out
+
+
+def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    class_uid = {
+        "authentication": AUTH_CLASS_UID,
+        "account_change": ACCOUNT_CHANGE_CLASS_UID,
+        "user_access_management": USER_ACCESS_CLASS_UID,
+    }.get(canonical["record_type"], AUTH_CLASS_UID)
+    class_name = {
+        AUTH_CLASS_UID: AUTH_CLASS_NAME,
+        ACCOUNT_CHANGE_CLASS_UID: ACCOUNT_CHANGE_CLASS_NAME,
+        USER_ACCESS_CLASS_UID: USER_ACCESS_CLASS_NAME,
+    }[class_uid]
+    out: dict[str, Any] = {
+        "activity_id": canonical["activity_id"],
+        "category_uid": CATEGORY_UID,
+        "category_name": CATEGORY_NAME,
+        "class_uid": class_uid,
+        "class_name": class_name,
+        "type_uid": class_uid * 100 + canonical["activity_id"],
+        "severity_id": canonical["severity_id"],
+        "status_id": canonical["status_id"],
+        "time": canonical["time_ms"],
+        "message": canonical["message"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": canonical["event_uid"],
+            "product": {
+                "name": "cloud-ai-security-skills",
+                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["identity", "okta", "system-log", "ingest"],
+        },
+        "unmapped": canonical["unmapped"],
+    }
+    for field in ("actor", "src_endpoint", "user", "session", "resources", "service", "privileges", "status_detail"):
+        if canonical.get(field):
+            out[field] = canonical[field]
+    return out
+
+
+def _render_native_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["output_format"] = "native"
+    return native
 
 
 def validate_event(event: dict[str, Any]) -> tuple[bool, str]:
@@ -337,7 +407,7 @@ def validate_event(event: dict[str, Any]) -> tuple[bool, str]:
     return True, ""
 
 
-def convert_event(event: dict[str, Any]) -> dict[str, Any]:
+def convert_event(event: dict[str, Any], output_format: str = "ocsf") -> dict[str, Any]:
     event_type = str(event.get("eventType") or "")
     route = _classify_event(event_type)
     if route is None:
@@ -345,11 +415,17 @@ def convert_event(event: dict[str, Any]) -> dict[str, Any]:
 
     class_uid, _class_name, activity_id = route
     if class_uid == AUTH_CLASS_UID:
-        return _build_authentication_event(event, activity_id)
-    if class_uid == ACCOUNT_CHANGE_CLASS_UID:
-        return _build_account_change_event(event, activity_id)
-    if class_uid == USER_ACCESS_CLASS_UID:
-        return _build_user_access_event(event, activity_id)
+        canonical = _build_authentication_event(event, activity_id)
+    elif class_uid == ACCOUNT_CHANGE_CLASS_UID:
+        canonical = _build_account_change_event(event, activity_id)
+    elif class_uid == USER_ACCESS_CLASS_UID:
+        canonical = _build_user_access_event(event, activity_id)
+    else:
+        raise ValueError(f"unsupported class route for {event_type}")
+    if output_format == "native":
+        return _render_native_event(canonical)
+    if output_format == "ocsf":
+        return _render_ocsf_event(canonical)
     raise ValueError(f"unsupported class route for {event_type}")
 
 
@@ -401,30 +477,38 @@ def iter_raw_events(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object or Okta wrapper", file=sys.stderr)
 
 
-def ingest(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
     for raw in iter_raw_events(stream):
         ok, reason = validate_event(raw)
         if not ok:
             print(f"[{SKILL_NAME}] skipping event: {reason}", file=sys.stderr)
             continue
         try:
-            yield convert_event(raw)
+            yield convert_event(raw, output_format=output_format)
         except Exception as exc:
             print(f"[{SKILL_NAME}] skipping event: convert error: {exc}", file=sys.stderr)
             continue
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Convert raw Okta System Log JSON to OCSF 1.8 IAM JSONL.")
+    parser = argparse.ArgumentParser(description="Convert raw Okta System Log JSON to OCSF or native IAM JSONL.")
     parser.add_argument("input", nargs="?", help="Input JSON/JSONL file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=OUTPUT_FORMATS,
+        default="ocsf",
+        help="Render OCSF IAM events (default) or the native canonical projection.",
+    )
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
     try:
-        for event in ingest(in_stream):
+        for event in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(event, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py
@@ -23,7 +23,9 @@ AUTH_ACTIVITY_LOGOFF = _INGEST.AUTH_ACTIVITY_LOGOFF
 AUTH_ACTIVITY_LOGON = _INGEST.AUTH_ACTIVITY_LOGON
 AUTH_ACTIVITY_OTHER = _INGEST.AUTH_ACTIVITY_OTHER
 AUTH_CLASS_UID = _INGEST.AUTH_CLASS_UID
+CANONICAL_VERSION = _INGEST.CANONICAL_VERSION
 OCSF_VERSION = _INGEST.OCSF_VERSION
+OUTPUT_FORMATS = _INGEST.OUTPUT_FORMATS
 SKILL_NAME = _INGEST.SKILL_NAME
 STATUS_FAILURE = _INGEST.STATUS_FAILURE
 STATUS_SUCCESS = _INGEST.STATUS_SUCCESS
@@ -193,6 +195,18 @@ class TestConvert:
         assert event["session"]["uid"] == "sess-123"
         assert event["src_endpoint"]["ip"] == "198.51.100.10"
 
+    def test_native_projection_strips_ocsf_envelope(self):
+        event = convert_event(_event(), output_format="native")
+        assert OUTPUT_FORMATS == ("ocsf", "native")
+        assert event["schema_mode"] == "native"
+        assert event["canonical_schema_version"] == CANONICAL_VERSION
+        assert event["record_type"] == "authentication"
+        assert event["event_uid"] == "okta-evt-1"
+        assert event["provider"] == "Okta"
+        assert event["event_type"] == "user.session.start"
+        assert "class_uid" not in event
+        assert "metadata" not in event
+
     def test_authentication_failure_without_session(self):
         event = convert_event(
             _event(
@@ -328,3 +342,11 @@ class TestGoldenFixture:
         produced = list(ingest([RAW_FIXTURE.read_text()]))
         expected = _load_jsonl(OCSF_FIXTURE)
         assert produced == expected
+
+    def test_native_fixture_projection(self):
+        produced = list(ingest([RAW_FIXTURE.read_text()], output_format="native"))
+        expected = _load_jsonl(OCSF_FIXTURE)
+        assert len(produced) == len(expected)
+        assert produced[0]["schema_mode"] == "native"
+        assert produced[0]["event_uid"] == expected[0]["metadata"]["uid"]
+        assert "class_uid" not in produced[0]


### PR DESCRIPTION
Summary:
- add --output-format ocsf|native to ingest-okta-system-log-ocsf through a canonical internal model
- let detect-okta-mfa-fatigue accept native or OCSF input and emit native or OCSF findings
- update the Okta skill contracts, rollout docs, and tests for the dual-mode pilot

Validation:
- python scripts/validate_skill_contract.py
- python scripts/validate_ocsf_metadata.py
- uv run pytest skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server.py -q -o addopts=''
- uv run ruff check skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py skills/detection/detect-okta-mfa-fatigue/src/detect.py skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py --config pyproject.toml
