### PR TITLE
fix: harden sink write paths and runner caps

### DIFF
--- a/runners/azure-blob-eventgrid-detect/README.md
+++ b/runners/azure-blob-eventgrid-detect/README.md
@@ -70,6 +70,14 @@ The template itself provisions:
 - a fan-out topic
 - a Table Storage account for replay-safe dedupe state
 
+## Concurrency ceiling
+
+The Bicep template exports `recommendedMaxInstances` and defaults it to `50`.
+Because this runner intentionally does not provision the Function App or
+Container Apps packaging layer, the ceiling is an operator-facing contract: wire
+the same value into your chosen Azure runtime so queue-driven scale does not run
+unbounded.
+
 ## Security model
 
 - no shell invocation; skill commands are tokenized with `shlex.split`

--- a/runners/azure-blob-eventgrid-detect/template.bicep
+++ b/runners/azure-blob-eventgrid-detect/template.bicep
@@ -27,6 +27,9 @@ param dedupeStorageAccountName string
 @description('Table name used for replay-safe dedupe state.')
 param dedupeTableName string = 'runnerdedupe'
 
+@description('Recommended maximum concurrent runtime instances for the operator-managed ingest and detect compute. The template does not provision the Function App or Container App itself, so this value is exported as an operator contract rather than enforced infrastructure.')
+param recommendedMaxInstances int = 50
+
 resource sourceStorage 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: sourceStorageAccountName
 }
@@ -125,3 +128,4 @@ output alertsTopicName string = alertsTopicName
 output dedupeStorageAccountName string = dedupeStorageAccountName
 output dedupeTableName string = dedupeTableName
 output blobCreatedSubscriptionName string = blobCreatedToIngestQueue.name
+output recommendedMaxInstances int = recommendedMaxInstances

--- a/runners/gcp-gcs-pubsub-detect/README.md
+++ b/runners/gcp-gcs-pubsub-detect/README.md
@@ -60,8 +60,15 @@ The Terraform template expects:
 - one GCS bucket for Cloud Function source archives
 - one object name for the ingest function archive
 - one object name for the detect function archive
+- an explicit `max_instance_count` ceiling (defaults to `50`)
 
 That keeps the template deployable without assuming a build system.
+
+## Concurrency ceiling
+
+The template exposes `max_instance_count` and defaults it to `50` for both the
+ingest and detect Cloud Functions. Operators should lower or raise that ceiling
+based on cost, quota, and downstream sink pressure for their environment.
 
 ## Security model
 

--- a/runners/gcp-gcs-pubsub-detect/main.tf
+++ b/runners/gcp-gcs-pubsub-detect/main.tf
@@ -51,6 +51,11 @@ variable "dedupe_collection" {
   default = "runner_dedupe"
 }
 
+variable "max_instance_count" {
+  type    = number
+  default = 50
+}
+
 resource "google_pubsub_topic" "detect" {
   name = "cloud-security-detect"
 }
