### PR TITLE
docs: add operator debugging and rollout guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on Keep a Changelog.
 ### Added
 
 - [`docs/NATIVE_VS_OCSF.md`](docs/NATIVE_VS_OCSF.md) and [`docs/STATE_AND_TIMELINE_MODEL.md`](docs/STATE_AND_TIMELINE_MODEL.md) to make `native`, `canonical`, `ocsf`, and `bridge` modes explicit and to pin historical-state, tombstone, and timeline expectations across just-in-time and persistent runs.
+- [`docs/DEBUGGING.md`](docs/DEBUGGING.md) and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) for operator-facing format, CI, and runtime troubleshooting.
 - `ingest-okta-system-log-ocsf` as the first external identity-vendor ingestion skill, mapping verified Okta System Log session, user lifecycle, and membership events into OCSF Authentication (3002), Account Change (3001), and User Access Management (3005).
 - `detect-okta-mfa-fatigue` as the first Okta-native detection skill, emitting OCSF Detection Finding (2004) for repeated Okta Verify push challenge and denial bursts aligned to MITRE ATT&CK T1621.
 - `ingest-entra-directory-audit-ocsf` as the Microsoft Entra / Graph identity-audit ingestion skill, mapping verified `directoryAudit` application, service-principal, app-role-assignment, and federated-credential events into OCSF API Activity (6003).
@@ -38,6 +39,7 @@ The format is loosely based on Keep a Changelog.
 - Extended the native/OCSF pilot to `ingest-entra-directory-audit-ocsf` and `detect-entra-credential-addition`, so Entra directory-audit ingestion and credential-addition detection now support native or OCSF input/output without changing the underlying detection semantics.
 - Extended the native/OCSF pilot to `ingest-okta-system-log-ocsf` and `detect-okta-mfa-fatigue`, so the Okta System Log ingestion and MFA-fatigue detection path now supports native or OCSF input/output without changing the underlying detection semantics.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
