### PR TITLE
feat: add azure blob eventgrid detect runner template

### DIFF
--- a/runners/azure-blob-eventgrid-detect/README.md
+++ b/runners/azure-blob-eventgrid-detect/README.md
@@ -1,0 +1,80 @@
+# azure-blob-eventgrid-detect
+
+Reference persistent runner template for Azure Blob Storage event-driven ingest
+and detection pipelines.
+
+## Flow
+
+```text
+Blob create
+  -> Event Grid subscription
+  -> ingest queue
+  -> ingest handler
+  -> detect queue
+  -> detect handler
+  -> Table Storage dedupe
+  -> Service Bus topic
+```
+
+The runner keeps state and side effects at the edges:
+- Blob Storage is the raw source
+- Event Grid routes blob-created events into the ingest queue
+- the ingest handler reads the blob, runs an ingest skill, and enqueues lines
+- the detect handler consumes queue messages, runs a detect skill, dedupes on a
+  stable UID, and publishes new findings to a topic
+
+The skills remain unchanged and stateless.
+
+## When to use it
+
+- You want a repo-owned Azure persistent runner example beyond IAM departures
+- You need a minimal Azure pattern for continuous ingest -> detect with replay
+  safety
+- You want to wire any compatible `ingest-*` and `detect-*` skill pair into a
+  queue-driven loop
+
+## What it does not do
+
+- It is not a generic sink framework for every cloud or SIEM
+- It does not package Azure Function App artifacts for you
+- It does not hardcode a specific skill family, sink vendor, or storage format
+
+## Required environment variables
+
+### Ingest handler
+
+- `INGEST_SKILL_CMD`
+  Example: `python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py --output-format native`
+- `DETECT_QUEUE_NAME`
+- `SERVICE_BUS_FQDN`
+
+### Detect handler
+
+- `DETECT_SKILL_CMD`
+  Example: `python skills/detection/detect-lateral-movement/src/detect.py --output-format native`
+- `DETECT_QUEUE_NAME`
+- `ALERT_TOPIC_NAME`
+- `DEDUPE_TABLE_NAME`
+- `TABLE_ACCOUNT_URL`
+- `SERVICE_BUS_FQDN`
+
+## Packaging model
+
+The template expects the operator to package the queue handlers together with
+their Python dependencies and bind them to an Azure runtime of their choice.
+The template itself provisions:
+
+- the Event Grid subscription for blob-created events
+- an ingest queue
+- a detect queue
+- a fan-out topic
+- a Table Storage account for replay-safe dedupe state
+
+## Security model
+
+- no shell invocation; skill commands are tokenized with `shlex.split`
+- `subprocess.run(..., shell=False)` only
+- Event Grid payloads are treated as untrusted input
+- dedupe prevents duplicate publishes on replay
+- operators should scope the Azure role assignments to the specific blob
+  source, queue, topic, and table resources in their environment

--- a/runners/azure-blob-eventgrid-detect/requirements.txt
+++ b/runners/azure-blob-eventgrid-detect/requirements.txt
@@ -1,0 +1,4 @@
+azure-data-tables>=12.6,<13
+azure-identity>=1.17,<2
+azure-servicebus>=7.13,<8
+azure-storage-blob>=12.24,<13

