### PR TITLE
ci: add repo-aware mypy lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,20 @@ jobs:
       - run: python scripts/validate_framework_coverage.py
       - run: python scripts/validate_ocsf_metadata.py
 
-  safe-skill-bar:
+  type-check:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: "3.11"
+          packages: mypy
+      - run: bash scripts/run_mypy.sh
+
+  safe-skill-bar:
+    runs-on: ubuntu-latest
+    needs: [lint, skill-contract, type-check]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -61,7 +72,7 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -73,7 +84,7 @@ jobs:
   # ── Unit tests, grouped into category lanes ───────────────────
   test-compliance:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -100,7 +111,7 @@ jobs:
 
   test-remediation:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -115,7 +126,7 @@ jobs:
 
   test-detection-engineering:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -159,7 +170,7 @@ jobs:
 
   test-ai-infra-security:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     name: test-ai-infra
     steps:
       - uses: actions/checkout@v6
@@ -188,7 +199,7 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -200,7 +211,7 @@ jobs:
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
   validate-iac:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -220,7 +231,7 @@ jobs:
   # ── agent-bom scans (code + skills + fs + IaC with SARIF upload) ─
   agent-bom:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract, safe-skill-bar]
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is loosely based on Keep a Changelog.
 - a runtime-surfaces visual showing that CLI, CI, MCP, and persistent wrappers all call the same `SKILL.md + src/ + tests/` contract instead of creating parallel implementations.
 - expanded the vendor icon asset set with Okta plus Microsoft Entra and Google Workspace stand-ins so the visual system can represent shipped identity sources alongside cloud and data-platform vendors.
 - broadened the contract validator to fail on skill-like directories missing `SKILL.md`, and expanded the Bandit CI lane from a few hand-picked paths to `skills/`, `mcp-server/`, and `scripts/`.
+- added a repo-aware `mypy` runner and CI lane that type-checks each skill `src/` directory in isolation plus `mcp-server/src/` and `scripts/`, so the repeated `ingest.py` / `detect.py` layout no longer blocks meaningful type enforcement.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 check_untyped_defs = true
 exclude = "(^|/)(tests|infra)/"
+
+[[tool.mypy.overrides]]
+module = ["yaml"]
+ignore_missing_imports = true

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${UV_CACHE_DIR:=/tmp/cloud-security-core-foundation-uv-cache}"
+export UV_CACHE_DIR
+
+for dir in skills/*/*/src; do
+  uv run mypy "$dir" --config-file pyproject.toml
+done
+
+uv run mypy mcp-server/src scripts --config-file pyproject.toml

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -4,8 +4,14 @@ set -euo pipefail
 : "${UV_CACHE_DIR:=/tmp/cloud-security-core-foundation-uv-cache}"
 export UV_CACHE_DIR
 
+if command -v uv >/dev/null 2>&1; then
+  MYPY_CMD=(uv run mypy)
+else
+  MYPY_CMD=(python -m mypy)
+fi
+
 for dir in skills/*/*/src; do
-  uv run mypy "$dir" --config-file pyproject.toml
+  "${MYPY_CMD[@]}" "$dir" --config-file pyproject.toml
 done
 
-uv run mypy mcp-server/src scripts --config-file pyproject.toml
+"${MYPY_CMD[@]}" mcp-server/src scripts --config-file pyproject.toml

--- a/scripts/validate_ocsf_metadata.py
+++ b/scripts/validate_ocsf_metadata.py
@@ -14,7 +14,7 @@ def _declares_ocsf_output(raw_modes: str) -> bool:
     return "ocsf" in {part.strip() for part in raw_modes.split(",") if part.strip()}
 
 
-def _const_str(node: ast.AST) -> str | None:
+def _const_str(node: ast.AST | None) -> str | None:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
     return None

