### PR TITLE
docs: tighten skill metadata for agents and sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is loosely based on Keep a Changelog.
 
 ### Changed
 
+- trimmed the handful of overlong `SKILL.md` frontmatter descriptions so tool-selection metadata stays concise for Claude, Codex, Cursor, Windsurf, Cortex, and MCP clients.
+- added optional `network_egress` skill metadata, exposed it through the MCP tool registry, and documented it in the skill/runtime contracts for sandbox-aware wrappers.
+- added an explicit `## Do NOT do` anti-pattern section to `iam-departures-remediation` and surfaced network egress allowlist hints for the write-capable workflow.
 - Expanded the coverage registry and framework mapping docs to track Okta, Entra / Graph, and Google Workspace as first-class OCSF identity-ingestion sources and detections.
 - Expanded `ingest-okta-system-log-ocsf` to cover the verified Okta Verify push and denial event families needed for narrow MFA fatigue detection.
 - Reframed the repo contract so OCSF remains a first-class interoperability option, but not a mandatory storage or execution model; the stable internal contract is now explicitly source truth -> canonical model -> `native` / `ocsf` / `bridge` output.

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -12,6 +12,7 @@ Each shipped `SKILL.md` now declares:
 - `approval_model`
 - `execution_modes`
 - `side_effects`
+- optional `network_egress`
 
 Agents and wrappers should treat those fields as part of the runtime contract, not optional documentation.
 

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -37,6 +37,10 @@ Optional:
 - `input_formats`
 - `output_formats`
 
+Optional:
+
+- `network_egress`
+
 Rules:
 
 - `name` must match `^[a-z0-9-]+$`
@@ -79,6 +83,11 @@ Rules:
   - `ocsf`
   - `bridge`
 - every skill must declare the formats it supports today, even if only one mode is implemented
+- `network_egress`, when present, must be a comma-separated list of hostnames or wildcard hostnames such as:
+  - `api.workday.com`
+  - `*.snowflakecomputing.com`
+  - `*.databricks.com`
+  - `*.clickhouse.cloud`
 
 ## Required language
 
@@ -88,6 +97,9 @@ Each `SKILL.md` must contain both:
 - `Do NOT use`
 
 This keeps routing explicit and guardrails visible for Claude, Codex, Cursor, Windsurf, Cortex Code CLI, and other MCP-aware agents.
+
+Write-capable skills should also include a body-level `## Do NOT do` section for
+operator anti-patterns that must never be bypassed.
 
 ## Required references
 

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -29,6 +29,7 @@ class SkillSpec:
     side_effects: tuple[str, ...]
     input_formats: tuple[str, ...]
     output_formats: tuple[str, ...]
+    network_egress: tuple[str, ...]
 
     @property
     def supported(self) -> bool:
@@ -144,6 +145,7 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 side_effects=_parse_modes(metadata.get("side_effects")),
                 input_formats=_parse_modes(metadata.get("input_formats")),
                 output_formats=_parse_modes(metadata.get("output_formats")),
+                network_egress=_parse_modes(metadata.get("network_egress")),
             )
         )
     return specs
@@ -184,11 +186,13 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
 def tool_definition(skill: SkillSpec) -> dict[str, object]:
     mode_list = ", ".join(skill.execution_modes) if skill.execution_modes else "unspecified"
     effect_list = ", ".join(skill.side_effects) if skill.side_effects else "unspecified"
