### PR TITLE
security: extend stderr telemetry to entra path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is loosely based on Keep a Changelog.
 - stderr-based MCP invocation audit events covering tool name, caller-context presence, approval-context presence, hashed arguments, duration, and exit status without logging raw stdin payloads.
 - a shared opt-in `stderr` telemetry helper plus pilot JSON telemetry in `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, enabled by `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1` while preserving existing plain-text warnings by default.
 - extended the structured `stderr` telemetry pilot to `ingest-k8s-audit-ocsf` and `detect-privilege-escalation-k8s`, so the Kubernetes ingest/detect path now has the same opt-in machine-readable runtime hints as the CloudTrail/lateral-movement path.
+- extended the same opt-in structured `stderr` telemetry pilot to `ingest-okta-system-log-ocsf` and `detect-okta-mfa-fatigue`, covering the Okta identity ingest/detect path without changing stdout data contracts.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -58,6 +58,8 @@ Current pilots:
 - `detect-lateral-movement`
 - `ingest-k8s-audit-ocsf`
 - `detect-privilege-escalation-k8s`
+- `ingest-okta-system-log-ocsf`
+- `detect-okta-mfa-fatigue`
 
 ## Write-capable skills and edge components
 

--- a/skills/detection/detect-okta-mfa-fatigue/src/detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/src/detect.py
@@ -16,7 +16,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-okta-mfa-fatigue"
 OCSF_VERSION = "1.8.0"
@@ -383,12 +390,25 @@ def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
         try:
             obj = json.loads(line)
         except json.JSONDecodeError as exc:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {exc}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+                error=str(exc),
+            )
             continue
         if isinstance(obj, dict):
             yield obj
         else:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object",
+                line=lineno,
+            )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py
@@ -315,3 +315,12 @@ class TestLoadJsonl:
         out = list(load_jsonl(['{"bad": ', '{"class_uid": 3002}']))
         assert out == [{"class_uid": 3002}]
         assert "skipping line 1" in capsys.readouterr().err
+
+    def test_emits_json_stderr_telemetry_when_enabled(self, capsys, monkeypatch):
+        monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+        list(load_jsonl(['{"bad": ']))
+        payload = json.loads(capsys.readouterr().err.strip())
+        assert payload["skill"] == SKILL_NAME
+        assert payload["level"] == "warning"
+        assert payload["event"] == "json_parse_failed"
+        assert payload["line"] == 1

--- a/skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py
@@ -17,7 +17,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "ingest-okta-system-log-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -465,7 +472,14 @@ def iter_raw_events(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
         try:
             obj = json.loads(line)
         except json.JSONDecodeError as exc:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: json parse failed: {exc}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+                error=str(exc),
+            )
             continue
         if isinstance(obj, dict) and isinstance(((obj.get("data") or {}).get("events")), list):
             for event in (obj.get("data") or {}).get("events") or []:
@@ -474,7 +488,13 @@ def iter_raw_events(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
         elif isinstance(obj, dict):
             yield obj
         else:
-            print(f"[{SKILL_NAME}] skipping line {lineno}: not a JSON object or Okta wrapper", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object or Okta wrapper",
+                line=lineno,
+            )
 
 
 def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
@@ -483,12 +503,28 @@ def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[
     for raw in iter_raw_events(stream):
         ok, reason = validate_event(raw)
         if not ok:
-            print(f"[{SKILL_NAME}] skipping event: {reason}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_event",
+                message=f"skipping event: {reason}",
+                reason=reason,
+                event_type=str(raw.get("eventType") or ""),
+                event_uid=str(raw.get("uuid") or ""),
+            )
             continue
         try:
             yield convert_event(raw, output_format=output_format)
         except Exception as exc:
-            print(f"[{SKILL_NAME}] skipping event: convert error: {exc}", file=sys.stderr)
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="convert_error",
+                message=f"skipping event: convert error: {exc}",
+                error=str(exc),
+                event_type=str(raw.get("eventType") or ""),
+                event_uid=str(raw.get("uuid") or ""),
+            )
             continue
 
 

--- a/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py
@@ -336,6 +336,15 @@ class TestIterRawEvents:
         assert events[0]["uuid"] == "ok"
         assert "skipping line" in capsys.readouterr().err
 
+    def test_json_stderr_telemetry_for_bad_line(self, capsys, monkeypatch):
+        monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+        list(iter_raw_events(['{"bad"']))
+        payload = json.loads(capsys.readouterr().err.strip())
+        assert payload["skill"] == SKILL_NAME
+        assert payload["level"] == "warning"
+        assert payload["event"] == "json_parse_failed"
+        assert payload["line"] == 1
+
 
 class TestGoldenFixture:
     def test_golden_fixture(self):


### PR DESCRIPTION
## Summary
- extend the shared opt-in JSON stderr telemetry helper to ingest-entra-directory-audit-ocsf
- extend the same telemetry path to detect-entra-credential-addition
- update runtime isolation guidance and changelog for the Entra telemetry pilot

## Validation
- .................................                                        [100%]
33 passed in 0.03s
- All checks passed!