### PR TITLE
chore: tighten mypy on shared runtime paths

### DIFF
--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -8,7 +8,7 @@ import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO, cast
 
 CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
@@ -47,7 +47,7 @@ def _result_response(request_id: Any, result: Any) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": request_id, "result": result}
 
 
-def _read_message(stream) -> dict[str, Any] | None:
+def _read_message(stream: BinaryIO) -> dict[str, Any] | None:
     headers: dict[str, str] = {}
     while True:
         line = stream.readline()
@@ -62,10 +62,13 @@ def _read_message(stream) -> dict[str, Any] | None:
     if length <= 0:
         return None
     payload = stream.read(length)
-    return json.loads(payload.decode("utf-8"))
+    decoded = json.loads(payload.decode("utf-8"))
+    if not isinstance(decoded, dict):
+        raise ValueError("JSON-RPC message payload must be an object")
+    return cast(dict[str, Any], decoded)
 
 
-def _write_message(stream, message: dict[str, Any]) -> None:
+def _write_message(stream: BinaryIO, message: dict[str, Any]) -> None:
     payload = json.dumps(message).encode("utf-8")
     stream.write(f"Content-Length: {len(payload)}\r\n\r\n".encode("utf-8"))
     stream.write(payload)
@@ -109,7 +112,7 @@ def _validate_context(raw_context: Any, field_name: str) -> dict[str, Any] | Non
             validated[key] = value
             continue
         if isinstance(value, list) and all(isinstance(item, str) for item in value):
-            validated[key] = value
+            validated[key] = cast(list[str], value)
             continue
         raise ValueError(f"`{field_name}.{key}` must be a string or array of strings")
     return validated

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -10,6 +10,17 @@ else
   MYPY_CMD=(python -m mypy)
 fi
 
+# Tighten the shared/runtime surfaces first. Keep per-skill checking gradual
+# while this repo incrementally removes Any and missing annotations.
+"${MYPY_CMD[@]}" \
+  skills/_shared/runtime_telemetry.py \
+  mcp-server/src \
+  scripts \
+  --config-file pyproject.toml \
+  --disallow-untyped-defs \
+  --disallow-incomplete-defs \
+  --warn-return-any
+
 for dir in skills/*/*/src; do
   "${MYPY_CMD[@]}" "$dir" --config-file pyproject.toml
 done

--- a/scripts/validate_framework_coverage.py
+++ b/scripts/validate_framework_coverage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from typing import TypedDict
 
 from skill_validation_common import ROOT, discover_skill_contracts
 
@@ -10,9 +11,36 @@ ALLOWED_STATUSES = {"gap", "mapped", "implemented", "tested", "validated"}
 ALLOWED_EXECUTION_MODES = {"cli", "ci", "mcp", "persistent"}
 
 
-def load_registry() -> dict:
+class CoverageSkillEntry(TypedDict, total=False):
+    path: str
+    layer: str
+    coverage_status: str
+    providers: list[str]
+    asset_classes: list[str]
+    execution_modes: list[str]
+    frameworks: list[str]
+
+
+class CoverageTargetEntry(TypedDict, total=False):
+    framework: str
+
+
+class CoverageFrameworkEntry(TypedDict, total=False):
+    id: str
+
+
+class CoverageRegistry(TypedDict, total=False):
+    frameworks: list[CoverageFrameworkEntry]
+    skills: list[CoverageSkillEntry]
+    coverage_targets: list[CoverageTargetEntry]
+
+
+def load_registry() -> CoverageRegistry:
     path = ROOT / "docs" / "framework-coverage.json"
-    return json.loads(path.read_text())
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError("docs/framework-coverage.json must contain a top-level object")
+    return raw  # type: ignore[return-value]
 
 
 def main() -> int:
@@ -26,7 +54,7 @@ def main() -> int:
     expected_paths = {
         str(skill.skill_dir.relative_to(ROOT)): skill for skill in discover_skill_contracts()
     }
-    registered_paths: dict[str, dict] = {}
+    registered_paths: dict[str, CoverageSkillEntry] = {}
 
     for entry in registry.get("skills", []):
         path = entry.get("path", "")

