### PR TITLE
feat: add gcp gcs pubsub detect runner template

### DIFF
--- a/runners/gcp-gcs-pubsub-detect/README.md
+++ b/runners/gcp-gcs-pubsub-detect/README.md
@@ -1,0 +1,73 @@
+# gcp-gcs-pubsub-detect
+
+Reference persistent runner template for continuous ingest -> detect pipelines
+on GCP.
+
+## What it does
+
+```text
+GCS object finalized
+  -> ingest Cloud Function
+  -> Pub/Sub detect topic
+  -> detect Cloud Function
+  -> Firestore dedupe
+  -> Pub/Sub findings topic
+```
+
+The runner keeps state and side effects at the edges:
+- Cloud Storage is the raw object source
+- Pub/Sub provides durable decoupling and downstream fan-out
+- Firestore stores replay-safe dedupe keys
+- the skills remain unchanged and stateless
+
+## When to use it
+
+- You want a repo-owned GCP pattern that mirrors the shipped AWS runner
+- You need continuous ingest -> detect on GCP without changing skill code
+- You want a queue-driven example that can wrap any compatible `ingest-*` and
+  `detect-*` pair
+
+## What it does not do
+
+- It is not a generic sink framework for every GCP destination
+- It does not package Cloud Function archives for you
+- It does not hardcode a specific skill family, detector, or downstream sink
+
+## Required environment variables
+
+### Ingest function
+
+- `INGEST_SKILL_CMD`
+  Example: `python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py --output-format native`
+- `DETECT_TOPIC`
+  Fully qualified Pub/Sub topic path such as
+  `projects/my-project/topics/cloud-security-detect`
+
+### Detect function
+
+- `DETECT_SKILL_CMD`
+  Example: `python skills/detection/detect-lateral-movement/src/detect.py --output-format native`
+- `DEDUPE_COLLECTION`
+  Firestore collection used for replay-safe dedupe keys
+- `FINDINGS_TOPIC`
+  Fully qualified Pub/Sub topic path such as
+  `projects/my-project/topics/cloud-security-findings`
+
+## Packaging model
+
+The Terraform template expects:
+- an existing source bucket name
+- one GCS bucket for Cloud Function source archives
+- one object name for the ingest function archive
+- one object name for the detect function archive
+
+That keeps the template deployable without assuming a build system.
+
+## Security model
+
+- no shell invocation; skill commands are tokenized with `shlex.split`
+- `subprocess.run(..., shell=False)` only
+- Firestore `create()` semantics prevent duplicate publish on replay
+- Pub/Sub findings fan-out sees only deduped findings
+- operators should scope the service accounts to the specific bucket, topics,
+  and Firestore collection for their environment

