### PR TITLE
feat: add snowflake source adapter skill

### DIFF
--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -81,6 +81,7 @@ Rules:
   - `native`
   - `ocsf`
 - `output_formats` must be a comma-separated subset of:
+  - `raw`
   - `native`
   - `ocsf`
   - `bridge`

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -23,6 +23,15 @@
   ],
   "skills": [
     {
+      "path": "skills/ingestion/source-snowflake-query",
+      "layer": "ingestion",
+      "providers": ["snowflake"],
+      "asset_classes": ["lakehouse", "query-results", "audit-logs"],
+      "execution_modes": ["cli", "ci", "mcp", "persistent"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated"
+    },
+    {
       "path": "skills/ingestion/ingest-cloudtrail-ocsf",
       "layer": "ingestion",
       "providers": ["aws"],

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -24,6 +24,7 @@ class TestDiscovery:
         skills = discover_skills(REPO_ROOT)
         assert len(skills) >= 35
         assert {skill.name for skill in skills} >= {
+            "source-snowflake-query",
             "ingest-cloudtrail-ocsf",
             "ingest-entra-directory-audit-ocsf",
             "ingest-okta-system-log-ocsf",
@@ -51,6 +52,7 @@ class TestDiscovery:
 
     def test_supported_tools_include_ingest_detect_and_evaluate(self):
         tools = tool_map(REPO_ROOT)
+        assert "source-snowflake-query" in tools
         assert "ingest-cloudtrail-ocsf" in tools
         assert "ingest-entra-directory-audit-ocsf" in tools
         assert "ingest-okta-system-log-ocsf" in tools
@@ -103,6 +105,13 @@ class TestToolDefinition:
         assert remediation.caller_roles == ("security_engineer", "incident_responder")
         assert remediation.approver_roles == ("security_lead", "cis_officer")
         assert remediation.min_approvers == 1
+
+    def test_source_snowflake_query_exposes_raw_output(self):
+        skill = tool_map(REPO_ROOT)["source-snowflake-query"]
+        tool = tool_definition(skill)
+        assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["raw"]
+        assert skill.output_formats == ("raw",)
+        assert skill.network_egress == ("*.snowflakecomputing.com",)
 
     def test_build_command_uses_fixed_entrypoint(self):
         skill = tool_map(REPO_ROOT)["detect-lateral-movement"]

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -31,7 +31,7 @@ SIDE_EFFECT_VALUES = {
     "writes-audit",
 }
 INPUT_FORMAT_VALUES = {"raw", "canonical", "native", "ocsf"}
-OUTPUT_FORMAT_VALUES = {"native", "ocsf", "bridge"}
+OUTPUT_FORMAT_VALUES = {"raw", "native", "ocsf", "bridge"}
 NETWORK_EGRESS_RE = re.compile(r"^(?:\*\.)?(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+$")
 
 ENTRYPOINT_CANDIDATES = (

--- a/skills/ingestion/source-snowflake-query/REFERENCES.md
+++ b/skills/ingestion/source-snowflake-query/REFERENCES.md
@@ -1,0 +1,19 @@
+# References — source-snowflake-query
+
+## Source and transport
+
+- **Snowflake Connector for Python** — https://docs.snowflake.com/en/developer-guide/python-connector/python-connector
+- **Connecting with the Snowflake Connector for Python** — https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect
+- **Executing queries with the Snowflake Connector for Python** — https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example
+
+## Read-only SQL semantics
+
+- **SELECT** — https://docs.snowflake.com/en/sql-reference/constructs/select
+- **WITH** — https://docs.snowflake.com/en/sql-reference/constructs/with
+- **SHOW commands** — https://docs.snowflake.com/en/sql-reference/sql/show
+- **DESCRIBE commands** — https://docs.snowflake.com/en/sql-reference/sql/desc
+
+## Security and credential posture
+
+- **Key-pair authentication and federated auth patterns** — https://docs.snowflake.com/en/user-guide/key-pair-auth
+- **Python connector connection parameters** — https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api

--- a/skills/ingestion/source-snowflake-query/SKILL.md
+++ b/skills/ingestion/source-snowflake-query/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: source-snowflake-query
+description: >-
+  Run a read-only Snowflake query and emit the result set as raw JSONL rows
+  for downstream ingestion, detection, or view skills. Accepts explicit
+  `--query` SQL or reads the query from stdin when no `--query` is provided.
+  Only `SELECT`, `WITH`, `SHOW`, and `DESCRIBE` statements are allowed, and
+  multiple statements are rejected. Use when the user already has security
+  data in Snowflake and wants to pipe lake rows into existing skills without
+  exporting files first. Do NOT use for writes, DDL, or admin changes. Do NOT
+  use as a detector or normalizer by itself.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: raw
+output_formats: raw
+network_egress: "*.snowflakecomputing.com"
+---
+
+# source-snowflake-query
+
+Read-only source adapter: Snowflake query in, raw JSONL rows out. This skill
+does not normalize vendor data, detect threats, or write back to Snowflake.
+It exists so operators and agents can fetch already-landed lake data and pipe
+it into the existing `ingest-*`, `detect-*`, `discover-*`, or `view/*` skills.
+
+## Use when
+
+- Security data already lives in Snowflake
+- You want to fetch rows directly into a skill pipeline
+- You need a read-only source step before `ingest-*` or `detect-*`
+
+## Do NOT use
+
+- For `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `COPY`, `CREATE`, `ALTER`, `DROP`, or grant operations
+- As a detection or remediation skill
+- When the source data is not in Snowflake
+
+## Input
+
+The skill accepts one read-only SQL statement via:
+
+- `--query "SELECT ..."` on the CLI, or
+- stdin when `--query` is omitted
+
+Allowed statement families:
+
+- `SELECT`
+- `WITH`
+- `SHOW`
+- `DESCRIBE`
+
+The skill rejects multiple statements and non-read-only verbs.
+
+## Output
+
+Raw JSONL rows exactly as the Snowflake connector returns them, serialized with
+JSON-safe string conversion for datetimes and other non-JSON-native values.
+
+Typical compositions:
+
+```bash
+# Data already projected to the fields your downstream skill expects
+python skills/ingestion/source-snowflake-query/src/ingest.py \
+  --query "SELECT raw_json FROM sec.cloudtrail_ocsf LIMIT 100" \
+  | jq -c '.raw_json' \
+  | python skills/detection/detect-lateral-movement/src/detect.py
+
+# Data still in raw vendor shape
+python skills/ingestion/source-snowflake-query/src/ingest.py \
+  --query "SELECT raw_event FROM sec.cloudtrail_raw LIMIT 100" \
+  | jq -c '.raw_event' \
+  | python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
+```
+
+## Credentials
+
+Uses the standard Snowflake connector environment variables:
+
+- `SNOWFLAKE_ACCOUNT`
+- `SNOWFLAKE_USER`
+- `SNOWFLAKE_PASSWORD`
+
+Optional:
+
+- `SNOWFLAKE_WAREHOUSE`
+- `SNOWFLAKE_DATABASE`
+- `SNOWFLAKE_SCHEMA`
+- `SNOWFLAKE_ROLE`
+
+This skill is read-only but still egresses to Snowflake. Prefer short-lived,
+manager-injected credentials or workload identity patterns where your
+Snowflake environment supports them.

--- a/skills/ingestion/source-snowflake-query/src/ingest.py
+++ b/skills/ingestion/source-snowflake-query/src/ingest.py
@@ -1,0 +1,114 @@
+"""Run a read-only Snowflake query and emit raw JSONL rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Any, Iterable
+
+SKILL_NAME = "source-snowflake-query"
+ALLOWED_PREFIXES = ("SELECT", "WITH", "SHOW", "DESCRIBE")
+
+
+def _configure_snowflake_logging() -> None:
+    logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
+
+
+def _read_query(cli_query: str | None, stdin: Iterable[str]) -> str:
+    if cli_query and cli_query.strip():
+        return cli_query.strip()
+    stdin_text = "".join(stdin).strip()
+    if stdin_text:
+        return stdin_text
+    raise ValueError("provide a read-only SQL query via --query or stdin")
+
+
+def _normalize_query(query: str) -> str:
+    cleaned = query.strip()
+    if not cleaned:
+        raise ValueError("query must not be empty")
+    while cleaned.endswith(";"):
+        cleaned = cleaned[:-1].rstrip()
+    if ";" in cleaned:
+        raise ValueError("multiple SQL statements are not allowed")
+
+    head = cleaned.lstrip("(\n\t ").upper()
+    if not any(head.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+        raise ValueError("only SELECT, WITH, SHOW, and DESCRIBE statements are allowed")
+    return cleaned
+
+
+def _connect() -> Any:
+    import snowflake.connector
+
+    _configure_snowflake_logging()
+    kwargs: dict[str, str] = {
+        "account": os.environ["SNOWFLAKE_ACCOUNT"],
+        "user": os.environ["SNOWFLAKE_USER"],
+        "password": os.environ["SNOWFLAKE_PASSWORD"],
+    }
+    for env_name, key in (
+        ("SNOWFLAKE_WAREHOUSE", "warehouse"),
+        ("SNOWFLAKE_DATABASE", "database"),
+        ("SNOWFLAKE_SCHEMA", "schema"),
+        ("SNOWFLAKE_ROLE", "role"),
+    ):
+        value = os.environ.get(env_name)
+        if value:
+            kwargs[key] = value
+    return snowflake.connector.connect(**kwargs)
+
+
+def _dict_cursor_class() -> Any:
+    import snowflake.connector
+
+    return snowflake.connector.DictCursor
+
+
+def fetch_rows(query: str) -> list[dict[str, Any]]:
+    conn = _connect()
+    try:
+        cursor = conn.cursor(_dict_cursor_class())
+        try:
+            cursor.execute(_normalize_query(query))
+            rows = cursor.fetchall()
+        finally:
+            cursor.close()
+    finally:
+        conn.close()
+
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            normalized.append(dict(row))
+        else:
+            normalized.append({"value": row})
+    return normalized
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a read-only Snowflake query and emit raw JSONL rows.")
+    parser.add_argument("--query", help="Read-only SQL query to run. If omitted, the query is read from stdin.")
+    parser.add_argument(
+        "--output-format",
+        choices=("raw",),
+        default="raw",
+        help="Declared output rendering mode for this source adapter.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        query = _read_query(args.query, sys.stdin)
+        for row in fetch_rows(query):
+            sys.stdout.write(json.dumps(row, default=str, separators=(",", ":")) + "\n")
+    except Exception as exc:
+        print(f"[{SKILL_NAME}] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ingestion/source-snowflake-query/tests/test_ingest.py
+++ b/skills/ingestion/source-snowflake-query/tests/test_ingest.py
@@ -1,0 +1,102 @@
+"""Tests for source-snowflake-query."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "ingest.py"
+_SPEC = importlib.util.spec_from_file_location("source_snowflake_query", _SRC)
+assert _SPEC and _SPEC.loader
+_INGEST = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_INGEST)
+
+_normalize_query = _INGEST._normalize_query
+_read_query = _INGEST._read_query
+fetch_rows = _INGEST.fetch_rows
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self.rows = rows
+        self.executed = None
+        self.closed = False
+
+    def execute(self, query):
+        self.executed = query
+
+    def fetchall(self):
+        return self.rows
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, rows):
+        self.rows = rows
+        self.closed = False
+        self.cursor_instance = None
+
+    def cursor(self, _cursor_cls):
+        self.cursor_instance = _FakeCursor(self.rows)
+        return self.cursor_instance
+
+    def close(self):
+        self.closed = True
+
+
+class TestNormalizeQuery:
+    def test_allows_select(self):
+        assert _normalize_query("SELECT * FROM foo") == "SELECT * FROM foo"
+
+    def test_allows_with(self):
+        assert _normalize_query("WITH t AS (SELECT 1) SELECT * FROM t") == "WITH t AS (SELECT 1) SELECT * FROM t"
+
+    def test_rejects_multiple_statements(self):
+        try:
+            _normalize_query("SELECT 1; SELECT 2")
+        except ValueError as exc:
+            assert "multiple SQL statements" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_write_statement(self):
+        try:
+            _normalize_query("DELETE FROM foo")
+        except ValueError as exc:
+            assert "only SELECT, WITH, SHOW, and DESCRIBE" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestReadQuery:
+    def test_prefers_cli_query(self):
+        assert _read_query("SELECT 1", ["SELECT 2"]) == "SELECT 1"
+
+    def test_falls_back_to_stdin(self):
+        assert _read_query(None, ["SELECT ", "1"]) == "SELECT 1"
+
+
+class TestFetchRows:
+    def test_fetches_dict_rows(self, monkeypatch):
+        fake = _FakeConnection([{"EVENT_TIME": "2026-04-15T00:00:00Z", "ACTION": "AssumeRole"}])
+        monkeypatch.setattr(_INGEST, "_connect", lambda: fake)
+        monkeypatch.setattr(_INGEST, "_dict_cursor_class", lambda: object)
+
+        rows = fetch_rows("SELECT * FROM sec.cloudtrail_ocsf")
+
+        assert rows == [{"EVENT_TIME": "2026-04-15T00:00:00Z", "ACTION": "AssumeRole"}]
+        assert fake.cursor_instance is not None
+        assert fake.cursor_instance.executed == "SELECT * FROM sec.cloudtrail_ocsf"
+        assert fake.cursor_instance.closed is True
+        assert fake.closed is True
+
+    def test_wraps_non_dict_rows(self, monkeypatch):
+        fake = _FakeConnection([("value",)])
+        monkeypatch.setattr(_INGEST, "_connect", lambda: fake)
+        monkeypatch.setattr(_INGEST, "_dict_cursor_class", lambda: object)
+
+        rows = fetch_rows("SHOW TABLES")
+
+        assert rows == [{"value": ("value",)}]

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -59,6 +59,7 @@ class TestSkillValidationCommon:
         skills = COMMON.discover_skill_contracts()
         assert len(skills) >= 32
         names = {skill.name for skill in skills}
+        assert "source-snowflake-query" in names
         assert "detect-lateral-movement" in names
         assert "detect-okta-mfa-fatigue" in names
         assert "detect-entra-credential-addition" in names


### PR DESCRIPTION
## Summary
- allow raw as a declared skill output format for read-only source adapters
- add skills/ingestion/source-snowflake-query as a read-only Snowflake query skill that emits raw JSONL rows
- register the new skill in framework coverage and MCP/tool-registry tests

## Validation
- uv run pytest skills/ingestion/source-snowflake-query/tests/test_ingest.py mcp-server/tests/test_tool_registry.py tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run ruff check skills/ingestion/source-snowflake-query/src/ingest.py skills/ingestion/source-snowflake-query/tests/test_ingest.py scripts/skill_validation_common.py mcp-server/tests/test_tool_registry.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml
- python scripts/validate_skill_contract.py && python scripts/validate_framework_coverage.py && python scripts/validate_dependency_consistency.py
- python scripts/validate_skill_integrity.py && python scripts/validate_safe_skill_bar.py