--- a/runners/azure-blob-eventgrid-detect/src/detect_handler.py
+++ b/runners/azure-blob-eventgrid-detect/src/detect_handler.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Any
+
+SKILL_NAME = "azure-blob-eventgrid-detect"
+
+
+def _skill_command() -> list[str]:
+    raw = os.environ.get("DETECT_SKILL_CMD", "").strip()
+    if not raw:
+        raise ValueError("DETECT_SKILL_CMD is required")
+    return shlex.split(raw)
+
+
+def _service_bus_fqdn() -> str:
+    fqdn = os.environ.get("SERVICE_BUS_FQDN", "").strip()
+    if not fqdn:
+        raise ValueError("SERVICE_BUS_FQDN is required")
+    return fqdn
+
+
+def _alert_topic_name() -> str:
+    topic = os.environ.get("ALERT_TOPIC_NAME", "").strip()
+    if not topic:
+        raise ValueError("ALERT_TOPIC_NAME is required")
+    return topic
+
+
+def _dedupe_table_name() -> str:
+    table_name = os.environ.get("DEDUPE_TABLE_NAME", "").strip()
+    if not table_name:
+        raise ValueError("DEDUPE_TABLE_NAME is required")
+    return table_name
+
+
+def _table_account_url() -> str:
+    url = os.environ.get("TABLE_ACCOUNT_URL", "").strip()
+    if not url:
+        raise ValueError("TABLE_ACCOUNT_URL is required")
+    return url
+
+
+def _run_skill(lines: list[str]) -> list[str]:
+    completed = subprocess.run(
+        _skill_command(),
+        input="\n".join(lines) + ("\n" if lines else ""),
+        text=True,
+        capture_output=True,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "detect skill failed")
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _extract_uid(record: dict[str, Any]) -> str:
+    finding_info = record.get("finding_info")
+    if isinstance(finding_info, dict):
+        uid = finding_info.get("uid")
+        if isinstance(uid, str) and uid:
+            return uid
+
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        uid = metadata.get("uid")
+        if isinstance(uid, str) and uid:
+            return uid
+
+    event_uid = record.get("event_uid")
+    if isinstance(event_uid, str) and event_uid:
+        return event_uid
+
+    raise ValueError("record is missing finding_info.uid, metadata.uid, and event_uid")
+
+
+def _dedupe_table():
+    from azure.data.tables import TableServiceClient
+    from azure.identity import DefaultAzureCredential
+
+    service = TableServiceClient(
+        endpoint=_table_account_url(),
+        credential=DefaultAzureCredential(),
+    )
+    table = service.get_table_client(table_name=_dedupe_table_name())
+    table.create_table_if_not_exists()
+    return table
+
+
+def _put_if_new(uid: str, payload: str) -> bool:
+    from azure.core.exceptions import ResourceExistsError
+
+    table = _dedupe_table()
+    item = {
+        "PartitionKey": "finding",
+        "RowKey": uid,
+        "seen_at": datetime.now(UTC).isoformat(),
+        "payload_sha256": sha256(payload.encode("utf-8")).hexdigest(),
+    }
+    try:
+        table.create_entity(entity=item)
+        return True
+    except ResourceExistsError:
+        return False
+
+
+def _publish_finding(line: str, uid: str) -> None:
+    from azure.identity import DefaultAzureCredential
+    from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+    client = ServiceBusClient(
+        fully_qualified_namespace=_service_bus_fqdn(),
+        credential=DefaultAzureCredential(),
+    )
+    with client:
+        sender = client.get_topic_sender(topic_name=_alert_topic_name())
+        with sender:
+            sender.send_messages(ServiceBusMessage(line, subject=f"skill-finding:{uid}"))
+
+
+def handle_detect_messages(messages: list[str]) -> dict[str, int]:
+    findings = _run_skill(messages)
+    published = 0
+    duplicates = 0
+    for line in findings:
+        record = json.loads(line)
+        uid = _extract_uid(record)
+        if _put_if_new(uid, line):
+            _publish_finding(line, uid)
+            published += 1
+        else:
+            duplicates += 1
+    return {
+        "messages_processed": len(messages),
+        "published": published,
+        "duplicates": duplicates,
+    }

