### PR TITLE
feat: add databricks lateral-movement pack

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -2,4 +2,4 @@
 dialect = snowflake
 templater = raw
 max_line_length = 120
-exclude_rules = AL09,AM05,CP05,CV11,LT02,LT05,LT08,LT09,RF02,RF04,ST09
+exclude_rules = AL09,AM05,CP02,CP03,CP05,CV11,LT02,LT05,LT08,LT09,RF02,RF04,ST09

--- a/packs/lateral-movement/README.md
+++ b/packs/lateral-movement/README.md
@@ -1,10 +1,10 @@
 # lateral-movement query pack
 
-Warehouse-native Snowflake implementation of the same detection intent as [`skills/detection/detect-lateral-movement`](../../skills/detection/detect-lateral-movement/SKILL.md).
+Warehouse-native SQL implementations of the same detection intent as [`skills/detection/detect-lateral-movement`](../../skills/detection/detect-lateral-movement/SKILL.md).
 
 Use this pack when:
 - your lake already stores OCSF-shaped API Activity (`6003`) and Network Activity (`4001`) rows
-- you want the correlation to run inside Snowflake with zero egress
+- you want the correlation to run inside Snowflake or Databricks SQL with zero egress
 - you want OCSF-compatible finding rows without piping data through Python first
 
 Do not use this pack when:
@@ -14,7 +14,10 @@ Do not use this pack when:
 
 ## Input contract
 
-This SQL expects a pre-existing Snowflake table or view with a single `raw_json VARIANT` column containing one OCSF 1.8 event per row.
+The shipped SQL files expect a pre-existing table or view containing one OCSF 1.8 event per row:
+
+- `snowflake.sql`: `raw_json VARIANT`
+- `databricks.sql`: `raw_json STRING`
 
 Minimum event families:
 - API Activity (`class_uid = 6003`) for identity-pivot anchors
@@ -28,14 +31,17 @@ The pack applies the same core thresholds as the Python detector:
 
 ## Run
 
-Set the source table, then run the SQL in Snowflake:
+Set the source table, then run the SQL in your warehouse:
 
 ```sql
 SET source_table = 'SECURITY_EVENTS_OCSF';
 SET lookback_hours = 24;
 ```
 
-Then execute [`snowflake.sql`](./snowflake.sql).
+Then execute one of:
+
+- [`snowflake.sql`](./snowflake.sql)
+- [`databricks.sql`](./databricks.sql)
 
 If your column is not named `raw_json`, create a small view that aliases it:
 