+- Added a runnable README hello-world path, clarified that the `DATA_FLOW.md` rollout list is now driven by README + `SKILL.md` frontmatter, and documented bounded-batch guidance for `detect-lateral-movement`.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
 - `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@
 - Read-only by default, least-privilege, zero-trust
 - Deterministic, auditable, and grounded in official vendor docs
 
+## 1-minute hello world
+
+Run a real bundled fixture through an end-to-end pipeline:
+
+```bash
+python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
+  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
+  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
+  | python skills/view/convert-ocsf-to-sarif/src/convert.py \
+  > findings.sarif
+```
+
+Or keep the repo-native format for the ingest + detect path:
+
+```bash
+python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
+  --output-format native \
+  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
+  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
+      --output-format native \
+  > findings.native.jsonl
+```
+
 ## Quick start
 
 **Start here**
@@ -26,6 +49,7 @@
 - Schema modes and interoperability: [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md)
 - Canonical schema and data flow: [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md) and [docs/DATA_FLOW.md](docs/DATA_FLOW.md)
 - Historical state and timeline handling: [docs/STATE_AND_TIMELINE_MODEL.md](docs/STATE_AND_TIMELINE_MODEL.md)
+- Debugging and troubleshooting: [docs/DEBUGGING.md](docs/DEBUGGING.md) and [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
 - Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), and [docs/ROADMAP.md](docs/ROADMAP.md)
 
 | Tool | Best integration path | What to rely on |
@@ -63,7 +87,7 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
 
 | Layer | Role | Output |
 |---|---|---|
-| **Ingest** | Per-source raw payload → canonical model, with optional OCSF or bridge output | native JSON, canonical JSON, or OCSF API / Network / HTTP / Application Activity |
+| **Ingest** | Per-source raw payload → canonical model, with optional native / OCSF / bridge output | native JSON, OCSF API / Network / HTTP / Application Activity, or bridge JSON |
 | **Discover** | point-in-time inventory / graph / evidence / AI BOM | deterministic JSON graph, canonical evidence, OCSF inventory/evidence bridge events, or CycloneDX-aligned BOM |
 | **Detect** | canonical or OCSF telemetry → finding + MITRE ATT&CK | Detection Finding (class 2004) or documented native/canonical finding output |
 | **Evaluate** | canonical or OCSF telemetry → framework check | Compliance Finding (class 2003) or documented evidence/check output |
@@ -260,6 +284,8 @@ This is a security tool. Trustworthiness is the first feature, not an afterthoug
 | [`ROADMAP.md`](docs/ROADMAP.md) | Coverage and execution roadmap for cloud, AI, and framework depth |
 | [`RUNTIME_ISOLATION.md`](docs/RUNTIME_ISOLATION.md) | Sandbox, credential, transport, integrity, and approval guidance by execution mode |
 | [`SIEM_INDEX_GUIDE.md`](docs/SIEM_INDEX_GUIDE.md) | Index fields, dedupe keys, timestamps, and transport guidance for OCSF consumers |
+| [`DEBUGGING.md`](docs/DEBUGGING.md) | Common integration failures, format mismatches, and scaling guidance |
+| [`TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) | Short answers for common operator, reviewer, and CI questions |
 | [`mcp-server/README.md`](mcp-server/README.md) | Thin local MCP wrapper for auto-discovered skills |
 | [`DEPENDENCY_HYGIENE_SKILL.md`](docs/DEPENDENCY_HYGIENE_SKILL.md) | Proposed safe dependency-update skill contract |
 | [`SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) | Minimum files, metadata, and guardrails for shipped skills |

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -39,11 +39,15 @@ flowchart LR
 
 ## Current rollout
 
-Fully dual-mode today:
+Dual-mode is now rolling out skill-by-skill rather than landing as a one-shot
+repo rewrite.
 
-- `ingest-cloudtrail-ocsf`
-- `ingest-vpc-flow-logs-ocsf`
-- `detect-lateral-movement`
+Current source of truth:
+
+- the `README.md` schema-mode section lists every currently dual-mode skill
+- each skill's `SKILL.md` frontmatter declares the supported `input_formats`
+  and `output_formats`
+- `validate_skill_contract.py` enforces that those declarations are present
 
 Native-first with optional bridge today:
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,124 @@
+# Debugging
+
+Use this doc when a skill runs but the output is empty, malformed, or not in
+the schema mode you expected.
+
+## Fast checklist
+
+1. Confirm the skill contract:
+   - check `input_formats`
+   - check `output_formats`
+   - check `approval_model`
+2. Confirm the invocation mode:
+   - CLI
+   - CI
+   - MCP
+   - persistent runner wrapper
+3. Confirm the input shape:
+   - `raw`
+   - `native`
+   - `canonical`
+   - `ocsf`
+4. Confirm you are reading `stdout` for structured results and `stderr` for
+   warnings or partial-skip hints.
+
+## Common failures
+
+### `--output-format native` fails
+
+Cause:
+- the skill has not shipped dual-mode support yet
+
+Check:
+- the skill's `SKILL.md` `output_formats`
+- the repo `README.md` schema-mode rollout section
+
+Fix:
+- use the default supported output mode for that skill
+- or compose through a dual-mode upstream/downstream skill that already supports
+  `native`
+
+### Native output still looks like OCSF
+
+Expected behavior:
+- native output keeps the repo's canonical identity fields
+- native output must not include the OCSF envelope fields such as:
+  - `class_uid`
+  - `category_uid`
+  - `type_uid`
+  - `metadata`
+
+Check:
+- `schema_mode` should be `native`
+- `canonical_schema_version` should be present on current dual-mode skills
+
+### Detector returns nothing
+
+Most common causes:
+- wrong input mode for that detector
+- required upstream ingester was skipped
+- timestamps fall outside the correlation window
+- the source event family is out of scope for that rule
+
+For windowed detectors, inspect:
+- event ordering
+- event timestamps
+- provider and account alignment
+- session identifiers
+
+## Large-batch guidance
+
+`detect-lateral-movement` currently materializes the normalized event stream for
+the current run before correlation. That is fine for bounded batch windows, but
+operators should not treat it as an infinite-stream daemon.
+
+Recommended pattern today:
+- partition by provider and account or tenant where possible
+- process in bounded time windows
+- keep each batch near the existing `15-minute` correlation window or another
+  explicit operator-chosen chunk size
+- for enterprise-scale replay, use a runner that chunks upstream data instead of
+  pushing a full day of mixed audit and flow telemetry into one process
+
+If you expect `100k+` events per day for one detection pass, document and apply
+the chunking policy in the surrounding runner or job definition.
+
+## MCP-specific debugging
+
+If an MCP call fails before the skill runs:
+- confirm the requested `output_format` is declared by the skill
+- confirm write-capable skills include `--dry-run` where required
+- confirm the MCP wrapper is exposing the latest skill metadata from `SKILL.md`
+
+Relevant files:
+- `mcp-server/src/server.py`
+- `mcp-server/src/tool_registry.py`
+
+## Cloud SDK import failures
+
+Many cloud SDKs are imported lazily inside provider-specific functions.
+
+If a skill loads but fails only when a provider branch executes:
+- install the required dependency group
+- confirm the provider SDK is declared in `pyproject.toml`
+- confirm the target API response shape still matches the documented source
+
+Use:
+- `docs/SKILL_CONTRACT.md`
+- `docs/DEPENDENCY_HYGIENE_SKILL.md`
+- the skill's `REFERENCES.md`
+
+## When to suspect schema drift
+
+Look for:
+- new enum values
+- renamed nested fields
+- timestamp format changes
+- missing natural IDs
+- provider-side deprecations
+
+Fix pattern:
+- add a fixture for the new shape
+- keep the old shape covered during migration
+- update `REFERENCES.md`
+- update the skill contract only in the same PR as the code change

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,86 @@
+# Troubleshooting
+
+## Why does a skill name still end in `-ocsf` if OCSF is optional?
+
+`-ocsf` means OCSF is the default wire format for that skill family. It does
+not mean OCSF is the only supported mode. Check the skill's `output_formats`
+frontmatter for the current truth.
+
+## Why doesn't every skill support `native` yet?
+
+The repo is rolling out dual-mode support skill-by-skill. The contract is
+stable now, but implementation is intentionally phased to avoid a risky
+big-bang rewrite.
+
+Use the `README.md` schema-mode section and `SKILL.md` frontmatter as the
+source of truth for current support.
+
+## Can I ask for `canonical` output?
+
+Not directly today. `canonical` is the repo's stable internal model. Current
+wire outputs are:
+- `native`
+- `ocsf`
+- `bridge`
+
+The skill code normalizes into canonical internally and then projects outward.
+
+## Why does `execution_modes: persistent` not mean a daemon already exists?
+
+`persistent` means the skill is safe to embed unchanged in a runner, queue
+consumer, scheduler, or serverless loop. It does not mean the repo already
+ships that runner for every skill.
+
+Current shipped exception:
+- `iam-departures-remediation`
+
+## Why is a read-only skill refusing to write or mutate anything?
+
+That is the intended contract. Read-only skills must not perform hidden writes.
+If you need a state-changing action, use a documented remediation or sink path
+with the correct approval model.
+
+## Why is a write-capable skill asking for dry-run or human approval?
+
+Because the repo treats approval metadata as runtime policy, not just
+documentation. Agents and wrappers should stop for approval where the skill
+contract says they must.
+
+## What happens when a user, service principal, or resource disappears?
+
+The repo should preserve:
+- historical events
+- last-known state
+- last-seen time
+- lifecycle status when the source exposes it
+
+Absence from a later snapshot should be treated as a state signal, not as an
+instruction to erase history.
+
+See:
+- `docs/STATE_AND_TIMELINE_MODEL.md`
+
+## Why do I see `Expected — Waiting for status to be reported` on a PR?
+
+In practice this usually means one of two things:
+- the PR branch is stale or marked conflicted, so GitHub has not started the
+  required checks on the latest mergeable head
+- branch protection still expects an old check name that no longer exists
+
+Rebase or refresh the PR branch first before assuming Actions is frozen.
+
+## How should I store this data in a database or lake?
+
+Prefer the canonical model for:
+- tables
+- views
+- joins
+- indexes
+- metrics
+
+Treat OCSF as a transport and interoperability projection, not the only storage
+schema.
+
+See:
+- `docs/CANONICAL_SCHEMA.md`
+- `docs/SIEM_INDEX_GUIDE.md`

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -99,6 +99,22 @@ event family.
 
 Default 15 minutes post-anchor. Rationale: attackers tend to act fast after acquiring a more powerful cloud identity. A longer window catches more but produces more false positives on legitimate cross-service traffic.
 
+### Batch sizing guidance
+
+This detector is designed for bounded batch windows, not as an infinite-stream
+in-memory correlator. Today it materializes the normalized event set for the
+current run before correlation.
+
+Recommended operator pattern:
+
+- partition by provider and account or tenant where possible
+- keep replay or scheduled jobs in explicit time windows
+- use upstream chunking for higher-volume environments instead of sending a full
+  mixed day of audit and flow telemetry through one process
+
+If you need continuous or very high-volume operation, put a runner in front of
+this skill and let the runner own checkpointing and chunk boundaries.
+
 ### Why RFC1918-only
 
 The purpose of this rule is **east-west detection**. Egress to the public internet is a different detector (data exfiltration). Filtering to RFC1918 destinations — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, plus the shared `100.64.0.0/10` — means any fire is definitionally east-west.


### PR DESCRIPTION
## Summary
- add a runnable 1-minute hello-world path near the top of the README and link new operator docs from the main doc surfaces
- replace the stale hard-coded dual-mode list in DATA_FLOW.md with README + SKILL.md as the rollout source of truth
- add DEBUGGING and TROUBLESHOOTING docs, plus bounded-batch guidance for detect-lateral-movement so the current memory model is documented honestly

## Validation
- python scripts/validate_skill_contract.py
- uv run pytest tests/integration/test_skill_validation_scripts.py -q -o addopts=''