### PR TITLE
feat: add first snowflake lateral movement query pack

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ The repo is easiest to read as **six shipped skill layers**, plus **three edge/r
 |---|---|---|
 | L0 | external sources and vendor APIs | outside the repo boundary |
 | L7 | sinks and persistence edges | contract and patterns documented; generic sink family not fully shipped |
-| L8 | query packs and warehouse-native analytics | planned |
+| L8 | query packs and warehouse-native analytics | partial shipping |
 | L9 | agent/runtime surface (`mcp-server`, runners, wrappers) | shipped as thin wrappers around the same skill contract |
 
 The repo operates across four schema modes:
@@ -126,7 +126,7 @@ For the detailed contract, see:
 | L5 remediate | shipping | IAM departures is the current flagship write path |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |
 | L7 sinks | planned / partial patterns | customer-controlled persistence patterns are documented; generic sink family is not fully shipped |
-| L8 query packs | planned | warehouse-native SQL packs remain future work |
+| L8 query packs | partial shipping | first Snowflake pack shipped under `packs/`; broader warehouse-native pack framework remains future work |
 | L9 agent/runtime surfaces | shipping | `mcp-server`, CLI, CI, and runners call the same skill contract |
 
 ## 4. Two execution modes
@@ -237,10 +237,10 @@ cloud-ai-security-skills/
 │   ├── src/server.py
 │   ├── src/tool_registry.py
 │   └── tests/
-├── query/                    # L8 — SQL packs, Cortex prompts, Grafana JSON
-│   ├── snowflake/
-│   ├── clickhouse/
-│   └── grafana/
+├── packs/                    # L8 — SQL packs and warehouse-native analytics
+│   ├── lateral-movement/
+│   ├── privilege-escalation-k8s/
+│   └── clickhouse/
 ├── tests/integration/
 └── docs/
     ├── ARCHITECTURE.md
