### PR TITLE
feat: add clickhouse jsonl sink skill

### DIFF
--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -372,6 +372,15 @@
       "frameworks": ["ocsf-1.8", "soc2-tsc"],
       "coverage_status": "validated",
       "execution_modes": ["cli", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/remediation/sink-clickhouse-jsonl",
+      "layer": "remediation",
+      "providers": ["clickhouse"],
+      "asset_classes": ["findings", "evidence", "audit-logs", "lakehouse"],
+      "frameworks": ["ocsf-1.8", "soc2-tsc"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "mcp", "persistent"]
     }
   ],
   "coverage_targets": [

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -26,6 +26,7 @@ class TestDiscovery:
         assert {skill.name for skill in skills} >= {
             "source-snowflake-query",
             "sink-snowflake-jsonl",
+            "sink-clickhouse-jsonl",
             "ingest-cloudtrail-ocsf",
             "ingest-entra-directory-audit-ocsf",
             "ingest-okta-system-log-ocsf",
@@ -55,6 +56,7 @@ class TestDiscovery:
         tools = tool_map(REPO_ROOT)
         assert "source-snowflake-query" in tools
         assert "sink-snowflake-jsonl" in tools
+        assert "sink-clickhouse-jsonl" in tools
         assert "ingest-cloudtrail-ocsf" in tools
         assert "ingest-entra-directory-audit-ocsf" in tools
         assert "ingest-okta-system-log-ocsf" in tools
@@ -124,6 +126,16 @@ class TestToolDefinition:
         assert skill.output_formats == ("native",)
         assert skill.capability == "write-sink"
         assert skill.approver_roles == ("security_lead", "data_platform_owner")
+
+    def test_sink_clickhouse_jsonl_exposes_write_metadata(self):
+        skill = tool_map(REPO_ROOT)["sink-clickhouse-jsonl"]
+        tool = tool_definition(skill)
+        assert tool["annotations"]["readOnlyHint"] is False
+        assert tool["annotations"]["destructiveHint"] is True
+        assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["native"]
+        assert skill.output_formats == ("native",)
+        assert skill.capability == "write-sink"
+        assert skill.network_egress == ("*.clickhouse.cloud",)
 
     def test_build_command_uses_fixed_entrypoint(self):
         skill = tool_map(REPO_ROOT)["detect-lateral-movement"]

--- a/skills/remediation/sink-clickhouse-jsonl/REFERENCES.md
+++ b/skills/remediation/sink-clickhouse-jsonl/REFERENCES.md
@@ -1,0 +1,5 @@
+# References — sink-clickhouse-jsonl
+
+- **ClickHouse Connect Python driver** — https://clickhouse.com/docs/integrations/python
+- **ClickHouse Connect API** — https://clickhouse.com/docs/integrations/language-clients/python/driver-api
+- **ClickHouse SQL identifiers** — https://clickhouse.com/docs/en/sql-reference/syntax#identifiers

--- a/skills/remediation/sink-clickhouse-jsonl/SKILL.md
+++ b/skills/remediation/sink-clickhouse-jsonl/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: sink-clickhouse-jsonl
+description: >-
+  Append JSONL records from stdin into a pre-provisioned ClickHouse table using
+  the official ClickHouse client insert API only. Dry-run is the default and
+  emits a native sink-result summary without writing. Use when the user
+  already has findings, evidence, or audit rows and wants to persist them to
+  ClickHouse without changing the producing skill. Do NOT use for DDL, schema
+  creation, table mutation, or arbitrary SQL execution. Do NOT use as an
+  ingest, detect, or evaluation skill.
+license: Apache-2.0
+capability: write-sink
+approval_model: human_required
+execution_modes: jit, mcp, persistent
+side_effects: writes-database
+input_formats: raw, native, ocsf
+output_formats: native
+network_egress: "*.clickhouse.cloud"
+caller_roles: security_engineer, platform_engineer
+approver_roles: security_lead, data_platform_owner
+min_approvers: 1
+---
+
+# sink-clickhouse-jsonl
+
+Append-only ClickHouse sink: JSONL in on `stdin`, client-side insert into a
+pre-provisioned ClickHouse table, native sink-result summary out on `stdout`.
+
+## Use when
+
+- Findings, evidence, or audit records already exist on stdin as JSONL
+- You need a repo-owned persistence step after `detect-*`, `discover-*`, `view/*`, or another sink-safe producer
+- The target ClickHouse table already exists and should remain append-only
+
+## Do NOT use
+
+- For `CREATE`, `ALTER`, `DROP`, `TRUNCATE`, `OPTIMIZE`, or grant operations
+- For schema migration or table bootstrap
+- As a detector, ingest normalizer, or remediation workflow by itself
+- When you need to write to a system other than ClickHouse
+
+## Do NOT do
+
+- Do **not** point this skill at privileged admin tables
+- Do **not** use `--apply` without an operator approval step outside the CLI
+- Do **not** pass arbitrary SQL as a table name
+- Do **not** assume this skill creates or changes schema for you
+
+## Input
+
+Reads JSONL from `stdin`. Each line must be a valid JSON object.
+
+Accepted source shapes:
+
+- repo-native event or finding JSON
+- OCSF JSON
+- raw JSON objects you intentionally want to persist as-is
+
+Required CLI argument:
+
+- `--table <table>` where `<table>` is a validated ClickHouse identifier path:
+  - `table`
+  - `database.table`
+
+Safety flags:
+
+- default mode is dry-run
+- `--apply` executes writes
+- `--dry-run` keeps the write path disabled explicitly
+
+## Output
+
+Emits one repo-native sink-result JSON object to `stdout`:
+
+- `schema_mode: "native"`
+- `record_type: "sink_result"`
+- `sink: "clickhouse"`
+- `table`
+- `dry_run`
+- `input_records`
+- `inserted_records`
+- `would_insert_records`
+- `schema_modes`
+
+## Sink table contract
+
+This skill expects a pre-created table with at least these columns:
+
+```sql
+CREATE TABLE security.findings_sink (
+  payload String,
+  schema_mode LowCardinality(String),
+  event_uid String,
+  finding_uid String,
+  ingested_at DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY (schema_mode, event_uid, finding_uid);
+```
+
+The skill only inserts into:
+
+- `payload`
+- `schema_mode`
+- `event_uid`
+- `finding_uid`
+
+It does not create, alter, or merge schema.
+
+## Examples
+
+```bash
+# Dry-run by default
+python skills/detection/detect-lateral-movement/src/detect.py < events.ocsf.jsonl \
+  | python skills/remediation/sink-clickhouse-jsonl/src/sink.py \
+      --table security.findings_sink
+
+# Explicit apply for direct operator use
+python skills/discovery/discover-control-evidence/src/discover.py \
+  | python skills/remediation/sink-clickhouse-jsonl/src/sink.py \
+      --table security.evidence_sink \
+      --apply
+```
+
+## Credentials
+
+Uses the standard ClickHouse connector environment variables:
+
+- `CLICKHOUSE_HOST`
+- `CLICKHOUSE_USER`
+- `CLICKHOUSE_PASSWORD`
+
+Optional:
+
+- `CLICKHOUSE_PORT`
+- `CLICKHOUSE_DATABASE`
+- `CLICKHOUSE_SECURE`
+
+Prefer manager-injected credentials and TLS-enabled ClickHouse Cloud endpoints.

--- a/skills/remediation/sink-clickhouse-jsonl/src/sink.py
+++ b/skills/remediation/sink-clickhouse-jsonl/src/sink.py
@@ -1,0 +1,176 @@
+"""Append JSONL records into a pre-provisioned ClickHouse table."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+SKILL_NAME = "sink-clickhouse-jsonl"
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,254}$")
+
+
+@dataclass(frozen=True)
+class PreparedRow:
+    payload_json: str
+    schema_mode: str
+    event_uid: str
+    finding_uid: str
+
+
+def _quote_identifier(identifier: str) -> str:
+    if not IDENTIFIER_RE.fullmatch(identifier):
+        raise ValueError(f"invalid ClickHouse identifier `{identifier}`")
+    return identifier
+
+
+def _normalize_table_name(raw_table: str) -> str:
+    table = raw_table.strip()
+    if not table:
+        raise ValueError("table must not be empty")
+    parts = table.split(".")
+    if not 1 <= len(parts) <= 2:
+        raise ValueError("table must be one of: table or database.table")
+    return ".".join(_quote_identifier(part) for part in parts)
+
+
+def _extract_schema_mode(record: dict[str, Any]) -> str:
+    schema_mode = record.get("schema_mode")
+    if isinstance(schema_mode, str) and schema_mode.strip():
+        return schema_mode
+    if "class_uid" in record or "finding_info" in record or "metadata" in record:
+        return "ocsf"
+    return "raw"
+
+
+def _extract_event_uid(record: dict[str, Any]) -> str:
+    event_uid = record.get("event_uid")
+    if isinstance(event_uid, str):
+        return event_uid
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        metadata_uid = metadata.get("uid")
+        if isinstance(metadata_uid, str):
+            return metadata_uid
+    return ""
+
+
+def _extract_finding_uid(record: dict[str, Any]) -> str:
+    finding_uid = record.get("finding_uid")
+    if isinstance(finding_uid, str):
+        return finding_uid
+    finding_info = record.get("finding_info")
+    if isinstance(finding_info, dict):
+        finding_info_uid = finding_info.get("uid")
+        if isinstance(finding_info_uid, str):
+            return finding_info_uid
+    return ""
+
+
+def _prepare_rows(stdin: Iterable[str]) -> list[PreparedRow]:
+    rows: list[PreparedRow] = []
+    for line_number, raw_line in enumerate(stdin, start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number}: invalid JSON ({exc.msg})") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"line {line_number}: expected a JSON object")
+        rows.append(
+            PreparedRow(
+                payload_json=json.dumps(payload, separators=(",", ":"), sort_keys=True),
+                schema_mode=_extract_schema_mode(payload),
+                event_uid=_extract_event_uid(payload),
+                finding_uid=_extract_finding_uid(payload),
+            )
+        )
+    return rows
+
+
+def _connect() -> Any:
+    import clickhouse_connect
+
+    kwargs: dict[str, Any] = {
+        "host": os.environ["CLICKHOUSE_HOST"],
+        "username": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+    }
+    if (port := os.environ.get("CLICKHOUSE_PORT")):
+        kwargs["port"] = int(port)
+    if (database := os.environ.get("CLICKHOUSE_DATABASE")):
+        kwargs["database"] = database
+    if (secure := os.environ.get("CLICKHOUSE_SECURE")):
+        kwargs["secure"] = secure.lower() not in {"0", "false", "no"}
+    return clickhouse_connect.get_client(**kwargs)
+
+
+def _insert_rows(table_name: str, rows: list[PreparedRow]) -> int:
+    client = _connect()
+    try:
+        client.insert(
+            table=table_name,
+            data=[
+                [row.payload_json, row.schema_mode, row.event_uid, row.finding_uid]
+                for row in rows
+            ],
+            column_names=["payload", "schema_mode", "event_uid", "finding_uid"],
+        )
+    finally:
+        client.close()
+    return len(rows)
+
+
+def _summary(table_name: str, rows: list[PreparedRow], dry_run: bool, inserted: int) -> dict[str, Any]:
+    schema_modes = Counter(row.schema_mode for row in rows)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": "v1",
+        "record_type": "sink_result",
+        "sink": "clickhouse",
+        "table": table_name,
+        "dry_run": dry_run,
+        "input_records": len(rows),
+        "inserted_records": inserted,
+        "would_insert_records": len(rows) if dry_run else 0,
+        "schema_modes": dict(sorted(schema_modes.items())),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Append JSONL records into a pre-provisioned ClickHouse table.")
+    parser.add_argument("--table", required=True, help="Target ClickHouse table: table or database.table.")
+    parser.add_argument(
+        "--output-format",
+        choices=("native",),
+        default="native",
+        help="Declared output rendering mode for the sink result.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="dry_run", action="store_true", help="Validate and summarize without inserting.")
+    mode.add_argument("--apply", dest="dry_run", action="store_false", help="Execute ClickHouse inserts.")
+    parser.set_defaults(dry_run=True)
+    args = parser.parse_args(argv)
+
+    try:
+        table_name = _normalize_table_name(args.table)
+        rows = _prepare_rows(sys.stdin)
+        if not rows:
+            raise ValueError("stdin did not contain any JSONL records")
+        inserted = 0 if args.dry_run else _insert_rows(table_name, rows)
+        sys.stdout.write(json.dumps(_summary(table_name, rows, args.dry_run, inserted), separators=(",", ":")) + "\n")
+    except Exception as exc:
+        print(f"[{SKILL_NAME}] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py
+++ b/skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py
@@ -1,0 +1,127 @@
+"""Tests for sink-clickhouse-jsonl."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "sink.py"
+_SPEC = importlib.util.spec_from_file_location("sink_clickhouse_jsonl", _SRC)
+assert _SPEC and _SPEC.loader
+_SINK = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SINK
+_SPEC.loader.exec_module(_SINK)
+
+_normalize_table_name = _SINK._normalize_table_name
+_prepare_rows = _SINK._prepare_rows
+_summary = _SINK._summary
+main = _SINK.main
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls = []
+        self.closed = False
+
+    def insert(self, *, table, data, column_names) -> None:
+        self.calls.append(
+            {
+                "table": table,
+                "data": data,
+                "column_names": column_names,
+            }
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestNormalizeTableName:
+    def test_accepts_database_table(self):
+        assert _normalize_table_name("security.findings_sink") == "security.findings_sink"
+
+    def test_rejects_invalid_identifier(self):
+        try:
+            _normalize_table_name("security.findings-sink")
+        except ValueError as exc:
+            assert "invalid ClickHouse identifier" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestPrepareRows:
+    def test_extracts_metadata_from_native_and_ocsf(self):
+        rows = _prepare_rows(
+            [
+                '{"schema_mode":"native","event_uid":"evt-1","finding_uid":"f-1"}\n',
+                '{"metadata":{"uid":"evt-2"},"finding_info":{"uid":"f-2"}}\n',
+            ]
+        )
+
+        assert rows[0].schema_mode == "native"
+        assert rows[1].schema_mode == "ocsf"
+        assert rows[1].event_uid == "evt-2"
+        assert rows[1].finding_uid == "f-2"
+
+
+class TestInsertAndMain:
+    def test_apply_uses_client_insert(self, monkeypatch):
+        fake = _FakeClient()
+        monkeypatch.setattr(_SINK, "_connect", lambda: fake)
+
+        inserted = _SINK._insert_rows(
+            "security.findings_sink",
+            _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1","finding_uid":"f-1"}\n']),
+        )
+
+        assert inserted == 1
+        assert fake.calls == [
+            {
+                "table": "security.findings_sink",
+                "data": [['{"event_uid":"evt-1","finding_uid":"f-1","schema_mode":"native"}', "native", "evt-1", "f-1"]],
+                "column_names": ["payload", "schema_mode", "event_uid", "finding_uid"],
+            }
+        ]
+        assert fake.closed is True
+
+    def test_summary_reports_dry_run(self):
+        rows = _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1"}\n'])
+        result = _summary("security.findings_sink", rows, True, 0)
+
+        assert result["record_type"] == "sink_result"
+        assert result["sink"] == "clickhouse"
+        assert result["would_insert_records"] == 1
+
+    def test_main_defaults_to_dry_run(self, monkeypatch, capsys):
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"schema_mode":"native","event_uid":"evt-1"}\n'))
+
+        exit_code = main(["--table", "security.findings_sink"])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is True
+        assert payload["would_insert_records"] == 1
+
+    def test_main_apply_executes_insert(self, monkeypatch, capsys):
+        fake = _FakeClient()
+        monkeypatch.setattr(_SINK, "_connect", lambda: fake)
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"metadata":{"uid":"evt-2"}}\n'))
+
+        exit_code = main(["--table", "security.findings_sink", "--apply"])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is False
+        assert payload["inserted_records"] == 1
+        assert fake.calls
+
+    def test_main_requires_records(self, monkeypatch, capsys):
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO(""))
+
+        exit_code = main(["--table", "security.findings_sink"])
+
+        assert exit_code == 1
+        assert "stdin did not contain any JSONL records" in capsys.readouterr().err

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -61,6 +61,7 @@ class TestSkillValidationCommon:
         names = {skill.name for skill in skills}
         assert "source-snowflake-query" in names
         assert "sink-snowflake-jsonl" in names
