### PR TITLE
docs: add runtime surface visual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is loosely based on Keep a Changelog.
 - tightened the README and skill catalog entry path around use cases, skill selection, plug-in surfaces, and clearer layer guidance, plus added `docs/USE_CASES.md` as the practical crosswalk for sources, assets, frameworks, and starting skills.
 - clarified in the README and use-case guide that repo-owned remediation audit lands in DynamoDB + S3 today, while customer-controlled sinks such as Snowflake / Snowpipe belong to the planned sink / runner layer rather than the currently shipped generic path.
 - a new start-here visual and updated IAM departures data-flow visual so operators can see sources, layer choice, outputs, runtime surfaces, and the shipped-vs-optional sink boundary without reading the full architecture docs first.
+- a runtime-surfaces visual showing that CLI, CI, MCP, and persistent wrappers all call the same `SKILL.md + src/ + tests/` contract instead of creating parallel implementations.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The repo keeps one source of truth:
 | If you want to see... | Open... |
 |---|---|
 | where to start by source, layer, output, and runtime | [Start here guide](docs/images/start-here-guide.svg) |
+| how CLI, CI, MCP, and persistent wrappers call the same skill contract | [Runtime surfaces](docs/images/runtime-surfaces.svg) |
 | the overall repo shape | [Repo architecture](docs/images/repo-architecture.svg) |
 | how ingest → detect → export fits together | [Detection pipeline](docs/images/detection-pipeline.svg) |
 | the flagship HITL remediation workflow | [IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,6 +125,7 @@ For the detailed contract, see:
 
 For quick orientation, use the visual set in [`DIAGRAMS.md`](./DIAGRAMS.md):
 
+- **Runtime surfaces** — [`runtime-surfaces.svg`](./images/runtime-surfaces.svg)
 - **Repo architecture** — [`repo-architecture.svg`](./images/repo-architecture.svg)
 - **IAM departures data flow** — [`iam-departures-data-flow.svg`](./images/iam-departures-data-flow.svg)
 - **Detection pipeline** — [`detection-pipeline.svg`](./images/detection-pipeline.svg)

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -5,6 +5,7 @@ Keep the markdown source diagrams lightweight and reviewable, then pair them wit
 ## Visual set
 
 - [Start here guide](images/start-here-guide.svg)
+- [Runtime surfaces](images/runtime-surfaces.svg)
 - [IAM departures cross-cloud workflow](images/iam-departures-architecture.svg)
 - [Repository architecture](images/repo-architecture.svg)
 - [IAM departures data flow](images/iam-departures-data-flow.svg)

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
+  <title id="title">Runtime surfaces call the same skill contract</title>
+  <desc id="desc">CLI, CI, MCP, and persistent wrappers all invoke the same skill bundle and produce the same governed outputs.</desc>
+  <rect width="1280" height="520" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="472" rx="28" fill="#0f172a" stroke="#334155"/>
+
+  <g font-family="Arial, sans-serif">
+    <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">One skill contract, many runtime surfaces</text>
+    <text x="56" y="102" fill="#94a3b8" font-size="17">CLI, CI, MCP, and persistent wrappers are access paths. They do not fork the skill implementation.</text>
+
+    <rect x="56" y="152" width="220" height="240" rx="20" fill="#172554" stroke="#60a5fa"/>
+    <text x="82" y="190" fill="#dbeafe" font-size="24" font-weight="700">Runtime surfaces</text>
+    <text x="82" y="226" fill="#eff6ff" font-size="17" font-weight="700">CLI / Unix pipes</text>
+    <text x="82" y="250" fill="#cbd5e1" font-size="15">one-shot analysis and local pipelines</text>
+    <text x="82" y="286" fill="#eff6ff" font-size="17" font-weight="700">CI</text>
+    <text x="82" y="310" fill="#cbd5e1" font-size="15">PR checks, SARIF, scheduled snapshots</text>
+    <text x="82" y="346" fill="#eff6ff" font-size="17" font-weight="700">MCP</text>
+    <text x="82" y="370" fill="#cbd5e1" font-size="15">Claude, Codex, Cursor, Windsurf, Cortex</text>
+
+    <rect x="360" y="118" width="560" height="308" rx="24" fill="#111827" stroke="#94a3b8"/>
+    <text x="390" y="160" fill="#f8fafc" font-size="28" font-weight="700">Shared skill bundle</text>
+    <text x="390" y="192" fill="#94a3b8" font-size="16">Every surface calls the same repo-owned contract.</text>
+
+    <rect x="392" y="228" width="216" height="150" rx="18" fill="#083344" stroke="#2dd4bf"/>
+    <text x="418" y="262" fill="#ccfbf1" font-size="22" font-weight="700">Contract</text>
+    <text x="418" y="290" fill="#ecfeff" font-size="15">SKILL.md</text>
+    <text x="418" y="312" fill="#cbd5e1" font-size="14">approval_model</text>
+    <text x="418" y="332" fill="#cbd5e1" font-size="14">execution_modes</text>
+    <text x="418" y="352" fill="#cbd5e1" font-size="14">input_formats / output_formats</text>
+
+    <rect x="640" y="228" width="248" height="150" rx="18" fill="#3b0764" stroke="#c084fc"/>
+    <text x="668" y="262" fill="#f3e8ff" font-size="22" font-weight="700">Implementation</text>
+    <text x="668" y="290" fill="#f8fafc" font-size="15">src/ + tests/ + REFERENCES.md</text>
+    <text x="668" y="312" fill="#ddd6fe" font-size="14">same code path across wrappers</text>
+    <text x="668" y="332" fill="#ddd6fe" font-size="14">native / canonical / OCSF aware</text>
+    <text x="668" y="352" fill="#ddd6fe" font-size="14">deterministic IDs and audit rules</text>
+
+    <rect x="1004" y="152" width="220" height="240" rx="20" fill="#1f2937" stroke="#94a3b8"/>
+    <text x="1030" y="190" fill="#f8fafc" font-size="24" font-weight="700">Outputs</text>
+    <text x="1030" y="226" fill="#f8fafc" font-size="17" font-weight="700">Data streams</text>
+    <text x="1030" y="250" fill="#cbd5e1" font-size="15">native, OCSF, bridge, evidence</text>
+    <text x="1030" y="286" fill="#f8fafc" font-size="17" font-weight="700">Exports</text>
+    <text x="1030" y="310" fill="#cbd5e1" font-size="15">SARIF, Mermaid, AI BOM</text>
+    <text x="1030" y="346" fill="#f8fafc" font-size="17" font-weight="700">Guarded writes</text>
+    <text x="1030" y="370" fill="#cbd5e1" font-size="15">dry-run plan and audited actions</text>
+
+    <path d="M276 272 L360 272" stroke="#60a5fa" stroke-width="4" fill="none"/>
+    <path d="M920 272 L1004 272" stroke="#94a3b8" stroke-width="4" fill="none"/>
+
+    <rect x="56" y="420" width="1168" height="48" rx="16" fill="#111827" stroke="#475569"/>
+    <text x="82" y="450" fill="#f8fafc" font-size="17" font-weight="700">Rule:</text>
+    <text x="138" y="450" fill="#cbd5e1" font-size="16">wrappers can add gating, scheduling, caller context, or sinks; they must not create a second implementation model.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a runtime-surfaces SVG that shows CLI, CI, MCP, and persistent wrappers all calling the same skill contract
- wire the visual into the README, architecture docs, diagrams index, and changelog
- make the runtime story clearer without changing the underlying architecture contract

## Validation
- reviewed the README, architecture, and diagram-index diffs for consistency with current shipped repo behavior