--- a/scripts/validate_safe_skill_bar.py
+++ b/scripts/validate_safe_skill_bar.py
@@ -23,12 +23,16 @@ WILDCARD_PATTERNS = (
 POLICY_SUFFIXES = (".json", ".tf", ".yaml", ".yml")
 
 
-def validate_read_only_no_subprocess(skill) -> list[str]:
+def validate_read_only_no_subprocess(skill: object) -> list[str]:
     errors: list[str] = []
-    if skill.is_write_capable:
+    skill_dir = getattr(skill, "skill_dir")
+    is_write_capable = bool(getattr(skill, "is_write_capable"))
+    approval_model = getattr(skill, "approval_model")
+    side_effects = getattr(skill, "side_effects")
+    if is_write_capable:
         return errors
 
-    for path in sorted((skill.skill_dir / "src").rglob("*.py")):
+    for path in sorted((skill_dir / "src").rglob("*.py")):
         text = path.read_text()
         for pattern in SUBPROCESS_PATTERNS:
             if pattern in text:
@@ -36,28 +40,31 @@ def validate_read_only_no_subprocess(skill) -> list[str]:
                 errors.append(
                     f"{rel}: read-only skill must not use subprocess/shell pattern `{pattern}`"
                 )
-    if skill.approval_model != "none":
-        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: read-only skill must keep approval_model `none`")
-    if skill.side_effects != ("none",):
-        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: read-only skill must keep side_effects `none`")
+    if approval_model != "none":
+        errors.append(f"{skill_dir.relative_to(ROOT)}: read-only skill must keep approval_model `none`")
+    if side_effects != ("none",):
+        errors.append(f"{skill_dir.relative_to(ROOT)}: read-only skill must keep side_effects `none`")
     return errors
 
 
-def validate_write_skill_dry_run(skill) -> list[str]:
+def validate_write_skill_dry_run(skill: object) -> list[str]:
     errors: list[str] = []
-    if not skill.is_write_capable:
+    skill_dir = getattr(skill, "skill_dir")
+    is_write_capable = bool(getattr(skill, "is_write_capable"))
+    approval_model = getattr(skill, "approval_model")
+    if not is_write_capable:
         return errors
 
-    skill_md = (skill.skill_dir / "SKILL.md").read_text().lower()
+    skill_md = (skill_dir / "SKILL.md").read_text().lower()
     if "dry-run" not in skill_md and "dry_run" not in skill_md:
-        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: write-capable skill must document dry-run in SKILL.md")
+        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must document dry-run in SKILL.md")
 
-    tests_dir = skill.skill_dir / "tests"
+    tests_dir = skill_dir / "tests"
     test_text = "\n".join(path.read_text() for path in sorted(tests_dir.rglob("*.py")))
     if "dry_run" not in test_text and "--dry-run" not in test_text and "dry-run" not in test_text:
-        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: write-capable skill must exercise dry-run in tests")
-    if skill.approval_model != "human_required":
-        errors.append(f"{skill.skill_dir.relative_to(ROOT)}: write-capable skill must require human approval")
+        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must exercise dry-run in tests")
+    if approval_model != "human_required":
+        errors.append(f"{skill_dir.relative_to(ROOT)}: write-capable skill must require human approval")
 
     return errors
 

--- a/scripts/validate_skill_integrity.py
+++ b/scripts/validate_skill_integrity.py
@@ -4,6 +4,7 @@ import importlib.util
 import re
 import sys
 from pathlib import Path
+from typing import Protocol
 
 from skill_validation_common import (
     ROOT,
@@ -12,7 +13,7 @@ from skill_validation_common import (
     reference_url_allowed,
 )
 
-DANGEROUS_CODE_PATTERNS = {
+DANGEROUS_CODE_PATTERNS: dict[str, str] = {
     r"\beval\(": "eval() is not allowed in shipped skill code",
     r"(?<!\.)\bexec\(": "exec() is not allowed in shipped skill code",
     r"\bpickle\.loads\(": "pickle.loads() is not allowed in shipped skill code",
@@ -21,7 +22,17 @@ DANGEROUS_CODE_PATTERNS = {
 }
 
 
-def _load_tool_registry():
+class _ToolRegistryModule(Protocol):
+    def discover_skills(self, root: Path) -> list["_RegistrySkill"]: ...
+
+
+class _RegistrySkill(Protocol):
+    name: str
+    description: str
+    supported: bool
+
+
+def _load_tool_registry() -> _ToolRegistryModule:
     path = ROOT / "mcp-server" / "src" / "tool_registry.py"
     spec = importlib.util.spec_from_file_location("cloud_security_tool_registry_integrity", path)
     assert spec and spec.loader


### PR DESCRIPTION
## Summary
- enforce stricter mypy checks on the shared/runtime surfaces first: `skills/_shared`, `mcp-server/src`, and `scripts`
- add the missing annotations and JSON-shape typing those stricter checks exposed
- keep the per-skill mypy rollout gradual while the shared/runtime paths are held to a higher bar

## Validation
- `uv run mypy skills/_shared/runtime_telemetry.py mcp-server/src scripts --config-file pyproject.toml --disallow-untyped-defs --disallow-incomplete-defs --warn-return-any`
- `bash scripts/run_mypy.sh`
- `uv run ruff check mcp-server/src/server.py scripts/validate_skill_integrity.py scripts/validate_safe_skill_bar.py scripts/validate_framework_coverage.py --config pyproject.toml`
- `python scripts/validate_skill_contract.py && python scripts/validate_skill_integrity.py && python scripts/validate_framework_coverage.py && python scripts/validate_safe_skill_bar.py`