@@ -54,10 +60,11 @@ The query returns one row per deterministic `(provider, session_uid, dst_ip, dst
 
 The locked output columns and types are listed in:
 - [`golden/expected_columns.json`](./golden/expected_columns.json)
-- [`golden/expected_column_types.json`](./golden/expected_column_types.json)
+- [`golden/expected_column_types.json`](./golden/expected_column_types.json) for Snowflake
+- [`golden/expected_column_types_databricks.json`](./golden/expected_column_types_databricks.json) for Databricks
 
 ## Notes
 
-- This pack keeps the data in Snowflake, but the detection logic stays aligned with the shipped Python skill.
+- This pack keeps the data in the warehouse, but the detection logic stays aligned with the shipped Python skill.
 - The SQL is intentionally explicit instead of abstracted through macros so operators can audit it directly.
 - This pack is read-only. Persisting the findings is a separate step, for example through `sink-snowflake-jsonl`.

--- a/packs/lateral-movement/databricks.sql
+++ b/packs/lateral-movement/databricks.sql
@@ -1,0 +1,254 @@
+-- sqlfluff:dialect:databricks
+-- lateral-movement query pack for Databricks SQL
+--
+-- Required parameter substitution before execution:
+--   replace ${source_table} with the source table or view name
+--   replace ${lookback_hours} with an integer hour window
+--
+-- Input contract:
+--   ${source_table} must expose a `raw_json STRING` column with one
+--   OCSF 1.8 event per row.
+--
+-- Output contract:
+--   One OCSF-compatible Detection Finding row per deterministic
+--   (provider, session_uid, dst_ip, dst_port) tuple.
+
+WITH source_events AS (
+    SELECT raw_json AS event
+    FROM ${source_table}
+    WHERE COALESCE(CAST(get_json_object(raw_json, '$.time') AS BIGINT), 0) >= unix_millis(
+        current_timestamp() - INTERVAL ${lookback_hours} HOURS
+    )
+),
+normalized AS (
+    SELECT
+        event,
+        CAST(get_json_object(event, '$.class_uid') AS INT) AS class_uid,
+        CAST(get_json_object(event, '$.activity_id') AS INT) AS activity_id,
+        UPPER(COALESCE(get_json_object(event, '$.cloud.provider'), '')) AS provider,
+        COALESCE(get_json_object(event, '$.cloud.account.uid'), '') AS account_uid,
+        COALESCE(CAST(get_json_object(event, '$.time') AS BIGINT), 0) AS time_ms,
+        COALESCE(get_json_object(event, '$.actor.session.uid'), '') AS session_uid,
+        COALESCE(get_json_object(event, '$.actor.user.name'), '') AS actor_name,
+        COALESCE(get_json_object(event, '$.api.operation'), '') AS operation,
+        COALESCE(get_json_object(event, '$.api.service.name'), '') AS service_name,
+        COALESCE(get_json_object(event, '$.src_endpoint.ip'), '') AS src_ip,
+        COALESCE(get_json_object(event, '$.src_endpoint.instance_uid'), '') AS src_instance_uid,
+        COALESCE(get_json_object(event, '$.dst_endpoint.ip'), '') AS dst_ip,
+        CAST(get_json_object(event, '$.dst_endpoint.port') AS INT) AS dst_port,
+        COALESCE(CAST(get_json_object(event, '$.traffic.bytes') AS BIGINT), 0) AS traffic_bytes
+    FROM source_events
+    WHERE CAST(get_json_object(event, '$.class_uid') AS INT) IN (6003, 4001)
+),
+identity_anchors AS (
+    SELECT *
+    FROM normalized
+    WHERE class_uid = 6003
+      AND (
+        (
+            provider = 'AWS'
+            AND operation IN ('AssumeRole', 'AssumeRoleWithSAML', 'AssumeRoleWithWebIdentity')
+        )
+        OR (
+            provider = 'GCP'
+            AND UPPER(service_name) IN ('IAMCREDENTIALS.GOOGLEAPIS.COM', 'IAM.GOOGLEAPIS.COM')
+            AND operation RLIKE '(GenerateAccessToken|GenerateIdToken|SignJwt|SignBlob|CreateServiceAccountKey)$'
+        )
+        OR (
+            provider = 'AZURE'
+            AND (
+                UPPER(operation) IN (
+                    'MICROSOFT.AUTHORIZATION/ROLEASSIGNMENTS/WRITE',
+                    'MICROSOFT.AUTHORIZATION/ELEVATEACCESS/ACTION',
+                    'MICROSOFT.MANAGEDIDENTITY/USERASSIGNEDIDENTITIES/ASSIGN/ACTION'
+                )
+                OR (
+                    UPPER(service_name) IN (
+                        'GRAPH.MICROSOFT.COM',
+                        'MICROSOFT GRAPH',
+                        'MICROSOFT ENTRA ID',
+                        'CORE DIRECTORY'
+                    )
+                    AND (
+                        UPPER(operation) IN (
+                            'ADD SERVICE PRINCIPAL CREDENTIALS',
+                            'UPDATE APPLICATION - CERTIFICATES AND SECRETS MANAGEMENT',
+                            'ADD APP ROLE ASSIGNMENT TO SERVICE PRINCIPAL',
+                            'CREATE FEDERATED IDENTITY CREDENTIAL',
+                            'ADD FEDERATED IDENTITY CREDENTIAL'
+                        )
+                        OR REPLACE(UPPER(operation), ' ', '') RLIKE 'ADDPASSWORD|ADDKEY'
+                        OR REPLACE(UPPER(operation), ' ', '') RLIKE 'APPROLEASSIGNMENTS|APPROLEASSIGNEDTO'
+                        OR REPLACE(UPPER(operation), ' ', '') RLIKE 'FEDERATEDIDENTITYCREDENTIALS'
+                    )
+                )
+            )
+        )
+      )
+),
+flows AS (
+    SELECT *
+    FROM normalized
+    WHERE class_uid = 4001
+      AND activity_id = 6
+      AND traffic_bytes >= 1024
+      AND (
+        dst_ip RLIKE '^10\\.'
+        OR dst_ip RLIKE '^192\\.168\\.'
+        OR dst_ip RLIKE '^172\\.(1[6-9]|2[0-9]|3[0-1])\\.'
+        OR dst_ip RLIKE '^100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\.'
+      )
+),
+candidate_pairs AS (
+    SELECT
+        anchor.provider,
+        anchor.account_uid,
+        anchor.session_uid,
+        anchor.actor_name,
+        anchor.operation AS anchor_operation,
+        flow.src_instance_uid,
+        flow.src_ip,
+        flow.dst_ip,
+        flow.dst_port,
+        flow.traffic_bytes,
+        anchor.time_ms AS first_seen_time_ms,
+        flow.time_ms AS last_seen_time_ms,
+        flow.time_ms AS finding_time_ms,
+        ROW_NUMBER() OVER (
+            PARTITION BY anchor.provider, anchor.session_uid, flow.dst_ip, flow.dst_port
+            ORDER BY flow.time_ms
+        ) AS pair_rank
+    FROM identity_anchors AS anchor
+    INNER JOIN flows AS flow
+      ON flow.provider = anchor.provider
+     AND (
+        anchor.account_uid = ''
+        OR flow.account_uid = ''
+        OR flow.account_uid = anchor.account_uid
+     )
+     AND flow.time_ms BETWEEN anchor.time_ms AND anchor.time_ms + 900000
+),
+findings AS (
+    SELECT
+        provider,
+        account_uid,
+        session_uid,
+        actor_name,
+        anchor_operation,
+        src_instance_uid,
+        src_ip,
+        dst_ip,
+        dst_port,
+        traffic_bytes,
+        first_seen_time_ms,
+        last_seen_time_ms,
+        finding_time_ms,
+        CONCAT(
+            'det-lm-',
+            SUBSTRING(SHA2(LOWER(COALESCE(NULLIF(provider, ''), 'cloud')), 256), 1, 8),
+            '-',
+            SUBSTRING(SHA2(COALESCE(session_uid, ''), 256), 1, 8),
+            '-',
+            SUBSTRING(SHA2(CONCAT(COALESCE(dst_ip, ''), ':', COALESCE(CAST(dst_port AS STRING), '')), 256), 1, 8)
+        ) AS finding_uid,
+        CASE WHEN provider = 'AZURE' THEN 'Azure' ELSE provider END AS provider_display
+    FROM candidate_pairs
+    WHERE pair_rank = 1
+)
+SELECT
+    CAST(finding_uid AS STRING) AS finding_uid,
+    CAST(finding_uid AS STRING) AS event_uid,
+    CAST(provider AS STRING) AS provider,
+    CAST(account_uid AS STRING) AS account_uid,
+    CAST(session_uid AS STRING) AS session_uid,
+    CAST(actor_name AS STRING) AS actor_name,
+    CAST(anchor_operation AS STRING) AS anchor_operation,
+    CAST(src_instance_uid AS STRING) AS src_instance_uid,
+    CAST(src_ip AS STRING) AS src_ip,
+    CAST(dst_ip AS STRING) AS dst_ip,
+    CAST(dst_port AS INT) AS dst_port,
+    CAST(traffic_bytes AS BIGINT) AS traffic_bytes,
+    CAST(first_seen_time_ms AS BIGINT) AS first_seen_time_ms,
+    CAST(last_seen_time_ms AS BIGINT) AS last_seen_time_ms,
+    CAST(finding_time_ms AS BIGINT) AS finding_time_ms,
+    CAST(900 AS INT) AS correlation_window_seconds,
+    CAST('cloud-lateral-movement' AS STRING) AS finding_type,
+    CAST('T1021' AS STRING) AS primary_technique_uid,
+    CAST('T1078.004' AS STRING) AS secondary_technique_uid,
+    CAST(
+        TO_JSON(
+            NAMED_STRUCT(
+            'activity_id', 1,
+            'category_uid', 2,
+            'category_name', 'Findings',
+            'class_uid', 2004,
+            'class_name', 'Detection Finding',
+            'type_uid', 200401,
+            'severity_id', 4,
+            'status_id', 1,
+            'time', finding_time_ms,
+            'metadata', NAMED_STRUCT(
+                'version', '1.8.0',
+                'uid', finding_uid,
+                'product', NAMED_STRUCT(
+                    'name', 'cloud-ai-security-skills',
+                    'vendor_name', 'msaad00/cloud-ai-security-skills',
+                    'feature', NAMED_STRUCT('name', 'packs/lateral-movement/databricks.sql')
+                ),
+                'labels', ARRAY('query-pack', LOWER(provider), 'lateral-movement', 'databricks')
+            ),
+            'finding_info', NAMED_STRUCT(
+                'uid', finding_uid,
+                'title', CONCAT(provider_display, ' lateral movement: identity pivot followed by east-west traffic'),
+                'desc', CONCAT(
+                    'Principal ''', actor_name, ''' triggered identity pivot operation ''', anchor_operation,
+                    ''' (session ''', session_uid,
+                    '''), and within the 15-minute correlation window an accepted east-west flow moved ',
+                    CAST(traffic_bytes AS STRING), ' bytes from ',
+                    COALESCE(NULLIF(src_instance_uid, ''), src_ip),
+                    ' to ', dst_ip, ':', COALESCE(CAST(dst_port AS STRING), ''),
+                    '. This is the canonical ', provider_display,
+                    ' lateral movement pattern (MITRE T1021 Remote Services via T1078.004 Cloud Accounts).'
+                ),
+                'types', ARRAY('cloud-lateral-movement'),
+                'first_seen_time', first_seen_time_ms,
+                'last_seen_time', last_seen_time_ms,
+                'attacks', ARRAY(
+                    NAMED_STRUCT(
+                        'version', 'v14',
+                        'tactic', NAMED_STRUCT('name', 'Lateral Movement', 'uid', 'TA0008'),
+                        'technique', NAMED_STRUCT('name', 'Remote Services', 'uid', 'T1021')
+                    ),
+                    NAMED_STRUCT(
+                        'version', 'v14',
+                        'tactic', NAMED_STRUCT('name', 'Persistence', 'uid', 'TA0003'),
+                        'technique', NAMED_STRUCT('name', 'Valid Accounts', 'uid', 'T1078'),
+                        'sub_technique', NAMED_STRUCT('name', 'Cloud Accounts', 'uid', 'T1078.004')
+                    )
+                )
+            ),
+            'observables', ARRAY(
+                NAMED_STRUCT('name', 'cloud.provider', 'type', 'Other', 'value', provider_display),
+                NAMED_STRUCT('name', 'cloud.account', 'type', 'Other', 'value', account_uid),
+                NAMED_STRUCT('name', 'session.uid', 'type', 'Other', 'value', session_uid),
+                NAMED_STRUCT('name', 'actor.name', 'type', 'Other', 'value', actor_name),
+                NAMED_STRUCT('name', 'anchor.operation', 'type', 'Other', 'value', anchor_operation),
+                NAMED_STRUCT('name', 'src.instance_uid', 'type', 'Other', 'value', src_instance_uid),
+                NAMED_STRUCT('name', 'src.ip', 'type', 'Other', 'value', src_ip),
+                NAMED_STRUCT('name', 'dst.ip', 'type', 'Other', 'value', dst_ip),
+                NAMED_STRUCT('name', 'dst.port', 'type', 'Other', 'value', COALESCE(CAST(dst_port AS STRING), '')),
+                NAMED_STRUCT('name', 'traffic.bytes', 'type', 'Other', 'value', CAST(traffic_bytes AS STRING)),
+                NAMED_STRUCT('name', 'window.seconds', 'type', 'Other', 'value', '900'),
+                NAMED_STRUCT('name', 'rule', 'type', 'Other', 'value', 'cloud-lateral-movement')
+            ),
+            'evidence', NAMED_STRUCT(
+                'events_observed', 2,
+                'first_seen_time', first_seen_time_ms,
+                'last_seen_time', last_seen_time_ms,
+                'raw_events', ARRAY()
+            )
+            )
+        ) AS STRING
+    ) AS finding_json
+FROM findings
+ORDER BY provider, session_uid, dst_ip, dst_port;

--- a/packs/lateral-movement/golden/expected_column_types_databricks.json
+++ b/packs/lateral-movement/golden/expected_column_types_databricks.json
@@ -1,0 +1,22 @@
+{
+  "finding_uid": "string",
+  "event_uid": "string",
+  "provider": "string",
+  "account_uid": "string",
+  "session_uid": "string",
+  "actor_name": "string",
+  "anchor_operation": "string",
+  "src_instance_uid": "string",
+  "src_ip": "string",
+  "dst_ip": "string",
+  "dst_port": "int",
+  "traffic_bytes": "bigint",
+  "first_seen_time_ms": "bigint",
+  "last_seen_time_ms": "bigint",
+  "finding_time_ms": "bigint",
+  "correlation_window_seconds": "int",
+  "finding_type": "string",
+  "primary_technique_uid": "string",
+  "secondary_technique_uid": "string",
+  "finding_json": "string"
+}

--- a/tests/integration/test_lateral_movement_query_pack.py
+++ b/tests/integration/test_lateral_movement_query_pack.py
@@ -4,22 +4,26 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PACK_DIR = ROOT / "packs" / "lateral-movement"
-PACK_SQL = PACK_DIR / "snowflake.sql"
+SNOWFLAKE_SQL = PACK_DIR / "snowflake.sql"
+DATABRICKS_SQL = PACK_DIR / "databricks.sql"
 PACK_README = PACK_DIR / "README.md"
 EXPECTED_COLUMNS = PACK_DIR / "golden" / "expected_columns.json"
 EXPECTED_COLUMN_TYPES = PACK_DIR / "golden" / "expected_column_types.json"
+EXPECTED_DATABRICKS_COLUMN_TYPES = PACK_DIR / "golden" / "expected_column_types_databricks.json"
 
 
 def test_lateral_movement_pack_files_exist() -> None:
     assert PACK_DIR.is_dir()
-    assert PACK_SQL.is_file()
+    assert SNOWFLAKE_SQL.is_file()
+    assert DATABRICKS_SQL.is_file()
     assert PACK_README.is_file()
     assert EXPECTED_COLUMNS.is_file()
     assert EXPECTED_COLUMN_TYPES.is_file()
+    assert EXPECTED_DATABRICKS_COLUMN_TYPES.is_file()
 
 
 def test_snowflake_pack_keeps_detector_contract() -> None:
-    sql = PACK_SQL.read_text()
+    sql = SNOWFLAKE_SQL.read_text()
 
     for marker in (
         "IDENTIFIER($source_table)",
@@ -46,7 +50,7 @@ def test_snowflake_pack_keeps_detector_contract() -> None:
 
 
 def test_snowflake_pack_emits_expected_columns() -> None:
-    sql = PACK_SQL.read_text()
+    sql = SNOWFLAKE_SQL.read_text()
     expected_columns = json.loads(EXPECTED_COLUMNS.read_text())
 
     for column in expected_columns:
@@ -54,7 +58,7 @@ def test_snowflake_pack_emits_expected_columns() -> None:
 
 
 def test_snowflake_pack_locks_expected_column_types() -> None:
-    sql = PACK_SQL.read_text()
+    sql = SNOWFLAKE_SQL.read_text()
     expected_column_types = json.loads(EXPECTED_COLUMN_TYPES.read_text())
 
     for column, column_type in expected_column_types.items():
@@ -65,14 +69,73 @@ def test_snowflake_pack_locks_expected_column_types() -> None:
         ), column
 
 
+def test_databricks_pack_keeps_detector_contract() -> None:
+    sql = DATABRICKS_SQL.read_text()
+
+    for marker in (
+        "${source_table}",
+        "${lookback_hours}",
+        "AssumeRole",
+        "GenerateAccessToken",
+        "MICROSOFT.AUTHORIZATION/ROLEASSIGNMENTS/WRITE",
+        "activity_id = 6",
+        "traffic_bytes >= 1024",
+        "anchor.time_ms + 900000",
+        "T1021",
+        "T1078.004",
+        "cloud-lateral-movement",
+        "TO_JSON",
+        "NAMED_STRUCT",
+        "-- sqlfluff:dialect:databricks",
+    ):
+        assert marker in sql
+
+    for cidr_pattern in (
+        r"^10\\.",
+        r"^192\\.168\\.",
+        r"^172\\.(1[6-9]|2[0-9]|3[0-1])\\.",
+        r"^100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\.",
+    ):
+        assert cidr_pattern in sql
+
+
+def test_databricks_pack_emits_expected_columns() -> None:
+    sql = DATABRICKS_SQL.read_text()
+    expected_columns = json.loads(EXPECTED_COLUMNS.read_text())
+
+    for column in expected_columns:
+        assert re.search(rf"\bAS\s+{re.escape(column)}\b", sql, re.IGNORECASE), column
+
+
+def test_databricks_pack_locks_expected_column_types() -> None:
+    sql = DATABRICKS_SQL.read_text()
+    expected_column_types = json.loads(EXPECTED_DATABRICKS_COLUMN_TYPES.read_text())
+
+    for column, column_type in expected_column_types.items():
+        if column == "finding_json":
+            assert re.search(
+                rf"CAST\(\s*TO_JSON\(.+?\)\s+AS\s+{re.escape(column_type)}\s*\)\s+AS\s+{re.escape(column)}\b",
+                sql,
+                re.IGNORECASE | re.DOTALL,
+            ), column
+            continue
+        assert re.search(
+            rf"CAST\(.+?\s+AS\s+{re.escape(column_type)}\)\s+AS\s+{re.escape(column)}\b",
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        ), column
+
+
 def test_readme_describes_input_and_limits() -> None:
     readme = PACK_README.read_text()
 
     for phrase in (
         "raw_json VARIANT",
+        "raw_json STRING",
         "15-minute correlation window",
         "traffic.bytes >= 1024",
         "OCSF-compatible Detection Finding",
+        "databricks.sql",
         "sink-snowflake-jsonl",
     ):
         assert phrase in readme


### PR DESCRIPTION
## Summary
- add a Databricks SQL implementation for the shipped lateral-movement query pack
- lock Databricks-specific output types alongside the existing Snowflake contract
- extend the pack README and integration coverage so the pack layer now proves second-warehouse portability

## Validation
- uv run pytest /tmp/cloud-security-core-foundation/tests/integration/test_lateral_movement_query_pack.py -q -o addopts=''
- uv run ruff check /tmp/cloud-security-core-foundation/tests/integration/test_lateral_movement_query_pack.py --config /tmp/cloud-security-core-foundation/pyproject.toml
- uv tool run --from sqlfluff sqlfluff lint /tmp/cloud-security-core-foundation/packs