### PR TITLE
feat: add k8s privilege-escalation snowflake pack

### DIFF
--- a/packs/privilege-escalation-k8s/README.md
+++ b/packs/privilege-escalation-k8s/README.md
@@ -1,0 +1,64 @@
+# privilege-escalation-k8s query pack
+
+Warehouse-native Snowflake implementation of the same detection intent as [`skills/detection/detect-privilege-escalation-k8s`](../../skills/detection/detect-privilege-escalation-k8s/SKILL.md).
+
+Use this pack when:
+- your lake already stores OCSF-shaped Kubernetes API Activity (`6003`) rows
+- you want Kubernetes privilege-escalation detection to run inside Snowflake with zero egress
+- you want OCSF-compatible finding rows without piping audit data through Python first
+
+Do not use this pack when:
+- your table stores raw kube-apiserver audit payloads instead of OCSF-shaped events
+- you need the repo-native finding shape instead of OCSF-compatible output
+- you need generalized warehouse macros; this pack is an explicit, auditable Snowflake artifact
+
+## Input contract
+
+This SQL expects a pre-existing Snowflake table or view with a single `raw_json VARIANT` column containing one OCSF 1.8 event per row.
+
+Minimum event family:
+- API Activity (`class_uid = 6003`) for normalized Kubernetes audit events
+
+The pack implements the same four rule families as the Python detector:
+- service-account secret enumeration + read (`T1552.007`)
+- service-account pod exec (`T1611`)
+- non-admin RBAC self-grant (`T1098`)
+- service-account token self-grant (`T1550.001`)
+
+The same Rule 1 correlation window is used:
+- `300` seconds / 5 minutes
+
+## Run
+
+Set the source table, then run the SQL in Snowflake:
+
+```sql
+SET source_table = 'K8S_AUDIT_OCSF';
+SET lookback_hours = 24;
+```
+
+Then execute [`snowflake.sql`](./snowflake.sql).
+
+If your column is not named `raw_json`, create a small view that aliases it:
+
+```sql
+CREATE OR REPLACE VIEW K8S_AUDIT_OCSF AS
+SELECT payload AS raw_json
+FROM RAW_K8S_AUDIT;
+```
+
+## Output contract
+
+The query returns one row per deterministic finding with:
+- stable `finding_uid` / `event_uid`
+- `rule_name`
+- ATT&CK `T1552.007`, `T1611`, `T1098`, or `T1550.001`
+- `finding_json` as an OCSF-compatible Detection Finding object
+
+The locked output columns are listed in [`golden/expected_columns.json`](./golden/expected_columns.json).
+
+## Notes
+
+- This pack keeps the data in Snowflake, but the detection logic stays aligned with the shipped Python skill.
+- The SQL is intentionally explicit so operators can audit each rule directly.
+- This pack is read-only. Persisting findings is a separate step, for example through `sink-snowflake-jsonl`.

--- a/packs/privilege-escalation-k8s/golden/expected_columns.json
+++ b/packs/privilege-escalation-k8s/golden/expected_columns.json
@@ -1,0 +1,18 @@
+[
+  "finding_uid",
+  "event_uid",
+  "rule_name",
+  "severity_id",
+  "actor_name",
+  "namespace",
+  "target_name",
+  "resource_type",
+  "subresource",
+  "first_seen_time_ms",
+  "last_seen_time_ms",
+  "finding_time_ms",
+  "mitre_technique_uid",
+  "mitre_subtechnique_uid",
+  "finding_type",
+  "finding_json"
+]