+        assert "sink-clickhouse-jsonl" in names
         assert "detect-lateral-movement" in names
         assert "detect-okta-mfa-fatigue" in names
         assert "detect-entra-credential-addition" in names
@@ -214,6 +215,16 @@ class TestValidationScripts:
     def test_sink_skill_declares_human_approval(self):
         skills = {skill.name: skill for skill in COMMON.discover_skill_contracts()}
         sink = skills["sink-snowflake-jsonl"]
+        assert sink.approval_model == "human_required"
+        assert sink.execution_modes == ("jit", "mcp", "persistent")
+        assert sink.side_effects == ("writes-database",)
+        assert sink.caller_roles == ("security_engineer", "platform_engineer")
+        assert sink.approver_roles == ("security_lead", "data_platform_owner")
+        assert sink.min_approvers == 1
+
+    def test_clickhouse_sink_declares_human_approval(self):
+        skills = {skill.name: skill for skill in COMMON.discover_skill_contracts()}
+        sink = skills["sink-clickhouse-jsonl"]
         assert sink.approval_model == "human_required"
         assert sink.execution_modes == ("jit", "mcp", "persistent")
         assert sink.side_effects == ("writes-database",)


### PR DESCRIPTION
## Summary
- add `sink-clickhouse-jsonl` as the second shipped append-only sink skill
- keep the sink narrow and safe: pre-provisioned table only, ClickHouse client insert API only, dry-run by default
- extend coverage and MCP registry tests for the new sink tool

## Validation
- `uv run pytest skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py tests/integration/test_skill_validation_scripts.py mcp-server/tests/test_tool_registry.py -q -o addopts=''`
- `uv run ruff check skills/remediation/sink-clickhouse-jsonl/src/sink.py skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py mcp-server/tests/test_tool_registry.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml`
- `python scripts/validate_skill_contract.py && python scripts/validate_framework_coverage.py && python scripts/validate_safe_skill_bar.py && python scripts/validate_dependency_consistency.py`
- `uv run bandit -r skills/remediation/sink-clickhouse-jsonl/src -c pyproject.toml --severity-level medium`