### PR TITLE
docs: guide users by use case and integration path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is loosely based on Keep a Changelog.
 - a shared opt-in `stderr` telemetry helper plus pilot JSON telemetry in `ingest-cloudtrail-ocsf` and `detect-lateral-movement`, enabled by `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1` while preserving existing plain-text warnings by default.
 - extended the structured `stderr` telemetry pilot to `ingest-k8s-audit-ocsf` and `detect-privilege-escalation-k8s`, so the Kubernetes ingest/detect path now has the same opt-in machine-readable runtime hints as the CloudTrail/lateral-movement path.
 - extended the same opt-in structured `stderr` telemetry pilot to `ingest-okta-system-log-ocsf` and `detect-okta-mfa-fatigue`, covering the Okta identity ingest/detect path without changing stdout data contracts.
+- tightened the README and skill catalog entry path around use cases, skill selection, plug-in surfaces, and clearer layer guidance, plus added `docs/USE_CASES.md` as the practical crosswalk for sources, assets, frameworks, and starting skills.
+- clarified in the README and use-case guide that repo-owned remediation audit lands in DynamoDB + S3 today, while customer-controlled sinks such as Snowflake / Snowpipe belong to the planned sink / runner layer rather than the currently shipped generic path.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,9 +37,52 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
   > findings.native.jsonl
 ```
 
-## Quick start
+## Start by use case
 
-**Start here**
+| If you need to... | Start with... | Common sources / assets | Typical output |
+|---|---|---|---|
+| Normalize raw cloud, identity, Kubernetes, or MCP logs | `ingest-*` | CloudTrail, VPC Flow, Azure Activity, GCP Audit, K8s audit, Okta, Entra, Workspace, MCP proxy | native or OCSF JSONL |
+| Detect an attack pattern in event streams | `ingest-*` + `detect-*` | identity pivots, suspicious logins, MFA fatigue, K8s abuse, MCP drift, east-west traffic | Detection Finding (OCSF 2004) or native finding JSON |
+| Check posture or benchmark compliance | `evaluation/*` | AWS, Azure, GCP, K8s, containers, GPU clusters, model serving | benchmark / control results |
+| Inventory cloud or AI assets | `discover-environment` or `discover-ai-bom` | cloud resources, AI services, endpoints, registries, datasets | graph JSON, AI BOM, OCSF bridge |
+| Build evidence for audits and reviews | `discover-control-evidence` or `discover-cloud-control-evidence` | discovery output, live cloud inventory | evidence JSON, OCSF bridge events |
+| Export findings into review tools | `view/*` | OCSF findings | SARIF, Mermaid attack flow |
+| Fix offboarding and access drift safely | `iam-departures-remediation` | HR departure feeds, AWS, Entra, GCP, Snowflake, Databricks | audited dry run or remediation plan |
+
+For the full source / asset / framework crosswalk, see [docs/USE_CASES.md](docs/USE_CASES.md).
+
+## What it plugs into
+
+| Surface | Use it when... | Typical fit |
+|---|---|---|
+| **CLI / Unix pipes** | you want one-shot analysis or a reproducible local pipeline | local triage, fixture testing, ad-hoc conversions |
+| **MCP** | you want Claude, Codex, Cursor, Windsurf, or Cortex Code CLI to call the same skills | agent workflows, tool-driven investigations, guarded remediation |
+| **CI** | you want the same skills in pull requests or scheduled checks | SARIF generation, benchmark snapshots, policy gates |
+| **SIEM / lakehouse** | you want normalized findings, evidence, or audit records in an existing store | Splunk, Sentinel, Chronicle, Elastic, Snowflake, ClickHouse |
+| **Persistent runner** | you want scheduled or event-driven operation | serverless, queue-driven, or batch runners around the same stateless skills |
+
+The important distinction is:
+- **shipped today**: stateless skills, MCP wrapper, CI paths, and the repo-owned IAM departures audit path in DynamoDB + S3
+- **supported integration pattern**: customer-controlled sinks like Snowflake / Snowpipe, Security Lake, ClickHouse, or BigQuery via append-only runners and sink layers
+- **not shipped yet**: a generic sink / runner framework for every skill family
+
+## Start here
+
+- New to the repo: start with this README, then [docs/USE_CASES.md](docs/USE_CASES.md) and [skills/README.md](skills/README.md).
+- Using an agent or MCP client: read [AGENTS.md](AGENTS.md), [CLAUDE.md](CLAUDE.md), [docs/agent-integrations.md](docs/agent-integrations.md), and [`.mcp.json`](.mcp.json).
+- Need the architecture and schema contract: read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md), [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md), and [docs/DATA_FLOW.md](docs/DATA_FLOW.md).
+- Need operational trust and rollout status: read [docs/RUNTIME_ISOLATION.md](docs/RUNTIME_ISOLATION.md), [docs/SIEM_INDEX_GUIDE.md](docs/SIEM_INDEX_GUIDE.md), [docs/DEBUGGING.md](docs/DEBUGGING.md), [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md), [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md), and [docs/ROADMAP.md](docs/ROADMAP.md).
+
+| Role | Read first |
+|---|---|
+| **Security engineer / detection engineer** | [docs/USE_CASES.md](docs/USE_CASES.md), [skills/README.md](skills/README.md), [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md) |
+| **Platform / cloud engineer** | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/RUNTIME_ISOLATION.md](docs/RUNTIME_ISOLATION.md), [docs/SIEM_INDEX_GUIDE.md](docs/SIEM_INDEX_GUIDE.md) |
+| **Agent / MCP integrator** | [AGENTS.md](AGENTS.md), [docs/agent-integrations.md](docs/agent-integrations.md), [`.mcp.json`](.mcp.json) |
+| **Compliance / GRC reviewer** | [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md) |
+
+<details>
+<summary><b>Full docs index</b></summary>
+
 - Agents: [AGENTS.md](AGENTS.md)
 - Claude Code memory: [CLAUDE.md](CLAUDE.md)
 - MCP usage: [docs/agent-integrations.md](docs/agent-integrations.md) and [`.mcp.json`](.mcp.json)
@@ -50,7 +93,9 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
 - Canonical schema and data flow: [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md) and [docs/DATA_FLOW.md](docs/DATA_FLOW.md)
 - Historical state and timeline handling: [docs/STATE_AND_TIMELINE_MODEL.md](docs/STATE_AND_TIMELINE_MODEL.md)
 - Debugging and troubleshooting: [docs/DEBUGGING.md](docs/DEBUGGING.md) and [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
-- Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), and [docs/ROADMAP.md](docs/ROADMAP.md)
+- Coverage and roadmap: [docs/COVERAGE_MODEL.md](docs/COVERAGE_MODEL.md), [docs/framework-coverage.json](docs/framework-coverage.json), [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md), and [docs/ROADMAP.md](docs/ROADMAP.md)
+
+</details>
 
 | Tool | Best integration path | What to rely on |
 |---|---|---|
@@ -66,15 +111,21 @@ The repo keeps one source of truth:
 - `SKILL.md` for each skill contract
 - MCP as the access layer, not a second implementation
 
-## Flagship workflow
+## Visual guide
 
 ![IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
 
-**Visuals**
-- [IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
-- [Repo architecture](docs/images/repo-architecture.svg)
-- [IAM departures flow](docs/images/iam-departures-data-flow.svg)
-- [Detection pipeline](docs/images/detection-pipeline.svg)
+| If you want to see... | Open... |
+|---|---|
+| the overall repo shape | [Repo architecture](docs/images/repo-architecture.svg) |
+| how ingest → detect → export fits together | [Detection pipeline](docs/images/detection-pipeline.svg) |
+| the flagship HITL remediation workflow | [IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg) |
+| the remediation data path and audit trail | [IAM departures flow](docs/images/iam-departures-data-flow.svg) |
+
+For the IAM departures flow specifically:
+- **shipped default audit path**: DynamoDB + S3
+- **supported customer pattern**: forward or sink the same audit trail into Snowflake, Security Lake, ClickHouse, or another customer-controlled store via a dedicated sink / runner layer
+- **current repo state**: that external sink pattern is part of the architecture contract, not a shipped generic sink yet
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
@@ -85,14 +136,14 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.log \
 
 ## Layers
 
-| Layer | Role | Output |
-|---|---|---|
-| **Ingest** | Per-source raw payload → canonical model, with optional native / OCSF / bridge output | native JSON, OCSF API / Network / HTTP / Application Activity, or bridge JSON |
-| **Discover** | point-in-time inventory / graph / evidence / AI BOM | deterministic JSON graph, canonical evidence, OCSF inventory/evidence bridge events, or CycloneDX-aligned BOM |
-| **Detect** | canonical or OCSF telemetry → finding + MITRE ATT&CK | Detection Finding (class 2004) or documented native/canonical finding output |
-| **Evaluate** | canonical or OCSF telemetry → framework check | Compliance Finding (class 2003) or documented evidence/check output |
-| **View** | canonical or OCSF → SARIF / Mermaid / graph | GitHub Security tab, PR comments, dashboards |
-| **Remediate** | Finding → action (HITL-gated, audited) | Dual-write audit row |
+| Layer | Use it when... | Start with... | Common output |
+|---|---|---|---|
+| **Ingest** | you have one raw source and need a stable event stream | a source-specific `ingest-*` skill | native JSONL, OCSF JSONL, or bridge output |
+| **Discover** | you need current inventory, graph context, or evidence | `discover-environment`, `discover-ai-bom`, or evidence discovery skills | graph JSON, evidence JSON, AI BOM, OCSF bridge |
+| **Detect** | you want deterministic attack-pattern findings | the matching `detect-*` skill after ingest | native finding JSON or OCSF Detection Finding |
+| **Evaluate** | you want benchmark or posture checks | the relevant evaluation skill for cloud, K8s, container, GPU, or model serving | benchmark / control results |
+| **View** | you need findings in another tool’s format | `convert-ocsf-to-sarif` or `convert-ocsf-to-mermaid-attack-flow` | SARIF, Mermaid |
+| **Remediate** | you need a guarded write path with HITL and audit | `iam-departures-remediation` | dry-run plan or audited action log |
 
 Each skill is a standalone Python bundle following [Anthropic's skill spec](https://platform.claude.com/docs/en/build-with-claude/skills-guide): `SKILL.md`, `src/`, `tests/`, `REFERENCES.md`, explicit `Use when...`, and explicit `Do NOT use...`.
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -1,0 +1,82 @@
+# Use Cases and Skill Selection
+
+This guide answers the practical question first: **what are you trying to do, and which skill should you start with?**
+
+Use it when the README feels too high-level and `skills/README.md` feels too catalog-like.
+
+## Start by goal
+
+| Goal | Start with | Common sources | Asset focus | Typical output |
+|---|---|---|---|---|
+| Normalize one raw log source | source-specific `ingest-*` skill | CloudTrail, Azure Activity, GCP Audit, VPC Flow, K8s audit, Okta, Entra, Workspace, MCP proxy | identities, API activity, network, app activity | native or OCSF JSONL |
+| Detect suspicious behavior in event streams | `ingest-*` + matching `detect-*` | identity, network, K8s, MCP, workspace auth | users, service principals, sessions, secrets, east-west traffic | Detection Finding (OCSF 2004) or native finding |
+| Benchmark security posture | `evaluation/*` | live cloud APIs and control-plane state | accounts, policies, clusters, containers, GPUs, model endpoints | posture or compliance results |
+| Inventory cloud or AI assets | `discover-environment` or `discover-ai-bom` | live cloud APIs, AI service inventories | resources, graphs, AI endpoints, registries, datasets | inventory graph or CycloneDX-aligned AI BOM |
+| Build audit evidence | `discover-control-evidence` or `discover-cloud-control-evidence` | discovery output and live inventory | controls, settings, evidence artifacts | evidence JSON or OCSF bridge |
+| Centralize remediation audit in your own lakehouse | `iam-departures-remediation` plus a customer-owned sink pattern | IAM departures workflow audit rows | identities, approvals, actions, audit history | DynamoDB + S3 today, external sink pattern via Snowflake / Snowpipe or another lakehouse later |
+| Export findings to downstream tools | `view/*` | OCSF findings | detections and evidence | SARIF, Mermaid attack flow |
+| Remediate offboarding safely | `iam-departures-remediation` | HR departure feeds + cloud / data-platform APIs | users, IAM identities, warehouse identities | dry-run plan or audited remediation |
+
+## Start by source
+
+| Source / vendor | First skill | Typical next skill |
+|---|---|---|
+| AWS CloudTrail | `ingest-cloudtrail-ocsf` | `detect-lateral-movement` |
+| AWS VPC Flow Logs | `ingest-vpc-flow-logs-ocsf` | `detect-lateral-movement` |
+| Azure Activity Logs | `ingest-azure-activity-ocsf` | `detect-lateral-movement` |
+| GCP Audit Logs | `ingest-gcp-audit-ocsf` | `detect-lateral-movement` |
+| Kubernetes audit logs | `ingest-k8s-audit-ocsf` | `detect-privilege-escalation-k8s` or `detect-sensitive-secret-read-k8s` |
+| Okta System Log | `ingest-okta-system-log-ocsf` | `detect-okta-mfa-fatigue` |
+| Microsoft Entra / Graph `directoryAudit` | `ingest-entra-directory-audit-ocsf` | `detect-entra-credential-addition` or `detect-entra-role-grant-escalation` |
+| Google Workspace login audit | `ingest-google-workspace-login-ocsf` | `detect-google-workspace-suspicious-login` |
+| MCP proxy activity | `ingest-mcp-proxy-ocsf` | `detect-mcp-tool-drift` |
+| GuardDuty / Security Hub / SCC / Defender | source-specific `ingest-*` finding ingester | `view/*` or SIEM export |
+
+## Start by asset class
+
+| Asset class | Best starting layer | Skills to look at first |
+|---|---|---|
+| Human identities | ingest / detect | Okta, Entra, Workspace, CloudTrail identity paths |
+| Service principals / app credentials | ingest / detect | Entra ingest + Entra credential / role detectors |
+| Cloud API activity | ingest / detect / evaluate | CloudTrail, Azure Activity, GCP Audit, CSPM skills |
+| Network activity | ingest / detect | VPC / NSG flow ingesters + `detect-lateral-movement` |
+| Kubernetes workloads and secrets | ingest / detect / evaluate | K8s audit ingester, K8s detectors, K8s benchmark |
+| Containers and GPU clusters | evaluate | `container-security`, `gpu-cluster-security` |
+| AI services and model endpoints | discover / evaluate | `discover-ai-bom`, `discover-environment`, `model-serving-security` |
+| Audit evidence and control state | discovery | `discover-control-evidence`, `discover-cloud-control-evidence` |
+| Offboarding / access cleanup | remediation | `iam-departures-remediation` |
+
+## Start by framework
+
+| Framework need | Start here |
+|---|---|
+| OCSF transport and interoperability | [NATIVE_VS_OCSF.md](NATIVE_VS_OCSF.md), [CANONICAL_SCHEMA.md](CANONICAL_SCHEMA.md), [DATA_FLOW.md](DATA_FLOW.md) |
+| MITRE ATT&CK / ATLAS mapping | [FRAMEWORK_MAPPINGS.md](FRAMEWORK_MAPPINGS.md) |
+| Coverage depth and current status | [framework-coverage.json](framework-coverage.json), [COVERAGE_MODEL.md](COVERAGE_MODEL.md) |
+| Compliance and roadmap gaps | [ROADMAP.md](ROADMAP.md) |
+
+## What it plugs into
+
+| Surface | Use it for |
+|---|---|
+| CLI / Unix pipes | direct local analysis and reproducible pipelines |
+| MCP | Claude, Codex, Cursor, Windsurf, Cortex Code CLI |
+| CI | scheduled checks, PR gates, SARIF generation |
+| SIEM / lakehouse | normalized event, finding, evidence, and customer-controlled audit ingestion |
+| Serverless / persistent runners | event-driven or scheduled operation around the same stateless skills |
+
+## What is shipped vs planned
+
+| Topic | Shipped today | Planned / contract-supported |
+|---|---|---|
+| Native / OCSF dual mode | selected ingest and detect skills, plus native-first discovery | repo-wide rollout across remaining ingest/detect paths |
+| Persistent execution | IAM departures event-driven path | generic runners for broader ingest → detect → sink loops |
+| Audit sinks | IAM departures dual-write to DynamoDB + S3 | external customer sinks like Snowflake / Snowpipe, Security Lake, ClickHouse, BigQuery |
+| Visuals | repo architecture, detection pipeline, IAM departures workflow + data flow | deeper source / asset / plug-in visuals as the surface grows |
+
+## Read next
+
+- Need the big picture: [ARCHITECTURE.md](ARCHITECTURE.md)
+- Need the skill inventory: [../skills/README.md](../skills/README.md)
+- Need trust and runtime controls: [RUNTIME_ISOLATION.md](RUNTIME_ISOLATION.md)
+- Need troubleshooting: [DEBUGGING.md](DEBUGGING.md) and [TROUBLESHOOTING.md](TROUBLESHOOTING.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,12 +1,12 @@
 # Skills Catalog
 
-Skills are grouped by **layered function**, not by vendor. An agent or operator chooses the layer that matches the job, then picks the skill inside that layer.
+Skills are grouped by **layered function**, not by vendor. Start with the problem you are solving, then pick the layer and skill that match it. If you want a guided entry point instead of a catalog, read [`docs/USE_CASES.md`](../docs/USE_CASES.md) first.
 
 | Category | Question it answers | Output shape |
 |---|---|---|
-| [`ingestion/`](ingestion/) | "How do I normalize this raw source into OCSF?" | OCSF 1.8 JSONL |
+| [`ingestion/`](ingestion/) | "How do I normalize this raw source into a stable event stream?" | native or OCSF JSONL, depending on the skill |
 | [`discovery/`](discovery/) | "What does this cloud / AI estate look like right now?" | deterministic inventory / graph JSON |
-| [`detection/`](detection/) | "What attack pattern does this event stream show?" | OCSF Detection Finding (class 2004) |
+| [`detection/`](detection/) | "What attack pattern does this event stream show?" | native or OCSF detection finding |
 | [`evaluation/`](evaluation/) | "Does this posture or event stream meet a benchmark?" | Compliance / posture result |
 | [`view/`](view/) | "How should I render or export this OCSF output?" | SARIF, Mermaid, other review formats |
 | [`remediation/`](remediation/) | "Something is wrong. How do I fix it safely?" | Audited action + re-verification |


### PR DESCRIPTION
## Summary
- tighten the README around start-by-use-case, start-by-role, and plug-in surfaces
- add docs/USE_CASES.md as a practical crosswalk for sources, assets, frameworks, and starting skills
- clarify that repo-owned remediation audit sinks are DynamoDB + S3 today, while Snowflake / Snowpipe and other lakehouse sinks remain architecture-supported but not yet shipped as a generic sink layer

## Notes
- this is a docs-only onboarding cleanup
- it is meant to reduce confusion around layers, entry points, and integration surfaces without changing runtime behavior