--- a/packs/privilege-escalation-k8s/snowflake.sql
+++ b/packs/privilege-escalation-k8s/snowflake.sql
@@ -1,0 +1,323 @@
+-- privilege-escalation-k8s query pack for Snowflake
+--
+-- Required session variables:
+--   SET source_table = 'K8S_AUDIT_OCSF';
+--   SET lookback_hours = 24;
+--
+-- Input contract:
+--   IDENTIFIER($source_table) must expose a `raw_json VARIANT` column with one
+--   OCSF 1.8 API Activity event per row.
+--
+-- Output contract:
+--   One OCSF-compatible Detection Finding row per deterministic
+--   privilege-escalation event or correlation.
+
+WITH source_events AS (
+    SELECT raw_json AS event
+    FROM IDENTIFIER($source_table)
+    WHERE COALESCE(TRY_TO_NUMBER(raw_json:time), 0) >= DATE_PART(
+        EPOCH_MILLISECOND,
+        DATEADD('hour', -$lookback_hours, CURRENT_TIMESTAMP())
+    )
+),
+normalized AS (
+    SELECT
+        event,
+        COALESCE(TRY_TO_NUMBER(event:time), 0) AS time_ms,
+        COALESCE(event:actor.user.name::string, '') AS actor_name,
+        COALESCE(event:actor.user.type::string, '') AS actor_type,
+        COALESCE(event:api.operation::string, '') AS operation,
+        COALESCE(event:resources[0].type::string, '') AS resource_type,
+        COALESCE(event:resources[0].name::string, '') AS resource_name,
+        COALESCE(event:resources[0].namespace::string, '') AS namespace,
+        COALESCE(event:resources[0].subresource::string, '') AS subresource
+    FROM source_events
+    WHERE TRY_TO_NUMBER(event:class_uid) = 6003
+),
+service_account_events AS (
+    SELECT *
+    FROM normalized
+    WHERE actor_type = 'ServiceAccount'
+),
+rule1_list AS (
+    SELECT actor_name, namespace, time_ms
+    FROM service_account_events
+    WHERE operation = 'list'
+      AND resource_type = 'secrets'
+),
+rule1_findings AS (
+    SELECT
+        CONCAT('r1|', getter.actor_name, '|', getter.namespace, '|', getter.resource_name) AS dedupe_key,
+        'r1-secret-enum' AS rule_name,
+        4 AS severity_id,
+        getter.actor_name AS actor_name,
+        getter.namespace AS namespace,
+        getter.resource_name AS target_name,
+        getter.resource_type AS resource_type,
+        getter.subresource AS subresource,
+        MIN(lister.time_ms) AS first_seen_time_ms,
+        getter.time_ms AS last_seen_time_ms,
+        getter.time_ms AS finding_time_ms,
+        'T1552' AS mitre_technique_uid,
+        'T1552.007' AS mitre_subtechnique_uid,
+        'k8s-r1-secret-enum' AS finding_type,
+        'Service account enumerated and read a Kubernetes secret' AS title,
+        'Credential Access' AS tactic_name,
+        'TA0006' AS tactic_uid,
+        'Unsecured Credentials' AS technique_name,
+        'Container API' AS subtechnique_name,
+        getter.resource_name AS observable_name
+    FROM service_account_events AS getter
+    JOIN rule1_list AS lister
+      ON getter.actor_name = lister.actor_name
+     AND getter.namespace = lister.namespace
+     AND getter.time_ms > lister.time_ms
+     AND getter.time_ms - lister.time_ms <= 300000
+    WHERE getter.operation = 'get'
+      AND getter.resource_type = 'secrets'
+    GROUP BY getter.actor_name, getter.namespace, getter.resource_name, getter.resource_type, getter.subresource, getter.time_ms
+),
+rule2_findings AS (
+    SELECT DISTINCT
+        CONCAT('r2|', actor_name, '|', namespace, '/', resource_name) AS dedupe_key,
+        'r2-pod-exec' AS rule_name,
+        5 AS severity_id,
+        actor_name,
+        namespace,
+        resource_name AS target_name,
+        resource_type,
+        subresource,
+        time_ms AS first_seen_time_ms,
+        time_ms AS last_seen_time_ms,
+        time_ms AS finding_time_ms,
+        'T1611' AS mitre_technique_uid,
+        CAST(NULL AS STRING) AS mitre_subtechnique_uid,
+        'k8s-r2-pod-exec' AS finding_type,
+        'Service account executed a shell inside a pod' AS title,
+        'Privilege Escalation' AS tactic_name,
+        'TA0004' AS tactic_uid,
+        'Escape to Host' AS technique_name,
+        CAST(NULL AS STRING) AS subtechnique_name,
+        resource_name AS observable_name
+    FROM service_account_events
+    WHERE operation = 'create'
+      AND resource_type = 'pods'
+      AND subresource = 'exec'
+),
+admin_groups AS (
+    SELECT
+        event,
+        ARRAY_AGG(COALESCE(group_item.value:name::string, group_item.value::string)) AS group_names
+    FROM source_events,
+         LATERAL FLATTEN(input => event:actor.user.groups, outer => TRUE) AS group_item
+    GROUP BY event
+),
+rule3_base AS (
+    SELECT
+        n.*,
+        COALESCE(a.group_names, ARRAY_CONSTRUCT()) AS actor_groups
+    FROM normalized AS n
+    LEFT JOIN admin_groups AS a
+      ON n.event = a.event
+),
+rule3_findings AS (
+    SELECT DISTINCT
+        CONCAT('r3|', actor_name, '|', resource_type, '/', namespace, '/', resource_name) AS dedupe_key,
+        'r3-rbac-self-grant' AS rule_name,
+        5 AS severity_id,
+        actor_name,
+        namespace,
+        resource_name AS target_name,
+        resource_type,
+        subresource,
+        time_ms AS first_seen_time_ms,
+        time_ms AS last_seen_time_ms,
+        time_ms AS finding_time_ms,
+        'T1098' AS mitre_technique_uid,
+        CAST(NULL AS STRING) AS mitre_subtechnique_uid,
+        'k8s-r3-rbac-self-grant' AS finding_type,
+        IFF(resource_type = 'clusterrolebindings', 'Non-admin principal created a clusterrolebinding', 'Non-admin principal created a rolebinding') AS title,
+        'Persistence' AS tactic_name,
+        'TA0003' AS tactic_uid,
+        'Account Manipulation' AS technique_name,
+        CAST(NULL AS STRING) AS subtechnique_name,
+        resource_name AS observable_name
+    FROM rule3_base
+    WHERE operation = 'create'
+      AND resource_type IN ('rolebindings', 'clusterrolebindings')
+      AND actor_name NOT IN ('kubernetes-admin', 'kube-admin')
+      AND NOT ARRAY_CONTAINS('system:masters'::VARIANT, actor_groups)
+),
+rule4_findings AS (
+    SELECT DISTINCT
+        CONCAT('r4|', actor_name, '|', namespace, '/', resource_name) AS dedupe_key,
+        'r4-token-self-grant' AS rule_name,
+        4 AS severity_id,
+        actor_name,
+        namespace,
+        resource_name AS target_name,
+        resource_type,
+        subresource,
+        time_ms AS first_seen_time_ms,
+        time_ms AS last_seen_time_ms,
+        time_ms AS finding_time_ms,
+        'T1550' AS mitre_technique_uid,
+        'T1550.001' AS mitre_subtechnique_uid,
+        'k8s-r4-token-self-grant' AS finding_type,
+        'Service account issued itself (or another SA) an API token' AS title,
+        'Lateral Movement' AS tactic_name,
+        'TA0008' AS tactic_uid,
+        'Use Alternate Authentication Material' AS technique_name,
+        'Application Access Tokens' AS subtechnique_name,
+        resource_name AS observable_name
+    FROM service_account_events
+    WHERE operation = 'create'
+      AND (
+        (resource_type = 'serviceaccounts' AND subresource IN ('token', 'tokenrequest'))
+        OR resource_type = 'tokenreviews'
+      )
+),
+combined AS (
+    SELECT * FROM rule1_findings
+    UNION ALL
+    SELECT * FROM rule2_findings
+    UNION ALL
+    SELECT * FROM rule3_findings
+    UNION ALL
+    SELECT * FROM rule4_findings
+),
+final_findings AS (
+    SELECT
+        rule_name,
+        severity_id,
+        actor_name,
+        namespace,
+        target_name,
+        resource_type,
+        subresource,
+        first_seen_time_ms,
+        last_seen_time_ms,
+        finding_time_ms,
+        mitre_technique_uid,
+        mitre_subtechnique_uid,
+        finding_type,
+        title,
+        tactic_name,
+        tactic_uid,
+        technique_name,
+        subtechnique_name,
+        CONCAT(
+            'det-k8s-',
+            rule_name,
+            '-',
+            SUBSTR(SHA2(COALESCE(actor_name, ''), 256), 1, 8),
+            '-',
+            SUBSTR(SHA2(COALESCE(namespace, '') || '/' || COALESCE(target_name, ''), 256), 1, 8)
+        ) AS finding_uid
+    FROM combined
+)
+SELECT
+    finding_uid AS finding_uid,
+    finding_uid AS event_uid,
+    rule_name AS rule_name,
+    severity_id AS severity_id,
+    actor_name AS actor_name,
+    namespace AS namespace,
+    target_name AS target_name,
+    resource_type AS resource_type,
+    subresource AS subresource,
+    first_seen_time_ms AS first_seen_time_ms,
+    last_seen_time_ms AS last_seen_time_ms,
+    finding_time_ms AS finding_time_ms,
+    mitre_technique_uid AS mitre_technique_uid,
+    mitre_subtechnique_uid AS mitre_subtechnique_uid,
+    finding_type AS finding_type,
+    OBJECT_CONSTRUCT(
+        'activity_id', 1,
+        'category_uid', 2,
+        'category_name', 'Findings',
+        'class_uid', 2004,
+        'class_name', 'Detection Finding',
+        'type_uid', 200401,
+        'severity_id', severity_id,
+        'status_id', 1,
+        'time', finding_time_ms,
+        'metadata', OBJECT_CONSTRUCT(
+            'version', '1.8.0',
+            'uid', finding_uid,
+            'product', OBJECT_CONSTRUCT(
+                'name', 'cloud-ai-security-skills',
+                'vendor_name', 'msaad00/cloud-ai-security-skills',
+                'feature', OBJECT_CONSTRUCT('name', 'packs/privilege-escalation-k8s/snowflake.sql')
+            ),
+            'labels', ARRAY_CONSTRUCT('query-pack', 'kubernetes', 'privilege-escalation', rule_name)
+        ),
+        'finding_info', OBJECT_CONSTRUCT(
+            'uid', finding_uid,
+            'title', title,
+            'desc',
+                CASE
+                    WHEN rule_name = 'r1-secret-enum' THEN
+                        'Service account ''' || actor_name || ''' performed `list` on secrets in namespace '''
+                        || namespace || ''' and then `get` on secret ''' || target_name
+                        || ''' within the 300-second correlation window. Workloads that need secret data should mount secrets as files, not call the K8s API for them — this pattern is a strong signal of a compromised pod searching for credentials. (MITRE T1552.007)'
+                    WHEN rule_name = 'r2-pod-exec' THEN
+                        'Service account ''' || actor_name || ''' called `create` on pods/exec for pod '''
+                        || target_name || ''' in namespace ''' || namespace
+                        || '''. Workloads (as opposed to human operators) should never exec into other pods — this is the precursor to container escape. (MITRE T1611)'
+                    WHEN rule_name = 'r3-rbac-self-grant' THEN
+                        'Principal ''' || actor_name || ''' created ' || IFF(resource_type = 'clusterrolebindings', 'clusterrolebinding', 'rolebinding')
+                        || ' ''' || target_name || ''''
+                        || IFF(namespace = '', '', ' in namespace ' || namespace)
+                        || '. This principal is not in system:masters and is not a recognised admin user — creating a binding is the canonical K8s privilege-escalation move after initial compromise. (MITRE T1098)'
+                    ELSE
+                        'Service account ''' || actor_name || ''' created a token for '''
+                        || IFF(target_name = '', 'tokenreview', target_name)
+                        || ''' in namespace ''' || namespace
+                        || '''. Combined with secret access or RBAC manipulation this is token-theft in progress. (MITRE T1550.001)'
+                END,
+            'types', ARRAY_CONSTRUCT(finding_type),
+            'first_seen_time', first_seen_time_ms,
+            'last_seen_time', last_seen_time_ms,
+            'attacks', ARRAY_CONSTRUCT(
+                IFF(
+                    mitre_subtechnique_uid IS NULL,
+                    OBJECT_CONSTRUCT(
+                        'version', 'v14',
+                        'tactic', OBJECT_CONSTRUCT('name', tactic_name, 'uid', tactic_uid),
+                        'technique', OBJECT_CONSTRUCT('name', technique_name, 'uid', mitre_technique_uid)
+                    ),
+                    OBJECT_CONSTRUCT(
+                        'version', 'v14',
+                        'tactic', OBJECT_CONSTRUCT('name', tactic_name, 'uid', tactic_uid),
+                        'technique', OBJECT_CONSTRUCT('name', technique_name, 'uid', mitre_technique_uid),
+                        'sub_technique', OBJECT_CONSTRUCT('name', subtechnique_name, 'uid', mitre_subtechnique_uid)
+                    )
+                )
+            )
+        ),
+        'observables', ARRAY_CONSTRUCT(
+            OBJECT_CONSTRUCT('name', 'actor.name', 'type', 'Other', 'value', actor_name),
+            OBJECT_CONSTRUCT(
+                'name',
+                CASE
+                    WHEN rule_name = 'r1-secret-enum' THEN 'secret.name'
+                    WHEN rule_name = 'r2-pod-exec' THEN 'pod.name'
+                    WHEN rule_name = 'r3-rbac-self-grant' THEN 'binding.name'
+                    ELSE 'target.serviceaccount'
+                END,
+                'type', 'Other',
+                'value', target_name
+            ),
+            OBJECT_CONSTRUCT('name', 'namespace', 'type', 'Other', 'value', namespace),
+            OBJECT_CONSTRUCT('name', 'rule', 'type', 'Other', 'value', rule_name)
+        ),
+        'evidence', OBJECT_CONSTRUCT(
+            'events_observed', IFF(rule_name = 'r1-secret-enum', 2, 1),
+            'first_seen_time', first_seen_time_ms,
+            'last_seen_time', last_seen_time_ms,
+            'raw_events', ARRAY_CONSTRUCT()
+        )
+    ) AS finding_json
+FROM final_findings
+ORDER BY finding_time_ms, rule_name, actor_name, target_name;

--- a/tests/integration/test_k8s_priv_esc_query_pack.py
+++ b/tests/integration/test_k8s_priv_esc_query_pack.py
@@ -1,0 +1,63 @@
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PACK_DIR = ROOT / "packs" / "privilege-escalation-k8s"
+PACK_SQL = PACK_DIR / "snowflake.sql"
+PACK_README = PACK_DIR / "README.md"
+EXPECTED_COLUMNS = PACK_DIR / "golden" / "expected_columns.json"
+
+
+def test_k8s_priv_esc_pack_files_exist() -> None:
+    assert PACK_DIR.is_dir()
+    assert PACK_SQL.is_file()
+    assert PACK_README.is_file()
+    assert EXPECTED_COLUMNS.is_file()
+
+
+def test_k8s_priv_esc_pack_keeps_detector_contract() -> None:
+    sql = PACK_SQL.read_text()
+
+    for marker in (
+        "IDENTIFIER($source_table)",
+        "300000",
+        "r1-secret-enum",
+        "r2-pod-exec",
+        "r3-rbac-self-grant",
+        "r4-token-self-grant",
+        "resource_type = 'secrets'",
+        "subresource = 'exec'",
+        "resource_type IN ('rolebindings', 'clusterrolebindings')",
+        "subresource IN ('token', 'tokenrequest')",
+        "resource_type = 'tokenreviews'",
+        "T1552.007",
+        "T1611",
+        "T1098",
+        "T1550.001",
+        "finding_json",
+    ):
+        assert marker in sql
+
+
+def test_k8s_priv_esc_pack_emits_expected_columns() -> None:
+    sql = PACK_SQL.read_text()
+    expected_columns = json.loads(EXPECTED_COLUMNS.read_text())
+
+    for column in expected_columns:
+        assert re.search(rf"\bAS\s+{re.escape(column)}\b", sql, re.IGNORECASE), column
+
+
+def test_k8s_priv_esc_readme_describes_rules_and_window() -> None:
+    readme = PACK_README.read_text()
+
+    for phrase in (
+        "API Activity (`6003`)",
+        "T1552.007",
+        "T1611",
+        "T1098",
+        "T1550.001",
+        "5 minutes",
+        "sink-snowflake-jsonl",
+    ):
+        assert phrase in readme


### PR DESCRIPTION
## Summary
- add a second warehouse-native query pack for Kubernetes privilege escalation detection
- ship a Snowflake SQL pack, locked expected columns, and integration coverage
- keep the pack aligned with the existing Python detector rule families and thresholds

## Validation
- uv run pytest /tmp/cloud-security-core-foundation/tests/integration/test_k8s_priv_esc_query_pack.py -q -o addopts=''
- uv run ruff check /tmp/cloud-security-core-foundation/tests/integration/test_k8s_priv_esc_query_pack.py --config /tmp/cloud-security-core-foundation/pyproject.toml