--- a/runners/azure-blob-eventgrid-detect/src/ingest_handler.py
+++ b/runners/azure-blob-eventgrid-detect/src/ingest_handler.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from collections.abc import Iterable
+from typing import Any
+
+SKILL_NAME = "azure-blob-eventgrid-detect"
+
+
+def _skill_command() -> list[str]:
+    raw = os.environ.get("INGEST_SKILL_CMD", "").strip()
+    if not raw:
+        raise ValueError("INGEST_SKILL_CMD is required")
+    return shlex.split(raw)
+
+
+def _service_bus_fqdn() -> str:
+    fqdn = os.environ.get("SERVICE_BUS_FQDN", "").strip()
+    if not fqdn:
+        raise ValueError("SERVICE_BUS_FQDN is required")
+    return fqdn
+
+
+def _ingest_queue_name() -> str:
+    queue_name = os.environ.get("DETECT_QUEUE_NAME", "").strip()
+    if not queue_name:
+        raise ValueError("DETECT_QUEUE_NAME is required")
+    return queue_name
+
+
+def _event_payloads(message_body: str) -> list[dict[str, Any]]:
+    parsed = json.loads(message_body)
+    if isinstance(parsed, dict):
+        return [parsed]
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
+    raise ValueError("Event Grid payload must be a JSON object or array of objects")
+
+
+def _blob_url(event: dict[str, Any]) -> str:
+    data = event.get("data")
+    if isinstance(data, dict):
+        url = data.get("url") or data.get("blobUrl")
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+    raise ValueError("Event Grid blob event is missing data.url")
+
+
+def _download_blob_text(blob_url: str) -> str:
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import BlobClient
+
+    blob = BlobClient.from_blob_url(blob_url, credential=DefaultAzureCredential())
+    return blob.download_blob().readall().decode("utf-8")
+
+
+def _run_skill(payload: str) -> list[str]:
+    completed = subprocess.run(
+        _skill_command(),
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+        shell=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "ingest skill failed")
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _enqueue_detect_lines(lines: Iterable[str]) -> int:
+    from azure.identity import DefaultAzureCredential
+    from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+    client = ServiceBusClient(
+        fully_qualified_namespace=_service_bus_fqdn(),
+        credential=DefaultAzureCredential(),
+    )
+    total = 0
+    with client:
+        sender = client.get_queue_sender(queue_name=_ingest_queue_name())
+        with sender:
+            for line in lines:
+                if not line.strip():
+                    continue
+                sender.send_messages(ServiceBusMessage(line))
+                total += 1
+    return total
+
+
+def handle_ingest_message(message_body: str) -> dict[str, int]:
+    events = _event_payloads(message_body)
+    blobs_processed = 0
+    messages_enqueued = 0
+    for event in events:
+        payload = _download_blob_text(_blob_url(event))
+        lines = _run_skill(payload)
+        blobs_processed += 1
+        messages_enqueued += _enqueue_detect_lines(lines)
+    return {
+        "blob_events_processed": len(events),
+        "blobs_processed": blobs_processed,
+        "messages_enqueued": messages_enqueued,
+    }
+
+
+def handle_ingest_messages(messages: list[str]) -> dict[str, int]:
+    totals = {
+        "queue_messages_processed": len(messages),
+        "blob_events_processed": 0,
+        "blobs_processed": 0,
+        "messages_enqueued": 0,
+    }
+    for body in messages:
+        result = handle_ingest_message(body)
+        for key in ("blob_events_processed", "blobs_processed", "messages_enqueued"):
+            totals[key] += result[key]
+    return totals

