### PR TITLE
feat: add native mode to gcp scc ingest

### DIFF
--- a/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
@@ -14,7 +14,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: ocsf
+output_formats: ocsf, native
 ---
 
 # ingest-gcp-scc-ocsf
@@ -47,3 +47,22 @@ OCSF 1.8 Detection Findings with:
 - SCC severity mapped to OCSF severity_id
 - GCP resource context in `resources[]` and `cloud`
 - raw passthrough provenance preserved in `observables[]`
+
+When `--output-format native` is selected, the skill emits the repo's native enriched finding shape instead of the OCSF envelope.
+
+## Native output format
+
+`--output-format native` returns one JSON object per SCC finding with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "detection_finding"`
+- `event_uid` and `finding_uid`
+- `provider`, `account_uid`, `region`
+- `time_ms`
+- `severity_id`, `severity`, `status_id`, `status`
+- `title`, `description`, `finding_types`
+- `resources`, `cloud`, `source`, and `evidence`
+
+The native shape keeps the same normalized semantics as the OCSF projection,
+but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.

--- a/skills/ingestion/ingest-gcp-scc-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/src/ingest.py
@@ -1,4 +1,8 @@
-"""Convert GCP Security Command Center findings to OCSF 1.8 Detection Finding."""
+"""Convert GCP Security Command Center findings to OCSF 1.8 Detection Finding.
+
+Output defaults to OCSF JSONL, or emits the repo's native enriched finding
+shape when --output-format native is selected.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +16,7 @@ from typing import Any, Iterable
 
 SKILL_NAME = "ingest-gcp-scc-ocsf"
 OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-04"
 
 CLASS_UID = 2004
 CLASS_NAME = "Detection Finding"
@@ -82,10 +87,10 @@ def _project_id(finding: dict[str, Any]) -> str:
     return ""
 
 
-def convert_finding(finding: dict[str, Any]) -> dict[str, Any]:
+def _build_canonical_finding(finding: dict[str, Any]) -> dict[str, Any]:
     project = _project_id(finding)
     event_time = parse_ts_ms(finding.get("eventTime") or finding.get("createTime"))
-    uid = f"det-scc-{hashlib.sha256(str(finding.get('name', '')).encode()).hexdigest()[:8]}"
+    finding_uid = f"det-scc-{hashlib.sha256(str(finding.get('name', '')).encode()).hexdigest()[:8]}"
     resource_name = str(finding.get("resourceName") or "")
     category = str(finding.get("category") or "Security Command Center finding")
     description = str(finding.get("description") or category)
@@ -93,44 +98,36 @@ def convert_finding(finding: dict[str, Any]) -> dict[str, Any]:
     finding_class = str(finding.get("findingClass") or "")
     severity = str(finding.get("severity") or "UNSPECIFIED")
 
-    event: dict[str, Any] = {
-        "activity_id": ACTIVITY_CREATE,
-        "category_uid": CATEGORY_UID,
-        "category_name": CATEGORY_NAME,
-        "class_uid": CLASS_UID,
-        "class_name": CLASS_NAME,
-        "type_uid": TYPE_UID,
+    canonical: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "event_uid": str(finding.get("name") or finding_uid),
+        "finding_uid": finding_uid,
+        "provider": "GCP",
+        "account_uid": project,
+        "region": "",
+        "time_ms": event_time,
         "severity_id": severity_to_id(severity),
         "status_id": STATUS_SUCCESS,
-        "time": event_time,
-        "metadata": {
-            "version": OCSF_VERSION,
-            "uid": str(finding.get("name") or uid),
-            "product": {
-                "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
-                "feature": {"name": SKILL_NAME},
-            },
-            "labels": ["detection-engineering", "gcp", "scc", "ingest", "passthrough"],
-        },
-        "finding_info": {
-            "uid": uid,
-            "title": category,
-            "desc": description,
-            "types": [category],
-            "first_seen_time": event_time,
-            "last_seen_time": event_time,
-            "attacks": [],
-        },
+        "status": "success",
+        "severity": severity,
+        "title": category,
+        "description": description,
+        "finding_types": [category],
+        "first_seen_time_ms": event_time,
+        "last_seen_time_ms": event_time,
+        "attacks": [],
         "resources": [{"name": resource_name, "type": finding_class or "scc-finding"}] if resource_name else [],
         "cloud": {"provider": "GCP"},
-        "observables": [
-            {"name": "scc.name", "type": "Other", "value": str(finding.get("name") or "")},
-            {"name": "scc.state", "type": "Other", "value": state},
-            {"name": "scc.category", "type": "Other", "value": category},
-            {"name": "scc.severity", "type": "Other", "value": severity},
-            {"name": "scc.finding_class", "type": "Other", "value": finding_class},
-        ],
+        "source": {
+            "kind": "gcp.security-command-center",
+            "finding_name": str(finding.get("name") or ""),
+            "state": state,
+            "category": category,
+            "finding_class": finding_class,
+            "resource_name": resource_name,
+        },
         "evidence": {
             "events_observed": 1,
             "first_seen_time": event_time,
@@ -139,8 +136,72 @@ def convert_finding(finding: dict[str, Any]) -> dict[str, Any]:
         },
     }
     if project:
-        event["cloud"]["account"] = {"uid": project}
+        canonical["cloud"]["account"] = {"uid": project}
+    return canonical
+
+
+def _build_observables(canonical: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"name": "scc.name", "type": "Other", "value": canonical["source"]["finding_name"]},
+        {"name": "scc.state", "type": "Other", "value": canonical["source"]["state"]},
+        {"name": "scc.category", "type": "Other", "value": canonical["source"]["category"]},
+        {"name": "scc.severity", "type": "Other", "value": canonical["severity"]},
+        {"name": "scc.finding_class", "type": "Other", "value": canonical["source"]["finding_class"]},
+    ]
+
+
+def _render_ocsf_finding(canonical: dict[str, Any]) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "activity_id": ACTIVITY_CREATE,
+        "category_uid": CATEGORY_UID,
+        "category_name": CATEGORY_NAME,
+        "class_uid": CLASS_UID,
+        "class_name": CLASS_NAME,
+        "type_uid": TYPE_UID,
+        "severity_id": canonical["severity_id"],
+        "status_id": canonical["status_id"],
+        "time": canonical["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": canonical["event_uid"],
+            "product": {
+                "name": "cloud-ai-security-skills",
+                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["detection-engineering", "gcp", "scc", "ingest", "passthrough"],
+        },
+        "finding_info": {
+            "uid": canonical["finding_uid"],
+            "title": canonical["title"],
+            "desc": canonical["description"],
+            "types": canonical["finding_types"],
+            "first_seen_time": canonical["first_seen_time_ms"],
+            "last_seen_time": canonical["last_seen_time_ms"],
+            "attacks": canonical["attacks"],
+        },
+        "resources": canonical["resources"],
+        "cloud": canonical["cloud"],
+        "observables": _build_observables(canonical),
+        "evidence": canonical["evidence"],
+    }
     return event
+
+
+def _render_native_finding(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["source_skill"] = SKILL_NAME
+    native["output_format"] = "native"
+    return native
+
+
+def convert_finding(finding: dict[str, Any]) -> dict[str, Any]:
+    return _render_ocsf_finding(_build_canonical_finding(finding))
+
+
+def convert_finding_native(finding: dict[str, Any]) -> dict[str, Any]:
+    return _render_native_finding(_build_canonical_finding(finding))
 
 
 def iter_raw_findings(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
@@ -183,25 +244,30 @@ def iter_raw_findings(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
             yield item
 
 
-def ingest(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     for finding in iter_raw_findings(stream):
         valid, reason = validate_finding(finding)
         if not valid:
             print(f"[{SKILL_NAME}] skipping finding: {reason}", file=sys.stderr)
             continue
-        yield convert_finding(finding)
+        canonical = _build_canonical_finding(finding)
+        if output_format == "native":
+            yield _render_native_finding(canonical)
+        else:
+            yield _render_ocsf_finding(canonical)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Convert GCP SCC findings to OCSF 1.8 Detection Finding JSONL.")
     parser.add_argument("input", nargs="?", help="Input JSON or JSONL file. Defaults to stdin.")
     parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=("ocsf", "native"), default="ocsf", help="Output shape. Defaults to ocsf.")
     args = parser.parse_args(argv)
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
     try:
-        for event in ingest(in_stream):
+        for event in ingest(in_stream, output_format=args.output_format):
             out_stream.write(json.dumps(event, separators=(",", ":")) + "\n")
     finally:
         if args.input:

--- a/skills/ingestion/ingest-gcp-scc-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/tests/test_ingest.py
@@ -23,6 +23,7 @@ SEVERITY_MEDIUM = _INGEST.SEVERITY_MEDIUM
 SKILL_NAME = _INGEST.SKILL_NAME
 TYPE_UID = _INGEST.TYPE_UID
 convert_finding = _INGEST.convert_finding
+convert_finding_native = _INGEST.convert_finding_native
 ingest = _INGEST.ingest
 iter_raw_findings = _INGEST.iter_raw_findings
 severity_to_id = _INGEST.severity_to_id
@@ -85,6 +86,23 @@ class TestConvert:
         assert event["cloud"]["account"]["uid"] == "prod-project"
         assert event["finding_info"]["title"] == "PUBLIC_BUCKET"
 
+    def test_native_output_has_no_ocsf_envelope(self):
+        native = convert_finding_native(_finding())
+        assert native["schema_mode"] == "native"
+        assert native["record_type"] == "detection_finding"
+        assert native["provider"] == "GCP"
+        assert native["title"] == "PUBLIC_BUCKET"
+        assert "class_uid" not in native
+        assert "category_uid" not in native
+        assert "metadata" not in native
+
+    def test_native_and_ocsf_share_same_uid_basis(self):
+        raw = _finding(name="organizations/123/sources/456/findings/finding-same")
+        native = convert_finding_native(raw)
+        ocsf = convert_finding(raw)
+        assert native["event_uid"] == ocsf["metadata"]["uid"] == raw["name"]
+        assert native["finding_uid"] == ocsf["finding_info"]["uid"]
+
 
 class TestStream:
     def test_wrapper_parsing(self):
@@ -95,3 +113,13 @@ class TestStream:
         produced = list(ingest([RAW_FIXTURE.read_text()]))
         expected = _load_jsonl(OCSF_FIXTURE)
         assert produced == expected
+
+    def test_native_output_mode_emits_enriched_findings(self):
+        produced = list(ingest([RAW_FIXTURE.read_text()], output_format="native"))
+        assert produced
+        first = produced[0]
+        assert first["schema_mode"] == "native"
+        assert first["record_type"] == "detection_finding"
+        assert first["provider"] == "GCP"
+        assert "class_uid" not in first
+        assert "metadata" not in first


### PR DESCRIPTION
## Summary
- add `--output-format ocsf|native` to `ingest-gcp-scc-ocsf`
- route SCC passthrough ingestion through a canonical internal finding shape before rendering OCSF or native output
- update the skill contract and tests to prove native mode preserves the same UID basis without leaking the OCSF envelope

## Validation
- `uv run pytest skills/ingestion/ingest-gcp-scc-ocsf/tests/test_ingest.py -q -o addopts=''`
- `uv run ruff check skills/ingestion/ingest-gcp-scc-ocsf/src/ingest.py skills/ingestion/ingest-gcp-scc-ocsf/tests/test_ingest.py --config pyproject.toml`
- `python scripts/validate_skill_contract.py`
