### PR TITLE
ci: sign SBOM artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,9 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract, type-check, safe-skill-bar]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -244,10 +247,20 @@ jobs:
             --format cyclonedx1.5 \
             --all-groups \
             --output-file cloud-ai-security-skills-full-lock.cdx.json
+      - uses: sigstore/cosign-installer@v3.8.1
+      - name: Sign SBOM with GitHub OIDC
+        run: |
+          cosign sign-blob --yes \
+            --output-signature cloud-ai-security-skills-full-lock.cdx.json.sig \
+            --output-certificate cloud-ai-security-skills-full-lock.cdx.json.pem \
+            cloud-ai-security-skills-full-lock.cdx.json
       - uses: actions/upload-artifact@v4
         with:
           name: cyclonedx-sbom
-          path: cloud-ai-security-skills-full-lock.cdx.json
+          path: |
+            cloud-ai-security-skills-full-lock.cdx.json
+            cloud-ai-security-skills-full-lock.cdx.json.sig
+            cloud-ai-security-skills-full-lock.cdx.json.pem
 
   # ── IaC validation (CloudFormation + Terraform in one job) ─────
   validate-iac:

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -27,7 +27,7 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - `coverage`
   - repo coverage gates for overall, detection, and evaluation floors
 - `sbom`
-  - publishes a CycloneDX artifact for the full locked dependency graph
+  - publishes a signed CycloneDX artifact set for the full locked dependency graph
 - `validate-iac`
   - CloudFormation and Terraform validation
 - `agent-bom`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -69,7 +69,7 @@ git push origin vX.Y.Z
 4. Verify GitHub Actions passed on the tagged commit if a release workflow uses
    tag triggers.
 5. If a release artifact is published, include or reference the latest
-   CycloneDX SBOM artifact from CI.
+   signed CycloneDX SBOM artifact set from CI.
 
 ## Post-Release
 

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -84,12 +84,24 @@ We do **not** add dependencies casually for:
 The CI pipeline now publishes a CycloneDX SBOM artifact generated from the
 locked dependency graph.
 
+That artifact is now accompanied by a Sigstore keyless signature and
+certificate generated from GitHub Actions OIDC during the `sbom` lane.
+
 That artifact is intended to support:
 
 - auditor review
 - release review
 - dependency provenance discussion
 - downstream customer ingest into their own supply-chain tooling
+
+The uploaded artifact set contains:
+
+- `cloud-ai-security-skills-full-lock.cdx.json`
+- `cloud-ai-security-skills-full-lock.cdx.json.sig`
+- `cloud-ai-security-skills-full-lock.cdx.json.pem`
+
+This gives consumers both the SBOM itself and the materials needed to verify
+that the CI workflow, not an out-of-band process, produced it.
 
 See:
 
@@ -101,6 +113,6 @@ See:
 
 - export a runtime-group SBOM artifact once the repo's non-package group layout
   supports a clean grouped CycloneDX export without workarounds
-- attach the CycloneDX artifact to tagged releases
-- add signed provenance or release attestations if the release flow grows beyond
-  the current repo-level tag process
+- attach the signed CycloneDX artifact set to tagged releases
+- add broader signed provenance or release attestations if the release flow
+  grows beyond the current repo-level tag process


### PR DESCRIPTION
## Summary
- sign the CycloneDX SBOM artifact in CI with Sigstore keyless signing via GitHub OIDC
- upload the SBOM, signature, and certificate together as one artifact set
- update the supply-chain and release docs so the trust story matches the workflow

## Validation
- python scripts/validate_skill_contract.py
- GitHub-only behavior: the actual OIDC signature step runs in Actions