--- a/skills/detection/detect-privilege-escalation-k8s/src/detect.py
+++ b/skills/detection/detect-privilege-escalation-k8s/src/detect.py
@@ -302,8 +302,8 @@ def rule1_secret_enumeration(events: list[dict[str, Any]]) -> Iterable[dict[str,
             continue
         if event["resource_type"] != "secrets":
             continue
-        key = (event["actor_name"], event["namespace"])
-        list_events.setdefault(key, []).append((event["time_ms"], event))
+        list_key = (event["actor_name"], event["namespace"])
+        list_events.setdefault(list_key, []).append((event["time_ms"], event))
 
     seen_findings: set[str] = set()
     for event in normalized:

--- a/skills/discovery/discover-ai-bom/src/discover.py
+++ b/skills/discovery/discover-ai-bom/src/discover.py
@@ -506,7 +506,7 @@ def _to_service(asset: dict[str, Any]) -> dict[str, Any]:
 
 
 def _metadata_properties(document: dict[str, Any], assets: list[dict[str, Any]]) -> list[dict[str, str]]:
-    counts = defaultdict(int)
+    counts: defaultdict[str, int] = defaultdict(int)
     for asset in assets:
         counts[f"cloud-security:count.{asset['provider']}.{asset['kind']}"] += 1
 
@@ -546,9 +546,9 @@ def build_bom(document: dict[str, Any]) -> dict[str, Any]:
         else:
             components.append(_to_component(asset))
 
-    dependencies = []
+    dependencies: list[dict[str, Any]] = []
     for asset in assets:
-        refs = [_string(dep) for dep in asset.get("dependencies", []) if _string(dep)]
+        refs = [dep_text for dep in asset.get("dependencies", []) if (dep_text := _string(dep))]
         if refs:
             dependencies.append({"ref": _bom_ref(asset), "dependsOn": sorted(set(refs))})
 

--- a/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
@@ -221,7 +221,7 @@ def check_4_2_no_unrestricted_ssh_rdp(compute_client, project_id: str) -> Findin
             if rule.direction != "INGRESS" or rule.disabled:
                 continue
             for allowed in rule.allowed or []:
-                ports = []
+                ports: list[int] = []
                 for p in allowed.ports or []:
                     if "-" in p:
                         low, high = p.split("-")

--- a/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/src/ingest.py
@@ -87,7 +87,7 @@ def parse_flow_tuple(value: str, version: int | str = 2) -> dict[str, str]:
     parts = [part.strip() for part in value.split(",")]
     version_num = int(version)
     if version_num >= 2 and len(parts) >= 13:
-        keys = (
+        keys: tuple[str, ...] = (
             "time",
             "src_ip",
             "dst_ip",

--- a/skills/remediation/iam-departures-remediation/src/reconciler/change_detect.py
+++ b/skills/remediation/iam-departures-remediation/src/reconciler/change_detect.py
@@ -54,12 +54,12 @@ class ChangeDetector:
             # a remediation export when the underlying departure data is unchanged.
             payload.pop("last_checked_at", None)
             stable_records.append(payload)
-        payload = json.dumps(
+        canonical_payload = json.dumps(
             stable_records,
             sort_keys=True,
             default=str,
         )
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        return hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
 
     def get_previous_hash(self) -> str | None:
         """Read the last-known hash from S3.


### PR DESCRIPTION
## Summary
- add a repo-aware mypy runner that checks each skill src/ directory in isolation plus mcp-server/src and scripts
- wire the runner into CI as a dedicated type-check lane
- fix the concrete type issues the new lane surfaced in OCSF metadata validation, AI BOM discovery, K8s privilege escalation, GCP CIS checks, Azure NSG ingest, and IAM departures reconciliation

## Validation
- bash scripts/run_mypy.sh
- python scripts/validate_skill_contract.py
- uv run pytest tests/integration/test_skill_validation_scripts.py skills/discovery/discover-ai-bom/tests/test_discover.py skills/detection/detect-privilege-escalation-k8s/tests/test_detect.py skills/evaluation/cspm-gcp-cis-benchmark/tests/test_checks.py skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/tests/test_ingest.py skills/remediation/iam-departures-remediation/tests/test_reconciler.py -q -o addopts=''
- uv run ruff check scripts/validate_ocsf_metadata.py scripts/skill_validation_common.py scripts/validate_skill_contract.py skills/discovery/discover-ai-bom/src/discover.py skills/detection/detect-privilege-escalation-k8s/src/detect.py skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/src/ingest.py skills/remediation/iam-departures-remediation/src/reconciler/change_detect.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml
