### PR TITLE
ci: enforce coverage floors and ship runner template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,25 @@ jobs:
           packages: pytest pytest-cov
       - run: pytest tests/integration/ mcp-server/tests/ -v -o "testpaths=tests"
 
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [lint, skill-contract, type-check, safe-skill-bar]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: "3.11"
+          packages: >-
+            boto3 moto pytest pytest-cov
+            google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
+            azure-identity azure-mgmt-network azure-mgmt-resource azure-mgmt-storage
+            google-api-python-client
+            clickhouse-connect databricks-sql-connector httpx snowflake-connector-python
+      - name: Run full test suite with coverage gates
+        run: pytest skills/ tests/integration/ mcp-server/tests/ --cov=skills --cov-report=term-missing --cov-report=xml
+      - name: Validate coverage floors
+        run: python scripts/validate_test_coverage.py coverage.xml
+
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
   validate-iac:
     runs-on: ubuntu-latest
@@ -225,6 +244,7 @@ jobs:
         run: |
           cfn-lint skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
           cfn-lint skills/remediation/iam-departures-remediation/infra/cross_account_stackset.yaml
+          cfn-lint runners/aws-s3-sqs-detect/template.yaml
       - name: terraform validate
         run: cd skills/remediation/iam-departures-remediation/infra/terraform && terraform init -backend=false && terraform validate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: pytest pytest-cov
+          packages: pytest pytest-cov defusedxml
       - run: pytest tests/integration/ mcp-server/tests/ -v -o "testpaths=tests"
 
   coverage:
@@ -218,6 +218,7 @@ jobs:
           python-version: "3.11"
           packages: >-
             boto3 moto pytest pytest-cov
+            defusedxml
             google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
             azure-identity azure-mgmt-network azure-mgmt-resource azure-mgmt-storage
             google-api-python-client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is loosely based on Keep a Changelog.
 - expanded the vendor icon asset set with Okta plus Microsoft Entra and Google Workspace stand-ins so the visual system can represent shipped identity sources alongside cloud and data-platform vendors.
 - broadened the contract validator to fail on skill-like directories missing `SKILL.md`, and expanded the Bandit CI lane from a few hand-picked paths to `skills/`, `mcp-server/`, and `scripts/`.
 - added a repo-aware `mypy` runner and CI lane that type-checks each skill `src/` directory in isolation plus `mcp-server/src/` and `scripts/`, so the repeated `ingest.py` / `detect.py` layout no longer blocks meaningful type enforcement.
+- `scripts/validate_test_coverage.py` plus a dedicated CI coverage lane that now enforces real repo-level thresholds: `overall >= 70%`, `detection >= 80%`, and `evaluation >= 60%`.
+- `runners/aws-s3-sqs-detect`, a repo-owned AWS reference runner template for `S3 -> ingest Lambda -> SQS -> detect Lambda -> DynamoDB dedupe -> SNS`, so persistent execution is no longer docs-only outside the IAM departures workflow.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ For the full source / asset / framework crosswalk, see [docs/USE_CASES.md](docs/
 | **MCP** | you want Claude, Codex, Cursor, Windsurf, or Cortex Code CLI to call the same skills | agent workflows, tool-driven investigations, guarded remediation |
 | **CI** | you want the same skills in pull requests or scheduled checks | SARIF generation, benchmark snapshots, policy gates |
 | **SIEM / lakehouse** | you want normalized findings, evidence, or audit records in an existing store | Splunk, Sentinel, Chronicle, Elastic, Snowflake, ClickHouse |
-| **Persistent runner** | you want scheduled or event-driven operation | serverless, queue-driven, or batch runners around the same stateless skills |
+| **Persistent runner** | you want scheduled or event-driven operation | serverless, queue-driven, or batch runners around the same stateless skills, including the shipped [`runners/aws-s3-sqs-detect`](runners/aws-s3-sqs-detect/) reference template |
 
 The important distinction is:
-- **shipped today**: stateless skills, MCP wrapper, CI paths, and the repo-owned IAM departures audit path in DynamoDB + S3
+- **shipped today**: stateless skills, MCP wrapper, CI paths, the repo-owned IAM departures audit path in DynamoDB + S3, and a generic AWS reference runner template under [`runners/`](runners/)
 - **supported integration pattern**: customer-controlled sinks like Snowflake / Snowpipe, Security Lake, ClickHouse, or BigQuery via append-only runners and sink layers
 - **not shipped yet**: a generic sink / runner framework for every skill family
 
@@ -197,7 +197,11 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layered design, 
 
 The important rule is that the **skill code does not change between modes**. `SKILL.md + src/ + tests/` stays the product; the runner, pipeline, or MCP wrapper is only the access path.
 
-`execution_modes: persistent` means the skill is safe to embed in a persistent runner or serverless loop. It does **not** mean this repo already ships a dedicated daemon, queue worker, or sink for that skill. Today the only fully shipped persistent workflow is `iam-departures-remediation`; the broader runner and sink layer remains an explicit roadmap item.
+`execution_modes: persistent` means the skill is safe to embed in a persistent runner or serverless loop. It does **not** mean this repo already ships a dedicated daemon, queue worker, or sink for that skill. Today the repo ships:
+- the fully owned `iam-departures-remediation` event-driven workflow
+- a generic AWS reference runner template in [`runners/aws-s3-sqs-detect`](runners/aws-s3-sqs-detect/)
+
+Broader multi-sink and multi-cloud runner coverage remains an explicit roadmap item.
 
 ## Safety model
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,7 +178,12 @@ A **runner** (L9 driver, not a skill) drives the skills in a loop from a source 
                          └─ checkpoint state in DynamoDB / Snowflake STREAM
 ```
 
-Example runners (none exist yet — land in PR V):
+Shipped reference runner:
+```
+runners/aws-s3-sqs-detect              # S3 -> ingest Lambda -> SQS -> detect Lambda -> DynamoDB dedupe -> SNS
+```
+
+Additional example runners:
 ```
 runners/runner-s3-to-snowflake          # S3 → skill → Snowflake COPY INTO
 runners/runner-eventbridge-to-security-lake   # EventBridge → skill → Parquet → Security Lake

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -19,7 +19,7 @@ Agents and wrappers should treat those fields as part of the runtime contract, n
 Important meaning:
 - `execution_modes: persistent` means the skill is compatible with a persistent runner or serverless loop
 - it does **not** mean the repo already ships a dedicated daemon, queue worker, sink, or Lambda wrapper for that skill
-- today, most skills are persistent-compatible but still run as stateless CLI tools; only a small number of workflows ship repo-owned persistent code paths
+- today, most skills are persistent-compatible but still run as stateless CLI tools; the repo ships a small number of persistent code paths, including `iam-departures-remediation` and the reference runner under `runners/aws-s3-sqs-detect/`
 
 ## Modes
 
@@ -68,10 +68,11 @@ Current pilots:
 These are the only places where side effects should happen:
 - `remediation/`
 - future `sinks/`
-- future `runners/`
+- `runners/`
 
-Current shipped exception:
+Current shipped exceptions:
 - `iam-departures-remediation` includes repo-owned Lambda handlers and infrastructure for its event-driven persistent path
+- `runners/aws-s3-sqs-detect` ships a generic AWS reference runner for S3 → ingest → SQS → detect → DynamoDB dedupe → SNS
 
 Required controls:
 - `--dry-run` support

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -70,7 +70,7 @@ Use it when the README feels too high-level and `skills/README.md` feels too cat
 | Topic | Shipped today | Planned / contract-supported |
 |---|---|---|
 | Native / OCSF dual mode | selected ingest and detect skills, plus native-first discovery | repo-wide rollout across remaining ingest/detect paths |
-| Persistent execution | IAM departures event-driven path | generic runners for broader ingest → detect → sink loops |
+| Persistent execution | IAM departures event-driven path, plus `runners/aws-s3-sqs-detect` | broader multi-sink and multi-cloud runner coverage |
 | Audit sinks | IAM departures dual-write to DynamoDB + S3 | external customer sinks like Snowflake / Snowpipe, Security Lake, ClickHouse, BigQuery |
 | Visuals | repo architecture, detection pipeline, IAM departures workflow + data flow | deeper source / asset / plug-in visuals as the surface grows |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ package = false
 [dependency-groups]
 dev = [
   "bandit[toml]>=1.9.4,<2",
+  "defusedxml>=0.7.1,<1",
   "moto>=5,<6",
   "mypy>=1.11,<2",
   "pip-audit>=2.7,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ exclude_dirs = ["tests", ".venv", ".git", "__pycache__"]
 skips = ["B101"]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib -q --cov=skills --cov-report=term-missing --cov-report=xml --cov-fail-under=35"
+addopts = "--import-mode=importlib -q"
 testpaths = ["skills"]
 python_files = "test_*.py"
 python_classes = "Test*"

--- a/runners/README.md
+++ b/runners/README.md
@@ -1,0 +1,22 @@
+# Runners
+
+Runners are the persistent edge components around the stateless skills.
+
+They own:
+- source subscriptions and queue triggers
+- checkpointing and replay position
+- dedupe tables or sink merge semantics
+- retry / DLQ behavior
+- sink writes and alert fan-out
+
+They do **not** change the skill contract. The same `SKILL.md + src/ + tests/`
+bundle should still run unchanged from the CLI, CI, MCP, or a persistent loop.
+
+## Shipped reference runner
+
+- [`aws-s3-sqs-detect`](aws-s3-sqs-detect/): S3 object create trigger → ingest
+  Lambda → SQS detect queue → detect Lambda → DynamoDB dedupe → SNS publish
+
+This is a reference template, not a multi-tenant managed service. Operators still
+own packaging, deployment, sink wiring, IAM review, and environment-specific
+controls.

--- a/runners/aws-s3-sqs-detect/README.md
+++ b/runners/aws-s3-sqs-detect/README.md
@@ -1,0 +1,71 @@
+# aws-s3-sqs-detect
+
+Reference persistent runner template for continuous ingest → detect pipelines on
+AWS. The template attaches to an existing source bucket and keeps the queue,
+dedupe table, and alert path inside the stack.
+
+## What it does
+
+```
+S3 object create
+  -> ingest Lambda
+  -> SQS queue
+  -> detect Lambda
+  -> DynamoDB dedupe
+  -> SNS fan-out
+```
+
+The runner keeps state and side effects at the edges:
+- S3 is the raw object source
+- SQS provides durable decoupling
+- DynamoDB stores replay-safe dedupe keys
+- SNS distributes new findings downstream
+
+The skills remain unchanged and stateless.
+
+## When to use it
+
+- You want a repo-owned example of a persistent execution path beyond IAM departures
+- You need a minimal AWS pattern for continuous ingest → detect with replay safety
+- You want to wire any compatible `ingest-*` and `detect-*` skill pair into a
+  queue-driven loop
+
+## What it does not do
+
+- It is not a generic sink framework for every cloud or SIEM
+- It does not package Lambda zip artifacts for you
+- It does not hardcode a specific skill family, sink vendor, or storage format
+
+## Required environment variables
+
+### Ingest Lambda
+
+- `INGEST_SKILL_CMD`
+  Example: `python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py --output-format native`
+- `DETECT_QUEUE_URL`
+
+### Detect Lambda
+
+- `DETECT_SKILL_CMD`
+  Example: `python skills/detection/detect-lateral-movement/src/detect.py --output-format native`
+- `DEDUPE_TABLE`
+- `SNS_TOPIC_ARN`
+
+## Packaging model
+
+The CloudFormation template expects:
+- an existing source bucket name
+- one zip for the ingest handler
+- one zip for the detect handler
+
+That keeps the template deployable without assuming SAM or an external build
+system.
+
+## Security model
+
+- no shell invocation; skill commands are tokenized with `shlex.split`
+- `subprocess.run(..., shell=False)` only
+- DynamoDB conditional writes prevent duplicate publish on replay
+- SNS only sees deduped findings
+- operators should scope the Lambda roles to the specific source bucket, queue,
+  topic, and table ARNs in their environment

--- a/runners/aws-s3-sqs-detect/src/detect_handler.py
+++ b/runners/aws-s3-sqs-detect/src/detect_handler.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Any
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only in minimal local test envs
+    boto3 = None
+
+    class ClientError(Exception):
+        pass
+
+
+def _sns_client():
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for the AWS runner")
+    return boto3.client("sns")
+
+
+def _dynamodb_resource():
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for the AWS runner")
+    return boto3.resource("dynamodb")
+
+
+def _skill_command() -> list[str]:
+    raw = os.environ.get("DETECT_SKILL_CMD", "").strip()
+    if not raw:
+        raise ValueError("DETECT_SKILL_CMD is required")
+    return shlex.split(raw)
+
+
+def _run_skill(lines: list[str]) -> list[str]:
+    completed = subprocess.run(
+        _skill_command(),
+        input="\n".join(lines) + ("\n" if lines else ""),
+        text=True,
+        capture_output=True,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "detect skill failed")
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _extract_uid(record: dict[str, Any]) -> str:
+    finding_info = record.get("finding_info")
+    if isinstance(finding_info, dict):
+        uid = finding_info.get("uid")
+        if isinstance(uid, str) and uid:
+            return uid
+
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        uid = metadata.get("uid")
+        if isinstance(uid, str) and uid:
+            return uid
+
+    event_uid = record.get("event_uid")
+    if isinstance(event_uid, str) and event_uid:
+        return event_uid
+
+    raise ValueError("record is missing finding_info.uid, metadata.uid, and event_uid")
+
+
+def _dedupe_table():
+    table_name = os.environ.get("DEDUPE_TABLE", "").strip()
+    if not table_name:
+        raise ValueError("DEDUPE_TABLE is required")
+    return _dynamodb_resource().Table(table_name)
+
+
+def _sns_topic() -> str:
+    topic = os.environ.get("SNS_TOPIC_ARN", "").strip()
+    if not topic:
+        raise ValueError("SNS_TOPIC_ARN is required")
+    return topic
+
+
+def _put_if_new(uid: str, payload: str) -> bool:
+    table = _dedupe_table()
+    item = {
+        "pk": uid,
+        "seen_at": datetime.now(UTC).isoformat(),
+        "payload_sha256": sha256(payload.encode("utf-8")).hexdigest(),
+    }
+    try:
+        table.put_item(Item=item, ConditionExpression="attribute_not_exists(pk)")
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, int]:
+    input_lines = [record["body"] for record in event.get("Records", [])]
+    findings = _run_skill(input_lines)
+
+    published = 0
+    duplicates = 0
+    for line in findings:
+        record = json.loads(line)
+        uid = _extract_uid(record)
+        if _put_if_new(uid, line):
+            _sns_client().publish(TopicArn=_sns_topic(), Message=line, Subject=f"skill-finding:{uid}")
+            published += 1
+        else:
+            duplicates += 1
+
+    return {"messages_processed": len(input_lines), "published": published, "duplicates": duplicates}

--- a/runners/aws-s3-sqs-detect/src/ingest_handler.py
+++ b/runners/aws-s3-sqs-detect/src/ingest_handler.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from collections.abc import Iterable
+from typing import Any
+
+try:
+    import boto3
+except ImportError:  # pragma: no cover - exercised only in minimal local test envs
+    boto3 = None
+
+
+def _s3_client():
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for the AWS runner")
+    return boto3.client("s3")
+
+
+def _sqs_client():
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for the AWS runner")
+    return boto3.client("sqs")
+
+
+def _skill_command() -> list[str]:
+    raw = os.environ.get("INGEST_SKILL_CMD", "").strip()
+    if not raw:
+        raise ValueError("INGEST_SKILL_CMD is required")
+    return shlex.split(raw)
+
+
+def _run_skill(payload: str) -> list[str]:
+    completed = subprocess.run(
+        _skill_command(),
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "ingest skill failed")
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _batched(values: Iterable[str], size: int = 10) -> Iterable[list[str]]:
+    batch: list[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) == size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _queue_url() -> str:
+    url = os.environ.get("DETECT_QUEUE_URL", "").strip()
+    if not url:
+        raise ValueError("DETECT_QUEUE_URL is required")
+    return url
+
+
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, int]:
+    total_records = 0
+    total_messages = 0
+
+    for record in event.get("Records", []):
+        bucket = record["s3"]["bucket"]["name"]
+        key = record["s3"]["object"]["key"]
+        obj = _s3_client().get_object(Bucket=bucket, Key=key)
+        payload = obj["Body"].read().decode("utf-8")
+        lines = _run_skill(payload)
+        total_records += 1
+        for line in lines:
+            _sqs_client().send_message(QueueUrl=_queue_url(), MessageBody=line)
+            total_messages += 1
+
+    return {"objects_processed": total_records, "messages_enqueued": total_messages}

