### PR TITLE
chore: tighten query pack contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: ruff
+          packages: ruff sqlfluff
       - run: ruff check skills/ tests/ mcp-server/ scripts/ --config pyproject.toml
+      - run: sqlfluff lint packs
 
   skill-contract:
     runs-on: ubuntu-latest

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,5 @@
+[sqlfluff]
+dialect = snowflake
+templater = raw
+max_line_length = 120
+exclude_rules = AL09,AM05,CP05,CV11,LT02,LT05,LT08,LT09,RF02,RF04,ST09

--- a/packs/README.md
+++ b/packs/README.md
@@ -1,0 +1,33 @@
+# Query Packs
+
+`packs/` contains warehouse-native analytics artifacts that run detection intent inside the customer's data platform instead of piping events through Python.
+
+Use a pack when:
+- your lake already stores OCSF-shaped rows
+- you want the detection to run inside Snowflake with zero egress
+- you want OCSF-compatible finding rows that can flow into the same sinks as the Python skills
+
+Do not use a pack when:
+- your source data is still raw vendor JSON and needs an `ingest-*` skill first
+- you need repo-native output instead of OCSF-compatible findings
+- you need a broad multi-warehouse framework; the shipped packs are explicit, auditable SQL artifacts
+
+## Contract
+
+Each pack directory should include:
+- `README.md` describing the runtime, input contract, and limits
+- one or more warehouse-specific SQL files such as `snowflake.sql`
+- `golden/expected_columns.json` locking the output column names
+- `golden/expected_column_types.json` locking the output Snowflake types
+- integration coverage that proves the SQL keeps the same detection intent as its Python sibling
+
+## Shipped Packs
+
+- `lateral-movement`
+- `privilege-escalation-k8s`
+
+## Runtime Selection
+
+- Python skills remain the reference implementation for stdin/stdout pipelines and golden fixtures.
+- Query packs are the warehouse-native lane for customers who already store normalized OCSF in their lake.
+- Persistence is a separate step, for example through `sink-snowflake-jsonl` or `sink-clickhouse-jsonl`.