@@ -123,6 +128,7 @@ resource "google_cloudfunctions2_function" "ingest" {
 
   service_config {
     available_memory      = "512M"
+    max_instance_count    = var.max_instance_count
     timeout_seconds       = 300
     service_account_email = google_service_account.ingest.email
     environment_variables = {
@@ -159,6 +165,7 @@ resource "google_cloudfunctions2_function" "detect" {
 
   service_config {
     available_memory      = "512M"
+    max_instance_count    = var.max_instance_count
     timeout_seconds       = 300
     service_account_email = google_service_account.detect.email
     environment_variables = {

--- a/skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py
+++ b/skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py
@@ -22,11 +22,14 @@ main = _SINK.main
 
 
 class _FakeClient:
-    def __init__(self) -> None:
+    def __init__(self, *, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
         self.calls = []
         self.closed = False
 
     def insert(self, *, table, data, column_names) -> None:
+        if self.should_fail:
+            raise RuntimeError("insert failed")
         self.calls.append(
             {
                 "table": table,
@@ -87,6 +90,22 @@ class TestInsertAndMain:
         ]
         assert fake.closed is True
 
+    def test_insert_closes_client_when_insert_fails(self, monkeypatch):
+        fake = _FakeClient(should_fail=True)
+        monkeypatch.setattr(_SINK, "_connect", lambda: fake)
+
+        try:
+            _SINK._insert_rows(
+                "security.findings_sink",
+                _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1","finding_uid":"f-1"}\n']),
+            )
+        except RuntimeError as exc:
+            assert "insert failed" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+        assert fake.closed is True
+
     def test_summary_reports_dry_run(self):
         rows = _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1"}\n'])
         result = _summary("security.findings_sink", rows, True, 0)
@@ -117,6 +136,17 @@ class TestInsertAndMain:
         assert payload["dry_run"] is False
         assert payload["inserted_records"] == 1
         assert fake.calls
+
+    def test_main_apply_returns_error_when_insert_fails(self, monkeypatch, capsys):
+        fake = _FakeClient(should_fail=True)
+        monkeypatch.setattr(_SINK, "_connect", lambda: fake)
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"metadata":{"uid":"evt-2"}}\n'))
+
+        exit_code = main(["--table", "security.findings_sink", "--apply"])
+
+        assert exit_code == 1
+        assert "insert failed" in capsys.readouterr().err
+        assert fake.closed is True
 
     def test_main_requires_records(self, monkeypatch, capsys):
         monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO(""))

--- a/skills/remediation/sink-snowflake-jsonl/src/sink.py
+++ b/skills/remediation/sink-snowflake-jsonl/src/sink.py
@@ -118,7 +118,9 @@ def _connect() -> Any:
         value = os.environ.get(env_name)
         if value:
             kwargs[key] = value
-    return snowflake.connector.connect(**kwargs)
+    conn = snowflake.connector.connect(**kwargs)
+    conn.autocommit(False)
+    return conn
 
 
 def _insert_rows(table_name: str, rows: list[PreparedRow]) -> int:
@@ -136,7 +138,11 @@ def _insert_rows(table_name: str, rows: list[PreparedRow]) -> int:
                 ),
                 [(row.payload_json, row.schema_mode, row.event_uid, row.finding_uid) for row in rows],
             )
+            conn.commit()
             inserted = len(rows)
+        except Exception:
+            conn.rollback()
+            raise
         finally:
             cursor.close()
     finally:

--- a/skills/remediation/sink-snowflake-jsonl/tests/test_sink.py
+++ b/skills/remediation/sink-snowflake-jsonl/tests/test_sink.py
@@ -22,7 +22,9 @@ main = _SINK.main
 
 
 class _FakeCursor:
-    def __init__(self) -> None:
+    def __init__(self, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self.raise_message = "insert failed"
         self.executemany_sql = ""
         self.executemany_params = []
         self.closed = False
@@ -30,18 +32,32 @@ class _FakeCursor:
     def executemany(self, sql, params) -> None:
         self.executemany_sql = sql
         self.executemany_params = list(params)
+        if self.should_fail:
+            raise RuntimeError(self.raise_message)
 
     def close(self) -> None:
         self.closed = True
 
 
 class _FakeConnection:
-    def __init__(self) -> None:
-        self.cursor_instance = _FakeCursor()
+    def __init__(self, *, should_fail: bool = False) -> None:
+        self.cursor_instance = _FakeCursor(should_fail=should_fail)
         self.closed = False
+        self.autocommit_calls = []
+        self.commit_called = False
+        self.rollback_called = False
+
+    def autocommit(self, value) -> None:
+        self.autocommit_calls.append(value)
 
     def cursor(self):
         return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commit_called = True
+
+    def rollback(self) -> None:
+        self.rollback_called = True
 
     def close(self) -> None:
         self.closed = True
@@ -101,6 +117,27 @@ class TestInsertAndMain:
         assert fake.cursor_instance.executemany_params == [
             ('{"event_uid":"evt-1","finding_uid":"f-1","schema_mode":"native"}', "native", "evt-1", "f-1")
         ]
+        assert fake.commit_called is True
+        assert fake.rollback_called is False
+        assert fake.cursor_instance.closed is True
+        assert fake.closed is True
+
+    def test_insert_rolls_back_when_executemany_fails(self, monkeypatch):
+        fake = _FakeConnection(should_fail=True)
+        monkeypatch.setattr(_SINK, "_connect", lambda: fake)
+
+        try:
+            _SINK._insert_rows(
+                '"security_db"."ops"."findings_sink"',
+                _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1","finding_uid":"f-1"}\n']),
+            )
+        except RuntimeError as exc:
+            assert "insert failed" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+        assert fake.commit_called is False
+        assert fake.rollback_called is True
         assert fake.cursor_instance.closed is True
         assert fake.closed is True
 
@@ -135,6 +172,18 @@ class TestInsertAndMain:
         assert payload["dry_run"] is False
         assert payload["inserted_records"] == 1
         assert fake.cursor_instance.executemany_params
+
+    def test_main_apply_returns_error_when_insert_fails(self, monkeypatch, capsys):
+        fake = _FakeConnection(should_fail=True)
+        monkeypatch.setattr(_SINK, "_connect", lambda: fake)
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"metadata":{"uid":"evt-2"}}\n'))
+
+        exit_code = main(["--table", "security_db.ops.findings_sink", "--apply"])
+
+        assert exit_code == 1
+        assert "insert failed" in capsys.readouterr().err
+        assert fake.commit_called is False
+        assert fake.rollback_called is True
 
     def test_main_requires_records(self, monkeypatch, capsys):
         monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO(""))


### PR DESCRIPTION
## Summary
- add explicit commit/rollback handling to the Snowflake sink write path
- add failure-path tests for both Snowflake and ClickHouse sinks
- add an explicit GCP max instance cap and an Azure operator-facing concurrency ceiling contract

## Notes
- GCP now enforces  in Terraform with a default of 
- Azure still intentionally does not provision the compute runtime, so the Bicep change exports  for the operator to wire into their Function App or Container Apps deployment

## Validation
- 
no tests ran in 0.00s
- 
no tests ran in 0.00s
- E902 No such file or directory (os error 2)
--> skills/remediation/sink-clickhouse-jsonl/tests/test_sink.py:1:1

E902 No such file or directory (os error 2)
--> skills/remediation/sink-snowflake-jsonl/src/sink.py:1:1

E902 No such file or directory (os error 2)
--> skills/remediation/sink-snowflake-jsonl/tests/test_sink.py:1:1

Found 3 errors.
- 

## Not run locally
-  for  because  is not installed in this environment