@@ -249,7 +249,7 @@ cloud-ai-security-skills/
     └── RUNNER_CONTRACT.md     # new, PR V
 ```
 
-**Rationale for separating `sinks/`, `runners/`, `mcp-server/`, `query/` from `skills/`:** the "skills are pure, edges have side effects" mental model becomes visible in the directory tree. A reviewer can tell at a glance whether a change touches pure code or effectful code. This is cheap documentation that pays for itself on every PR.
+**Rationale for separating `sinks/`, `runners/`, `mcp-server/`, and `packs/` from `skills/`:** the "skills are pure, edges have side effects" mental model becomes visible in the directory tree. A reviewer can tell at a glance whether a change touches pure code or effectful code. This is cheap documentation that pays for itself on every PR.
 
 The layered skill directories are now canonical. `skills/detection-engineering/`
 remains only as the shared OCSF contract and frozen-fixture namespace used by

--- a/packs/lateral-movement/README.md
+++ b/packs/lateral-movement/README.md
@@ -1,0 +1,61 @@
+# lateral-movement query pack
+
+Warehouse-native Snowflake implementation of the same detection intent as [`skills/detection/detect-lateral-movement`](../../skills/detection/detect-lateral-movement/SKILL.md).
+
+Use this pack when:
+- your lake already stores OCSF-shaped API Activity (`6003`) and Network Activity (`4001`) rows
+- you want the correlation to run inside Snowflake with zero egress
+- you want OCSF-compatible finding rows without piping data through Python first
+
+Do not use this pack when:
+- your table stores raw vendor payloads instead of OCSF-shaped events
+- you need the repo-native finding shape instead of OCSF-compatible output
+- you need a generalized SQL-pack framework across warehouses; this pack is the first shipped artifact, not a full framework
+
+## Input contract
+
+This SQL expects a pre-existing Snowflake table or view with a single `raw_json VARIANT` column containing one OCSF 1.8 event per row.
+
+Minimum event families:
+- API Activity (`class_uid = 6003`) for identity-pivot anchors
+- Network Activity (`class_uid = 4001`) for accepted east-west traffic
+
+The pack applies the same core thresholds as the Python detector:
+- 15-minute correlation window
+- `activity_id = 6` for accepted network traffic only
+- `traffic.bytes >= 1024`
+- destination IP must be RFC1918 or CGNAT (`100.64.0.0/10`)
+
+## Run
+
+Set the source table, then run the SQL in Snowflake:
+
+```sql
+SET source_table = 'SECURITY_EVENTS_OCSF';
+SET lookback_hours = 24;
+```
+
+Then execute [`snowflake.sql`](./snowflake.sql).
+
+If your column is not named `raw_json`, create a small view that aliases it:
+
+```sql
+CREATE OR REPLACE VIEW SECURITY_EVENTS_OCSF AS
+SELECT payload AS raw_json
+FROM RAW_SECURITY_EVENTS;
+```
+
+## Output contract
+
+The query returns one row per deterministic `(provider, session_uid, dst_ip, dst_port)` tuple with:
+- stable `finding_uid` / `event_uid`
+- ATT&CK `T1021` and `T1078.004`
+- `finding_json` as an OCSF-compatible Detection Finding object
+
+The locked output columns are listed in [`golden/expected_columns.json`](./golden/expected_columns.json).
+
+## Notes
+
+- This pack keeps the data in Snowflake, but the detection logic stays aligned with the shipped Python skill.
+- The SQL is intentionally explicit instead of abstracted through macros so operators can audit it directly.
+- This pack is read-only. Persisting the findings is a separate step, for example through `sink-snowflake-jsonl`.

--- a/packs/lateral-movement/golden/expected_columns.json
+++ b/packs/lateral-movement/golden/expected_columns.json
@@ -1,0 +1,22 @@
+[
+  "finding_uid",
+  "event_uid",
+  "provider",
+  "account_uid",
+  "session_uid",
+  "actor_name",
+  "anchor_operation",
+  "src_instance_uid",
+  "src_ip",
+  "dst_ip",
+  "dst_port",
+  "traffic_bytes",
+  "first_seen_time_ms",
+  "last_seen_time_ms",
+  "finding_time_ms",
+  "correlation_window_seconds",
+  "finding_type",
+  "primary_technique_uid",
+  "secondary_technique_uid",
+  "finding_json"
+]

--- a/packs/lateral-movement/snowflake.sql
+++ b/packs/lateral-movement/snowflake.sql
@@ -1,0 +1,253 @@
+-- lateral-movement query pack for Snowflake
+--
+-- Required session variables:
+--   SET source_table = 'SECURITY_EVENTS_OCSF';
+--   SET lookback_hours = 24;
+--
+-- Input contract:
+--   IDENTIFIER($source_table) must expose a `raw_json VARIANT` column with one
+--   OCSF 1.8 event per row.
+--
+-- Output contract:
+--   One OCSF-compatible Detection Finding row per deterministic
+--   (provider, session_uid, dst_ip, dst_port) tuple.
+
+WITH source_events AS (
+    SELECT raw_json AS event
+    FROM IDENTIFIER($source_table)
+    WHERE COALESCE(TRY_TO_NUMBER(raw_json:time), 0) >= DATE_PART(
+        EPOCH_MILLISECOND,
+        DATEADD('hour', -$lookback_hours, CURRENT_TIMESTAMP())
+    )
+),
+normalized AS (
+    SELECT
+        event,
+        TRY_TO_NUMBER(event:class_uid) AS class_uid,
+        TRY_TO_NUMBER(event:activity_id) AS activity_id,
+        UPPER(COALESCE(event:cloud.provider::string, '')) AS provider,
+        COALESCE(event:cloud.account.uid::string, '') AS account_uid,
+        COALESCE(TRY_TO_NUMBER(event:time), 0) AS time_ms,
+        COALESCE(event:actor.session.uid::string, '') AS session_uid,
+        COALESCE(event:actor.user.name::string, '') AS actor_name,
+        COALESCE(event:api.operation::string, '') AS operation,
+        COALESCE(event:api.service.name::string, '') AS service_name,
+        COALESCE(event:src_endpoint.ip::string, '') AS src_ip,
+        COALESCE(event:src_endpoint.instance_uid::string, '') AS src_instance_uid,
+        COALESCE(event:dst_endpoint.ip::string, '') AS dst_ip,
+        TRY_TO_NUMBER(event:dst_endpoint.port) AS dst_port,
+        COALESCE(TRY_TO_NUMBER(event:traffic.bytes), 0) AS traffic_bytes
+    FROM source_events
+    WHERE TRY_TO_NUMBER(event:class_uid) IN (6003, 4001)
+),
+identity_anchors AS (
+    SELECT *
+    FROM normalized
+    WHERE class_uid = 6003
+      AND (
+        (
+            provider = 'AWS'
+            AND operation IN ('AssumeRole', 'AssumeRoleWithSAML', 'AssumeRoleWithWebIdentity')
+        )
+        OR (
+            provider = 'GCP'
+            AND UPPER(service_name) IN ('IAMCREDENTIALS.GOOGLEAPIS.COM', 'IAM.GOOGLEAPIS.COM')
+            AND REGEXP_LIKE(
+                operation,
+                '(GenerateAccessToken|GenerateIdToken|SignJwt|SignBlob|CreateServiceAccountKey)$'
+            )
+        )
+        OR (
+            provider = 'AZURE'
+            AND (
+                UPPER(operation) IN (
+                    'MICROSOFT.AUTHORIZATION/ROLEASSIGNMENTS/WRITE',
+                    'MICROSOFT.AUTHORIZATION/ELEVATEACCESS/ACTION',
+                    'MICROSOFT.MANAGEDIDENTITY/USERASSIGNEDIDENTITIES/ASSIGN/ACTION'
+                )
+                OR (
+                    UPPER(service_name) IN (
+                        'GRAPH.MICROSOFT.COM',
+                        'MICROSOFT GRAPH',
+                        'MICROSOFT ENTRA ID',
+                        'CORE DIRECTORY'
+                    )
+                    AND (
+                        UPPER(operation) IN (
+                            'ADD SERVICE PRINCIPAL CREDENTIALS',
+                            'UPDATE APPLICATION - CERTIFICATES AND SECRETS MANAGEMENT',
+                            'ADD APP ROLE ASSIGNMENT TO SERVICE PRINCIPAL',
+                            'CREATE FEDERATED IDENTITY CREDENTIAL',
+                            'ADD FEDERATED IDENTITY CREDENTIAL'
+                        )
+                        OR REGEXP_LIKE(REPLACE(UPPER(operation), ' ', ''), 'ADDPASSWORD|ADDKEY')
+                        OR REGEXP_LIKE(
+                            REPLACE(UPPER(operation), ' ', ''),
+                            'APPROLEASSIGNMENTS|APPROLEASSIGNEDTO'
+                        )
+                        OR REGEXP_LIKE(
+                            REPLACE(UPPER(operation), ' ', ''),
+                            'FEDERATEDIDENTITYCREDENTIALS'
+                        )
+                    )
+                )
+            )
+        )
+      )
+),
+flows AS (
+    SELECT *
+    FROM normalized
+    WHERE class_uid = 4001
+      AND activity_id = 6
+      AND traffic_bytes >= 1024
+      AND (
+        REGEXP_LIKE(dst_ip, '^10\\.')
+        OR REGEXP_LIKE(dst_ip, '^192\\.168\\.')
+        OR REGEXP_LIKE(dst_ip, '^172\\.(1[6-9]|2[0-9]|3[0-1])\\.')
+        OR REGEXP_LIKE(dst_ip, '^100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\.')
+      )
+),
+candidate_pairs AS (
+    SELECT
+        anchor.provider,
+        anchor.account_uid,
+        anchor.session_uid,
+        anchor.actor_name,
+        anchor.operation AS anchor_operation,
+        flow.src_instance_uid,
+        flow.src_ip,
+        flow.dst_ip,
+        flow.dst_port,
+        flow.traffic_bytes,
+        anchor.time_ms AS first_seen_time_ms,
+        flow.time_ms AS last_seen_time_ms,
+        flow.time_ms AS finding_time_ms
+    FROM identity_anchors AS anchor
+    JOIN flows AS flow
+      ON flow.provider = anchor.provider
+     AND (
+        anchor.account_uid = ''
+        OR flow.account_uid = ''
+        OR flow.account_uid = anchor.account_uid
+     )
+     AND flow.time_ms BETWEEN anchor.time_ms AND anchor.time_ms + 900000
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY anchor.provider, anchor.session_uid, flow.dst_ip, flow.dst_port
+        ORDER BY flow.time_ms
+    ) = 1
+),
+findings AS (
+    SELECT
+        provider,
+        account_uid,
+        session_uid,
+        actor_name,
+        anchor_operation,
+        src_instance_uid,
+        src_ip,
+        dst_ip,
+        dst_port,
+        traffic_bytes,
+        first_seen_time_ms,
+        last_seen_time_ms,
+        finding_time_ms,
+        CONCAT(
+            'det-lm-',
+            SUBSTR(SHA2(LOWER(COALESCE(NULLIF(provider, ''), 'cloud')), 256), 1, 8),
+            '-',
+            SUBSTR(SHA2(COALESCE(session_uid, ''), 256), 1, 8),
+            '-',
+            SUBSTR(SHA2(CONCAT(COALESCE(dst_ip, ''), ':', COALESCE(dst_port::STRING, '')), 256), 1, 8)
+        ) AS finding_uid,
+        IFF(provider = 'AZURE', 'Azure', provider) AS provider_display
+    FROM candidate_pairs
+)
+SELECT
+    finding_uid AS finding_uid,
+    finding_uid AS event_uid,
+    provider AS provider,
+    account_uid AS account_uid,
+    session_uid AS session_uid,
+    actor_name AS actor_name,
+    anchor_operation AS anchor_operation,
+    src_instance_uid AS src_instance_uid,
+    src_ip AS src_ip,
+    dst_ip AS dst_ip,
+    dst_port AS dst_port,
+    traffic_bytes AS traffic_bytes,
+    first_seen_time_ms AS first_seen_time_ms,
+    last_seen_time_ms AS last_seen_time_ms,
+    finding_time_ms AS finding_time_ms,
+    900 AS correlation_window_seconds,
+    'cloud-lateral-movement' AS finding_type,
+    'T1021' AS primary_technique_uid,
+    'T1078.004' AS secondary_technique_uid,
+    OBJECT_CONSTRUCT(
+        'activity_id', 1,
+        'category_uid', 2,
+        'category_name', 'Findings',
+        'class_uid', 2004,
+        'class_name', 'Detection Finding',
+        'type_uid', 200401,
+        'severity_id', 4,
+        'status_id', 1,
+        'time', finding_time_ms,
+        'metadata', OBJECT_CONSTRUCT(
+            'version', '1.8.0',
+            'uid', finding_uid,
+            'product', OBJECT_CONSTRUCT(
+                'name', 'cloud-ai-security-skills',
+                'vendor_name', 'msaad00/cloud-ai-security-skills',
+                'feature', OBJECT_CONSTRUCT('name', 'packs/lateral-movement/snowflake.sql')
+            ),
+            'labels', ARRAY_CONSTRUCT('query-pack', LOWER(provider), 'lateral-movement', 'snowflake')
+        ),
+        'finding_info', OBJECT_CONSTRUCT(
+            'uid', finding_uid,
+            'title', provider_display || ' lateral movement: identity pivot followed by east-west traffic',
+            'desc', 'Principal ''' || actor_name || ''' triggered identity pivot operation ''' || anchor_operation
+                || ''' (session ''' || session_uid || '''), and within the 15-minute correlation window an accepted east-west flow moved '
+                || traffic_bytes::STRING || ' bytes from ' || COALESCE(NULLIF(src_instance_uid, ''), src_ip)
+                || ' to ' || dst_ip || ':' || COALESCE(dst_port::STRING, '') || '. This is the canonical '
+                || provider_display || ' lateral movement pattern (MITRE T1021 Remote Services via T1078.004 Cloud Accounts).',
+            'types', ARRAY_CONSTRUCT('cloud-lateral-movement'),
+            'first_seen_time', first_seen_time_ms,
+            'last_seen_time', last_seen_time_ms,
+            'attacks', ARRAY_CONSTRUCT(
+                OBJECT_CONSTRUCT(
+                    'version', 'v14',
+                    'tactic', OBJECT_CONSTRUCT('name', 'Lateral Movement', 'uid', 'TA0008'),
+                    'technique', OBJECT_CONSTRUCT('name', 'Remote Services', 'uid', 'T1021')
+                ),
+                OBJECT_CONSTRUCT(
+                    'version', 'v14',
+                    'tactic', OBJECT_CONSTRUCT('name', 'Persistence', 'uid', 'TA0003'),
+                    'technique', OBJECT_CONSTRUCT('name', 'Valid Accounts', 'uid', 'T1078'),
+                    'sub_technique', OBJECT_CONSTRUCT('name', 'Cloud Accounts', 'uid', 'T1078.004')
+                )
+            )
+        ),
+        'observables', ARRAY_CONSTRUCT(
+            OBJECT_CONSTRUCT('name', 'cloud.provider', 'type', 'Other', 'value', provider_display),
+            OBJECT_CONSTRUCT('name', 'cloud.account', 'type', 'Other', 'value', account_uid),
+            OBJECT_CONSTRUCT('name', 'session.uid', 'type', 'Other', 'value', session_uid),
+            OBJECT_CONSTRUCT('name', 'actor.name', 'type', 'Other', 'value', actor_name),
+            OBJECT_CONSTRUCT('name', 'anchor.operation', 'type', 'Other', 'value', anchor_operation),
+            OBJECT_CONSTRUCT('name', 'src.instance_uid', 'type', 'Other', 'value', src_instance_uid),
+            OBJECT_CONSTRUCT('name', 'src.ip', 'type', 'Other', 'value', src_ip),
+            OBJECT_CONSTRUCT('name', 'dst.ip', 'type', 'Other', 'value', dst_ip),
+            OBJECT_CONSTRUCT('name', 'dst.port', 'type', 'Other', 'value', COALESCE(dst_port::STRING, '')),
+            OBJECT_CONSTRUCT('name', 'traffic.bytes', 'type', 'Other', 'value', traffic_bytes::STRING),
+            OBJECT_CONSTRUCT('name', 'window.seconds', 'type', 'Other', 'value', '900'),
+            OBJECT_CONSTRUCT('name', 'rule', 'type', 'Other', 'value', 'cloud-lateral-movement')
+        ),
+        'evidence', OBJECT_CONSTRUCT(
+            'events_observed', 2,
+            'first_seen_time', first_seen_time_ms,
+            'last_seen_time', last_seen_time_ms,
+            'raw_events', ARRAY_CONSTRUCT()
+        )
+    ) AS finding_json
+FROM findings
+ORDER BY provider, session_uid, dst_ip, dst_port;

--- a/tests/integration/test_lateral_movement_query_pack.py
+++ b/tests/integration/test_lateral_movement_query_pack.py
@@ -1,0 +1,64 @@
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PACK_DIR = ROOT / "packs" / "lateral-movement"
+PACK_SQL = PACK_DIR / "snowflake.sql"
+PACK_README = PACK_DIR / "README.md"
+EXPECTED_COLUMNS = PACK_DIR / "golden" / "expected_columns.json"
+
+
+def test_lateral_movement_pack_files_exist() -> None:
+    assert PACK_DIR.is_dir()
+    assert PACK_SQL.is_file()
+    assert PACK_README.is_file()
+    assert EXPECTED_COLUMNS.is_file()
+
+
+def test_snowflake_pack_keeps_detector_contract() -> None:
+    sql = PACK_SQL.read_text()
+
+    for marker in (
+        "IDENTIFIER($source_table)",
+        "AssumeRole",
+        "GenerateAccessToken",
+        "MICROSOFT.AUTHORIZATION/ROLEASSIGNMENTS/WRITE",
+        "activity_id = 6",
+        "traffic_bytes >= 1024",
+        "anchor.time_ms + 900000",
+        "T1021",
+        "T1078.004",
+        "cloud-lateral-movement",
+        "finding_json",
+    ):
+        assert marker in sql
+
+    for cidr_pattern in (
+        r"^10\\.",
+        r"^192\\.168\\.",
+        r"^172\\.(1[6-9]|2[0-9]|3[0-1])\\.",
+        r"^100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\.",
+    ):
+        assert cidr_pattern in sql
+
+
+def test_snowflake_pack_emits_expected_columns() -> None:
+    sql = PACK_SQL.read_text()
+    expected_columns = json.loads(EXPECTED_COLUMNS.read_text())
+
+    for column in expected_columns:
+        assert re.search(rf"\bAS\s+{re.escape(column)}\b", sql, re.IGNORECASE), column
+
+
+def test_readme_describes_input_and_limits() -> None:
+    readme = PACK_README.read_text()
+
+    for phrase in (
+        "raw_json VARIANT",
+        "15-minute correlation window",
+        "traffic.bytes >= 1024",
+        "OCSF-compatible Detection Finding",
+        "sink-snowflake-jsonl",
+    ):
+        assert phrase in readme


### PR DESCRIPTION
## Summary
- add the first shipped warehouse-native query pack under packs/lateral-movement
- implement a Snowflake SQL pack that mirrors the shipped lateral-movement detector anchors, thresholds, and ATT&CK mapping
- add a bounded integration test plus a small architecture update so L8 is no longer documented as purely planned

## Validation
- uv run pytest tests/integration/test_lateral_movement_query_pack.py -q -o addopts=''
- uv run ruff check tests/integration/test_lateral_movement_query_pack.py --config pyproject.toml
- uv run python scripts/validate_skill_contract.py
