### PR TITLE
feat: add s3 select source adapter

### DIFF
--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -41,6 +41,15 @@
       "coverage_status": "validated"
     },
     {
+      "path": "skills/ingestion/source-s3-select",
+      "layer": "ingestion",
+      "providers": ["aws"],
+      "asset_classes": ["object-storage", "query-results", "audit-logs"],
+      "execution_modes": ["cli", "ci", "mcp", "persistent"],
+      "frameworks": ["ocsf-1.8"],
+      "coverage_status": "validated"
+    },
+    {
       "path": "skills/ingestion/ingest-cloudtrail-ocsf",
       "layer": "ingestion",
       "providers": ["aws"],

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -24,6 +24,7 @@ class TestDiscovery:
         skills = discover_skills(REPO_ROOT)
         assert len(skills) >= 35
         assert {skill.name for skill in skills} >= {
+            "source-s3-select",
             "source-databricks-query",
             "source-snowflake-query",
             "sink-snowflake-jsonl",
@@ -55,6 +56,7 @@ class TestDiscovery:
 
     def test_supported_tools_include_ingest_detect_and_evaluate(self):
         tools = tool_map(REPO_ROOT)
+        assert "source-s3-select" in tools
         assert "source-databricks-query" in tools
         assert "source-snowflake-query" in tools
         assert "sink-snowflake-jsonl" in tools
@@ -118,6 +120,13 @@ class TestToolDefinition:
         assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["raw"]
         assert skill.output_formats == ("raw",)
         assert skill.network_egress == ("*.snowflakecomputing.com",)
+
+    def test_source_s3_select_exposes_raw_output(self):
+        skill = tool_map(REPO_ROOT)["source-s3-select"]
+        tool = tool_definition(skill)
+        assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["raw"]
+        assert skill.output_formats == ("raw",)
+        assert skill.network_egress == ("*.amazonaws.com",)
 
     def test_source_databricks_query_exposes_raw_output(self):
         skill = tool_map(REPO_ROOT)["source-databricks-query"]

--- a/skills/ingestion/source-s3-select/REFERENCES.md
+++ b/skills/ingestion/source-s3-select/REFERENCES.md
@@ -1,0 +1,17 @@
+# References — source-s3-select
+
+## Source and transport
+
+- **Amazon S3 Select** — https://docs.aws.amazon.com/AmazonS3/latest/userguide/selecting-content-from-objects.html
+- **Boto3 S3 `select_object_content`** — https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/select_object_content.html
+- **AWS SDK credential provider chain** — https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+
+## Read-only SQL semantics
+
+- **S3 Select SQL reference** — https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-glacier-select-sql-reference-select.html
+- **JSON input and output serialization for S3 Select** — https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-glacier-select-sql-reference-data-types.html
+
+## Security and credential posture
+
+- **AWS IAM best practices** — https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- **Temporary security credentials in IAM** — https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html

--- a/skills/ingestion/source-s3-select/SKILL.md
+++ b/skills/ingestion/source-s3-select/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: source-s3-select
+description: >-
+  Run a read-only Amazon S3 Select query against an existing object and emit
+  the result set as raw JSONL rows for downstream ingestion, detection, or
+  view skills. Accepts explicit `--expression` SQL or reads the expression from
+  stdin when no `--expression` is provided. Only `SELECT` statements are
+  allowed, and multiple statements are rejected. Use when the user already has
+  security data in S3 and wants to pipe selected rows into existing skills
+  without downloading full objects first. Do NOT use for writes, object
+  mutation, or broad bucket inventory. Do NOT use as a detector or normalizer
+  by itself.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: raw
+output_formats: raw
+network_egress: "*.amazonaws.com"
+---
+
+# source-s3-select
+
+Read-only source adapter: Amazon S3 Select query in, raw JSONL rows out. This
+skill does not normalize vendor data, detect threats, or write back to S3. It
+exists so operators and agents can fetch already-landed lake data and pipe it
+into the existing `ingest-*`, `detect-*`, `discover-*`, or `view/*` skills.
+
+## Use when
+
+- Security data already lives in S3 as JSON lines or JSON documents
+- You want to fetch rows directly into a skill pipeline without downloading the full object
+- You need a read-only source step before `ingest-*` or `detect-*`
+
+## Do NOT use
+
+- For `PUT`, `COPY`, `DELETE`, lifecycle, ACL, bucket-policy, or object-mutation operations
+- As a detection or remediation skill
+- When the source data is not in S3
+- When the object format is not supported by S3 Select for JSON input
+
+## Input
+
+The skill accepts one read-only S3 Select expression via:
+
+- `--expression "SELECT ..."` on the CLI, or
+- stdin when `--expression` is omitted
+
+Required location arguments:
+
+- `--bucket`
+- `--key`
+
+Optional object parsing arguments:
+
+- `--input-serialization lines|document` (default: `lines`)
+- `--compression-type none|gzip|bzip2` (default: `none`)
+
+Allowed statement family:
+
+- `SELECT`
+
+The skill rejects multiple statements and non-read-only verbs.
+
+## Output
+
+Raw JSONL rows exactly as S3 Select returns them for JSON output,
+serialized one record per line. If a row is not a JSON object, it is wrapped
+as `{"value": ...}` so downstream skills still receive valid JSONL.
+
+Typical compositions:
+
+```bash
+# Data already projected to the fields your downstream skill expects
+python skills/ingestion/source-s3-select/src/ingest.py \
+  --bucket my-sec-lake \
+  --key cloudtrail/ocsf.jsonl \
+  --expression "SELECT s.raw_json FROM S3Object s LIMIT 100" \
+  | jq -c '.raw_json' \
+  | python skills/detection/detect-lateral-movement/src/detect.py
+
+# Data still in raw vendor shape
+python skills/ingestion/source-s3-select/src/ingest.py \
+  --bucket my-sec-lake \
+  --key cloudtrail/raw.jsonl \
+  --expression "SELECT s.raw_event FROM S3Object s LIMIT 100" \
+  | jq -c '.raw_event' \
+  | python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
+```
+
+## Credentials
+
+Uses the standard AWS SDK credential chain and optional region configuration:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN`
+- `AWS_PROFILE`
+- `AWS_REGION` / `AWS_DEFAULT_REGION`
+
+This skill is read-only but still egresses to AWS. Prefer short-lived,
+manager-injected credentials or workload identity patterns.

--- a/skills/ingestion/source-s3-select/src/ingest.py
+++ b/skills/ingestion/source-s3-select/src/ingest.py
@@ -1,0 +1,147 @@
+"""Run a read-only S3 Select query and emit raw JSONL rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Iterable
+
+SKILL_NAME = "source-s3-select"
+ALLOWED_PREFIXES = ("SELECT",)
+
+
+def _read_expression(cli_expression: str | None, stdin: Iterable[str]) -> str:
+    if cli_expression and cli_expression.strip():
+        return cli_expression.strip()
+    stdin_text = "".join(stdin).strip()
+    if stdin_text:
+        return stdin_text
+    raise ValueError("provide a read-only S3 Select expression via --expression or stdin")
+
+
+def _normalize_expression(expression: str) -> str:
+    cleaned = expression.strip()
+    if not cleaned:
+        raise ValueError("expression must not be empty")
+    while cleaned.endswith(";"):
+        cleaned = cleaned[:-1].rstrip()
+    if ";" in cleaned:
+        raise ValueError("multiple SQL statements are not allowed")
+
+    head = cleaned.lstrip("(\n\t ").upper()
+    if not any(head.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+        raise ValueError("only SELECT statements are allowed")
+    return cleaned
+
+
+def _input_serialization(kind: str, compression_type: str) -> dict[str, Any]:
+    json_kind = "LINES" if kind == "lines" else "DOCUMENT"
+    serialization: dict[str, Any] = {"JSON": {"Type": json_kind}}
+    if compression_type != "none":
+        serialization["CompressionType"] = compression_type.upper()
+    return serialization
+
+
+def _client() -> Any:
+    import boto3
+
+    region_name = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    kwargs: dict[str, str] = {}
+    if region_name:
+        kwargs["region_name"] = region_name
+    return boto3.client("s3", **kwargs)
+
+
+def _iter_record_payloads(payload: Iterable[dict[str, Any]]) -> Iterable[str]:
+    buffer = ""
+    for event in payload:
+        if "Records" not in event:
+            continue
+        chunk = event["Records"].get("Payload", b"")
+        if not chunk:
+            continue
+        buffer += chunk.decode("utf-8")
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            stripped = line.strip()
+            if stripped:
+                yield stripped
+    if buffer.strip():
+        yield buffer.strip()
+
+
+def fetch_rows(
+    *,
+    bucket: str,
+    key: str,
+    expression: str,
+    input_serialization: str,
+    compression_type: str,
+) -> list[dict[str, Any]]:
+    response = _client().select_object_content(
+        Bucket=bucket,
+        Key=key,
+        ExpressionType="SQL",
+        Expression=_normalize_expression(expression),
+        InputSerialization=_input_serialization(input_serialization, compression_type),
+        OutputSerialization={"JSON": {"RecordDelimiter": "\n"}},
+    )
+
+    normalized: list[dict[str, Any]] = []
+    for line in _iter_record_payloads(response["Payload"]):
+        value = json.loads(line)
+        if isinstance(value, dict):
+            normalized.append(value)
+        else:
+            normalized.append({"value": value})
+    return normalized
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a read-only S3 Select query and emit raw JSONL rows.")
+    parser.add_argument("--bucket", required=True, help="S3 bucket containing the object to query.")
+    parser.add_argument("--key", required=True, help="S3 object key to query with S3 Select.")
+    parser.add_argument(
+        "--expression",
+        help="Read-only S3 Select SQL expression. If omitted, the expression is read from stdin.",
+    )
+    parser.add_argument(
+        "--input-serialization",
+        choices=("lines", "document"),
+        default="lines",
+        help="JSON input shape for S3 Select: newline-delimited JSON or a JSON document.",
+    )
+    parser.add_argument(
+        "--compression-type",
+        choices=("none", "gzip", "bzip2"),
+        default="none",
+        help="Compression type for the source object.",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=("raw",),
+        default="raw",
+        help="Declared output rendering mode for this source adapter.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        expression = _read_expression(args.expression, sys.stdin)
+        for row in fetch_rows(
+            bucket=args.bucket,
+            key=args.key,
+            expression=expression,
+            input_serialization=args.input_serialization,
+            compression_type=args.compression_type,
+        ):
+            sys.stdout.write(json.dumps(row, default=str, separators=(",", ":")) + "\n")
+    except Exception as exc:
+        print(f"[{SKILL_NAME}] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ingestion/source-s3-select/tests/test_ingest.py
+++ b/skills/ingestion/source-s3-select/tests/test_ingest.py
@@ -1,0 +1,130 @@
+"""Tests for source-s3-select."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "ingest.py"
+_SPEC = importlib.util.spec_from_file_location("source_s3_select", _SRC)
+assert _SPEC and _SPEC.loader
+_INGEST = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_INGEST)
+
+_input_serialization = _INGEST._input_serialization
+_normalize_expression = _INGEST._normalize_expression
+_read_expression = _INGEST._read_expression
+fetch_rows = _INGEST.fetch_rows
+
+
+class _FakeS3Client:
+    def __init__(self, payload):
+        self.payload = payload
+        self.kwargs = None
+
+    def select_object_content(self, **kwargs):
+        self.kwargs = kwargs
+        return {"Payload": self.payload}
+
+
+class TestNormalizeExpression:
+    def test_allows_select(self):
+        assert _normalize_expression("SELECT * FROM S3Object s") == "SELECT * FROM S3Object s"
+
+    def test_rejects_multiple_statements(self):
+        try:
+            _normalize_expression("SELECT * FROM S3Object s; SELECT 2")
+        except ValueError as exc:
+            assert "multiple SQL statements" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_write_statement(self):
+        try:
+            _normalize_expression("DELETE FROM S3Object s")
+        except ValueError as exc:
+            assert "only SELECT statements" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestReadExpression:
+    def test_prefers_cli_expression(self):
+        assert _read_expression("SELECT * FROM S3Object s", ["SELECT 2"]) == "SELECT * FROM S3Object s"
+
+    def test_falls_back_to_stdin(self):
+        assert _read_expression(None, ["SELECT * ", "FROM S3Object s"]) == "SELECT * FROM S3Object s"
+
+
+class TestInputSerialization:
+    def test_builds_lines_serialization(self):
+        assert _input_serialization("lines", "none") == {"JSON": {"Type": "LINES"}}
+
+    def test_builds_document_serialization_with_compression(self):
+        assert _input_serialization("document", "gzip") == {
+            "JSON": {"Type": "DOCUMENT"},
+            "CompressionType": "GZIP",
+        }
+
+
+class TestFetchRows:
+    def test_fetches_json_objects(self, monkeypatch):
+        fake = _FakeS3Client(
+            [
+                {"Records": {"Payload": b'{"event":"a"}\n{"event":"b"}\n'}},
+                {"End": {}},
+            ]
+        )
+        monkeypatch.setattr(_INGEST, "_client", lambda: fake)
+
+        rows = fetch_rows(
+            bucket="sec-lake",
+            key="events.jsonl",
+            expression="SELECT * FROM S3Object s",
+            input_serialization="lines",
+            compression_type="none",
+        )
+
+        assert rows == [{"event": "a"}, {"event": "b"}]
+        assert fake.kwargs is not None
+        assert fake.kwargs["Bucket"] == "sec-lake"
+        assert fake.kwargs["Key"] == "events.jsonl"
+        assert fake.kwargs["Expression"] == "SELECT * FROM S3Object s"
+        assert fake.kwargs["InputSerialization"] == {"JSON": {"Type": "LINES"}}
+
+    def test_wraps_non_dict_rows(self, monkeypatch):
+        fake = _FakeS3Client(
+            [
+                {"Records": {"Payload": b'"value"\n'}},
+            ]
+        )
+        monkeypatch.setattr(_INGEST, "_client", lambda: fake)
+
+        rows = fetch_rows(
+            bucket="sec-lake",
+            key="values.jsonl",
+            expression="SELECT _1 FROM S3Object s",
+            input_serialization="lines",
+            compression_type="none",
+        )
+
+        assert rows == [{"value": "value"}]
+
+    def test_stitches_partial_record_chunks(self, monkeypatch):
+        fake = _FakeS3Client(
+            [
+                {"Records": {"Payload": b'{"event":"a"'}},
+                {"Records": {"Payload": b'}\n'}},
+            ]
+        )
+        monkeypatch.setattr(_INGEST, "_client", lambda: fake)
+
+        rows = fetch_rows(
+            bucket="sec-lake",
+            key="events.jsonl",
+            expression="SELECT * FROM S3Object s",
+            input_serialization="lines",
+            compression_type="none",
+        )
+
+        assert rows == [{"event": "a"}]

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -59,6 +59,7 @@ class TestSkillValidationCommon:
         skills = COMMON.discover_skill_contracts()
         assert len(skills) >= 32
         names = {skill.name for skill in skills}
+        assert "source-s3-select" in names
         assert "source-databricks-query" in names
         assert "source-snowflake-query" in names
         assert "sink-snowflake-jsonl" in names


### PR DESCRIPTION
## Summary
- add a read-only S3 Select source adapter that emits raw JSONL rows for downstream skills
- keep the same source-skill contract as Snowflake and Databricks with statement validation and raw output only
- wire the new adapter into framework coverage and MCP/tool-registry validation

## Validation
- uv run pytest /tmp/cloud-security-core-foundation/skills/ingestion/source-s3-select/tests/test_ingest.py /tmp/cloud-security-core-foundation/mcp-server/tests/test_tool_registry.py /tmp/cloud-security-core-foundation/tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run ruff check /tmp/cloud-security-core-foundation/skills/ingestion/source-s3-select/src/ingest.py /tmp/cloud-security-core-foundation/skills/ingestion/source-s3-select/tests/test_ingest.py /tmp/cloud-security-core-foundation/mcp-server/tests/test_tool_registry.py /tmp/cloud-security-core-foundation/tests/integration/test_skill_validation_scripts.py --config /tmp/cloud-security-core-foundation/pyproject.toml
- python /tmp/cloud-security-core-foundation/scripts/validate_skill_contract.py && python /tmp/cloud-security-core-foundation/scripts/validate_framework_coverage.py && python /tmp/cloud-security-core-foundation/scripts/validate_dependency_consistency.py && python /tmp/cloud-security-core-foundation/scripts/validate_skill_integrity.py && python /tmp/cloud-security-core-foundation/scripts/validate_safe_skill_bar.py