### PR TITLE
feat: add databricks query source skill

### DIFF
--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -32,6 +32,15 @@
       "coverage_status": "validated"
     },
     {
+      "path": "skills/ingestion/source-databricks-query",
+      "layer": "ingestion",
+      "providers": ["databricks"],
+      "asset_classes": ["lakehouse", "query-results", "audit-logs"],
+      "execution_modes": ["cli", "ci", "mcp", "persistent"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated"
+    },
+    {
       "path": "skills/ingestion/ingest-cloudtrail-ocsf",
       "layer": "ingestion",
       "providers": ["aws"],

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -24,6 +24,7 @@ class TestDiscovery:
         skills = discover_skills(REPO_ROOT)
         assert len(skills) >= 35
         assert {skill.name for skill in skills} >= {
+            "source-databricks-query",
             "source-snowflake-query",
             "sink-snowflake-jsonl",
             "sink-clickhouse-jsonl",
@@ -54,6 +55,7 @@ class TestDiscovery:
 
     def test_supported_tools_include_ingest_detect_and_evaluate(self):
         tools = tool_map(REPO_ROOT)
+        assert "source-databricks-query" in tools
         assert "source-snowflake-query" in tools
         assert "sink-snowflake-jsonl" in tools
         assert "sink-clickhouse-jsonl" in tools
@@ -116,6 +118,13 @@ class TestToolDefinition:
         assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["raw"]
         assert skill.output_formats == ("raw",)
         assert skill.network_egress == ("*.snowflakecomputing.com",)
+
+    def test_source_databricks_query_exposes_raw_output(self):
+        skill = tool_map(REPO_ROOT)["source-databricks-query"]
+        tool = tool_definition(skill)
+        assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["raw"]
+        assert skill.output_formats == ("raw",)
+        assert skill.network_egress == ("*.databricks.com",)
 
     def test_sink_snowflake_jsonl_exposes_write_metadata(self):
         skill = tool_map(REPO_ROOT)["sink-snowflake-jsonl"]

--- a/skills/ingestion/source-databricks-query/REFERENCES.md
+++ b/skills/ingestion/source-databricks-query/REFERENCES.md
@@ -1,0 +1,5 @@
+# References
+
+- Databricks SQL Connector for Python: https://docs.databricks.com/en/dev-tools/python-sql-connector.html
+- Databricks SQL language reference: https://docs.databricks.com/en/sql/language-manual/index.html
+- Databricks authentication for SQL Connector: https://docs.databricks.com/en/dev-tools/python-sql-connector.html#authentication

--- a/skills/ingestion/source-databricks-query/SKILL.md
+++ b/skills/ingestion/source-databricks-query/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: source-databricks-query
+description: >-
+  Run a read-only Databricks SQL query and emit the result set as raw JSONL
+  rows for downstream ingestion, detection, or view skills. Accepts explicit
+  `--query` SQL or reads the query from stdin when no `--query` is provided.
+  Only `SELECT`, `WITH`, `SHOW`, and `DESCRIBE` statements are allowed, and
+  multiple statements are rejected. Use when the user already has security
+  data in Databricks and wants to pipe lake rows into existing skills without
+  exporting files first. Do NOT use for writes, DDL, or admin changes. Do NOT
+  use as a detector or normalizer by itself.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: raw
+output_formats: raw
+network_egress: "*.databricks.com"
+---
+
+# source-databricks-query
+
+Read-only source adapter: Databricks SQL query in, raw JSONL rows out. This
+skill does not normalize vendor data, detect threats, or write back to
+Databricks. It exists so operators and agents can fetch already-landed lake
+data and pipe it into the existing `ingest-*`, `detect-*`, `discover-*`, or
+`view/*` skills.
+
+## Use when
+
+- Security data already lives in Databricks SQL
+- You want to fetch rows directly into a skill pipeline
+- You need a read-only source step before `ingest-*` or `detect-*`
+
+## Do NOT use
+
+- For `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `COPY`, `CREATE`, `ALTER`, `DROP`, or grant operations
+- As a detection or remediation skill
+- When the source data is not in Databricks
+
+## Input
+
+The skill accepts one read-only SQL statement via:
+
+- `--query "SELECT ..."` on the CLI, or
+- stdin when `--query` is omitted
+
+Allowed statement families:
+
+- `SELECT`
+- `WITH`
+- `SHOW`
+- `DESCRIBE`
+
+The skill rejects multiple statements and non-read-only verbs.
+
+## Output
+
+Raw JSONL rows exactly as the Databricks SQL connector returns them,
+serialized with JSON-safe string conversion for datetimes and other non-JSON-native values.
+
+Typical compositions:
+
+```bash
+# Data already projected to the fields your downstream skill expects
+python skills/ingestion/source-databricks-query/src/ingest.py \
+  --query "SELECT raw_json FROM sec.cloudtrail_ocsf LIMIT 100" \
+  | jq -c '.raw_json' \
+  | python skills/detection/detect-lateral-movement/src/detect.py
+
+# Data still in raw vendor shape
+python skills/ingestion/source-databricks-query/src/ingest.py \
+  --query "SELECT raw_event FROM sec.cloudtrail_raw LIMIT 100" \
+  | jq -c '.raw_event' \
+  | python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
+```
+
+## Credentials
+
+Uses the standard Databricks SQL connector environment variables:
+
+- `DATABRICKS_SERVER_HOSTNAME`
+- `DATABRICKS_HTTP_PATH`
+- `DATABRICKS_TOKEN`
+
+Optional:
+
+- `DATABRICKS_CATALOG`
+- `DATABRICKS_SCHEMA`
+
+This skill is read-only but still egresses to Databricks. Prefer short-lived,
+manager-injected credentials or workload identity patterns where your
+Databricks environment supports them.

--- a/skills/ingestion/source-databricks-query/src/ingest.py
+++ b/skills/ingestion/source-databricks-query/src/ingest.py
@@ -1,0 +1,103 @@
+"""Run a read-only Databricks SQL query and emit raw JSONL rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Iterable
+
+SKILL_NAME = "source-databricks-query"
+ALLOWED_PREFIXES = ("SELECT", "WITH", "SHOW", "DESCRIBE")
+
+
+def _read_query(cli_query: str | None, stdin: Iterable[str]) -> str:
+    if cli_query and cli_query.strip():
+        return cli_query.strip()
+    stdin_text = "".join(stdin).strip()
+    if stdin_text:
+        return stdin_text
+    raise ValueError("provide a read-only SQL query via --query or stdin")
+
+
+def _normalize_query(query: str) -> str:
+    cleaned = query.strip()
+    if not cleaned:
+        raise ValueError("query must not be empty")
+    while cleaned.endswith(";"):
+        cleaned = cleaned[:-1].rstrip()
+    if ";" in cleaned:
+        raise ValueError("multiple SQL statements are not allowed")
+
+    head = cleaned.lstrip("(\n\t ").upper()
+    if not any(head.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+        raise ValueError("only SELECT, WITH, SHOW, and DESCRIBE statements are allowed")
+    return cleaned
+
+
+def _connect() -> Any:
+    from databricks import sql
+
+    kwargs: dict[str, str] = {
+        "server_hostname": os.environ["DATABRICKS_SERVER_HOSTNAME"],
+        "http_path": os.environ["DATABRICKS_HTTP_PATH"],
+        "access_token": os.environ["DATABRICKS_TOKEN"],
+    }
+    catalog = os.environ.get("DATABRICKS_CATALOG")
+    schema = os.environ.get("DATABRICKS_SCHEMA")
+    if catalog:
+        kwargs["catalog"] = catalog
+    if schema:
+        kwargs["schema"] = schema
+    return sql.connect(**kwargs)
+
+
+def fetch_rows(query: str) -> list[dict[str, Any]]:
+    conn = _connect()
+    try:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(_normalize_query(query))
+            rows = cursor.fetchall()
+            column_names = [column[0] for column in (cursor.description or [])]
+        finally:
+            cursor.close()
+    finally:
+        conn.close()
+
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            normalized.append(dict(row))
+            continue
+        if column_names:
+            normalized.append({name: value for name, value in zip(column_names, row, strict=False)})
+        else:
+            normalized.append({"value": row})
+    return normalized
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a read-only Databricks SQL query and emit raw JSONL rows.")
+    parser.add_argument("--query", help="Read-only SQL query to run. If omitted, the query is read from stdin.")
+    parser.add_argument(
+        "--output-format",
+        choices=("raw",),
+        default="raw",
+        help="Declared output rendering mode for this source adapter.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        query = _read_query(args.query, sys.stdin)
+        for row in fetch_rows(query):
+            sys.stdout.write(json.dumps(row, default=str, separators=(",", ":")) + "\n")
+    except Exception as exc:
+        print(f"[{SKILL_NAME}] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ingestion/source-databricks-query/tests/test_ingest.py
+++ b/skills/ingestion/source-databricks-query/tests/test_ingest.py
@@ -1,0 +1,105 @@
+"""Tests for source-databricks-query."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "ingest.py"
+_SPEC = importlib.util.spec_from_file_location("source_databricks_query", _SRC)
+assert _SPEC and _SPEC.loader
+_INGEST = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_INGEST)
+
+_normalize_query = _INGEST._normalize_query
+_read_query = _INGEST._read_query
+fetch_rows = _INGEST.fetch_rows
+
+
+class _FakeCursor:
+    def __init__(self, rows, description=None):
+        self.rows = rows
+        self.description = description
+        self.executed = None
+        self.closed = False
+
+    def execute(self, query):
+        self.executed = query
+
+    def fetchall(self):
+        return self.rows
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, rows, description=None):
+        self.rows = rows
+        self.description = description
+        self.closed = False
+        self.cursor_instance = None
+
+    def cursor(self):
+        self.cursor_instance = _FakeCursor(self.rows, self.description)
+        return self.cursor_instance
+
+    def close(self):
+        self.closed = True
+
+
+class TestNormalizeQuery:
+    def test_allows_select(self):
+        assert _normalize_query("SELECT * FROM foo") == "SELECT * FROM foo"
+
+    def test_allows_describe(self):
+        assert _normalize_query("DESCRIBE TABLE foo") == "DESCRIBE TABLE foo"
+
+    def test_rejects_multiple_statements(self):
+        try:
+            _normalize_query("SELECT 1; SELECT 2")
+        except ValueError as exc:
+            assert "multiple SQL statements" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_write_statement(self):
+        try:
+            _normalize_query("DELETE FROM foo")
+        except ValueError as exc:
+            assert "only SELECT, WITH, SHOW, and DESCRIBE" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestReadQuery:
+    def test_prefers_cli_query(self):
+        assert _read_query("SELECT 1", ["SELECT 2"]) == "SELECT 1"
+
+    def test_falls_back_to_stdin(self):
+        assert _read_query(None, ["SELECT ", "1"]) == "SELECT 1"
+
+
+class TestFetchRows:
+    def test_fetches_rows_with_column_mapping(self, monkeypatch):
+        fake = _FakeConnection(
+            [("2026-04-15T00:00:00Z", "AssumeRole")],
+            description=[("EVENT_TIME",), ("ACTION",)],
+        )
+        monkeypatch.setattr(_INGEST, "_connect", lambda: fake)
+
+        rows = fetch_rows("SELECT * FROM sec.cloudtrail_ocsf")
+
+        assert rows == [{"EVENT_TIME": "2026-04-15T00:00:00Z", "ACTION": "AssumeRole"}]
+        assert fake.cursor_instance is not None
+        assert fake.cursor_instance.executed == "SELECT * FROM sec.cloudtrail_ocsf"
+        assert fake.cursor_instance.closed is True
+        assert fake.closed is True
+
+    def test_wraps_rows_without_description(self, monkeypatch):
+        fake = _FakeConnection([("value",)], description=None)
+        monkeypatch.setattr(_INGEST, "_connect", lambda: fake)
+
+        rows = fetch_rows("SHOW TABLES")
+
+        assert rows == [{"value": ("value",)}]

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -59,6 +59,7 @@ class TestSkillValidationCommon:
         skills = COMMON.discover_skill_contracts()
         assert len(skills) >= 32
         names = {skill.name for skill in skills}
+        assert "source-databricks-query" in names
         assert "source-snowflake-query" in names
         assert "sink-snowflake-jsonl" in names
         assert "sink-clickhouse-jsonl" in names


### PR DESCRIPTION
## Summary
- add  as the next read-only lake adapter
- mirror the shipped Snowflake source pattern for Databricks SQL
- update framework coverage and MCP/validation tests for the new source skill

## Validation
- .....................................                                    [100%]
37 passed in 0.42s
- All checks passed!
- Skill contract validation passed for 41 skills.
- Framework coverage validation passed for 41 skills and 17 frameworks.