--- a/runners/azure-blob-eventgrid-detect/template.bicep
+++ b/runners/azure-blob-eventgrid-detect/template.bicep
@@ -1,0 +1,127 @@
+targetScope = 'resourceGroup'
+
+@description('Existing Azure Storage account that emits blob-created events.')
+param sourceStorageAccountName string
+
+@description('Source container name that receives raw objects.')
+param sourceContainerName string
+
+@description('Azure region for the runner resources.')
+param location string = resourceGroup().location
+
+@description('Service Bus namespace used by the runner.')
+param serviceBusNamespaceName string
+
+@description('Queue name that receives Event Grid blob-created messages.')
+param ingestQueueName string = 'ingest-queue'
+
+@description('Queue name that carries normalized event lines into detection.')
+param detectQueueName string = 'detect-queue'
+
+@description('Topic name for deduped findings fan-out.')
+param alertsTopicName string = 'alerts-topic'
+
+@description('Storage account used for replay-safe dedupe state.')
+param dedupeStorageAccountName string
+
+@description('Table name used for replay-safe dedupe state.')
+param dedupeTableName string = 'runnerdedupe'
+
+resource sourceStorage 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+  name: sourceStorageAccountName
+}
+
+resource dedupeStorage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: dedupeStorageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
+  name: serviceBusNamespaceName
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+  properties: {
+    minimumTlsVersion: '1.2'
+  }
+}
+
+resource ingestQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: ingestQueueName
+  properties: {
+    lockDuration: 'PT5M'
+    maxDeliveryCount: 5
+    requiresDuplicateDetection: false
+    deadLetteringOnMessageExpiration: true
+  }
+}
+
+resource detectQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: detectQueueName
+  properties: {
+    lockDuration: 'PT5M'
+    maxDeliveryCount: 5
+    requiresDuplicateDetection: false
+    deadLetteringOnMessageExpiration: true
+  }
+}
+
+resource alertsTopic 'Microsoft.ServiceBus/namespaces/topics@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: alertsTopicName
+  properties: {
+    requiresDuplicateDetection: false
+  }
+}
+
+resource sourceSystemTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' = {
+  name: '${sourceStorageAccountName}-blob-events'
+  location: location
+  properties: {
+    source: sourceStorage.id
+    topicType: 'Microsoft.Storage.StorageAccounts'
+  }
+}
+
+resource blobCreatedToIngestQueue 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2022-06-15' = {
+  parent: sourceSystemTopic
+  name: 'blob-created-to-ingest-queue'
+  properties: {
+    eventDeliverySchema: 'EventGridSchema'
+    filter: {
+      includedEventTypes: [
+        'Microsoft.Storage.BlobCreated'
+      ]
+      subjectBeginsWith: '/blobServices/default/containers/${sourceContainerName}/blobs/'
+    }
+    destination: {
+      endpointType: 'ServiceBusQueue'
+      properties: {
+        resourceId: ingestQueue.id
+      }
+    }
+  }
+}
+
+output sourceStorageAccountName string = sourceStorageAccountName
+output sourceContainerName string = sourceContainerName
+output serviceBusNamespaceFqdn string = serviceBusNamespace.properties.serviceBusEndpoint
+output ingestQueueName string = ingestQueueName
+output detectQueueName string = detectQueueName
+output alertsTopicName string = alertsTopicName
+output dedupeStorageAccountName string = dedupeStorageAccountName
+output dedupeTableName string = dedupeTableName
+output blobCreatedSubscriptionName string = blobCreatedToIngestQueue.name

--- a/tests/integration/test_azure_runner_template.py
+++ b/tests/integration/test_azure_runner_template.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+INGEST = _load_module(
+    "cloud_security_azure_runner_ingest_handler_test",
+    ROOT / "runners" / "azure-blob-eventgrid-detect" / "src" / "ingest_handler.py",
+)
+DETECT = _load_module(
+    "cloud_security_azure_runner_detect_handler_test",
+    ROOT / "runners" / "azure-blob-eventgrid-detect" / "src" / "detect_handler.py",
+)
+
+
+class TestAzureBlobEventGridDetectRunner:
+    def test_ingest_skill_command_requires_env(self, monkeypatch):
+        monkeypatch.delenv("INGEST_SKILL_CMD", raising=False)
+        with pytest.raises(ValueError, match="INGEST_SKILL_CMD"):
+            INGEST._skill_command()
+
+    def test_ingest_service_bus_fqdn_requires_env(self, monkeypatch):
+        monkeypatch.delenv("SERVICE_BUS_FQDN", raising=False)
+        with pytest.raises(ValueError, match="SERVICE_BUS_FQDN"):
+            INGEST._service_bus_fqdn()
+
+    def test_ingest_queue_name_requires_env(self, monkeypatch):
+        monkeypatch.delenv("DETECT_QUEUE_NAME", raising=False)
+        with pytest.raises(ValueError, match="DETECT_QUEUE_NAME"):
+            INGEST._ingest_queue_name()
+
+    def test_ingest_handles_blob_event_and_enqueues_lines(self, monkeypatch):
+        monkeypatch.setattr(INGEST, "_download_blob_text", lambda url: f"blob:{url}")
+        monkeypatch.setattr(INGEST, "_run_skill", lambda payload: [f"{payload}:line1", f"{payload}:line2"])
+        seen_lines: list[str] = []
+        monkeypatch.setattr(
+            INGEST,
+            "_enqueue_detect_lines",
+            lambda lines: seen_lines.extend(lines) or len(lines),
+        )
+
+        result = INGEST.handle_ingest_message(
+            json.dumps({"data": {"url": "https://account.blob.core.windows.net/container/blob.jsonl"}})
+        )
+
+        assert result == {
+            "blob_events_processed": 1,
+            "blobs_processed": 1,
+            "messages_enqueued": 2,
+        }
+        assert seen_lines == [
+            "blob:https://account.blob.core.windows.net/container/blob.jsonl:line1",
+            "blob:https://account.blob.core.windows.net/container/blob.jsonl:line2",
+        ]
+
+    def test_detect_skill_command_requires_env(self, monkeypatch):
+        monkeypatch.delenv("DETECT_SKILL_CMD", raising=False)
+        with pytest.raises(ValueError, match="DETECT_SKILL_CMD"):
+            DETECT._skill_command()
+
+    def test_detect_service_bus_fqdn_requires_env(self, monkeypatch):
+        monkeypatch.delenv("SERVICE_BUS_FQDN", raising=False)
+        with pytest.raises(ValueError, match="SERVICE_BUS_FQDN"):
+            DETECT._service_bus_fqdn()
+
+    def test_detect_alert_topic_name_requires_env(self, monkeypatch):
+        monkeypatch.delenv("ALERT_TOPIC_NAME", raising=False)
+        with pytest.raises(ValueError, match="ALERT_TOPIC_NAME"):
+            DETECT._alert_topic_name()
+
+    def test_detect_dedupe_table_name_requires_env(self, monkeypatch):
+        monkeypatch.delenv("DEDUPE_TABLE_NAME", raising=False)
+        with pytest.raises(ValueError, match="DEDUPE_TABLE_NAME"):
+            DETECT._dedupe_table_name()
+
+    def test_detect_table_account_url_requires_env(self, monkeypatch):
+        monkeypatch.delenv("TABLE_ACCOUNT_URL", raising=False)
+        with pytest.raises(ValueError, match="TABLE_ACCOUNT_URL"):
+            DETECT._table_account_url()
+
+    def test_detect_extracts_uid_from_finding_info_then_metadata_then_event_uid(self):
+        assert DETECT._extract_uid({"finding_info": {"uid": "finding-1"}}) == "finding-1"
+        assert DETECT._extract_uid({"metadata": {"uid": "meta-1"}}) == "meta-1"
+        assert DETECT._extract_uid({"event_uid": "event-1"}) == "event-1"
+
+    def test_detect_handles_findings_and_dedupes(self, monkeypatch):
+        lines = [
+            json.dumps(
+                {
+                    "finding_info": {"uid": "finding-1"},
+                    "metadata": {"uid": "meta-1"},
+                    "event_uid": "event-1",
+                }
+            ),
+            json.dumps({"event_uid": "event-2"}),
+        ]
+        published: list[tuple[str, str]] = []
+        dedupe_results = iter([True, False])
+        monkeypatch.setattr(DETECT, "_run_skill", lambda messages: lines)
+        monkeypatch.setattr(DETECT, "_put_if_new", lambda uid, payload: next(dedupe_results))
+        monkeypatch.setattr(
+            DETECT,
+            "_publish_finding",
+            lambda line, uid: published.append((line, uid)),
+        )
+
+        result = DETECT.handle_detect_messages(["raw message"])
+
+        assert result == {
+            "messages_processed": 1,
+            "published": 1,
+            "duplicates": 1,
+        }
+        assert published == [(lines[0], "finding-1")]
+
+    def test_template_contains_azure_components(self):
+        template = (ROOT / "runners" / "azure-blob-eventgrid-detect" / "template.bicep").read_text()
+        assert "Microsoft.EventGrid/systemTopics" in template
+        assert "Microsoft.ServiceBus/namespaces" in template
+        assert "Microsoft.ServiceBus/namespaces/queues" in template
+        assert "ServiceBusQueue" in template
+        assert "Microsoft.Storage.BlobCreated" in template


### PR DESCRIPTION
## Summary
- add an Azure reference runner under `runners/azure-blob-eventgrid-detect`
- keep the runner isolated from shipped skill code by shelling out to existing skills
- add dedicated integration coverage for the Azure runner handlers and Bicep template

## Validation
- `uv run pytest tests/integration/test_azure_runner_template.py -q -o addopts=''`
- `uv run ruff check runners/azure-blob-eventgrid-detect/src/ingest_handler.py runners/azure-blob-eventgrid-detect/src/detect_handler.py tests/integration/test_azure_runner_template.py --config pyproject.toml`
- `python scripts/validate_skill_contract.py`