--- a/packs/lateral-movement/README.md
+++ b/packs/lateral-movement/README.md
@@ -52,7 +52,9 @@ The query returns one row per deterministic `(provider, session_uid, dst_ip, dst
 - ATT&CK `T1021` and `T1078.004`
 - `finding_json` as an OCSF-compatible Detection Finding object
 
-The locked output columns are listed in [`golden/expected_columns.json`](./golden/expected_columns.json).
+The locked output columns and types are listed in:
+- [`golden/expected_columns.json`](./golden/expected_columns.json)
+- [`golden/expected_column_types.json`](./golden/expected_column_types.json)
 
 ## Notes
 

--- a/packs/lateral-movement/golden/expected_column_types.json
+++ b/packs/lateral-movement/golden/expected_column_types.json
@@ -1,0 +1,22 @@
+{
+  "finding_uid": "varchar",
+  "event_uid": "varchar",
+  "provider": "varchar",
+  "account_uid": "varchar",
+  "session_uid": "varchar",
+  "actor_name": "varchar",
+  "anchor_operation": "varchar",
+  "src_instance_uid": "varchar",
+  "src_ip": "varchar",
+  "dst_ip": "varchar",
+  "dst_port": "number",
+  "traffic_bytes": "number",
+  "first_seen_time_ms": "number",
+  "last_seen_time_ms": "number",
+  "finding_time_ms": "number",
+  "correlation_window_seconds": "number",
+  "finding_type": "varchar",
+  "primary_technique_uid": "varchar",
+  "secondary_technique_uid": "varchar",
+  "finding_json": "object"
+}

--- a/packs/lateral-movement/snowflake.sql
+++ b/packs/lateral-movement/snowflake.sql
@@ -164,25 +164,25 @@ findings AS (
     FROM candidate_pairs
 )
 SELECT
-    finding_uid AS finding_uid,
-    finding_uid AS event_uid,
-    provider AS provider,
-    account_uid AS account_uid,
-    session_uid AS session_uid,
-    actor_name AS actor_name,
-    anchor_operation AS anchor_operation,
-    src_instance_uid AS src_instance_uid,
-    src_ip AS src_ip,
-    dst_ip AS dst_ip,
-    dst_port AS dst_port,
-    traffic_bytes AS traffic_bytes,
-    first_seen_time_ms AS first_seen_time_ms,
-    last_seen_time_ms AS last_seen_time_ms,
-    finding_time_ms AS finding_time_ms,
-    900 AS correlation_window_seconds,
-    'cloud-lateral-movement' AS finding_type,
-    'T1021' AS primary_technique_uid,
-    'T1078.004' AS secondary_technique_uid,
+    finding_uid::varchar AS finding_uid,
+    finding_uid::varchar AS event_uid,
+    provider::varchar AS provider,
+    account_uid::varchar AS account_uid,
+    session_uid::varchar AS session_uid,
+    actor_name::varchar AS actor_name,
+    anchor_operation::varchar AS anchor_operation,
+    src_instance_uid::varchar AS src_instance_uid,
+    src_ip::varchar AS src_ip,
+    dst_ip::varchar AS dst_ip,
+    dst_port::number AS dst_port,
+    traffic_bytes::number AS traffic_bytes,
+    first_seen_time_ms::number AS first_seen_time_ms,
+    last_seen_time_ms::number AS last_seen_time_ms,
+    finding_time_ms::number AS finding_time_ms,
+    900::number AS correlation_window_seconds,
+    'cloud-lateral-movement'::varchar AS finding_type,
+    'T1021'::varchar AS primary_technique_uid,
+    'T1078.004'::varchar AS secondary_technique_uid,
     OBJECT_CONSTRUCT(
         'activity_id', 1,
         'category_uid', 2,
@@ -248,6 +248,6 @@ SELECT
             'last_seen_time', last_seen_time_ms,
             'raw_events', ARRAY_CONSTRUCT()
         )
-    ) AS finding_json
+    )::object AS finding_json
 FROM findings
 ORDER BY provider, session_uid, dst_ip, dst_port;

--- a/packs/privilege-escalation-k8s/README.md
+++ b/packs/privilege-escalation-k8s/README.md
@@ -55,7 +55,9 @@ The query returns one row per deterministic finding with:
 - ATT&CK `T1552.007`, `T1611`, `T1098`, or `T1550.001`
 - `finding_json` as an OCSF-compatible Detection Finding object
 
-The locked output columns are listed in [`golden/expected_columns.json`](./golden/expected_columns.json).
+The locked output columns and types are listed in:
+- [`golden/expected_columns.json`](./golden/expected_columns.json)
+- [`golden/expected_column_types.json`](./golden/expected_column_types.json)
 
 ## Notes
 

--- a/packs/privilege-escalation-k8s/golden/expected_column_types.json
+++ b/packs/privilege-escalation-k8s/golden/expected_column_types.json
@@ -1,0 +1,18 @@
+{
+  "finding_uid": "varchar",
+  "event_uid": "varchar",
+  "rule_name": "varchar",
+  "severity_id": "number",
+  "actor_name": "varchar",
+  "namespace": "varchar",
+  "target_name": "varchar",
+  "resource_type": "varchar",
+  "subresource": "varchar",
+  "first_seen_time_ms": "number",
+  "last_seen_time_ms": "number",
+  "finding_time_ms": "number",
+  "mitre_technique_uid": "varchar",
+  "mitre_subtechnique_uid": "varchar",
+  "finding_type": "varchar",
+  "finding_json": "object"
+}

--- a/packs/privilege-escalation-k8s/snowflake.sql
+++ b/packs/privilege-escalation-k8s/snowflake.sql
@@ -217,21 +217,21 @@ final_findings AS (
     FROM combined
 )
 SELECT
-    finding_uid AS finding_uid,
-    finding_uid AS event_uid,
-    rule_name AS rule_name,
-    severity_id AS severity_id,
-    actor_name AS actor_name,
-    namespace AS namespace,
-    target_name AS target_name,
-    resource_type AS resource_type,
-    subresource AS subresource,
-    first_seen_time_ms AS first_seen_time_ms,
-    last_seen_time_ms AS last_seen_time_ms,
-    finding_time_ms AS finding_time_ms,
-    mitre_technique_uid AS mitre_technique_uid,
-    mitre_subtechnique_uid AS mitre_subtechnique_uid,
-    finding_type AS finding_type,
+    finding_uid::varchar AS finding_uid,
+    finding_uid::varchar AS event_uid,
+    rule_name::varchar AS rule_name,
+    severity_id::number AS severity_id,
+    actor_name::varchar AS actor_name,
+    namespace::varchar AS namespace,
+    target_name::varchar AS target_name,
+    resource_type::varchar AS resource_type,
+    subresource::varchar AS subresource,
+    first_seen_time_ms::number AS first_seen_time_ms,
+    last_seen_time_ms::number AS last_seen_time_ms,
+    finding_time_ms::number AS finding_time_ms,
+    mitre_technique_uid::varchar AS mitre_technique_uid,
+    mitre_subtechnique_uid::varchar AS mitre_subtechnique_uid,
+    finding_type::varchar AS finding_type,
     OBJECT_CONSTRUCT(
         'activity_id', 1,
         'category_uid', 2,
@@ -318,6 +318,6 @@ SELECT
             'last_seen_time', last_seen_time_ms,
             'raw_events', ARRAY_CONSTRUCT()
         )
-    ) AS finding_json
+    )::object AS finding_json
 FROM final_findings
 ORDER BY finding_time_ms, rule_name, actor_name, target_name;

--- a/tests/integration/test_k8s_priv_esc_query_pack.py
+++ b/tests/integration/test_k8s_priv_esc_query_pack.py
@@ -7,6 +7,7 @@ PACK_DIR = ROOT / "packs" / "privilege-escalation-k8s"
 PACK_SQL = PACK_DIR / "snowflake.sql"
 PACK_README = PACK_DIR / "README.md"
 EXPECTED_COLUMNS = PACK_DIR / "golden" / "expected_columns.json"
+EXPECTED_COLUMN_TYPES = PACK_DIR / "golden" / "expected_column_types.json"
 
 
 def test_k8s_priv_esc_pack_files_exist() -> None:
@@ -14,6 +15,7 @@ def test_k8s_priv_esc_pack_files_exist() -> None:
     assert PACK_SQL.is_file()
     assert PACK_README.is_file()
     assert EXPECTED_COLUMNS.is_file()
+    assert EXPECTED_COLUMN_TYPES.is_file()
 
 
 def test_k8s_priv_esc_pack_keeps_detector_contract() -> None:
@@ -46,6 +48,18 @@ def test_k8s_priv_esc_pack_emits_expected_columns() -> None:
 
     for column in expected_columns:
         assert re.search(rf"\bAS\s+{re.escape(column)}\b", sql, re.IGNORECASE), column
+
+
+def test_k8s_priv_esc_pack_locks_expected_column_types() -> None:
+    sql = PACK_SQL.read_text()
+    expected_column_types = json.loads(EXPECTED_COLUMN_TYPES.read_text())
+
+    for column, column_type in expected_column_types.items():
+        assert re.search(
+            rf"::\s*{re.escape(column_type)}\s+AS\s+{re.escape(column)}\b",
+            sql,
+            re.IGNORECASE,
+        ), column
 
 
 def test_k8s_priv_esc_readme_describes_rules_and_window() -> None:

--- a/tests/integration/test_lateral_movement_query_pack.py
+++ b/tests/integration/test_lateral_movement_query_pack.py
@@ -7,6 +7,7 @@ PACK_DIR = ROOT / "packs" / "lateral-movement"
 PACK_SQL = PACK_DIR / "snowflake.sql"
 PACK_README = PACK_DIR / "README.md"
 EXPECTED_COLUMNS = PACK_DIR / "golden" / "expected_columns.json"
+EXPECTED_COLUMN_TYPES = PACK_DIR / "golden" / "expected_column_types.json"
 
 
 def test_lateral_movement_pack_files_exist() -> None:
@@ -14,6 +15,7 @@ def test_lateral_movement_pack_files_exist() -> None:
     assert PACK_SQL.is_file()
     assert PACK_README.is_file()
     assert EXPECTED_COLUMNS.is_file()
+    assert EXPECTED_COLUMN_TYPES.is_file()
 
 
 def test_snowflake_pack_keeps_detector_contract() -> None:
@@ -49,6 +51,18 @@ def test_snowflake_pack_emits_expected_columns() -> None:
 
     for column in expected_columns:
         assert re.search(rf"\bAS\s+{re.escape(column)}\b", sql, re.IGNORECASE), column
+
+
+def test_snowflake_pack_locks_expected_column_types() -> None:
+    sql = PACK_SQL.read_text()
+    expected_column_types = json.loads(EXPECTED_COLUMN_TYPES.read_text())
+
+    for column, column_type in expected_column_types.items():
+        assert re.search(
+            rf"::\s*{re.escape(column_type)}\s+AS\s+{re.escape(column)}\b",
+            sql,
+            re.IGNORECASE,
+        ), column
 
 
 def test_readme_describes_input_and_limits() -> None:


### PR DESCRIPTION
## Summary
- add a top-level packs README and typed golden contracts for the shipped Snowflake packs
- lock output column types directly in the SQL and extend the integration tests to assert them
- add sqlfluff config and CI lint coverage for packs

## Validation
- uv run pytest /tmp/cloud-security-core-foundation/tests/integration/test_lateral_movement_query_pack.py /tmp/cloud-security-core-foundation/tests/integration/test_k8s_priv_esc_query_pack.py -q -o addopts=''
- uv run ruff check /tmp/cloud-security-core-foundation/tests/integration/test_lateral_movement_query_pack.py /tmp/cloud-security-core-foundation/tests/integration/test_k8s_priv_esc_query_pack.py --config /tmp/cloud-security-core-foundation/pyproject.toml
- uv tool run --from sqlfluff sqlfluff lint /tmp/cloud-security-core-foundation/packs