### PR TITLE
security: add caller and approval audit context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is loosely based on Keep a Changelog.
 - `detect-entra-role-grant-escalation` as the narrow Entra follow-up detector for successful app-role assignments to service principals, aligned to MITRE ATT&CK `T1098.003` Additional Cloud Roles.
 - a phased native/OCSF pilot for `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, including explicit `--output-format {ocsf,native}` support, native/canonical-friendly test coverage, and MCP output-format selection for supported skills.
 - repo-wide skill frontmatter for `approval_model`, `execution_modes`, and `side_effects`, plus CI enforcement and MCP tool-surface hints so human-in-the-loop expectations are explicit instead of inferred.
+- optional `caller_roles`, `approver_roles`, and `min_approvers` contract metadata plus MCP caller-context propagation into write-capable skills, so remediation audit trails can record who invoked, who approved, and which request or session triggered the action.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The important rule is that the **skill code does not change between modes**. `SK
 For every shipped skill, the contract is:
 - exact input and output format
 - explicit `approval_model`, `execution_modes`, and `side_effects` frontmatter so agents know when to stop for human approval
+- runtime-aware caller and approver context for write-capable workflows when the wrapper provides it
 - explicit `Use when...` and `Do NOT use...`
 - official vendor docs only in `REFERENCES.md`
 - failure-safe behavior on malformed input and deprecated API shapes

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -70,6 +70,15 @@ Required controls:
 - idempotency keys or merge-on-UID behavior
 - immutable or append-only audit trail where feasible
 
+Where the runtime supports it, write-capable skills should also preserve:
+- caller identity
+- approver identity
+- session or request identifiers
+- execution principal details
+- change-control or ticket references
+
+Those fields are part of the audit contract, not optional debug noise.
+
 ## Credentials and cloud access
 
 Best practice for operators:

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -38,8 +38,10 @@ Optional:
 - `output_formats`
 
 Optional:
-
 - `network_egress`
+- `caller_roles`
+- `approver_roles`
+- `min_approvers`
 
 Rules:
 
@@ -88,6 +90,11 @@ Rules:
   - `*.snowflakecomputing.com`
   - `*.databricks.com`
   - `*.clickhouse.cloud`
+- `caller_roles`, when present, should name the human or agent roles allowed to invoke the skill
+- `approver_roles`, when present, should name the roles allowed to approve write-capable actions
+- `min_approvers`, when present, must be an integer greater than or equal to 1
+- write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy
+- write-capable skills should preserve caller, approver, and request or session identifiers in their audit trail when the runtime provides them
 
 ## Required language
 
@@ -121,6 +128,7 @@ Examples:
 - explicit input/output shape
 - defensive parsing on untrusted input
 - explicit human-in-the-loop and runtime-mode declaration in frontmatter so agents know when they must stop for approval
+- preserve caller, approver, and execution identity context when the surrounding runtime provides it
 
 ## Required validation and error handling
 

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -79,6 +79,25 @@ def _validate_output_format(raw_output_format: Any) -> str | None:
     return raw_output_format
 
 
+def _validate_context(raw_context: Any, field_name: str) -> dict[str, Any] | None:
+    if raw_context is None:
+        return None
+    if not isinstance(raw_context, dict):
+        raise ValueError(f"`{field_name}` must be an object")
+    validated: dict[str, Any] = {}
+    for key, value in raw_context.items():
+        if not isinstance(key, str):
+            raise ValueError(f"`{field_name}` keys must be strings")
+        if isinstance(value, str):
+            validated[key] = value
+            continue
+        if isinstance(value, list) and all(isinstance(item, str) for item in value):
+            validated[key] = value
+            continue
+        raise ValueError(f"`{field_name}.{key}` must be a string or array of strings")
+    return validated
+
+
 def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     tools = tool_map()
     if name not in tools:
@@ -88,12 +107,34 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     args = _validate_args((arguments or {}).get("args"))
     stdin_text = _validate_input((arguments or {}).get("input"))
     output_format = _validate_output_format((arguments or {}).get("output_format"))
