### PR TITLE
security: extend stderr telemetry to k8s path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is loosely based on Keep a Changelog.
 - optional `caller_roles`, `approver_roles`, and `min_approvers` contract metadata plus MCP caller-context propagation into write-capable skills, so remediation audit trails can record who invoked, who approved, and which request or session triggered the action.
 - stderr-based MCP invocation audit events covering tool name, caller-context presence, approval-context presence, hashed arguments, duration, and exit status without logging raw stdin payloads.
 - a shared opt-in `stderr` telemetry helper plus pilot JSON telemetry in `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, enabled by `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1` while preserving existing plain-text warnings by default.
+- extended the structured `stderr` telemetry pilot to `ingest-k8s-audit-ocsf` and `detect-privilege-escalation-k8s`, so the Kubernetes ingest/detect path now has the same opt-in machine-readable runtime hints as the CloudTrail/lateral-movement path.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -53,6 +53,12 @@ Expected controls:
 - optional structured `stderr` telemetry via `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1` for wrappers and operators that need machine-readable runtime hints
 - strict input validation before parse, convert, or cloud calls
 
+Current pilots:
+- `ingest-cloudtrail-ocsf`
+- `detect-lateral-movement`
+- `ingest-k8s-audit-ocsf`
+- `detect-privilege-escalation-k8s`
+
 ## Write-capable skills and edge components
 
 These are the only places where side effects should happen:

--- a/skills/detection/detect-privilege-escalation-k8s/src/detect.py
+++ b/skills/detection/detect-privilege-escalation-k8s/src/detect.py
@@ -15,7 +15,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-privilege-escalation-k8s"
 OCSF_VERSION = "1.8.0"
@@ -551,12 +558,24 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
         try:
             obj = json.loads(line)
         except json.JSONDecodeError as exc:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {exc}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
             continue
         if isinstance(obj, dict):
             yield obj
         else:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object",
+                line=lineno,
+            )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py
+++ b/skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py
@@ -388,6 +388,16 @@ class TestLoadJsonl:
         assert out == [{"class_uid": 6003}]
         assert "skipping line 1" in capsys.readouterr().err
 
+    def test_skips_malformed_with_json_stderr(self, capsys, monkeypatch):
+        monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+        out = list(load_jsonl(['{"bad": ', '{"class_uid": 6003}']))
+        assert out == [{"class_uid": 6003}]
+        payload = json.loads(capsys.readouterr().err.strip())
+        assert payload["skill"] == SKILL_NAME
+        assert payload["level"] == "warning"
+        assert payload["event"] == "json_parse_failed"
+        assert payload["line"] == 1
+
 
 # ── Golden fixture parity ──────────────────────────────────────────────
 

--- a/skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py
@@ -15,7 +15,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "ingest-k8s-audit-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -424,12 +431,24 @@ def iter_raw_entries(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
         try:
             obj = json.loads(line)
         except json.JSONDecodeError as e:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {e}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {e}",
+                line=lineno,
+            )
             continue
         if isinstance(obj, dict):
             yield obj
         else:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object",
+                line=lineno,
+            )
 
 
 def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
@@ -437,7 +456,12 @@ def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[
         try:
             canonical = _build_canonical_event(raw)
         except Exception as e:
-            print(f"[{SKILL_NAME}] skipping entry: convert error: {e}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="convert_error",
+                message=f"skipping entry: convert error: {e}",
+            )
             continue
         if canonical is None:
             continue

--- a/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+import ingest as ingest_module  # type: ignore[import-not-found]
 from ingest import (  # type: ignore[import-not-found]
     ACTIVITY_CREATE,
     ACTIVITY_DELETE,
@@ -301,3 +302,15 @@ class TestGoldenFixture:
         events = _load_jsonl(OCSF_FIXTURE)
         actors = {e["actor"]["user"]["name"] for e in events}
         assert actors == {"system:serviceaccount:default:builder"}
+
+
+class TestStderrTelemetry:
+    def test_skips_malformed_with_json_stderr(self, capsys, monkeypatch):
+        monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+        out = list(ingest_module.iter_raw_entries(['{"bad": ', '{"kind": "Event"}']))
+        assert len(out) == 1
+        payload = json.loads(capsys.readouterr().err.strip())
+        assert payload["skill"] == SKILL_NAME
+        assert payload["level"] == "warning"
+        assert payload["event"] == "json_parse_failed"
+        assert payload["line"] == 1


### PR DESCRIPTION
## Summary
- extend the opt-in structured stderr telemetry pilot to the Kubernetes ingest and privilege-escalation detection path
- keep plain stderr warnings as the default behavior
- document the expanded pilot coverage in runtime isolation and changelog

## Validation
- uv run pytest skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py -q -o addopts=''
- uv run ruff check skills/_shared/runtime_telemetry.py skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py skills/detection/detect-privilege-escalation-k8s/src/detect.py skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py docs/RUNTIME_ISOLATION.md CHANGELOG.md --config pyproject.toml