### PR TITLE
ci: harden skill discovery and bandit scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: "3.11"
           packages: bandit
-      - run: bandit -r skills/evaluation/cspm-aws-cis-benchmark skills/remediation/iam-departures-remediation mcp-server -c pyproject.toml --severity-level medium
+      - run: bandit -r skills mcp-server scripts -c pyproject.toml --severity-level medium
 
   # ── Unit tests, grouped into category lanes ───────────────────
   test-compliance:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is loosely based on Keep a Changelog.
 - a new start-here visual and updated IAM departures data-flow visual so operators can see sources, layer choice, outputs, runtime surfaces, and the shipped-vs-optional sink boundary without reading the full architecture docs first.
 - a runtime-surfaces visual showing that CLI, CI, MCP, and persistent wrappers all call the same `SKILL.md + src/ + tests/` contract instead of creating parallel implementations.
 - expanded the vendor icon asset set with Okta plus Microsoft Entra and Google Workspace stand-ins so the visual system can represent shipped identity sources alongside cloud and data-platform vendors.
+- broadened the contract validator to fail on skill-like directories missing `SKILL.md`, and expanded the Bandit CI lane from a few hand-picked paths to `skills/`, `mcp-server/`, and `scripts/`.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -7,6 +7,14 @@ from urllib.parse import urlparse
 
 ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = ROOT / "skills"
+CANONICAL_SKILL_CATEGORIES = {
+    "ingestion",
+    "detection",
+    "discovery",
+    "evaluation",
+    "view",
+    "remediation",
+}
 
 NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
@@ -131,6 +139,20 @@ class SkillContract:
 
 def iter_skill_dirs() -> list[Path]:
     return sorted(path.parent for path in SKILLS_ROOT.glob("*/*/SKILL.md"))
+
+
+def iter_skill_like_dirs() -> list[Path]:
+    skill_dirs: list[Path] = []
+    for category_dir in sorted(SKILLS_ROOT.iterdir()):
+        if not category_dir.is_dir():
+            continue
+        if category_dir.name not in CANONICAL_SKILL_CATEGORIES:
+            continue
+        for skill_dir in sorted(category_dir.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            skill_dirs.append(skill_dir)
+    return skill_dirs
 
 
 def extract_frontmatter(skill_md: Path) -> str:

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -12,6 +12,7 @@ from skill_validation_common import (
     ROOT,
     SIDE_EFFECT_VALUES,
     discover_skill_contracts,
+    iter_skill_like_dirs,
 )
 
 
@@ -19,11 +20,16 @@ def main() -> int:
     errors: list[str] = []
     checked = 0
 
+    for skill_dir in iter_skill_like_dirs():
+        rel = skill_dir.relative_to(ROOT)
+        if not (skill_dir / "SKILL.md").exists():
+            errors.append(f"{rel}: missing required path `SKILL.md`")
+
     for skill in discover_skill_contracts():
         checked += 1
         rel = skill.skill_dir.relative_to(ROOT)
 
-        for required in ("src", "tests", "REFERENCES.md"):
+        for required in ("SKILL.md", "src", "tests", "REFERENCES.md"):
             if not (skill.skill_dir / required).exists():
                 errors.append(f"{rel}: missing required path `{required}`")
 

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -134,3 +134,15 @@ class TestValidationScripts:
         assert remediation.caller_roles == ("security_engineer", "incident_responder")
         assert remediation.approver_roles == ("security_lead", "cis_officer")
         assert remediation.min_approvers == 1
+
+    def test_skill_like_dirs_are_canonical_categories_only(self):
+        skill_like_dirs = COMMON.iter_skill_like_dirs()
+        assert skill_like_dirs
+        for path in skill_like_dirs:
+            assert path.parent.name in COMMON.CANONICAL_SKILL_CATEGORIES
+            assert path.name != "__pycache__"
+
+    def test_every_skill_like_dir_has_a_contract(self):
+        skill_like_dirs = COMMON.iter_skill_like_dirs()
+        missing = [path for path in skill_like_dirs if not (path / "SKILL.md").exists()]
+        assert missing == []


### PR DESCRIPTION
## Summary
- fail skill contract validation when a skill-like directory under the canonical layer categories is missing SKILL.md
- add integration coverage for the new skill-like directory discovery helper
- broaden the Bandit CI lane from a few hand-picked paths to skills/, mcp-server/, and scripts/

## Validation
- python scripts/validate_skill_contract.py
- uv run pytest tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run bandit -r skills mcp-server scripts -c pyproject.toml --severity-level medium
- uv run ruff check scripts/skill_validation_common.py scripts/validate_skill_contract.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml

## Notes
- The duplicate-path audit finding appears stale on current main; this PR closes the underlying future-proofing gap so stub skill directories cannot slip into the repo unnoticed.
- mypy is still a separate follow-up because the current repeated ingest.py / detect.py layout needs an explicit invocation strategy before it can be added as a meaningful CI gate.