--- a/runners/gcp-gcs-pubsub-detect/main.tf
+++ b/runners/gcp-gcs-pubsub-detect/main.tf
@@ -1,0 +1,187 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "source_bucket_name" {
+  type = string
+}
+
+variable "function_source_bucket" {
+  type = string
+}
+
+variable "ingest_source_object" {
+  type = string
+}
+
+variable "detect_source_object" {
+  type = string
+}
+
+variable "ingest_skill_command" {
+  type = string
+}
+
+variable "detect_skill_command" {
+  type = string
+}
+
+variable "dedupe_collection" {
+  type    = string
+  default = "runner_dedupe"
+}
+
+resource "google_pubsub_topic" "detect" {
+  name = "cloud-security-detect"
+}
+
+resource "google_pubsub_topic" "findings" {
+  name = "cloud-security-findings"
+}
+
+resource "google_firestore_database" "dedupe" {
+  project     = var.project_id
+  name        = "(default)"
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+}
+
+resource "google_service_account" "ingest" {
+  account_id   = "cloud-security-ingest"
+  display_name = "cloud-ai-security ingest runner"
+}
+
+resource "google_service_account" "detect" {
+  account_id   = "cloud-security-detect"
+  display_name = "cloud-ai-security detect runner"
+}
+
+resource "google_project_iam_member" "ingest_storage_reader" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.ingest.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "ingest_publisher" {
+  topic  = google_pubsub_topic.detect.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.ingest.email}"
+}
+
+resource "google_project_iam_member" "detect_firestore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.detect.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "detect_publisher" {
+  topic  = google_pubsub_topic.findings.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.detect.email}"
+}
+
+resource "google_storage_bucket_iam_member" "source_eventarc_reader" {
+  bucket = var.source_bucket_name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.ingest.email}"
+}
+
+resource "google_cloudfunctions2_function" "ingest" {
+  name     = "cloud-security-ingest"
+  location = var.region
+
+  build_config {
+    runtime     = "python311"
+    entry_point = "handle_gcs_event"
+    source {
+      storage_source {
+        bucket = var.function_source_bucket
+        object = var.ingest_source_object
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = "512M"
+    timeout_seconds       = 300
+    service_account_email = google_service_account.ingest.email
+    environment_variables = {
+      INGEST_SKILL_CMD = var.ingest_skill_command
+      DETECT_TOPIC     = "projects/${var.project_id}/topics/${google_pubsub_topic.detect.name}"
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.storage.object.v1.finalized"
+    event_filters {
+      attribute = "bucket"
+      value     = var.source_bucket_name
+    }
+    retry_policy = "RETRY_POLICY_RETRY"
+  }
+}
+
+resource "google_cloudfunctions2_function" "detect" {
+  name     = "cloud-security-detect"
+  location = var.region
+
+  build_config {
+    runtime     = "python311"
+    entry_point = "handle_pubsub_event"
+    source {
+      storage_source {
+        bucket = var.function_source_bucket
+        object = var.detect_source_object
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = "512M"
+    timeout_seconds       = 300
+    service_account_email = google_service_account.detect.email
+    environment_variables = {
+      DETECT_SKILL_CMD = var.detect_skill_command
+      DEDUPE_COLLECTION = var.dedupe_collection
+      FINDINGS_TOPIC   = "projects/${var.project_id}/topics/${google_pubsub_topic.findings.name}"
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic   = google_pubsub_topic.detect.id
+    retry_policy   = "RETRY_POLICY_RETRY"
+  }
+
+  depends_on = [google_firestore_database.dedupe]
+}
+
+output "detect_topic" {
+  value = google_pubsub_topic.detect.id
+}
+
+output "findings_topic" {
+  value = google_pubsub_topic.findings.id
+}

--- a/runners/gcp-gcs-pubsub-detect/src/detect_handler.py
+++ b/runners/gcp-gcs-pubsub-detect/src/detect_handler.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import subprocess
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Any
+
+try:
+    from google.api_core.exceptions import Conflict
+    from google.cloud import firestore, pubsub_v1
+except ImportError:  # pragma: no cover - exercised only in minimal local test envs
+    Conflict = RuntimeError
+    firestore = None
+    pubsub_v1 = None
+
+
+def _firestore_client():
+    if firestore is None:
+        raise RuntimeError("google-cloud-firestore is required for the GCP runner")
+    return firestore.Client()
+
+
+def _publisher_client():
+    if pubsub_v1 is None:
+        raise RuntimeError("google-cloud-pubsub is required for the GCP runner")
+    return pubsub_v1.PublisherClient()
+
+
+def _skill_command() -> list[str]:
+    raw = os.environ.get("DETECT_SKILL_CMD", "").strip()
+    if not raw:
+        raise ValueError("DETECT_SKILL_CMD is required")
+    return shlex.split(raw)
+
+
+def _dedupe_collection() -> str:
+    name = os.environ.get("DEDUPE_COLLECTION", "").strip()
+    if not name:
+        raise ValueError("DEDUPE_COLLECTION is required")
+    return name
+
+
+def _findings_topic() -> str:
+    topic = os.environ.get("FINDINGS_TOPIC", "").strip()
+    if not topic:
+        raise ValueError("FINDINGS_TOPIC is required")
+    return topic
+
+
+def _run_skill(lines: list[str]) -> list[str]:
+    completed = subprocess.run(
+        _skill_command(),
+        input="\n".join(lines) + ("\n" if lines else ""),
+        text=True,
+        capture_output=True,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "detect skill failed")
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _extract_uid(record: dict[str, Any]) -> str:
+    finding_info = record.get("finding_info")
+    if isinstance(finding_info, dict):
+        uid = finding_info.get("uid")
+        if isinstance(uid, str) and uid:
+            return uid
+
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        uid = metadata.get("uid")
+        if isinstance(uid, str) and uid:
+            return uid
+
+    event_uid = record.get("event_uid")
+    if isinstance(event_uid, str) and event_uid:
+        return event_uid
+
+    raise ValueError("record is missing finding_info.uid, metadata.uid, and event_uid")
+
+
+def _decode_pubsub_event(event: dict[str, Any]) -> list[str]:
+    data = event.get("data")
+    if not data:
+        return []
+    payload = base64.b64decode(data).decode("utf-8")
+    return [line for line in payload.splitlines() if line.strip()]
+
+
+def _put_if_new(uid: str, payload: str) -> bool:
+    document = _firestore_client().collection(_dedupe_collection()).document(uid)
+    item = {
+        "seen_at": datetime.now(UTC).isoformat(),
+        "payload_sha256": sha256(payload.encode("utf-8")).hexdigest(),
+    }
+    try:
+        document.create(item)
+        return True
+    except Conflict:
+        return False
+
+
+def handle_pubsub_event(event: dict[str, Any], _context: Any) -> dict[str, int]:
+    input_lines = _decode_pubsub_event(event)
+    findings = _run_skill(input_lines)
+
+    published = 0
+    duplicates = 0
+    topic = _findings_topic()
+    publisher = _publisher_client()
+
+    for line in findings:
+        record = json.loads(line)
+        uid = _extract_uid(record)
+        if _put_if_new(uid, line):
+            publisher.publish(topic, line.encode("utf-8"))
+            published += 1
+        else:
+            duplicates += 1
+
+    return {"messages_processed": len(input_lines), "published": published, "duplicates": duplicates}

--- a/runners/gcp-gcs-pubsub-detect/src/ingest_handler.py
+++ b/runners/gcp-gcs-pubsub-detect/src/ingest_handler.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from typing import Any
+
+try:
+    from google.cloud import pubsub_v1, storage
+except ImportError:  # pragma: no cover - exercised only in minimal local test envs
+    pubsub_v1 = None
+    storage = None
+
+
+def _storage_client():
+    if storage is None:
+        raise RuntimeError("google-cloud-storage is required for the GCP runner")
+    return storage.Client()
+
+
+def _publisher_client():
+    if pubsub_v1 is None:
+        raise RuntimeError("google-cloud-pubsub is required for the GCP runner")
+    return pubsub_v1.PublisherClient()
+
+
+def _skill_command() -> list[str]:
+    raw = os.environ.get("INGEST_SKILL_CMD", "").strip()
+    if not raw:
+        raise ValueError("INGEST_SKILL_CMD is required")
+    return shlex.split(raw)
+
+
+def _detect_topic() -> str:
+    topic = os.environ.get("DETECT_TOPIC", "").strip()
+    if not topic:
+        raise ValueError("DETECT_TOPIC is required")
+    return topic
+
+
+def _run_skill(payload: str) -> list[str]:
+    completed = subprocess.run(
+        _skill_command(),
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "ingest skill failed")
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _read_object(bucket: str, name: str) -> str:
+    blob = _storage_client().bucket(bucket).blob(name)
+    return blob.download_as_text()
+
+
+def handle_gcs_event(event: dict[str, Any], _context: Any) -> dict[str, int]:
+    bucket = event["bucket"]
+    name = event["name"]
+    payload = _read_object(bucket, name)
+    lines = _run_skill(payload)
+
+    topic = _detect_topic()
+    published = 0
+    publisher = _publisher_client()
+    for line in lines:
+        publisher.publish(topic, line.encode("utf-8"))
+        published += 1
+
+    return {"objects_processed": 1, "messages_enqueued": published}

--- a/tests/integration/test_gcp_runner_template.py
+++ b/tests/integration/test_gcp_runner_template.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+INGEST = _load_module(
+    "cloud_security_gcp_runner_ingest_handler_test",
+    ROOT / "runners" / "gcp-gcs-pubsub-detect" / "src" / "ingest_handler.py",
+)
+DETECT = _load_module(
+    "cloud_security_gcp_runner_detect_handler_test",
+    ROOT / "runners" / "gcp-gcs-pubsub-detect" / "src" / "detect_handler.py",
+)
+
+
+class TestGcpGcsPubsubDetectRunner:
+    def test_ingest_skill_command_requires_env(self, monkeypatch):
+        monkeypatch.delenv("INGEST_SKILL_CMD", raising=False)
+        try:
+            INGEST._skill_command()
+        except ValueError as exc:
+            assert "INGEST_SKILL_CMD" in str(exc)
+        else:
+            raise AssertionError("expected INGEST_SKILL_CMD validation failure")
+
+    def test_ingest_detect_topic_requires_env(self, monkeypatch):
+        monkeypatch.delenv("DETECT_TOPIC", raising=False)
+        try:
+            INGEST._detect_topic()
+        except ValueError as exc:
+            assert "DETECT_TOPIC" in str(exc)
+        else:
+            raise AssertionError("expected DETECT_TOPIC validation failure")
+
+    def test_detect_extracts_uid_from_finding_info(self):
+        record = {"finding_info": {"uid": "det-123"}, "metadata": {"uid": "meta-123"}}
+        assert DETECT._extract_uid(record) == "det-123"
+
+    def test_detect_falls_back_to_metadata_uid(self):
+        record = {"metadata": {"uid": "meta-123"}}
+        assert DETECT._extract_uid(record) == "meta-123"
+
+    def test_detect_falls_back_to_event_uid(self):
+        record = {"event_uid": "evt-123"}
+        assert DETECT._extract_uid(record) == "evt-123"
+
+    def test_decode_pubsub_event(self):
+        payload = "line-1\nline-2\n".encode("utf-8")
+        event = {"data": base64.b64encode(payload).decode("ascii")}
+        assert DETECT._decode_pubsub_event(event) == ["line-1", "line-2"]


### PR DESCRIPTION
## Summary
- add a GCP reference runner template at `runners/gcp-gcs-pubsub-detect/`
- keep the existing skill contract unchanged while adding GCS -> ingest function -> Pub/Sub -> detect function -> Firestore dedupe -> findings topic wiring
- add focused integration tests for the GCP runner handlers

## Validation
- `uv run pytest tests/integration/test_gcp_runner_template.py -q -o addopts=''`
- `uv run ruff check runners/gcp-gcs-pubsub-detect/src tests/integration/test_gcp_runner_template.py --config pyproject.toml`
- `python scripts/validate_skill_contract.py`
