### PR TITLE
docs: add guided start-here visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is loosely based on Keep a Changelog.
 - extended the same opt-in structured `stderr` telemetry pilot to `ingest-google-workspace-login-ocsf` and `detect-google-workspace-suspicious-login`, covering the Google Workspace identity ingest/detect path without changing stdout data contracts.
 - tightened the README and skill catalog entry path around use cases, skill selection, plug-in surfaces, and clearer layer guidance, plus added `docs/USE_CASES.md` as the practical crosswalk for sources, assets, frameworks, and starting skills.
 - clarified in the README and use-case guide that repo-owned remediation audit lands in DynamoDB + S3 today, while customer-controlled sinks such as Snowflake / Snowpipe belong to the planned sink / runner layer rather than the currently shipped generic path.
+- a new start-here visual and updated IAM departures data-flow visual so operators can see sources, layer choice, outputs, runtime surfaces, and the shipped-vs-optional sink boundary without reading the full architecture docs first.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -113,10 +113,13 @@ The repo keeps one source of truth:
 
 ## Visual guide
 
+![Start here guide](docs/images/start-here-guide.svg)
+
 ![IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
 
 | If you want to see... | Open... |
 |---|---|
+| where to start by source, layer, output, and runtime | [Start here guide](docs/images/start-here-guide.svg) |
 | the overall repo shape | [Repo architecture](docs/images/repo-architecture.svg) |
 | how ingest → detect → export fits together | [Detection pipeline](docs/images/detection-pipeline.svg) |
 | the flagship HITL remediation workflow | [IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg) |

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -4,6 +4,7 @@ Keep the markdown source diagrams lightweight and reviewable, then pair them wit
 
 ## Visual set
 
+- [Start here guide](images/start-here-guide.svg)
 - [IAM departures cross-cloud workflow](images/iam-departures-architecture.svg)
 - [Repository architecture](images/repo-architecture.svg)
 - [IAM departures data flow](images/iam-departures-data-flow.svg)

--- a/docs/images/iam-departures-data-flow.svg
+++ b/docs/images/iam-departures-data-flow.svg
@@ -1,45 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="420" viewBox="0 0 1280 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="500" viewBox="0 0 1280 500" role="img" aria-labelledby="title desc">
   <title id="title">IAM departures data flow</title>
-  <desc id="desc">HR source to reconciler to S3 to EventBridge to Step Functions to parser and worker to audit.</desc>
-  <rect width="1280" height="420" fill="#08111f"/>
+  <desc id="desc">HR source to reconciler to S3 to EventBridge to Step Functions to parser and worker to default audit, with an optional customer-controlled sink extension.</desc>
+  <rect width="1280" height="500" fill="#08111f"/>
   <text x="40" y="52" fill="#f8fafc" font-size="30" font-family="Arial, sans-serif" font-weight="700">IAM departures remediation flow</text>
+  <text x="40" y="80" fill="#94a3b8" font-size="16" font-family="Arial, sans-serif">Shipped default audit path on the top lane. Optional customer-owned sink extension on the lower lane.</text>
 
   <g font-family="Arial, sans-serif">
-    <rect x="40" y="120" width="150" height="84" rx="18" fill="#1d4ed8" stroke="#93c5fd"/>
-    <text x="72" y="158" fill="#eff6ff" font-size="20" font-weight="700">HR sources</text>
-    <text x="63" y="182" fill="#dbeafe" font-size="14">Workday / Snowflake</text>
+    <rect x="40" y="128" width="150" height="88" rx="18" fill="#1d4ed8" stroke="#93c5fd"/>
+    <text x="72" y="166" fill="#eff6ff" font-size="20" font-weight="700">HR sources</text>
+    <text x="62" y="190" fill="#dbeafe" font-size="14">Workday / Snowflake</text>
 
-    <rect x="230" y="120" width="170" height="84" rx="18" fill="#0f766e" stroke="#5eead4"/>
-    <text x="262" y="158" fill="#ecfeff" font-size="20" font-weight="700">Reconciler</text>
-    <text x="247" y="182" fill="#ccfbf1" font-size="14">hash diff + manifest</text>
+    <rect x="230" y="128" width="170" height="88" rx="18" fill="#0f766e" stroke="#5eead4"/>
+    <text x="262" y="166" fill="#ecfeff" font-size="20" font-weight="700">Reconciler</text>
+    <text x="247" y="190" fill="#ccfbf1" font-size="14">hash diff + manifest</text>
 
-    <rect x="440" y="120" width="140" height="84" rx="18" fill="#7c3aed" stroke="#c4b5fd"/>
-    <text x="490" y="158" fill="#f5f3ff" font-size="20" font-weight="700">S3</text>
-    <text x="462" y="182" fill="#ede9fe" font-size="14">versioned manifest</text>
+    <rect x="440" y="128" width="140" height="88" rx="18" fill="#7c3aed" stroke="#c4b5fd"/>
+    <text x="490" y="166" fill="#f5f3ff" font-size="20" font-weight="700">S3</text>
+    <text x="462" y="190" fill="#ede9fe" font-size="14">versioned manifest</text>
 
-    <rect x="620" y="120" width="170" height="84" rx="18" fill="#92400e" stroke="#fdba74"/>
-    <text x="642" y="158" fill="#fff7ed" font-size="20" font-weight="700">EventBridge</text>
-    <text x="653" y="182" fill="#ffedd5" font-size="14">object-created rule</text>
+    <rect x="620" y="128" width="170" height="88" rx="18" fill="#92400e" stroke="#fdba74"/>
+    <text x="642" y="166" fill="#fff7ed" font-size="20" font-weight="700">EventBridge</text>
+    <text x="653" y="190" fill="#ffedd5" font-size="14">object-created rule</text>
 
-    <rect x="830" y="92" width="180" height="140" rx="18" fill="#111827" stroke="#94a3b8"/>
-    <text x="856" y="128" fill="#f8fafc" font-size="22" font-weight="700">Step Functions</text>
-    <rect x="850" y="146" width="140" height="32" rx="10" fill="#172554" stroke="#60a5fa"/>
-    <text x="892" y="168" fill="#e0f2fe" font-size="15">Parser</text>
-    <rect x="850" y="188" width="140" height="32" rx="10" fill="#1f2937" stroke="#2dd4bf"/>
-    <text x="890" y="210" fill="#dcfce7" font-size="15">Worker</text>
+    <rect x="830" y="100" width="180" height="144" rx="18" fill="#111827" stroke="#94a3b8"/>
+    <text x="856" y="136" fill="#f8fafc" font-size="22" font-weight="700">Step Functions</text>
+    <rect x="850" y="154" width="140" height="34" rx="10" fill="#172554" stroke="#60a5fa"/>
+    <text x="892" y="177" fill="#e0f2fe" font-size="15">Parser</text>
+    <rect x="850" y="198" width="140" height="34" rx="10" fill="#1f2937" stroke="#2dd4bf"/>
+    <text x="890" y="221" fill="#dcfce7" font-size="15">Worker</text>
 
-    <rect x="1050" y="120" width="180" height="84" rx="18" fill="#3f1d1d" stroke="#fca5a5"/>
-    <text x="1105" y="158" fill="#fff1f2" font-size="20" font-weight="700">Audit</text>
-    <text x="1078" y="182" fill="#ffe4e6" font-size="14">DynamoDB + S3 evidence</text>
+    <rect x="1050" y="128" width="190" height="88" rx="18" fill="#3f1d1d" stroke="#fca5a5"/>
+    <text x="1098" y="166" fill="#fff1f2" font-size="20" font-weight="700">Default audit</text>
+    <text x="1074" y="190" fill="#ffe4e6" font-size="14">DynamoDB + S3 evidence</text>
+
+    <rect x="860" y="318" width="380" height="108" rx="18" fill="none" stroke="#22d3ee" stroke-width="2" stroke-dasharray="8 6"/>
+    <text x="888" y="352" fill="#67e8f9" font-size="21" font-weight="700">Optional customer-controlled sink</text>
+    <text x="888" y="378" fill="#cffafe" font-size="15">Snowflake / Snowpipe, Security Lake, ClickHouse, BigQuery</text>
+    <text x="888" y="402" fill="#94a3b8" font-size="14">via a dedicated sink or runner layer</text>
   </g>
 
   <g stroke-width="4" fill="none">
-    <path d="M190 162 L230 162" stroke="#93c5fd"/>
-    <path d="M400 162 L440 162" stroke="#5eead4"/>
-    <path d="M580 162 L620 162" stroke="#c4b5fd"/>
-    <path d="M790 162 L830 162" stroke="#fdba74"/>
-    <path d="M1010 162 L1050 162" stroke="#94a3b8"/>
+    <path d="M190 172 L230 172" stroke="#93c5fd"/>
+    <path d="M400 172 L440 172" stroke="#5eead4"/>
+    <path d="M580 172 L620 172" stroke="#c4b5fd"/>
+    <path d="M790 172 L830 172" stroke="#fdba74"/>
+    <path d="M1010 172 L1050 172" stroke="#94a3b8"/>
+    <path d="M1145 216 L1145 318" stroke="#22d3ee" stroke-dasharray="8 6"/>
   </g>
 
-  <text x="60" y="300" fill="#cbd5e1" font-size="18" font-family="Arial, sans-serif">Verification loop: audit ingest-back closes the loop and the next reconciler run confirms state convergence.</text>
+  <g font-family="Arial, sans-serif">
+    <text x="60" y="278" fill="#cbd5e1" font-size="18">Verification loop: audit ingest-back closes the loop and the next reconciler run confirms state convergence.</text>
+    <text x="60" y="458" fill="#94a3b8" font-size="14">The external sink lane is an architecture-supported pattern, not a generic shipped sink framework.</text>
+  </g>
 </svg>

--- a/docs/images/start-here-guide.svg
+++ b/docs/images/start-here-guide.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="620" viewBox="0 0 1280 620" role="img" aria-labelledby="title desc">
+  <title id="title">Start here guide for cloud-ai-security-skills</title>
+  <desc id="desc">A guided operator map from common sources and goals to skill layers, outputs, and runtime surfaces.</desc>
+  <rect width="1280" height="620" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="572" rx="28" fill="#0f172a" stroke="#334155"/>
+
+  <g font-family="Arial, sans-serif">
+    <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">Start here</text>
+    <text x="56" y="102" fill="#94a3b8" font-size="17">Choose a source or goal, pick the layer, then run the same skill from CLI, CI, MCP, or a persistent wrapper.</text>
+
+    <rect x="56" y="136" width="250" height="332" rx="20" fill="#172554" stroke="#60a5fa"/>
+    <text x="82" y="176" fill="#dbeafe" font-size="24" font-weight="700">1. Start with</text>
+    <text x="82" y="210" fill="#eff6ff" font-size="17" font-weight="700">Raw event sources</text>
+    <text x="82" y="236" fill="#cbd5e1" font-size="15">CloudTrail, VPC Flow, Azure Activity</text>
+    <text x="82" y="258" fill="#cbd5e1" font-size="15">GCP Audit, K8s audit, MCP proxy</text>
+    <text x="82" y="290" fill="#eff6ff" font-size="17" font-weight="700">Identity sources</text>
+    <text x="82" y="316" fill="#cbd5e1" font-size="15">Okta, Entra, Google Workspace</text>
+    <text x="82" y="348" fill="#eff6ff" font-size="17" font-weight="700">Inventory / evidence</text>
+    <text x="82" y="374" fill="#cbd5e1" font-size="15">Cloud assets, AI services, controls</text>
+    <text x="82" y="406" fill="#eff6ff" font-size="17" font-weight="700">Operational goal</text>
+    <text x="82" y="432" fill="#cbd5e1" font-size="15">Detect, evaluate, export, remediate</text>
+
+    <rect x="356" y="136" width="250" height="332" rx="20" fill="#083344" stroke="#2dd4bf"/>
+    <text x="382" y="176" fill="#ccfbf1" font-size="24" font-weight="700">2. Pick a layer</text>
+    <text x="382" y="212" fill="#f8fafc" font-size="17" font-weight="700">Ingest</text>
+    <text x="382" y="236" fill="#cbd5e1" font-size="15">normalize one source into native or OCSF</text>
+    <text x="382" y="268" fill="#f8fafc" font-size="17" font-weight="700">Discover</text>
+    <text x="382" y="292" fill="#cbd5e1" font-size="15">inventory, graph context, AI BOM, evidence</text>
+    <text x="382" y="324" fill="#f8fafc" font-size="17" font-weight="700">Detect / Evaluate</text>
+    <text x="382" y="348" fill="#cbd5e1" font-size="15">MITRE-tagged findings or benchmark results</text>
+    <text x="382" y="380" fill="#f8fafc" font-size="17" font-weight="700">View / Remediate</text>
+    <text x="382" y="404" fill="#cbd5e1" font-size="15">SARIF, Mermaid, or guarded write workflow</text>
+    <text x="382" y="444" fill="#99f6e4" font-size="14">Use cases and source crosswalks live in docs/USE_CASES.md</text>
+
+    <rect x="656" y="136" width="250" height="332" rx="20" fill="#3b0764" stroke="#c084fc"/>
+    <text x="682" y="176" fill="#f3e8ff" font-size="24" font-weight="700">3. Get output</text>
+    <text x="682" y="212" fill="#f8fafc" font-size="17" font-weight="700">Event streams</text>
+    <text x="682" y="236" fill="#ddd6fe" font-size="15">native JSONL, OCSF JSONL, bridge output</text>
+    <text x="682" y="268" fill="#f8fafc" font-size="17" font-weight="700">Findings / evidence</text>
+    <text x="682" y="292" fill="#ddd6fe" font-size="15">detection findings, benchmark results, evidence JSON</text>
+    <text x="682" y="324" fill="#f8fafc" font-size="17" font-weight="700">Exports</text>
+    <text x="682" y="348" fill="#ddd6fe" font-size="15">SARIF, Mermaid attack flow, AI BOM</text>
+    <text x="682" y="380" fill="#f8fafc" font-size="17" font-weight="700">Guarded actions</text>
+    <text x="682" y="404" fill="#ddd6fe" font-size="15">dry-run plan, audited remediation, dual audit trail</text>
+    <text x="682" y="444" fill="#e9d5ff" font-size="14">Canonical is internal; native, OCSF, and bridge are projections.</text>
+
+    <rect x="956" y="136" width="250" height="332" rx="20" fill="#1f2937" stroke="#94a3b8"/>
+    <text x="982" y="176" fill="#f8fafc" font-size="24" font-weight="700">4. Run it from</text>
+    <text x="982" y="212" fill="#f8fafc" font-size="17" font-weight="700">CLI / Unix pipes</text>
+    <text x="982" y="236" fill="#cbd5e1" font-size="15">local triage and repeatable pipelines</text>
+    <text x="982" y="268" fill="#f8fafc" font-size="17" font-weight="700">CI</text>
+    <text x="982" y="292" fill="#cbd5e1" font-size="15">policy gates, SARIF, benchmark snapshots</text>
+    <text x="982" y="324" fill="#f8fafc" font-size="17" font-weight="700">MCP / agents</text>
+    <text x="982" y="348" fill="#cbd5e1" font-size="15">Claude, Codex, Cursor, Windsurf, Cortex</text>
+    <text x="982" y="380" fill="#f8fafc" font-size="17" font-weight="700">Persistent wrappers</text>
+    <text x="982" y="404" fill="#cbd5e1" font-size="15">serverless, queue, or scheduler around the same skill</text>
+    <text x="982" y="444" fill="#cbd5e1" font-size="14">Shipped today: stateless skills and one event-driven remediation workflow.</text>
+
+    <path d="M306 302 L356 302" stroke="#60a5fa" stroke-width="4" fill="none"/>
+    <path d="M606 302 L656 302" stroke="#2dd4bf" stroke-width="4" fill="none"/>
+    <path d="M906 302 L956 302" stroke="#c084fc" stroke-width="4" fill="none"/>
+
+    <rect x="56" y="500" width="1150" height="60" rx="18" fill="#111827" stroke="#475569"/>
+    <text x="82" y="536" fill="#f8fafc" font-size="18" font-weight="700">Shipped vs optional sink pattern</text>
+    <text x="315" y="536" fill="#cbd5e1" font-size="16">Shipped today: stdout data paths plus DynamoDB + S3 audit for IAM departures.</text>
+    <text x="820" y="536" fill="#cbd5e1" font-size="16">Optional customer pattern: Snowflake / Snowpipe, Security Lake, ClickHouse, BigQuery via a sink or runner layer.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a new start-here SVG that maps sources and goals to layers, outputs, and runtime surfaces
- refine the IAM departures data-flow visual to separate the shipped DynamoDB + S3 audit path from optional customer-controlled sink patterns
- wire the new visuals into the README visual guide, diagrams index, and changelog

## Validation
- reviewed the SVG and README diffs for accuracy against current shipped repo behavior