+    egress_list = ", ".join(skill.network_egress) if skill.network_egress else "none"
     tool: dict[str, object] = {
         "name": skill.name,
         "description": (
             f"{skill.description} Approval model: {skill.approval_model or 'unspecified'}. "
-            f"Execution modes: {mode_list}. Side effects: {effect_list}."
+            f"Execution modes: {mode_list}. Side effects: {effect_list}. "
+            f"Network egress: {egress_list}."
         ),
         "inputSchema": tool_input_schema(skill),
         "annotations": {

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -78,11 +78,13 @@ class TestToolDefinition:
         assert "Approval model: none." in tool["description"]
         assert "Execution modes: jit, ci, mcp, persistent." in tool["description"]
         assert "Side effects: none." in tool["description"]
+        assert "Network egress: none." in tool["description"]
         assert skill.input_formats == ("raw",)
         assert skill.output_formats == ("ocsf", "native")
         assert skill.approval_model == "none"
         assert skill.execution_modes == ("jit", "ci", "mcp", "persistent")
         assert skill.side_effects == ("none",)
+        assert skill.network_egress == ()
 
     def test_build_command_uses_fixed_entrypoint(self):
         skill = tool_map(REPO_ROOT)["detect-lateral-movement"]

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -24,6 +24,7 @@ SIDE_EFFECT_VALUES = {
 }
 INPUT_FORMAT_VALUES = {"raw", "canonical", "native", "ocsf"}
 OUTPUT_FORMAT_VALUES = {"native", "ocsf", "bridge"}
+NETWORK_EGRESS_RE = re.compile(r"^(?:\*\.)?(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+$")
 
 ENTRYPOINT_CANDIDATES = (
     "src/ingest.py",
@@ -107,6 +108,10 @@ class SkillContract:
     @property
     def side_effects(self) -> tuple[str, ...]:
         return parse_modes(self.frontmatter.get("side_effects"))
+
+    @property
+    def network_egress(self) -> tuple[str, ...]:
+        return parse_modes(self.frontmatter.get("network_egress"))
 
 
 def iter_skill_dirs() -> list[Path]:

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -7,6 +7,7 @@ from skill_validation_common import (
     EXECUTION_MODE_VALUES,
     INPUT_FORMAT_VALUES,
     NAME_RE,
+    NETWORK_EGRESS_RE,
     OUTPUT_FORMAT_VALUES,
     ROOT,
     SIDE_EFFECT_VALUES,
@@ -85,6 +86,19 @@ def main() -> int:
                 errors.append(f"{rel}: invalid output_formats {unknown_output_formats}")
         elif output_formats:
             errors.append(f"{rel}: output_formats must not be empty")
+
+        network_egress = skill.frontmatter.get("network_egress")
+        parsed_network_egress = tuple(
+            part.strip() for part in network_egress.split(",") if part.strip()
+        ) if network_egress else ()
+        if parsed_network_egress:
+            invalid_network_egress = [
+                host for host in parsed_network_egress if not NETWORK_EGRESS_RE.fullmatch(host)
+            ]
+            if invalid_network_egress:
+                errors.append(f"{rel}: invalid network_egress entries {invalid_network_egress}")
+        elif network_egress:
+            errors.append(f"{rel}: network_egress must not be empty")
 
         if skill.is_write_capable:
             if skill.approval_model != "human_required":

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -1,22 +1,15 @@
 ---
 name: detect-lateral-movement
 description: >-
-  Detect cloud lateral movement by joining OCSF 1.8 API Activity events
-  from cloud audit ingestors (class 6003) with OCSF 1.8 Network Activity
-  events from cloud flow-log ingestors (class 4001) in a single
-  detection. Correlates a recent privileged identity pivot event with
-  accepted east-west traffic to an internal destination — the canonical
-  post-access movement pattern. Emits OCSF 1.8 Detection Finding (class
-  2004) with MITRE ATT&CK T1021 Remote Services and T1078.004 Cloud
-  Accounts inside finding_info.attacks[]. Multi-source, cross-cloud
-  detection that proves the OCSF fan-out architecture where one detector
-  consumes multiple ingest streams. Use when the user mentions lateral
-  movement, east-west pivot, cloud identity pivot followed by internal
-  traffic, or wants to detect attackers moving between cloud resources
-  after initial access. Do NOT use on raw logs — pipe audit and network
-  telemetry through their respective ingestion skills first. Do NOT
-  use for pre-compromise detection. Do NOT use as an exfiltration
-  detector — public internet destinations are deliberately filtered out.
+  Detect cloud lateral movement by joining normalized audit and flow telemetry
+  in native or OCSF mode. Correlates a recent privileged identity pivot with
+  accepted east-west traffic to an internal destination and emits a detection
+  finding aligned to MITRE ATT&CK T1021 and T1078.004. Use when the user
+  mentions lateral movement, east-west pivot, cloud identity abuse followed
+  by internal traffic, or wants to detect attackers moving between cloud
+  resources after initial access. Do NOT use on raw logs — pipe audit and
+  network telemetry through their respective ingestion skills first. Do NOT
+  use for pre-compromise detection. Do NOT use as an exfiltration detector.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent

--- a/skills/detection/detect-privilege-escalation-k8s/SKILL.md
+++ b/skills/detection/detect-privilege-escalation-k8s/SKILL.md
@@ -1,23 +1,16 @@
 ---
 name: detect-privilege-escalation-k8s
 description: >-
-  Detect Kubernetes privilege escalation patterns in OCSF 1.8 API Activity
-  events (class 6003) or the native enriched Kubernetes activity shape
-  produced by ingest-k8s-audit-ocsf. Reads normalised kube-apiserver audit
-  events, groups them by actor (service account or user) over a sliding
-  window, and fires OCSF 1.8 Detection Finding (class 2004) events by
-  default for four patterns: (1) service-account secret enumeration followed
-  by get (MITRE T1552.007 Container API), (2) service-account exec into a
-  pod (MITRE T1611 Escape to Host), (3) creation of a ClusterRoleBinding or
-  RoleBinding by a non-admin principal (MITRE T1098 Account Manipulation),
-  and (4) token-review or token-request self-grant by a service account
-  (MITRE T1550.001 Application Access Token). Use when the user mentions
-  Kubernetes threat detection, K8s privilege escalation, container escape,
-  RBAC abuse, service account compromise, or kube-apiserver audit analysis.
-  Do NOT use on raw audit logs — pipe them through ingest-k8s-audit-ocsf
-  first. Do NOT use for CloudTrail / GCP / Azure detection (those need their
-  own detectors — roadmap). Do NOT use as a compliance check; this is an
-  active detection skill that emits findings on observed behaviour.
+  Detect Kubernetes privilege-escalation patterns from normalized
+  kube-apiserver audit events in OCSF or native mode. Fires on four
+  high-signal behaviors: service-account secret enumeration plus read
+  (T1552.007), service-account pod exec (T1611), non-admin role-binding
+  creation (T1098), and token self-grant flows (T1550.001). Use when the
+  user mentions Kubernetes threat detection, RBAC abuse, service-account
+  compromise, container escape, or kube-apiserver audit analysis. Do NOT use
+  on raw audit logs — pipe them through ingest-k8s-audit-ocsf first. Do NOT
+  use for CloudTrail, GCP, or Azure detection. Do NOT use as a compliance
+  check; this emits findings on observed behavior.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent

--- a/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
+++ b/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
@@ -1,22 +1,15 @@
 ---
 name: detect-sensitive-secret-read-k8s
 description: >-
-  Detect reads of Kubernetes Secrets whose names match sensitive patterns
-  (credentials, tokens, API keys, cloud provider creds, TLS material, service
-  account tokens, and Docker config secrets). Reads OCSF 1.8 API Activity
-  (class 6003) events produced by ingest-k8s-audit-ocsf and emits OCSF 1.8
-  Detection Finding (class 2004) with MITRE ATT&CK T1552.007 (Unsecured
-  Credentials — Container API). Stateless pattern matcher — works on
-  Metadata-level audit logs, no Request/RequestResponse level required.
-  Complements detect-privilege-escalation-k8s Rule 1 by catching direct
-  targeted reads of high-value secrets even when there's no preceding list.
-  Use when the user mentions Kubernetes secret access, sensitive secret
-  detection, Container API credential access, or wants to detect workloads
-  reading credentials by name. Do NOT use on raw audit logs — pipe them
-  through ingest-k8s-audit-ocsf first. Do NOT use to detect list-then-get
-  enumeration patterns (that's detect-privilege-escalation-k8s Rule 1). Do
-  NOT use for cross-namespace analysis — that's a separate detector on the
-  roadmap.
+  Detect targeted reads of Kubernetes Secrets whose names match sensitive
+  patterns from normalized K8s audit events in native or OCSF mode. Emits
+  findings aligned to MITRE ATT&CK T1552.007 when workloads read high-value
+  secrets by name without requiring a preceding enumeration sequence. Use
+  when the user mentions Kubernetes secret access, credential reads through
+  the Container API, or workloads reading secrets by name. Do NOT use on raw
+  audit logs — pipe them through ingest-k8s-audit-ocsf first. Do NOT use for
+  list-then-get enumeration patterns; that belongs to
+  detect-privilege-escalation-k8s. Do NOT use for cross-namespace analysis.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
@@ -26,6 +19,12 @@ output_formats: native, ocsf
 ---
 
 # detect-sensitive-secret-read-k8s
+
+## Use when
+
+- Kubernetes secret-access telemetry is already normalized by `ingest-k8s-audit-ocsf`
+- you want a direct-read detector for high-value secret names
+- you want native or OCSF findings for targeted secret access attempts
 
 ## Attack pattern
 

--- a/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
@@ -1,21 +1,15 @@
 ---
 name: ingest-k8s-audit-ocsf
 description: >-
-  Convert raw Kubernetes audit logs (audit.k8s.io/v1) into OCSF 1.8 API
-  Activity events (class 6003). Reads the JSON format kube-apiserver writes to
-  its audit log sink (file, webhook, or dynamic backend). Maps user.username
-  and user.groups to OCSF actor, sourceIPs to src_endpoint, verb to
-  api.operation, api.service.name to "kubernetes", and infers activity_id
-  (Create / Read / Update / Delete) from the K8s verb. Sets status_id from
-  responseStatus.code. Captures objectRef (resource, namespace, name, apiGroup)
-  in resources[] with enough precision for detectors to spot
-  service-account-token-theft, privileged-pod creation, and secret access.
-  Use when the user mentions Kubernetes audit logs, kube-apiserver audit sink,
-  OCSF pipeline for K8s, k8s detection engineering, or feeding K8s audit into
-  a SIEM. Do NOT use for container runtime logs (different source), kubelet
-  logs (different source), or CloudTrail / GCP audit / Azure activity (use the
-  matching ingest-* skills). Do NOT use as a detection skill — this only
-  normalises events.
+  Convert raw Kubernetes audit logs (`audit.k8s.io/v1`) into normalized API
+  activity records, with OCSF as the default wire format and native output as
+  an option. Maps user, source IP, verb, objectRef, and response status with
+  enough fidelity for K8s privilege-escalation and secret-access detectors.
+  Use when the user mentions Kubernetes audit logs, kube-apiserver audit
+  sinks, K8s detection engineering, or feeding K8s audit into a SIEM. Do NOT
+  use for container runtime logs, kubelet logs, or CloudTrail / GCP audit /
+  Azure Activity. Do NOT use as a detection skill; this only normalizes
+  events.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent

--- a/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
@@ -1,22 +1,15 @@
 ---
 name: ingest-security-hub-ocsf
 description: >-
-  Convert AWS Security Hub findings in ASFF (AWS Security Finding Format) into
-  OCSF 1.8 Detection Finding events (class 2004). Validates the required ASFF
-  fields, maps the HIGH/MEDIUM/LOW/INFORMATIONAL label (plus the 0-100
-  Normalized score) to OCSF severity_id, preserves the aggregated
-  Resources[]/Types[]/Compliance context, and extracts MITRE ATT&CK
-  annotations from ProductFields when the upstream product emits them.
-  Handles single findings, the `{"Findings": [...]}` BatchImport wrapper,
-  and EventBridge `Security Hub Findings - Imported` envelopes. Use when the
-  user mentions Security Hub ingestion, ASFF normalisation, cross-account
-  aggregator pipelines, or unifying findings from multiple AWS security
-  services (GuardDuty, Inspector, Macie, Config rules) into OCSF. Do NOT use
-  for GuardDuty native findings (use ingest-guardduty-ocsf), CloudTrail audit
-  logs (use ingest-cloudtrail-ocsf), or VPC Flow Logs (use
-  ingest-vpc-flow-logs-ocsf). Do NOT use as a detection skill — Security Hub
-  aggregates detections from upstream products; this skill is a passthrough
-  normaliser/validator.
+  Convert AWS Security Hub ASFF findings into OCSF 1.8 Detection Finding
+  events. Validates the required ASFF fields, maps ASFF severity into OCSF,
+  preserves aggregated resource and compliance context, and extracts MITRE
+  ATT&CK hints when upstream products provide them. Supports single findings,
+  `{\"Findings\": [...]}` wrappers, and EventBridge imported-finding
+  envelopes. Use when the user mentions Security Hub ingestion, ASFF
+  normalization, or unifying upstream AWS findings into OCSF. Do NOT use for
+  GuardDuty native findings, CloudTrail audit logs, or VPC Flow Logs. Do NOT
+  use as a detection skill; this is a passthrough normalizer and validator.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, persistent
 side_effects: writes-identity, writes-storage, writes-database, writes-audit
 input_formats: raw, canonical
 output_formats: native
+network_egress: api.workday.com, *.snowflakecomputing.com, *.databricks.com, *.clickhouse.cloud
 compatibility: >-
   Requires AWS CLI, Python 3.11+, and boto3. Lambdas deploy to AWS. HR data
   source requires one of: Snowflake connector, Databricks SQL connector,
@@ -109,6 +110,13 @@ flowchart TD
 - **Encryption**: S3 manifests KMS-encrypted. DynamoDB encryption at rest. Lambda env vars encrypted.
 - **VPC isolation**: Both Lambdas run in VPC with no public internet (NAT gateway for AWS API calls only).
 - **Audit trail**: Every action dual-written to DynamoDB + S3. Ingest-back to source warehouse for reconciliation.
+
+## Do NOT do
+
+- Do NOT bypass the grace period by editing timestamps or manifest state by hand.
+- Do NOT call the Step Function or worker Lambda directly; enter through the documented EventBridge path.
+- Do NOT write directly to the audit DynamoDB or S3 records outside the shipped workflow.
+- Do NOT point this skill at production without a dry-run review and explicit human approval.
 
 ## Rehire Safety
 


### PR DESCRIPTION
## Summary
- trim the 5 overlong SKILL.md frontmatter descriptions so agent-facing tool metadata stays concise without losing routing guidance
- add optional network_egress metadata to the skill contract, validate it, and surface it through the MCP tool registry for sandbox-aware wrappers
- strengthen iam-departures-remediation guidance with explicit operator anti-patterns and declared egress targets

## Validation
- python scripts/validate_skill_contract.py
- uv run pytest tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py -q -o addopts=''