### PR TITLE
docs: simplify architecture page and repo visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
 
 | Mode | What it means | Use it when... |
 |---|---|---|
-| `native` | repo-owned JSONL with fields like `schema_mode`, `canonical_schema_version`, `record_type`, and stable UIDs | you want the repo's stable schema without an interoperability envelope |
+| `native` | repo-owned external wire format in JSONL, with fields like `schema_mode`, `canonical_schema_version`, `record_type`, and stable UIDs | you want the repo's stable schema without an interoperability envelope |
 | `ocsf` | OCSF JSONL pinned to the repo's OCSF contract | you want a standard external schema for SIEMs, exports, or downstream tooling |
 | `canonical` | internal-only normalization model | you are reading the docs or implementation, not choosing a CLI output mode |
 | `bridge` | interoperable output with native context preserved | you need both standard fields and repo context in one payload |
 
 `native` is not raw vendor JSON and not an OCSF envelope with fields stripped out.
+`native` = repo-owned external wire format. See [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md) and [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md).
 
 ## Flagship Example
 
@@ -103,7 +104,7 @@ Read next:
 |---|---|---|
 | Runtime surfaces | CLI, CI, MCP, `runners/aws-s3-sqs-detect`, IAM departures workflow | more multi-cloud runner templates |
 | Audit sinks | IAM departures dual-write to DynamoDB + S3 | customer sinks like Snowflake, Security Lake, ClickHouse, BigQuery |
-| Schema modes | native, canonical, OCSF, bridge contract | dual-mode rollout across remaining ingest / detect paths |
+| Schema modes | native, canonical, OCSF, bridge contract; ingest and detect are fully dual-mode | extend dual-mode patterns to more families where appropriate |
 | Remediation | IAM departures with HITL and audit | broader remediation families |
 
 <details>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document is the load-bearing design contract for `cloud-ai-security-skills`. Every future PR is reviewed against it. If you need to deviate, update this doc *in the same PR* — the contract drifts by design, never by accident.
 
+This file is the design contract. It explains how the repo is supposed to work and what future changes must preserve. [`DIAGRAMS.md`](./DIAGRAMS.md) is the visual companion: it indexes the small set of readable SVGs used in rendered docs.
+
 - **Wire format contract** — see [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
 - **Sink / persistence contract** — see [`./SINK_CONTRACT.md`](./SINK_CONTRACT.md) *(lands with PR T)*
 - **Runner / streaming contract** — see [`./RUNNER_CONTRACT.md`](./RUNNER_CONTRACT.md) *(lands with PR V)*
@@ -57,47 +59,31 @@ The repo cannot assume cloud APIs stay still. Providers deprecate fields, add en
 
 This is how the repo stays secure and reliable without turning every skill into an over-general abstraction layer.
 
-## 3. The 9 layers
+## 3. Layer model
 
-```
- ┌───────────────────────────────────────────────────────────────────┐
- │ L0  SOURCES         raw vendor formats (CloudTrail, VPC Flow,     │
- │                     Okta, Ramp, Snowflake audit, K8s audit, ...)  │
- ├───────────────────────────────────────────────────────────────────┤
- │ L1  INGEST          raw → canonical → native / OCSF / bridge      │
- │                     ingest-cloudtrail-ocsf, ingest-ramp-ocsf, ... │
- ├───────────────────────────────────────────────────────────────────┤
-│ L2  DISCOVER /      inventory + context                           │
-│     ENRICH          discover-environment, discover-ai-bom,        │
-│                     discover-control-evidence,                    │
-│                     discover-cloud-control-evidence,              │
-│                     enrich-asset-inventory, enrich-geoip,         │
-│                     enrich-mitre-navigator, enrich-pii-redact     │
- ├───────────────────────────────────────────────────────────────────┤
- │ L3  DETECT          canonical / OCSF → native / OCSF findings     │
- │                     detect-lateral-movement, detect-*             │
- ├───────────────────────────────────────────────────────────────────┤
- │ L4  EVALUATE        raw / canonical → compliance result + evidence│
- │                     cspm-*-cis-benchmark, evaluate-nist-ai-rmf    │
- ├───────────────────────────────────────────────────────────────────┤
- │ L5  REMEDIATE       Finding → IaC patch / SOAR action             │
- │                     iam-departures-remediation, revoke-key-*      │
- ├───────────────────────────────────────────────────────────────────┤
- │ L6  CONVERT         OCSF → other wire formats for delivery        │
- │                     convert-ocsf-to-sarif, to-sigma, to-jira,     │
- │                     to-mermaid-attack-flow                        │
- ├───────────────────────────────────────────────────────────────────┤
- │ L7  SINKS (opt)     OCSF → persisted store                        │
- │                     sink-snowflake, sink-security-lake,           │
- │                     sink-clickhouse, sink-bigquery                │
- ├───────────────────────────────────────────────────────────────────┤
- │ L8  QUERY / VIZ     SQL packs + Grafana packs + Cortex prompts    │
- │                     query-mitre-heatmap, cortex-triage-prompts    │
- ├───────────────────────────────────────────────────────────────────┤
- │ L9  AGENT SURFACE   mcp-server exposes every skill as a tool      │
- │                     → Claude Code, Cortex Code, Agent SDK         │
- └───────────────────────────────────────────────────────────────────┘
-```
+The repo is easiest to read as **six shipped skill layers**, plus **three edge/runtime layers** that sit around the pure skills.
+
+![Repository architecture](./images/repo-architecture.svg)
+
+### Shipped skill layers
+
+| Layer | Primary job | Current category |
+|---|---|---|
+| L1 | normalize one source into a stable event stream | `skills/ingestion/` |
+| L2 | inventory, evidence, AI BOM, and discovery context | `skills/discovery/` |
+| L3 | deterministic attack-pattern findings | `skills/detection/` |
+| L4 | posture and benchmark evaluation | `skills/evaluation/` |
+| L5 | guarded write paths with HITL and audit | `skills/remediation/` |
+| L6 | downstream export and conversion | `skills/view/` |
+
+### Edge and runtime layers
+
+| Layer | Role | Current state |
+|---|---|---|
+| L0 | external sources and vendor APIs | outside the repo boundary |
+| L7 | sinks and persistence edges | contract and patterns documented; generic sink family not fully shipped |
+| L8 | query packs and warehouse-native analytics | planned |
+| L9 | agent/runtime surface (`mcp-server`, runners, wrappers) | shipped as thin wrappers around the same skill contract |
 
 The repo operates across four schema modes:
 
@@ -121,31 +107,27 @@ For the detailed contract, see:
 - [`STATE_AND_TIMELINE_MODEL.md`](./STATE_AND_TIMELINE_MODEL.md)
 - [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
 
-### Visuals
+### How to read this doc
 
-For quick orientation, use the visual set in [`DIAGRAMS.md`](./DIAGRAMS.md):
-
-- **Runtime surfaces** — [`runtime-surfaces.svg`](./images/runtime-surfaces.svg)
-- **Repo architecture** — [`repo-architecture.svg`](./images/repo-architecture.svg)
-- **IAM departures data flow** — [`iam-departures-data-flow.svg`](./images/iam-departures-data-flow.svg)
-- **Detection pipeline** — [`detection-pipeline.svg`](./images/detection-pipeline.svg)
-
-The rule for this repo is simple: keep the architecture readable in Markdown, and keep polished SVGs in `docs/images/` for rendered docs.
+- `ARCHITECTURE.md` is the design contract and review baseline.
+- `DIAGRAMS.md` is the visual index.
+- the SVGs should simplify the design, not replace it
+- if a diagram and this doc disagree, this doc wins until both are updated in the same PR
 
 ### Layer status snapshot
 
-| Layer | Category | Status | Skills shipped | Roadmap |
-|---|---|---|---|---|
-| L0 | sources | (external) | n/a | vendor stories #30–#36, Ramp (PR Y), Snowflake audit (PR Z) |
-| L1 | `ingest-*` | **shipping** | cloudtrail, aws-vpc-flow, gcp-vpc-flow, azure-nsg-flow, guardduty, security-hub, gcp-scc, azure-defender, gcp-audit, azure-activity, k8s-audit, mcp-proxy | okta, github, workspace, slack, ramp |
-| L2 | `discovery/` + `enrich-*` | **shipping / planned** | discover-environment, discover-ai-bom, discover-control-evidence, discover-cloud-control-evidence | PR X (asset-inventory, geoip, mitre-navigator, **pii-redact is P0 before any sink in regulated env**) |
-| L3 | `detect-*` | **shipping** | lateral-movement, privesc-k8s, sensitive-secret-read-k8s, mcp-tool-drift | credential-access per cloud, unusual-assume-role, vector-store-poisoning |
-| L4 | `evaluate-*` | **shipping** | cspm-aws/gcp/azure-cis-benchmark, k8s-security-benchmark, container-security | evaluate-cis-aws-foundations (#29), NIST AI RMF, SOC2, PCI |
-| L5 | `remediate-*` | **shipping** | iam-departures-remediation | auto-close-exposed-s3, revoke-long-lived-key, patch-inspector-finding |
-| L6 | `convert-*` | **shipping** | ocsf-to-sarif, ocsf-to-mermaid-attack-flow | to-sigma, to-splunk-cim, to-jira, to-opa-rego |
-| L7 | `sinks/` | **planned** | none | PR T (snowflake), PR W (security-lake), PR AA (clickhouse), bigquery |
-| L8 | `query/` + packs | **planned** | none | PR T ships the first Cortex query pack alongside sink-snowflake |
-| L9 | `mcp-server/` | **shipping** | thin stdio wrapper | tighter input schemas, HTTP/SSE transport, remediation-safe wrappers |
+| Layer | Status | Current shape |
+|---|---|---|
+| L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
+| L1 ingest | shipping | 15+ source-specific ingesters plus `source-snowflake-query`; ingest and detect are now fully dual-mode |
+| L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
+| L3 detect | shipping | 9 shipped detectors across cloud, identity, Kubernetes, and MCP drift |
+| L4 evaluate | shipping | 8 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths |
+| L5 remediate | shipping | IAM departures is the current flagship write path |
+| L6 view | shipping | SARIF and Mermaid attack-flow exports |
+| L7 sinks | planned / partial patterns | customer-controlled persistence patterns are documented; generic sink family is not fully shipped |
+| L8 query packs | planned | warehouse-native SQL packs remain future work |
+| L9 agent/runtime surfaces | shipping | `mcp-server`, CLI, CI, and runners call the same skill contract |
 
 ## 4. Two execution modes
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -1,6 +1,8 @@
 # Diagrams
 
-Keep the markdown source diagrams lightweight and reviewable, then pair them with polished SVGs for docs pages and PRs.
+`ARCHITECTURE.md` is the design contract. This file is the visual companion.
+
+Keep markdown diagrams lightweight and reviewable, then pair them with polished SVGs for docs pages and PRs. If a diagram becomes dense enough to overlap or require zooming, simplify it instead of adding more boxes.
 
 ## Visual set
 
@@ -16,3 +18,5 @@ Keep the markdown source diagrams lightweight and reviewable, then pair them wit
 - Keep ASCII or Mermaid diagrams in markdown for git-friendly diffs.
 - Keep the polished SVGs in `docs/images/`.
 - Prefer 2-3 high-signal diagrams over a large diagram dump.
+- One diagram should answer one question. Do not mix repo structure, runtime surfaces, and roadmap detail in the same visual.
+- The flagship remediation diagram can be more detailed than the repo overview, but the repo overview should stay readable in GitHub preview without zooming.

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -1,42 +1,76 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" role="img" aria-labelledby="title desc">
-  <title id="title">cloud-ai-security-skills repository architecture</title>
-  <desc id="desc">Skill families feed shared contracts and CI lanes.</desc>
-  <rect width="1200" height="640" fill="#0b1220"/>
-  <rect x="40" y="40" width="1120" height="560" rx="24" fill="#111827" stroke="#334155"/>
-  <text x="70" y="90" fill="#f8fafc" font-size="32" font-family="Arial, sans-serif" font-weight="700">cloud-ai-security-skills</text>
-  <text x="70" y="122" fill="#94a3b8" font-size="16" font-family="Arial, sans-serif">Skill families, shared contracts, and CI lanes</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
+  <title id="title">cloud-ai-security-skills layered architecture</title>
+  <desc id="desc">A readable overview of external sources, six shipped skill layers, and runtime edges around the repo.</desc>
+  <rect width="1200" height="760" fill="#0b1220"/>
+  <rect x="32" y="32" width="1136" height="696" rx="24" fill="#111827" stroke="#334155"/>
 
-  <rect x="70" y="160" width="230" height="120" rx="18" fill="#172554" stroke="#60a5fa"/>
-  <text x="92" y="196" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">Compliance</text>
-  <text x="92" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">AWS / GCP / Azure CIS</text>
-  <text x="92" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">K8s + container posture</text>
+  <text x="68" y="84" fill="#f8fafc" font-size="34" font-family="Arial, sans-serif" font-weight="700">cloud-ai-security-skills</text>
+  <text x="68" y="116" fill="#94a3b8" font-size="17" font-family="Arial, sans-serif">Six shipped skill layers, three edge/runtime layers, one shared skill contract.</text>
 
-  <rect x="330" y="160" width="230" height="120" rx="18" fill="#1e3a5f" stroke="#38bdf8"/>
-  <text x="352" y="196" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">Detection</text>
-  <text x="352" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Ingest → detect → convert</text>
-  <text x="352" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">OCSF 1.8 by default, native available</text>
+  <rect x="68" y="146" width="1064" height="70" rx="18" fill="#0f172a" stroke="#475569"/>
+  <text x="92" y="176" fill="#e2e8f0" font-size="20" font-family="Arial, sans-serif" font-weight="700">L0 External sources</text>
+  <text x="92" y="202" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Cloud APIs, raw logs, identity providers, Kubernetes audit, lakehouse tables, MCP proxy events</text>
 
-  <rect x="590" y="160" width="230" height="120" rx="18" fill="#1f2937" stroke="#2dd4bf"/>
-  <text x="612" y="196" fill="#dcfce7" font-size="22" font-family="Arial, sans-serif" font-weight="700">Remediation</text>
-  <text x="612" y="226" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">IAM departures workflow</text>
-  <text x="612" y="248" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Dry-run + dual audit</text>
+  <rect x="68" y="246" width="1064" height="54" rx="16" fill="#082f49" stroke="#38bdf8"/>
+  <text x="92" y="280" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">Shipped skill layers</text>
 
-  <rect x="850" y="160" width="230" height="120" rx="18" fill="#3b0764" stroke="#c084fc"/>
-  <text x="872" y="196" fill="#f5d0fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">AI Infra</text>
-  <text x="872" y="226" fill="#ddd6fe" font-size="15" font-family="Arial, sans-serif">Model serving</text>
-  <text x="872" y="248" fill="#ddd6fe" font-size="15" font-family="Arial, sans-serif">GPU + environment discovery</text>
+  <rect x="68" y="322" width="154" height="118" rx="18" fill="#172554" stroke="#60a5fa"/>
+  <text x="88" y="355" fill="#e0f2fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">L1 Ingest</text>
+  <text x="88" y="381" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">raw source</text>
+  <text x="88" y="403" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">to repo-native,</text>
+  <text x="88" y="425" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">OCSF, or bridge</text>
 
-  <rect x="180" y="340" width="840" height="96" rx="18" fill="#0f172a" stroke="#475569"/>
-  <text x="210" y="378" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">Shared contracts</text>
-  <text x="210" y="408" fill="#cbd5e1" font-size="16" font-family="Arial, sans-serif">AGENTS.md • SKILL.md • OCSF contract • SECURITY_BAR • architecture docs</text>
+  <rect x="242" y="322" width="154" height="118" rx="18" fill="#1d4ed8" stroke="#60a5fa"/>
+  <text x="262" y="355" fill="#eff6ff" font-size="22" font-family="Arial, sans-serif" font-weight="700">L2 Discover</text>
+  <text x="262" y="381" fill="#dbeafe" font-size="15" font-family="Arial, sans-serif">inventory, evidence,</text>
+  <text x="262" y="403" fill="#dbeafe" font-size="15" font-family="Arial, sans-serif">AI BOM, context</text>
 
-  <rect x="140" y="474" width="920" height="86" rx="18" fill="#111827" stroke="#64748b"/>
-  <text x="170" y="510" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">CI lanes</text>
-  <text x="170" y="540" fill="#cbd5e1" font-size="16" font-family="Arial, sans-serif">lint • security-scan • test-compliance • test-remediation • test-detection-engineering • test-ai-infra • test-integration • validate-iac • agent-bom</text>
+  <rect x="416" y="322" width="154" height="118" rx="18" fill="#0f766e" stroke="#2dd4bf"/>
+  <text x="436" y="355" fill="#ccfbf1" font-size="22" font-family="Arial, sans-serif" font-weight="700">L3 Detect</text>
+  <text x="436" y="381" fill="#ccfbf1" font-size="15" font-family="Arial, sans-serif">deterministic</text>
+  <text x="436" y="403" fill="#ccfbf1" font-size="15" font-family="Arial, sans-serif">attack findings</text>
 
-  <path d="M185 280 L250 340" stroke="#60a5fa" stroke-width="3" fill="none"/>
-  <path d="M445 280 L460 340" stroke="#38bdf8" stroke-width="3" fill="none"/>
-  <path d="M705 280 L680 340" stroke="#2dd4bf" stroke-width="3" fill="none"/>
-  <path d="M965 280 L890 340" stroke="#c084fc" stroke-width="3" fill="none"/>
-  <path d="M600 436 L600 474" stroke="#94a3b8" stroke-width="3" fill="none"/>
+  <rect x="590" y="322" width="154" height="118" rx="18" fill="#14532d" stroke="#4ade80"/>
+  <text x="610" y="355" fill="#dcfce7" font-size="22" font-family="Arial, sans-serif" font-weight="700">L4 Evaluate</text>
+  <text x="610" y="381" fill="#dcfce7" font-size="15" font-family="Arial, sans-serif">benchmarks, posture,</text>
+  <text x="610" y="403" fill="#dcfce7" font-size="15" font-family="Arial, sans-serif">control evidence</text>
+
+  <rect x="764" y="322" width="154" height="118" rx="18" fill="#7c2d12" stroke="#fb923c"/>
+  <text x="784" y="355" fill="#ffedd5" font-size="22" font-family="Arial, sans-serif" font-weight="700">L5 Remediate</text>
+  <text x="784" y="381" fill="#ffedd5" font-size="15" font-family="Arial, sans-serif">guarded writes,</text>
+  <text x="784" y="403" fill="#ffedd5" font-size="15" font-family="Arial, sans-serif">HITL, dual audit</text>
+
+  <rect x="938" y="322" width="154" height="118" rx="18" fill="#581c87" stroke="#c084fc"/>
+  <text x="958" y="355" fill="#f5d0fe" font-size="22" font-family="Arial, sans-serif" font-weight="700">L6 View</text>
+  <text x="958" y="381" fill="#f5d0fe" font-size="15" font-family="Arial, sans-serif">SARIF, Mermaid,</text>
+  <text x="958" y="403" fill="#f5d0fe" font-size="15" font-family="Arial, sans-serif">delivery formats</text>
+
+  <path d="M145 300 L145 322" stroke="#60a5fa" stroke-width="3" fill="none"/>
+  <path d="M319 300 L319 322" stroke="#60a5fa" stroke-width="3" fill="none"/>
+  <path d="M493 300 L493 322" stroke="#60a5fa" stroke-width="3" fill="none"/>
+  <path d="M667 300 L667 322" stroke="#60a5fa" stroke-width="3" fill="none"/>
+  <path d="M841 300 L841 322" stroke="#60a5fa" stroke-width="3" fill="none"/>
+  <path d="M1015 300 L1015 322" stroke="#60a5fa" stroke-width="3" fill="none"/>
+
+  <rect x="68" y="474" width="1064" height="54" rx="16" fill="#1f2937" stroke="#64748b"/>
+  <text x="92" y="508" fill="#f8fafc" font-size="22" font-family="Arial, sans-serif" font-weight="700">Shared skill contract</text>
+  <text x="344" y="508" fill="#cbd5e1" font-size="16" font-family="Arial, sans-serif">SKILL.md • src/ • tests/ • REFERENCES.md • repo-native / canonical / OCSF / bridge</text>
+
+  <path d="M580 440 L580 474" stroke="#94a3b8" stroke-width="3" fill="none"/>
+  <path d="M620 440 L620 474" stroke="#94a3b8" stroke-width="3" fill="none"/>
+
+  <rect x="68" y="554" width="336" height="120" rx="18" fill="#0f172a" stroke="#475569"/>
+  <text x="92" y="589" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">L7 and L8 edge layers</text>
+  <text x="92" y="617" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">L7 sinks: customer-owned persistence edges</text>
+  <text x="92" y="639" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">L8 query packs: warehouse-native SQL analytics</text>
+
+  <rect x="432" y="554" width="336" height="120" rx="18" fill="#0f172a" stroke="#475569"/>
+  <text x="456" y="589" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">L9 runtime surfaces</text>
+  <text x="456" y="617" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">CLI, CI, MCP, and runners call the same skills</text>
+  <text x="456" y="639" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">wrappers add orchestration, not a second implementation</text>
+
+  <rect x="796" y="554" width="336" height="120" rx="18" fill="#0f172a" stroke="#475569"/>
+  <text x="820" y="589" fill="#f8fafc" font-size="24" font-family="Arial, sans-serif" font-weight="700">Key rule</text>
+  <text x="820" y="617" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Architecture doc explains the contract.</text>
+  <text x="820" y="639" fill="#cbd5e1" font-size="15" font-family="Arial, sans-serif">Diagrams exist to simplify it, not replace it.</text>
 </svg>


### PR DESCRIPTION
## Summary
- simplify `docs/ARCHITECTURE.md` so it reads as the design contract first and the visual companion second
- replace the dense repo overview with a cleaner layered SVG that stays readable in GitHub preview
- add a direct README definition and links for `native` as the repo-owned external wire format

## Validation
- `python scripts/validate_skill_contract.py` currently fails in this checkout because an empty local `skills/ingestion/source-snowflake-query/` directory is present without `SKILL.md`; that stale local directory is not part of this PR
- reviewed the rendered markdown diffs for `README.md`, `docs/ARCHITECTURE.md`, and `docs/DIAGRAMS.md`