--- a/runners/aws-s3-sqs-detect/template.yaml
+++ b/runners/aws-s3-sqs-detect/template.yaml
@@ -1,0 +1,166 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Reference runner for S3 -> ingest Lambda -> SQS -> detect Lambda -> DynamoDB dedupe -> SNS
+
+Parameters:
+  SourceBucketName:
+    Type: String
+    Description: Existing S3 bucket that receives raw objects for the ingest Lambda
+  IngestCodeBucket:
+    Type: String
+  IngestCodeKey:
+    Type: String
+  DetectCodeBucket:
+    Type: String
+  DetectCodeKey:
+    Type: String
+  IngestSkillCommand:
+    Type: String
+    Description: Command run by the ingest Lambda, for example `python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py --output-format native`
+  DetectSkillCommand:
+    Type: String
+    Description: Command run by the detect Lambda, for example `python skills/detection/detect-lateral-movement/src/detect.py --output-format native`
+
+Resources:
+  DetectQueueDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600
+
+  DetectQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DetectQueueDlq.Arn
+        maxReceiveCount: 5
+
+  DedupeTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: expires_at
+        Enabled: false
+
+  AlertsTopic:
+    Type: AWS::SNS::Topic
+
+  IngestRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: ingest-runner
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Sub arn:aws:s3:::${SourceBucketName}/*
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                Resource: !GetAtt DetectQueue.Arn
+
+  DetectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: detect-runner
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource: !GetAtt DedupeTable.Arn
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref AlertsTopic
+              - Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !GetAtt DetectQueue.Arn
+
+  IngestFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.11
+      Timeout: 300
+      Handler: ingest_handler.lambda_handler
+      Role: !GetAtt IngestRole.Arn
+      Code:
+        S3Bucket: !Ref IngestCodeBucket
+        S3Key: !Ref IngestCodeKey
+      Environment:
+        Variables:
+          INGEST_SKILL_CMD: !Ref IngestSkillCommand
+          DETECT_QUEUE_URL: !Ref DetectQueue
+
+  DetectFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.11
+      Timeout: 300
+      Handler: detect_handler.lambda_handler
+      Role: !GetAtt DetectRole.Arn
+      Code:
+        S3Bucket: !Ref DetectCodeBucket
+        S3Key: !Ref DetectCodeKey
+      Environment:
+        Variables:
+          DETECT_SKILL_CMD: !Ref DetectSkillCommand
+          DEDUPE_TABLE: !Ref DedupeTable
+          SNS_TOPIC_ARN: !Ref AlertsTopic
+
+  IngestInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref IngestFunction
+      Principal: s3.amazonaws.com
+      SourceArn: !Sub arn:aws:s3:::${SourceBucketName}
+
+  DetectEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 10
+      EventSourceArn: !GetAtt DetectQueue.Arn
+      FunctionName: !Ref DetectFunction
+
+Outputs:
+  SourceBucketName:
+    Value: !Ref SourceBucketName
+  DetectQueueUrl:
+    Value: !Ref DetectQueue
+  AlertsTopicArn:
+    Value: !Ref AlertsTopic
+  DedupeTableName:
+    Value: !Ref DedupeTable

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_XML = ROOT / "coverage.xml"
+OVERALL_FLOOR = 70.0
+LAYER_FLOORS = {
+    "detection": 80.0,
+    "evaluation": 60.0,
+}
+
+
+def _read_coverage_xml(path: Path) -> ET.Element:
+    try:
+        return ET.parse(path).getroot()
+    except FileNotFoundError:
+        print(f"Coverage validation failed: missing report `{path}`", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _collect_layer_stats(root: ET.Element) -> dict[str, tuple[int, int]]:
+    by_layer: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    for cls in root.findall(".//class"):
+        filename = cls.get("filename", "")
+        parts = filename.split("/")
+        if parts[0] == "skills":
+            parts = parts[1:]
+        if len(parts) < 2:
+            continue
+        layer = parts[0]
+        lines = cls.findall("./lines/line")
+        total = len(lines)
+        hit = sum(1 for line in lines if int(line.get("hits", "0")) > 0)
+        by_layer[layer][0] += hit
+        by_layer[layer][1] += total
+    return {layer: (stats[0], stats[1]) for layer, stats in by_layer.items()}
+
+
+def _coverage_percent(hit: int, total: int) -> float:
+    return (100.0 * hit / total) if total else 0.0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv or sys.argv[1:]
+    xml_path = Path(args[0]) if args else DEFAULT_XML
+
+    root = _read_coverage_xml(xml_path)
+    line_rate = float(root.get("line-rate", "0.0")) * 100.0
+    errors: list[str] = []
+    if line_rate < OVERALL_FLOOR:
+        errors.append(
+            f"overall coverage {line_rate:.2f}% is below required floor {OVERALL_FLOOR:.0f}%"
+        )
+
+    layer_stats = _collect_layer_stats(root)
+    for layer, floor in LAYER_FLOORS.items():
+        hit, total = layer_stats.get(layer, (0, 0))
+        pct = _coverage_percent(hit, total)
+        if pct < floor:
+            errors.append(f"{layer} coverage {pct:.2f}% is below required floor {floor:.0f}%")
+
+    if errors:
+        print("Coverage validation failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        "Coverage validation passed: "
+        f"overall={line_rate:.2f}% "
+        + " ".join(
+            f"{layer}={_coverage_percent(*layer_stats[layer]):.2f}%"
+            for layer in sorted(LAYER_FLOORS)
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import sys
-import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
+
+from defusedxml import ElementTree as ET
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_XML = ROOT / "coverage.xml"

--- a/tests/integration/test_runner_template.py
+++ b/tests/integration/test_runner_template.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+INGEST = _load_module(
+    "cloud_security_runner_ingest_handler_test",
+    ROOT / "runners" / "aws-s3-sqs-detect" / "src" / "ingest_handler.py",
+)
+DETECT = _load_module(
+    "cloud_security_runner_detect_handler_test",
+    ROOT / "runners" / "aws-s3-sqs-detect" / "src" / "detect_handler.py",
+)
+
+
+class TestAwsS3SqsDetectRunner:
+    def test_ingest_skill_command_requires_env(self, monkeypatch):
+        monkeypatch.delenv("INGEST_SKILL_CMD", raising=False)
+        try:
+            INGEST._skill_command()
+        except ValueError as exc:
+            assert "INGEST_SKILL_CMD" in str(exc)
+        else:
+            raise AssertionError("expected INGEST_SKILL_CMD validation failure")
+
+    def test_ingest_batches_lines_for_sqs_limits(self):
+        batches = list(INGEST._batched([str(i) for i in range(23)], size=10))
+        assert [len(batch) for batch in batches] == [10, 10, 3]
+
+    def test_detect_extracts_uid_from_finding_info(self):
+        record = {"finding_info": {"uid": "det-123"}, "metadata": {"uid": "meta-123"}}
+        assert DETECT._extract_uid(record) == "det-123"
+
+    def test_detect_falls_back_to_metadata_uid(self):
+        record = {"metadata": {"uid": "meta-123"}}
+        assert DETECT._extract_uid(record) == "meta-123"
+
+    def test_detect_falls_back_to_event_uid(self):
+        record = {"event_uid": "evt-123"}
+        assert DETECT._extract_uid(record) == "evt-123"

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -48,6 +48,10 @@ OCSF_METADATA = _load_module(
     "cloud_security_validate_ocsf_metadata_test",
     SCRIPTS / "validate_ocsf_metadata.py",
 )
+TEST_COVERAGE = _load_module(
+    "cloud_security_validate_test_coverage_test",
+    SCRIPTS / "validate_test_coverage.py",
+)
 
 
 class TestSkillValidationCommon:
@@ -105,6 +109,76 @@ class TestValidationScripts:
 
     def test_ocsf_metadata_validator_passes(self):
         assert OCSF_METADATA.main() == 0
+
+    def test_test_coverage_validator_passes(self, tmp_path: Path):
+        report = tmp_path / "coverage.xml"
+        report.write_text(
+            """<?xml version="1.0" ?>
+<coverage line-rate="0.82">
+  <packages>
+    <package name="skills">
+      <classes>
+        <class filename="skills/detection/example/src/detect.py">
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" />
+            <line number="3" hits="1" />
+            <line number="4" hits="1" />
+            <line number="5" hits="0" />
+          </lines>
+        </class>
+        <class filename="skills/evaluation/example/src/checks.py">
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" />
+            <line number="3" hits="1" />
+            <line number="4" hits="0" />
+            <line number="5" hits="0" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+""",
+            encoding="utf-8",
+        )
+        assert TEST_COVERAGE.main([str(report)]) == 0
+
+    def test_test_coverage_validator_fails_low_detection_floor(self, tmp_path: Path):
+        report = tmp_path / "coverage-low.xml"
+        report.write_text(
+            """<?xml version="1.0" ?>
+<coverage line-rate="0.82">
+  <packages>
+    <package name="skills">
+      <classes>
+        <class filename="skills/detection/example/src/detect.py">
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" />
+            <line number="3" hits="1" />
+            <line number="4" hits="0" />
+            <line number="5" hits="0" />
+          </lines>
+        </class>
+        <class filename="skills/evaluation/example/src/checks.py">
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" />
+            <line number="3" hits="1" />
+            <line number="4" hits="0" />
+            <line number="5" hits="0" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+""",
+            encoding="utf-8",
+        )
+        assert TEST_COVERAGE.main([str(report)]) == 1
 
     def test_gpu_skill_ai_framework_depth_is_registered(self):
         registry = json.loads((ROOT / "docs" / "framework-coverage.json").read_text())


### PR DESCRIPTION
Summary
- add a dedicated full-suite coverage lane plus layer-aware validation for overall, detection, and evaluation coverage floors
- add a repo-owned AWS reference runner template for S3 to ingest Lambda to SQS to detect Lambda to DynamoDB dedupe to SNS
- update README and runtime/architecture docs so generic persistent execution is no longer docs-only outside IAM departures

Validation
- full-suite pytest with coverage XML generation
- python scripts/validate_test_coverage.py coverage.xml
- integration tests for the coverage validator and runner helpers
- cfn-lint on runners/aws-s3-sqs-detect/template.yaml
- ruff on new Python files
- python -m mypy on the new coverage validator and integration tests
- python scripts/validate_skill_contract.py