### PR TITLE
docs: tighten README visuals and schema language

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Security skills for cloud and AI systems. Use source-specific ingest, discovery,
 
 | If you need to... | Start with... | Typical output |
 |---|---|---|
-| Normalize one raw source | `ingest-*` | `native` or OCSF JSONL |
-| Detect suspicious behavior | `ingest-*` + `detect-*` | native finding JSON or OCSF Detection Finding |
+| Normalize one raw source | `ingest-*` | repo-native JSONL or OCSF JSONL |
+| Detect suspicious behavior | `ingest-*` + `detect-*` | repo-native finding JSON or OCSF Detection Finding |
 | Benchmark posture | `evaluation/*` | benchmark or control results |
 | Inventory cloud or AI assets | `discover-environment` or `discover-ai-bom` | graph JSON, AI BOM, OCSF bridge |
 | Build evidence for audits | `discover-control-evidence` or `discover-cloud-control-evidence` | evidence JSON |
@@ -56,11 +56,36 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
   > findings.native.jsonl
 ```
 
-`native` means the repo emits its own stable schema with fields like `schema_mode`, `canonical_schema_version`, `record_type`, and stable UIDs. It is not raw vendor JSON and not an OCSF envelope with fields stripped out.
+## Native vs OCSF
 
-## One Visual
+| Mode | What it means | Use it when... |
+|---|---|---|
+| `native` | repo-owned JSONL with fields like `schema_mode`, `canonical_schema_version`, `record_type`, and stable UIDs | you want the repo's stable schema without an interoperability envelope |
+| `ocsf` | OCSF JSONL pinned to the repo's OCSF contract | you want a standard external schema for SIEMs, exports, or downstream tooling |
+| `canonical` | internal-only normalization model | you are reading the docs or implementation, not choosing a CLI output mode |
+| `bridge` | interoperable output with native context preserved | you need both standard fields and repo context in one payload |
 
-![Start here guide](docs/images/start-here-guide.svg)
+`native` is not raw vendor JSON and not an OCSF envelope with fields stripped out.
+
+## Flagship Example
+
+The flagship example skill family is IAM departures remediation: a guarded, event-driven workflow with a dual audit trail and clear trust boundaries.
+
+![IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
+
+## Trust, Security, And Supply Chain
+
+- Read-only by default; write paths require human approval and audit.
+- No hardcoded secrets; prefer workload identity and short-lived credentials.
+- Official vendor SDKs first, repo-owned code second, canonical OSS only when needed.
+- CI validates skill contracts, integrity, safe-skill bar, coverage, type checking, and SBOM generation.
+
+Read next:
+- [SECURITY.md](SECURITY.md)
+- [SECURITY_BAR.md](SECURITY_BAR.md)
+- [docs/CREDENTIAL_PROVENANCE.md](docs/CREDENTIAL_PROVENANCE.md)
+- [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md)
+- [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md)
 
 ## Core Surfaces
 
@@ -124,26 +149,10 @@ Read next:
 </details>
 
 <details>
-<summary><b>Trust, Security, And Supply Chain</b></summary>
-
-- Read-only by default; write paths require human approval and audit.
-- No hardcoded secrets; prefer workload identity and short-lived credentials.
-- Official vendor SDKs first, repo-owned code second, canonical OSS only when needed.
-- CI validates skill contracts, integrity, safe-skill bar, coverage, type checking, and SBOM generation.
-
-Read next:
-- [SECURITY.md](SECURITY.md)
-- [SECURITY_BAR.md](SECURITY_BAR.md)
-- [docs/CREDENTIAL_PROVENANCE.md](docs/CREDENTIAL_PROVENANCE.md)
-- [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md)
-- [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md)
-
-</details>
-
-<details>
 <summary><b>More Diagrams And Docs</b></summary>
 
 High-signal visuals:
+- [Start here guide](docs/images/start-here-guide.svg)
 - [Runtime surfaces](docs/images/runtime-surfaces.svg)
 - [Repository architecture](docs/images/repo-architecture.svg)
 - [Detection engineering pipeline](docs/images/detection-pipeline.svg)

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,54 +1,46 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
-  <title id="title">Runtime surfaces call the same skill contract</title>
-  <desc id="desc">CLI, CI, MCP, and persistent wrappers all invoke the same skill bundle and produce the same governed outputs.</desc>
-  <rect width="1280" height="520" fill="#08111f"/>
-  <rect x="24" y="24" width="1232" height="472" rx="28" fill="#0f172a" stroke="#334155"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
+  <title id="title">Runtime surfaces use one shared skill contract</title>
+  <desc id="desc">CLI, CI, MCP, and persistent runners call the same skill contract and implementation bundle.</desc>
+  <rect width="1280" height="460" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="412" rx="28" fill="#0f172a" stroke="#334155"/>
 
   <g font-family="Arial, sans-serif">
     <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">One skill contract, many runtime surfaces</text>
-    <text x="56" y="102" fill="#94a3b8" font-size="17">CLI, CI, MCP, and persistent wrappers are access paths. They do not fork the skill implementation.</text>
+    <text x="56" y="102" fill="#94a3b8" font-size="18">Runtimes add scheduling, gating, and transport. They do not create a second implementation model.</text>
 
-    <rect x="56" y="152" width="220" height="240" rx="20" fill="#172554" stroke="#60a5fa"/>
-    <text x="82" y="190" fill="#dbeafe" font-size="24" font-weight="700">Runtime surfaces</text>
-    <text x="82" y="226" fill="#eff6ff" font-size="17" font-weight="700">CLI / Unix pipes</text>
-    <text x="82" y="250" fill="#cbd5e1" font-size="15">one-shot analysis and local pipelines</text>
-    <text x="82" y="286" fill="#eff6ff" font-size="17" font-weight="700">CI</text>
-    <text x="82" y="310" fill="#cbd5e1" font-size="15">PR checks, SARIF, scheduled snapshots</text>
-    <text x="82" y="346" fill="#eff6ff" font-size="17" font-weight="700">MCP</text>
-    <text x="82" y="370" fill="#cbd5e1" font-size="15">Claude, Codex, Cursor, Windsurf, Cortex</text>
+    <rect x="56" y="148" width="250" height="190" rx="22" fill="#172554" stroke="#60a5fa"/>
+    <text x="84" y="188" fill="#dbeafe" font-size="24" font-weight="700">Access paths</text>
+    <text x="84" y="224" fill="#eff6ff" font-size="18" font-weight="700">CLI / Unix pipes</text>
+    <text x="84" y="250" fill="#cbd5e1" font-size="16">local runs and pipelines</text>
+    <text x="84" y="282" fill="#eff6ff" font-size="18" font-weight="700">CI and MCP</text>
+    <text x="84" y="308" fill="#cbd5e1" font-size="16">checks, agents, guarded actions</text>
 
-    <rect x="360" y="118" width="560" height="308" rx="24" fill="#111827" stroke="#94a3b8"/>
-    <text x="390" y="160" fill="#f8fafc" font-size="28" font-weight="700">Shared skill bundle</text>
-    <text x="390" y="192" fill="#94a3b8" font-size="16">Every surface calls the same repo-owned contract.</text>
+    <rect x="390" y="120" width="500" height="246" rx="24" fill="#111827" stroke="#94a3b8"/>
+    <text x="420" y="162" fill="#f8fafc" font-size="28" font-weight="700">Shared skill bundle</text>
+    <text x="420" y="194" fill="#94a3b8" font-size="17">The same repo-owned contract and code path sits behind every wrapper.</text>
 
-    <rect x="392" y="228" width="216" height="150" rx="18" fill="#083344" stroke="#2dd4bf"/>
-    <text x="418" y="262" fill="#ccfbf1" font-size="22" font-weight="700">Contract</text>
-    <text x="418" y="290" fill="#ecfeff" font-size="15">SKILL.md</text>
-    <text x="418" y="312" fill="#cbd5e1" font-size="14">approval_model</text>
-    <text x="418" y="332" fill="#cbd5e1" font-size="14">execution_modes</text>
-    <text x="418" y="352" fill="#cbd5e1" font-size="14">input_formats / output_formats</text>
+    <rect x="424" y="226" width="180" height="102" rx="18" fill="#083344" stroke="#2dd4bf"/>
+    <text x="450" y="258" fill="#ccfbf1" font-size="22" font-weight="700">Contract</text>
+    <text x="450" y="286" fill="#ecfeff" font-size="15">SKILL.md</text>
+    <text x="450" y="306" fill="#cbd5e1" font-size="14">approval, formats, side effects</text>
 
-    <rect x="640" y="228" width="248" height="150" rx="18" fill="#3b0764" stroke="#c084fc"/>
-    <text x="668" y="262" fill="#f3e8ff" font-size="22" font-weight="700">Implementation</text>
-    <text x="668" y="290" fill="#f8fafc" font-size="15">src/ + tests/ + REFERENCES.md</text>
-    <text x="668" y="312" fill="#ddd6fe" font-size="14">same code path across wrappers</text>
-    <text x="668" y="332" fill="#ddd6fe" font-size="14">native / canonical / OCSF aware</text>
-    <text x="668" y="352" fill="#ddd6fe" font-size="14">deterministic IDs and audit rules</text>
+    <rect x="646" y="226" width="210" height="102" rx="18" fill="#3b0764" stroke="#c084fc"/>
+    <text x="674" y="258" fill="#f3e8ff" font-size="22" font-weight="700">Implementation</text>
+    <text x="674" y="286" fill="#f8fafc" font-size="15">src/ + tests/ + REFERENCES.md</text>
+    <text x="674" y="306" fill="#ddd6fe" font-size="14">one code path, deterministic outputs</text>
 
-    <rect x="1004" y="152" width="220" height="240" rx="20" fill="#1f2937" stroke="#94a3b8"/>
-    <text x="1030" y="190" fill="#f8fafc" font-size="24" font-weight="700">Outputs</text>
-    <text x="1030" y="226" fill="#f8fafc" font-size="17" font-weight="700">Data streams</text>
-    <text x="1030" y="250" fill="#cbd5e1" font-size="15">native, OCSF, bridge, evidence</text>
-    <text x="1030" y="286" fill="#f8fafc" font-size="17" font-weight="700">Exports</text>
-    <text x="1030" y="310" fill="#cbd5e1" font-size="15">SARIF, Mermaid, AI BOM</text>
-    <text x="1030" y="346" fill="#f8fafc" font-size="17" font-weight="700">Guarded writes</text>
-    <text x="1030" y="370" fill="#cbd5e1" font-size="15">dry-run plan and audited actions</text>
+    <rect x="974" y="148" width="250" height="190" rx="22" fill="#1f2937" stroke="#94a3b8"/>
+    <text x="1002" y="188" fill="#f8fafc" font-size="24" font-weight="700">Outputs</text>
+    <text x="1002" y="224" fill="#f8fafc" font-size="18" font-weight="700">repo-native, OCSF, bridge</text>
+    <text x="1002" y="250" fill="#cbd5e1" font-size="16">data streams and evidence</text>
+    <text x="1002" y="282" fill="#f8fafc" font-size="18" font-weight="700">SARIF, Mermaid, actions</text>
+    <text x="1002" y="308" fill="#cbd5e1" font-size="16">exports and audited write paths</text>
 
-    <path d="M276 272 L360 272" stroke="#60a5fa" stroke-width="4" fill="none"/>
-    <path d="M920 272 L1004 272" stroke="#94a3b8" stroke-width="4" fill="none"/>
+    <path d="M306 244 L390 244" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M890 244 L974 244" stroke="#94a3b8" stroke-width="5" fill="none"/>
 
-    <rect x="56" y="420" width="1168" height="48" rx="16" fill="#111827" stroke="#475569"/>
-    <text x="82" y="450" fill="#f8fafc" font-size="17" font-weight="700">Rule:</text>
-    <text x="138" y="450" fill="#cbd5e1" font-size="16">wrappers can add gating, scheduling, caller context, or sinks; they must not create a second implementation model.</text>
+    <rect x="56" y="376" width="1168" height="34" rx="12" fill="#111827" stroke="#475569"/>
+    <text x="84" y="399" fill="#f8fafc" font-size="16" font-weight="700">Rule:</text>
+    <text x="136" y="399" fill="#cbd5e1" font-size="16">wrappers may add gating, caller context, queues, or sinks; they must not fork the skill model.</text>
   </g>
 </svg>

--- a/docs/images/start-here-guide.svg
+++ b/docs/images/start-here-guide.svg
@@ -1,68 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="620" viewBox="0 0 1280 620" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
   <title id="title">Start here guide for cloud-ai-security-skills</title>
-  <desc id="desc">A guided operator map from common sources and goals to skill layers, outputs, and runtime surfaces.</desc>
-  <rect width="1280" height="620" fill="#08111f"/>
-  <rect x="24" y="24" width="1232" height="572" rx="28" fill="#0f172a" stroke="#334155"/>
+  <desc id="desc">A simplified operator map showing inputs, skill layers, outputs, and runtime surfaces.</desc>
+  <rect width="1280" height="520" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="472" rx="28" fill="#0f172a" stroke="#334155"/>
 
   <g font-family="Arial, sans-serif">
     <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">Start here</text>
-    <text x="56" y="102" fill="#94a3b8" font-size="17">Choose a source or goal, pick the layer, then run the same skill from CLI, CI, MCP, or a persistent wrapper.</text>
+    <text x="56" y="102" fill="#94a3b8" font-size="18">Pick an input, choose a skill layer, then decide whether you need repo-native or OCSF output.</text>
 
-    <rect x="56" y="136" width="250" height="332" rx="20" fill="#172554" stroke="#60a5fa"/>
-    <text x="82" y="176" fill="#dbeafe" font-size="24" font-weight="700">1. Start with</text>
-    <text x="82" y="210" fill="#eff6ff" font-size="17" font-weight="700">Raw event sources</text>
-    <text x="82" y="236" fill="#cbd5e1" font-size="15">CloudTrail, VPC Flow, Azure Activity</text>
-    <text x="82" y="258" fill="#cbd5e1" font-size="15">GCP Audit, K8s audit, MCP proxy</text>
-    <text x="82" y="290" fill="#eff6ff" font-size="17" font-weight="700">Identity sources</text>
-    <text x="82" y="316" fill="#cbd5e1" font-size="15">Okta, Entra, Google Workspace</text>
-    <text x="82" y="348" fill="#eff6ff" font-size="17" font-weight="700">Inventory / evidence</text>
-    <text x="82" y="374" fill="#cbd5e1" font-size="15">Cloud assets, AI services, controls</text>
-    <text x="82" y="406" fill="#eff6ff" font-size="17" font-weight="700">Operational goal</text>
-    <text x="82" y="432" fill="#cbd5e1" font-size="15">Detect, evaluate, export, remediate</text>
+    <rect x="56" y="144" width="300" height="240" rx="22" fill="#172554" stroke="#60a5fa"/>
+    <text x="84" y="184" fill="#dbeafe" font-size="24" font-weight="700">1. Inputs</text>
+    <text x="84" y="220" fill="#eff6ff" font-size="18" font-weight="700">Raw logs</text>
+    <text x="84" y="246" fill="#cbd5e1" font-size="16">CloudTrail, Azure Activity, GCP Audit</text>
+    <text x="84" y="268" fill="#cbd5e1" font-size="16">VPC / NSG flow, K8s audit, MCP proxy</text>
+    <text x="84" y="304" fill="#eff6ff" font-size="18" font-weight="700">Identity and inventory</text>
+    <text x="84" y="330" fill="#cbd5e1" font-size="16">Okta, Entra, Workspace, cloud assets, AI services</text>
 
-    <rect x="356" y="136" width="250" height="332" rx="20" fill="#083344" stroke="#2dd4bf"/>
-    <text x="382" y="176" fill="#ccfbf1" font-size="24" font-weight="700">2. Pick a layer</text>
-    <text x="382" y="212" fill="#f8fafc" font-size="17" font-weight="700">Ingest</text>
-    <text x="382" y="236" fill="#cbd5e1" font-size="15">normalize one source into native or OCSF</text>
-    <text x="382" y="268" fill="#f8fafc" font-size="17" font-weight="700">Discover</text>
-    <text x="382" y="292" fill="#cbd5e1" font-size="15">inventory, graph context, AI BOM, evidence</text>
-    <text x="382" y="324" fill="#f8fafc" font-size="17" font-weight="700">Detect / Evaluate</text>
-    <text x="382" y="348" fill="#cbd5e1" font-size="15">MITRE-tagged findings or benchmark results</text>
-    <text x="382" y="380" fill="#f8fafc" font-size="17" font-weight="700">View / Remediate</text>
-    <text x="382" y="404" fill="#cbd5e1" font-size="15">SARIF, Mermaid, or guarded write workflow</text>
-    <text x="382" y="444" fill="#99f6e4" font-size="14">Use cases and source crosswalks live in docs/USE_CASES.md</text>
+    <rect x="490" y="120" width="300" height="288" rx="22" fill="#083344" stroke="#2dd4bf"/>
+    <text x="518" y="160" fill="#ccfbf1" font-size="24" font-weight="700">2. Skill layers</text>
+    <text x="518" y="198" fill="#f8fafc" font-size="18" font-weight="700">Ingest</text>
+    <text x="518" y="222" fill="#cbd5e1" font-size="16">normalize one source</text>
+    <text x="518" y="254" fill="#f8fafc" font-size="18" font-weight="700">Discover / detect / evaluate</text>
+    <text x="518" y="278" fill="#cbd5e1" font-size="16">inventory, findings, benchmarks, evidence</text>
+    <text x="518" y="310" fill="#f8fafc" font-size="18" font-weight="700">View / remediate</text>
+    <text x="518" y="334" fill="#cbd5e1" font-size="16">exports or guarded write workflows</text>
+    <text x="518" y="376" fill="#99f6e4" font-size="15">The same `SKILL.md + src/ + tests/` bundle runs everywhere.</text>
 
-    <rect x="656" y="136" width="250" height="332" rx="20" fill="#3b0764" stroke="#c084fc"/>
-    <text x="682" y="176" fill="#f3e8ff" font-size="24" font-weight="700">3. Get output</text>
-    <text x="682" y="212" fill="#f8fafc" font-size="17" font-weight="700">Event streams</text>
-    <text x="682" y="236" fill="#ddd6fe" font-size="15">native JSONL, OCSF JSONL, bridge output</text>
-    <text x="682" y="268" fill="#f8fafc" font-size="17" font-weight="700">Findings / evidence</text>
-    <text x="682" y="292" fill="#ddd6fe" font-size="15">detection findings, benchmark results, evidence JSON</text>
-    <text x="682" y="324" fill="#f8fafc" font-size="17" font-weight="700">Exports</text>
-    <text x="682" y="348" fill="#ddd6fe" font-size="15">SARIF, Mermaid attack flow, AI BOM</text>
-    <text x="682" y="380" fill="#f8fafc" font-size="17" font-weight="700">Guarded actions</text>
-    <text x="682" y="404" fill="#ddd6fe" font-size="15">dry-run plan, audited remediation, dual audit trail</text>
-    <text x="682" y="444" fill="#e9d5ff" font-size="14">Canonical is internal; native, OCSF, and bridge are projections.</text>
+    <rect x="924" y="144" width="300" height="240" rx="22" fill="#3b0764" stroke="#c084fc"/>
+    <text x="952" y="184" fill="#f3e8ff" font-size="24" font-weight="700">3. Outputs</text>
+    <text x="952" y="220" fill="#f8fafc" font-size="18" font-weight="700">repo-native JSONL</text>
+    <text x="952" y="246" fill="#ddd6fe" font-size="16">stable repo schema with deterministic UIDs</text>
+    <text x="952" y="282" fill="#f8fafc" font-size="18" font-weight="700">OCSF JSONL</text>
+    <text x="952" y="308" fill="#ddd6fe" font-size="16">interoperable wire format for downstream tools</text>
+    <text x="952" y="344" fill="#f8fafc" font-size="18" font-weight="700">Exports and actions</text>
+    <text x="952" y="370" fill="#ddd6fe" font-size="16">SARIF, Mermaid, evidence, audited remediation</text>
 
-    <rect x="956" y="136" width="250" height="332" rx="20" fill="#1f2937" stroke="#94a3b8"/>
-    <text x="982" y="176" fill="#f8fafc" font-size="24" font-weight="700">4. Run it from</text>
-    <text x="982" y="212" fill="#f8fafc" font-size="17" font-weight="700">CLI / Unix pipes</text>
-    <text x="982" y="236" fill="#cbd5e1" font-size="15">local triage and repeatable pipelines</text>
-    <text x="982" y="268" fill="#f8fafc" font-size="17" font-weight="700">CI</text>
-    <text x="982" y="292" fill="#cbd5e1" font-size="15">policy gates, SARIF, benchmark snapshots</text>
-    <text x="982" y="324" fill="#f8fafc" font-size="17" font-weight="700">MCP / agents</text>
-    <text x="982" y="348" fill="#cbd5e1" font-size="15">Claude, Codex, Cursor, Windsurf, Cortex</text>
-    <text x="982" y="380" fill="#f8fafc" font-size="17" font-weight="700">Persistent wrappers</text>
-    <text x="982" y="404" fill="#cbd5e1" font-size="15">serverless, queue, or scheduler around the same skill</text>
-    <text x="982" y="444" fill="#cbd5e1" font-size="14">Shipped today: stateless skills and one event-driven remediation workflow.</text>
+    <path d="M356 264 L490 264" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M790 264 L924 264" stroke="#2dd4bf" stroke-width="5" fill="none"/>
 
-    <path d="M306 302 L356 302" stroke="#60a5fa" stroke-width="4" fill="none"/>
-    <path d="M606 302 L656 302" stroke="#2dd4bf" stroke-width="4" fill="none"/>
-    <path d="M906 302 L956 302" stroke="#c084fc" stroke-width="4" fill="none"/>
-
-    <rect x="56" y="500" width="1150" height="60" rx="18" fill="#111827" stroke="#475569"/>
-    <text x="82" y="536" fill="#f8fafc" font-size="18" font-weight="700">Shipped vs optional sink pattern</text>
-    <text x="315" y="536" fill="#cbd5e1" font-size="16">Shipped today: stdout data paths plus DynamoDB + S3 audit for IAM departures.</text>
-    <text x="820" y="536" fill="#cbd5e1" font-size="16">Optional customer pattern: Snowflake / Snowpipe, Security Lake, ClickHouse, BigQuery via a sink or runner layer.</text>
+    <rect x="56" y="426" width="1168" height="42" rx="14" fill="#111827" stroke="#475569"/>
+    <text x="84" y="453" fill="#f8fafc" font-size="17" font-weight="700">Run the same skill from:</text>
+    <text x="310" y="453" fill="#cbd5e1" font-size="17">CLI</text>
+    <text x="352" y="453" fill="#64748b" font-size="17">|</text>
+    <text x="372" y="453" fill="#cbd5e1" font-size="17">CI</text>
+    <text x="401" y="453" fill="#64748b" font-size="17">|</text>
+    <text x="421" y="453" fill="#cbd5e1" font-size="17">MCP</text>
+    <text x="468" y="453" fill="#64748b" font-size="17">|</text>
+    <text x="488" y="453" fill="#cbd5e1" font-size="17">persistent runner</text>
+    <text x="668" y="453" fill="#64748b" font-size="17">|</text>
+    <text x="688" y="453" fill="#cbd5e1" font-size="17">customer sink pattern</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- make the IAM departures workflow the flagship README visual instead of the crowded generic panel
- clarify `native` vs `ocsf` with an explicit schema-mode table near the top of the README
- simplify the `start-here` and `runtime-surfaces` SVGs so they remain readable when GitHub scales them down

## Validation
- python scripts/validate_skill_contract.py