+    caller_context = _validate_context((arguments or {}).get("_caller_context"), "_caller_context")
+    approval_context = _validate_context((arguments or {}).get("_approval_context"), "_approval_context")
 
     if not skill.read_only and "--dry-run" not in args:
         raise ValueError("write-capable tools must be called with `--dry-run`")
+    if not skill.read_only and skill.approver_roles and approval_context is None:
+        raise ValueError("write-capable tools with approver_roles require `_approval_context`")
 
     env = os.environ.copy()
     env.setdefault("PYTHONUNBUFFERED", "1")
+    if caller_context:
+        if "user_id" in caller_context:
+            env["SKILL_CALLER_ID"] = caller_context["user_id"]
+        if "email" in caller_context:
+            env["SKILL_CALLER_EMAIL"] = caller_context["email"]
+        if "session_id" in caller_context:
+            env["SKILL_SESSION_ID"] = caller_context["session_id"]
+        if "roles" in caller_context:
+            env["SKILL_CALLER_ROLES"] = ",".join(caller_context["roles"])
+    if approval_context:
+        if "approver_id" in approval_context:
+            env["SKILL_APPROVER_ID"] = approval_context["approver_id"]
+        if "approver_email" in approval_context:
+            env["SKILL_APPROVER_EMAIL"] = approval_context["approver_email"]
+        if "ticket_id" in approval_context:
+            env["SKILL_APPROVAL_TICKET"] = approval_context["ticket_id"]
+        if "approval_timestamp" in approval_context:
+            env["SKILL_APPROVAL_TIMESTAMP"] = approval_context["approval_timestamp"]
     timeout_seconds = int(env.get("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
     completed = subprocess.run(
         build_command(skill, args, output_format=output_format),
@@ -114,6 +155,8 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
             "category": skill.category,
             "capability": skill.capability,
             "output_format": output_format or "default",
+            "caller_context_provided": caller_context is not None,
+            "approval_context_provided": approval_context is not None,
             "stdout": completed.stdout,
             "stderr": completed.stderr,
             "exit_code": completed.returncode,

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -30,6 +30,9 @@ class SkillSpec:
     input_formats: tuple[str, ...]
     output_formats: tuple[str, ...]
     network_egress: tuple[str, ...]
+    caller_roles: tuple[str, ...]
+    approver_roles: tuple[str, ...]
+    min_approvers: int | None
 
     @property
     def supported(self) -> bool:
@@ -146,6 +149,10 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 input_formats=_parse_modes(metadata.get("input_formats")),
                 output_formats=_parse_modes(metadata.get("output_formats")),
                 network_egress=_parse_modes(metadata.get("network_egress")),
+                network_egress=_parse_modes(metadata.get("network_egress")),
+                caller_roles=_parse_modes(metadata.get("caller_roles")),
+                approver_roles=_parse_modes(metadata.get("approver_roles")),
+                min_approvers=int(metadata["min_approvers"]) if metadata.get("min_approvers") else None,
             )
         )
     return specs
@@ -187,12 +194,17 @@ def tool_definition(skill: SkillSpec) -> dict[str, object]:
     mode_list = ", ".join(skill.execution_modes) if skill.execution_modes else "unspecified"
     effect_list = ", ".join(skill.side_effects) if skill.side_effects else "unspecified"
     egress_list = ", ".join(skill.network_egress) if skill.network_egress else "none"
+    caller_roles = ", ".join(skill.caller_roles) if skill.caller_roles else "unspecified"
+    approver_roles = ", ".join(skill.approver_roles) if skill.approver_roles else "unspecified"
+    min_approvers = skill.min_approvers if skill.min_approvers is not None else "unspecified"
     tool: dict[str, object] = {
         "name": skill.name,
         "description": (
             f"{skill.description} Approval model: {skill.approval_model or 'unspecified'}. "
             f"Execution modes: {mode_list}. Side effects: {effect_list}. "
-            f"Network egress: {egress_list}."
+            f"Network egress: {egress_list}. "
+            f"Caller roles: {caller_roles}. Approver roles: {approver_roles}. "
+            f"Min approvers: {min_approvers}."
         ),
         "inputSchema": tool_input_schema(skill),
         "annotations": {

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -149,7 +149,6 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 input_formats=_parse_modes(metadata.get("input_formats")),
                 output_formats=_parse_modes(metadata.get("output_formats")),
                 network_egress=_parse_modes(metadata.get("network_egress")),
-                network_egress=_parse_modes(metadata.get("network_egress")),
                 caller_roles=_parse_modes(metadata.get("caller_roles")),
                 approver_roles=_parse_modes(metadata.get("approver_roles")),
                 min_approvers=int(metadata["min_approvers"]) if metadata.get("min_approvers") else None,

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+SPEC = importlib.util.spec_from_file_location("cloud_security_server_test", SERVER_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class _FakeCompleted:
+    def __init__(self) -> None:
+        self.stdout = "ok\n"
+        self.stderr = ""
+        self.returncode = 0
+
+
+class _FakeSkill:
+    def __init__(self, read_only: bool = True, approver_roles: tuple[str, ...] = ()) -> None:
+        self.name = "fake-skill"
+        self.category = "detection"
+        self.capability = "read-only" if read_only else "write-remediation"
+        self.read_only = read_only
+        self.approver_roles = approver_roles
+
+
+def test_call_tool_injects_caller_and_approval_context(monkeypatch):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(MODULE, "tool_map", lambda: {"fake-skill": _FakeSkill(read_only=True)})
+    monkeypatch.setattr(MODULE, "build_command", lambda skill, args, output_format=None: ["python", "fake.py"])
+
+    def _fake_run(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _FakeCompleted()
+
+    monkeypatch.setattr(MODULE.subprocess, "run", _fake_run)
+
+    result = MODULE._call_tool(
+        "fake-skill",
+        {
+            "args": [],
+            "_caller_context": {
+                "user_id": "u-123",
+                "email": "user@example.com",
+                "session_id": "sess-1",
+                "roles": ["security_engineer"],
+            },
+            "_approval_context": {
+                "approver_id": "a-456",
+                "approver_email": "approver@example.com",
+                "ticket_id": "SEC-123",
+                "approval_timestamp": "2026-04-14T12:00:00Z",
+            },
+        },
+    )
+
+    env = captured["env"]
+    assert env["SKILL_CALLER_ID"] == "u-123"
+    assert env["SKILL_CALLER_EMAIL"] == "user@example.com"
+    assert env["SKILL_SESSION_ID"] == "sess-1"
+    assert env["SKILL_CALLER_ROLES"] == "security_engineer"
+    assert env["SKILL_APPROVER_ID"] == "a-456"
+    assert env["SKILL_APPROVER_EMAIL"] == "approver@example.com"
+    assert env["SKILL_APPROVAL_TICKET"] == "SEC-123"
+    assert env["SKILL_APPROVAL_TIMESTAMP"] == "2026-04-14T12:00:00Z"
+    assert result["structuredContent"]["caller_context_provided"] is True
+    assert result["structuredContent"]["approval_context_provided"] is True
+
+
+def test_call_tool_requires_approval_context_for_write_skill(monkeypatch):
+    monkeypatch.setattr(
+        MODULE,
+        "tool_map",
+        lambda: {"fake-skill": _FakeSkill(read_only=False, approver_roles=("security_lead",))},
+    )
+
+    try:
+        MODULE._call_tool("fake-skill", {"args": ["--dry-run"]})
+    except ValueError as exc:
+        assert "require `_approval_context`" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -88,7 +88,6 @@ class TestToolDefinition:
         assert skill.execution_modes == ("jit", "ci", "mcp", "persistent")
         assert skill.side_effects == ("none",)
         assert skill.network_egress == ()
-        assert skill.network_egress == ()
         assert skill.caller_roles == ()
         assert skill.approver_roles == ()
         assert skill.min_approvers is None

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -79,12 +79,31 @@ class TestToolDefinition:
         assert "Execution modes: jit, ci, mcp, persistent." in tool["description"]
         assert "Side effects: none." in tool["description"]
         assert "Network egress: none." in tool["description"]
+        assert "Caller roles: unspecified." in tool["description"]
+        assert "Approver roles: unspecified." in tool["description"]
+        assert "Min approvers: unspecified." in tool["description"]
         assert skill.input_formats == ("raw",)
         assert skill.output_formats == ("ocsf", "native")
         assert skill.approval_model == "none"
         assert skill.execution_modes == ("jit", "ci", "mcp", "persistent")
         assert skill.side_effects == ("none",)
         assert skill.network_egress == ()
+        assert skill.network_egress == ()
+        assert skill.caller_roles == ()
+        assert skill.approver_roles == ()
+        assert skill.min_approvers is None
+
+    def test_unsupported_write_skill_rbac_metadata_is_parsed(self):
+        remediation = next(skill for skill in discover_skills(REPO_ROOT) if skill.name == "iam-departures-remediation")
+        assert remediation.network_egress == (
+            "api.workday.com",
+            "*.snowflakecomputing.com",
+            "*.databricks.com",
+            "*.clickhouse.cloud",
+        )
+        assert remediation.caller_roles == ("security_engineer", "incident_responder")
+        assert remediation.approver_roles == ("security_lead", "cis_officer")
+        assert remediation.min_approvers == 1
 
     def test_build_command_uses_fixed_entrypoint(self):
         skill = tool_map(REPO_ROOT)["detect-lateral-movement"]

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -113,6 +113,21 @@ class SkillContract:
     def network_egress(self) -> tuple[str, ...]:
         return parse_modes(self.frontmatter.get("network_egress"))
 
+    @property
+    def caller_roles(self) -> tuple[str, ...]:
+        return parse_modes(self.frontmatter.get("caller_roles"))
+
+    @property
+    def approver_roles(self) -> tuple[str, ...]:
+        return parse_modes(self.frontmatter.get("approver_roles"))
+
+    @property
+    def min_approvers(self) -> int | None:
+        raw_value = self.frontmatter.get("min_approvers", "").strip()
+        if not raw_value:
+            return None
+        return int(raw_value)
+
 
 def iter_skill_dirs() -> list[Path]:
     return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -105,6 +105,19 @@ def main() -> int:
                 errors.append(f"{rel}: write-capable skills must set approval_model to `human_required`")
             if not skill.side_effects or skill.side_effects == ("none",):
                 errors.append(f"{rel}: write-capable skills must declare concrete side_effects")
+            min_approvers = skill.frontmatter.get("min_approvers")
+            if skill.frontmatter.get("caller_roles") and not skill.caller_roles:
+                errors.append(f"{rel}: caller_roles must not be empty")
+            if skill.frontmatter.get("approver_roles") and not skill.approver_roles:
+                errors.append(f"{rel}: approver_roles must not be empty")
+            if skill.approver_roles and not min_approvers:
+                errors.append(f"{rel}: approver_roles requires min_approvers")
+            if min_approvers:
+                try:
+                    if int(min_approvers) < 1:
+                        errors.append(f"{rel}: min_approvers must be >= 1")
+                except ValueError:
+                    errors.append(f"{rel}: min_approvers must be an integer")
         else:
             if skill.approval_model and skill.approval_model != "none":
                 errors.append(f"{rel}: read-only skills must set approval_model to `none`")

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -21,6 +21,9 @@ side_effects: writes-identity, writes-storage, writes-database, writes-audit
 input_formats: raw, canonical
 output_formats: native
 network_egress: api.workday.com, *.snowflakecomputing.com, *.databricks.com, *.clickhouse.cloud
+caller_roles: security_engineer, incident_responder
+approver_roles: security_lead, cis_officer
+min_approvers: 1
 compatibility: >-
   Requires AWS CLI, Python 3.11+, and boto3. Lambdas deploy to AWS. HR data
   source requires one of: Snowflake connector, Databricks SQL connector,

--- a/skills/remediation/iam-departures-remediation/examples.md
+++ b/skills/remediation/iam-departures-remediation/examples.md
@@ -98,6 +98,9 @@ SELECT
     target_account_id,
     remediation_actions,
     remediated_at,
+    invoked_by,
+    approved_by,
+    approval_ticket,
     lambda_request_id
 FROM security_db.iam.remediation_audit
 WHERE remediated_at >= DATEADD(day, -7, CURRENT_DATE())

--- a/skills/remediation/iam-departures-remediation/infra/snowflake_integration.sql
+++ b/skills/remediation/iam-departures-remediation/infra/snowflake_integration.sql
@@ -109,6 +109,14 @@ CREATE TABLE IF NOT EXISTS security_db.iam.remediation_audit (
   steps_completed     INTEGER,
   steps_failed        INTEGER,
   lambda_request_id   VARCHAR(255),
+  invoked_by          VARCHAR(255),
+  invoked_by_email    VARCHAR(255),
+  agent_session_id    VARCHAR(255),
+  caller_roles        VARCHAR(1024),
+  approved_by         VARCHAR(255),
+  approved_by_email   VARCHAR(255),
+  approval_ticket     VARCHAR(255),
+  approval_timestamp  TIMESTAMP_TZ,
   execution_arn       VARCHAR(512),
   ingested_at         TIMESTAMP_TZ   DEFAULT CURRENT_TIMESTAMP()
 );
@@ -122,7 +130,9 @@ AS
   COPY INTO security_db.iam.remediation_audit (
     iam_username, target_account_id, email, terminated_at,
     remediated_at, remediation_actions, steps_completed,
-    steps_failed, lambda_request_id, execution_arn
+    steps_failed, lambda_request_id, invoked_by, invoked_by_email,
+    agent_session_id, caller_roles, approved_by, approved_by_email,
+    approval_ticket, approval_timestamp, execution_arn
   )
   FROM (
     SELECT
@@ -135,6 +145,14 @@ AS
       $1:steps_completed::INTEGER,
       $1:steps_failed::INTEGER,
       $1:lambda_request_id::VARCHAR,
+      $1:invoked_by::VARCHAR,
+      $1:invoked_by_email::VARCHAR,
+      $1:agent_session_id::VARCHAR,
+      $1:caller_roles::VARCHAR,
+      $1:approved_by::VARCHAR,
+      $1:approved_by_email::VARCHAR,
+      $1:approval_ticket::VARCHAR,
+      $1:approval_timestamp::TIMESTAMP_TZ,
       $1:execution_arn::VARCHAR
     FROM @security_db.iam.audit_stage
   )

--- a/skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py
+++ b/skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py
@@ -97,7 +97,7 @@ def handler(event: dict, context: Any) -> dict:
             raise ValueError("recipient_account_id must be a 12-digit AWS account ID")
     except ValueError as exc:
         logger.warning("Invalid remediation payload: %s", exc)
-        audit_record = _build_audit_record(entry, [], "error", error="Invalid remediation payload")
+        audit_record = _build_audit_record(entry, [], "error", error="Invalid remediation payload", context=context)
         _write_audit(audit_record)
         return {
             "email": entry.get("email", ""),
@@ -162,7 +162,7 @@ def handler(event: dict, context: Any) -> dict:
         logger.info("Successfully deleted IAM user: %s", iam_username)
 
         # Step 12: Write audit record
-        audit_record = _build_audit_record(entry, actions_taken, "remediated")
+        audit_record = _build_audit_record(entry, actions_taken, "remediated", context=context)
         _write_audit(audit_record)
 
         return {
@@ -178,7 +178,7 @@ def handler(event: dict, context: Any) -> dict:
         logger.exception("Remediation failed for %s in %s", iam_username, account_id)
 
         # Still write audit — record the failure
-        audit_record = _build_audit_record(entry, actions_taken, "error", error=str(exc))
+        audit_record = _build_audit_record(entry, actions_taken, "error", error=str(exc), context=context)
         _write_audit(audit_record)
 
         return {
@@ -414,6 +414,7 @@ def _build_audit_record(
     actions: list[dict],
     status: str,
     error: str = "",
+    context: Any | None = None,
 ) -> dict:
     """Build a complete audit record for compliance logging."""
     return {
@@ -430,7 +431,15 @@ def _build_audit_record(
         "actions_taken": actions,
         "actions_count": len(actions),
         "lambda_function": os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "unknown"),
-        "lambda_request_id": "",  # Set from context in production
+        "lambda_request_id": getattr(context, "aws_request_id", ""),
+        "invoked_by": os.environ.get("SKILL_CALLER_ID", ""),
+        "invoked_by_email": os.environ.get("SKILL_CALLER_EMAIL", ""),
+        "agent_session_id": os.environ.get("SKILL_SESSION_ID", ""),
+        "caller_roles": os.environ.get("SKILL_CALLER_ROLES", ""),
+        "approved_by": os.environ.get("SKILL_APPROVER_ID", ""),
+        "approved_by_email": os.environ.get("SKILL_APPROVER_EMAIL", ""),
+        "approval_ticket": os.environ.get("SKILL_APPROVAL_TICKET", ""),
+        "approval_timestamp": os.environ.get("SKILL_APPROVAL_TIMESTAMP", ""),
     }
 
 

--- a/skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py
+++ b/skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py
@@ -11,6 +11,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from lambda_worker.handler import (
+    _build_audit_record,
     _deactivate_access_keys,
     _delete_inline_policies,
     _delete_login_profile,
@@ -208,6 +209,31 @@ class TestWorkerHandler:
         assert result["status"] == "error"
         assert result["error"] == "Invalid remediation payload"
         mock_audit.assert_called_once()
+
+    def test_audit_record_captures_caller_and_approval_context(self, monkeypatch):
+        class _Context:
+            aws_request_id = "req-123"
+
+        monkeypatch.setenv("SKILL_CALLER_ID", "u-123")
+        monkeypatch.setenv("SKILL_CALLER_EMAIL", "user@example.com")
+        monkeypatch.setenv("SKILL_SESSION_ID", "sess-1")
+        monkeypatch.setenv("SKILL_CALLER_ROLES", "security_engineer")
+        monkeypatch.setenv("SKILL_APPROVER_ID", "a-456")
+        monkeypatch.setenv("SKILL_APPROVER_EMAIL", "approver@example.com")
+        monkeypatch.setenv("SKILL_APPROVAL_TICKET", "SEC-123")
+        monkeypatch.setenv("SKILL_APPROVAL_TIMESTAMP", "2026-04-14T12:00:00Z")
+
+        record = _build_audit_record(_make_event()["entry"], [], "remediated", context=_Context())
+
+        assert record["invoked_by"] == "u-123"
+        assert record["invoked_by_email"] == "user@example.com"
+        assert record["agent_session_id"] == "sess-1"
+        assert record["caller_roles"] == "security_engineer"
+        assert record["approved_by"] == "a-456"
+        assert record["approved_by_email"] == "approver@example.com"
+        assert record["approval_ticket"] == "SEC-123"
+        assert record["approval_timestamp"] == "2026-04-14T12:00:00Z"
+        assert record["lambda_request_id"] == "req-123"
 
 
 class TestSnowflakeIdentifierSafety:

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -75,6 +75,9 @@ class TestSkillValidationCommon:
         assert ingest.approval_model == "none"
         assert ingest.execution_modes == ("jit", "ci", "mcp", "persistent")
         assert ingest.side_effects == ("none",)
+        assert ingest.caller_roles == ()
+        assert ingest.approver_roles == ()
+        assert ingest.min_approvers is None
 
     def test_reference_policy_accepts_known_official_hosts(self):
         assert COMMON.reference_url_allowed("https://docs.aws.amazon.com/IAM/latest/APIReference/")
@@ -128,3 +131,6 @@ class TestValidationScripts:
         assert remediation.approval_model == "human_required"
         assert remediation.execution_modes == ("jit", "persistent")
         assert "writes-identity" in remediation.side_effects
+        assert remediation.caller_roles == ("security_engineer", "incident_responder")
+        assert remediation.approver_roles == ("security_lead", "cis_officer")
+        assert remediation.min_approvers == 1


### PR DESCRIPTION
## Summary
- add optional caller/approver RBAC metadata to the skill contract and MCP tool surface
- propagate caller and approval context through the MCP server into write-capable skill environments
- record caller, approver, ticket, session, and Lambda request ID fields in IAM departures audit records and Snowflake ingestion examples

## Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_integrity.py
- uv run pytest tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server_unit.py skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py -q -o addopts=''
- uv run ruff check scripts/skill_validation_common.py scripts/validate_skill_contract.py mcp-server/src/server.py mcp-server/src/tool_registry.py mcp-server/tests/test_tool_registry.py mcp-server/tests/test_server_unit.py skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml