### PR TITLE
ci: attach signed sbom assets to releases

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,63 @@
+name: Release Assets
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to build release assets for
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  signed-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ steps.meta.outputs.tag }}
+
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: "3.11"
+          packages: uv==0.10.9
+
+      - name: Export full-lock CycloneDX SBOM
+        run: |
+          uv export \
+            --preview-features sbom-export \
+            --format cyclonedx1.5 \
+            --all-groups \
+            --output-file cloud-ai-security-skills-full-lock.cdx.json
+
+      - uses: sigstore/cosign-installer@v3.8.1
+
+      - name: Sign SBOM with GitHub OIDC
+        run: |
+          cosign sign-blob --yes \
+            --output-signature cloud-ai-security-skills-full-lock.cdx.json.sig \
+            --output-certificate cloud-ai-security-skills-full-lock.cdx.json.pem \
+            cloud-ai-security-skills-full-lock.cdx.json
+
+      - name: Upload signed SBOM set to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.meta.outputs.tag }}" \
+            cloud-ai-security-skills-full-lock.cdx.json \
+            cloud-ai-security-skills-full-lock.cdx.json.sig \
+            cloud-ai-security-skills-full-lock.cdx.json.pem \
+            --clobber

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -28,6 +28,8 @@ The CI pipeline is split into independent lanes so failures point at the right k
   - repo coverage gates for overall, detection, and evaluation floors
 - `sbom`
   - publishes a signed CycloneDX artifact set for the full locked dependency graph
+- `release-assets`
+  - rebuilds and attaches the signed CycloneDX SBOM set to published GitHub Releases
 - `validate-iac`
   - CloudFormation and Terraform validation
 - `agent-bom`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -68,8 +68,10 @@ git push origin vX.Y.Z
 3. Verify the tag points at the intended merge commit.
 4. Verify GitHub Actions passed on the tagged commit if a release workflow uses
    tag triggers.
-5. If a release artifact is published, include or reference the latest
-   signed CycloneDX SBOM artifact set from CI.
+5. Verify the release workflow attached the signed CycloneDX SBOM set:
+   - `cloud-ai-security-skills-full-lock.cdx.json`
+   - `cloud-ai-security-skills-full-lock.cdx.json.sig`
+   - `cloud-ai-security-skills-full-lock.cdx.json.pem`
 
 ## Post-Release
 

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -109,10 +109,23 @@ See:
 - [`SECURITY_BAR.md`](../SECURITY_BAR.md)
 - [`docs/RELEASE_CHECKLIST.md`](RELEASE_CHECKLIST.md)
 
+## Release Distribution
+
+Published GitHub Releases now rebuild and attach the same signed CycloneDX
+artifact set that CI produces:
+
+- `cloud-ai-security-skills-full-lock.cdx.json`
+- `cloud-ai-security-skills-full-lock.cdx.json.sig`
+- `cloud-ai-security-skills-full-lock.cdx.json.pem`
+
+That keeps the release surface self-contained for buyers, auditors, and
+downstream automation that reads release assets instead of CI artifacts.
+
 ## Future Tightenings
 
 - export a runtime-group SBOM artifact once the repo's non-package group layout
   supports a clean grouped CycloneDX export without workarounds
-- attach the signed CycloneDX artifact set to tagged releases
 - add broader signed provenance or release attestations if the release flow
   grows beyond the current repo-level tag process
+- emit SPDX alongside CycloneDX if a customer or procurement workflow requires
+  both formats


### PR DESCRIPTION
## Summary
- add a dedicated release workflow that rebuilds, signs, and uploads the CycloneDX SBOM set to published GitHub Releases
- keep the existing CI `sbom` lane for per-commit artifacts and add release-time distribution on top
- update supply-chain and release docs so the repo can accurately claim release-attached signed SBOM assets

## Validation
- `python scripts/validate_skill_contract.py`
- reviewed `.github/workflows/release-assets.yml`, `docs/SUPPLY_CHAIN.md`, `docs/CI_WORKFLOW.md`, and `docs/RELEASE_CHECKLIST.md`
