### PR TITLE
feat: add s3 jsonl sink

### DIFF
--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -390,6 +390,15 @@
       "frameworks": ["ocsf-1.8", "soc2-tsc"],
       "coverage_status": "validated",
       "execution_modes": ["cli", "mcp", "persistent"]
+    },
+    {
+      "path": "skills/remediation/sink-s3-jsonl",
+      "layer": "remediation",
+      "providers": ["aws"],
+      "asset_classes": ["findings", "evidence", "audit-logs", "object-storage"],
+      "frameworks": ["ocsf-1.8", "soc2-tsc"],
+      "coverage_status": "validated",
+      "execution_modes": ["cli", "mcp", "persistent"]
     }
   ],
   "coverage_targets": [

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -26,6 +26,7 @@ class TestDiscovery:
         assert {skill.name for skill in skills} >= {
             "source-databricks-query",
             "source-snowflake-query",
+            "sink-s3-jsonl",
             "sink-snowflake-jsonl",
             "sink-clickhouse-jsonl",
             "ingest-cloudtrail-ocsf",
@@ -57,6 +58,7 @@ class TestDiscovery:
         tools = tool_map(REPO_ROOT)
         assert "source-databricks-query" in tools
         assert "source-snowflake-query" in tools
+        assert "sink-s3-jsonl" in tools
         assert "sink-snowflake-jsonl" in tools
         assert "sink-clickhouse-jsonl" in tools
         assert "ingest-cloudtrail-ocsf" in tools
@@ -135,6 +137,16 @@ class TestToolDefinition:
         assert skill.output_formats == ("native",)
         assert skill.capability == "write-sink"
         assert skill.approver_roles == ("security_lead", "data_platform_owner")
+
+    def test_sink_s3_jsonl_exposes_write_metadata(self):
+        skill = tool_map(REPO_ROOT)["sink-s3-jsonl"]
+        tool = tool_definition(skill)
+        assert tool["annotations"]["readOnlyHint"] is False
+        assert tool["annotations"]["destructiveHint"] is True
+        assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["native"]
+        assert skill.output_formats == ("native",)
+        assert skill.capability == "write-sink"
+        assert skill.network_egress == ("*.amazonaws.com",)
 
     def test_sink_clickhouse_jsonl_exposes_write_metadata(self):
         skill = tool_map(REPO_ROOT)["sink-clickhouse-jsonl"]

--- a/skills/remediation/sink-s3-jsonl/REFERENCES.md
+++ b/skills/remediation/sink-s3-jsonl/REFERENCES.md
@@ -1,0 +1,13 @@
+# References — sink-s3-jsonl
+
+## Sink transport
+
+- **Boto3 S3 `put_object`** — https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/put_object.html
+- **Amazon S3 object key naming guidelines** — https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+- **Amazon S3 data consistency model** — https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#ConsistencyModel
+
+## Security and credential posture
+
+- **AWS IAM best practices** — https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- **Temporary security credentials in IAM** — https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html
+- **Default encryption for Amazon S3 buckets** — https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html

--- a/skills/remediation/sink-s3-jsonl/SKILL.md
+++ b/skills/remediation/sink-s3-jsonl/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: sink-s3-jsonl
+description: >-
+  Persist JSONL records from stdin into a new immutable object under a
+  pre-provisioned Amazon S3 bucket and prefix. Dry-run is the default and
+  emits a native sink-result summary without writing. Use when the user
+  already has findings, evidence, or audit rows and wants to persist them to
+  S3 without changing the producing skill. Do NOT use for bucket creation,
+  object deletion, overwrite flows, or arbitrary AWS mutations. Do NOT use as
+  an ingest, detect, or evaluation skill.
+license: Apache-2.0
+capability: write-sink
+approval_model: human_required
+execution_modes: jit, mcp, persistent
+side_effects: writes-storage
+input_formats: raw, native, ocsf
+output_formats: native
+network_egress: "*.amazonaws.com"
+caller_roles: security_engineer, platform_engineer
+approver_roles: security_lead, data_platform_owner
+min_approvers: 1
+---
+
+# sink-s3-jsonl
+
+Immutable S3 sink: JSONL in on `stdin`, one new object written under a
+validated bucket and prefix, native sink-result summary out on `stdout`.
+
+## Use when
+
+- Findings, evidence, or audit records already exist on stdin as JSONL
+- You need a repo-owned persistence step after `detect-*`, `discover-*`, `view/*`, or another sink-safe producer
+- The target bucket already exists and should remain append-only through new objects
+
+## Do NOT use
+
+- For bucket creation, policy changes, ACL mutation, lifecycle changes, or object deletion
+- For schema migration or data rewriting inside an existing object
+- As a detector, ingest normalizer, or remediation workflow by itself
+- When you need to write to a system other than Amazon S3
+
+## Do NOT do
+
+- Do **not** point this skill at privileged control-plane buckets
+- Do **not** use `--apply` without an operator approval step outside the CLI
+- Do **not** pass arbitrary S3 URIs or wildcard paths as the bucket name
+- Do **not** assume this skill mutates or appends to an existing object
+
+## Input
+
+Reads JSONL from `stdin`. Each line must be a valid JSON object.
+
+Accepted source shapes:
+
+- repo-native event or finding JSON
+- OCSF JSON
+- raw JSON objects you intentionally want to persist as-is
+
+Required CLI arguments:
+
+- `--bucket <bucket>`
+- `--prefix <prefix>`
+
+Safety flags:
+
+- default mode is dry-run
+- `--apply` executes the object write
+- `--dry-run` keeps the write path disabled explicitly
+
+## Output
+
+Emits one repo-native sink-result JSON object to `stdout`:
+
+- `schema_mode: "native"`
+- `record_type: "sink_result"`
+- `sink: "s3"`
+- `bucket`
+- `prefix`
+- `object_key`
+- `dry_run`
+- `input_records`
+- `written_objects`
+- `written_records`
+- `would_write_objects`
+- `would_write_records`
+- `schema_modes`
+
+## Sink object contract
+
+This skill writes exactly one new NDJSON object per apply run:
+
+- content type: `application/x-ndjson`
+- body: one JSON object per line
+- key shape: `<prefix>/YYYY/MM/DD/<timestamp>-<content-hash>.jsonl`
+
+The skill does not overwrite, append to, or mutate an existing object key.
+
+## Examples
+
+```bash
+# Dry-run by default
+python skills/detection/detect-lateral-movement/src/detect.py < events.ocsf.jsonl \
+  | python skills/remediation/sink-s3-jsonl/src/sink.py \
+      --bucket my-sec-lake \
+      --prefix findings/lateral-movement
+
+# Explicit apply for direct operator use
+python skills/discovery/discover-control-evidence/src/discover.py \
+  | python skills/remediation/sink-s3-jsonl/src/sink.py \
+      --bucket my-sec-lake \
+      --prefix evidence/control-exports \
+      --apply
+```
+
+## Credentials
+
+Uses the standard AWS SDK credential chain and optional region configuration:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN`
+- `AWS_PROFILE`
+- `AWS_REGION` / `AWS_DEFAULT_REGION`
+
+Prefer short-lived, manager-injected credentials or workload identity
+patterns.

--- a/skills/remediation/sink-s3-jsonl/src/sink.py
+++ b/skills/remediation/sink-s3-jsonl/src/sink.py
@@ -1,0 +1,217 @@
+"""Persist JSONL records into a new immutable S3 object."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Iterable
+
+SKILL_NAME = "sink-s3-jsonl"
+BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+PREFIX_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._=-]+$")
+
+
+@dataclass(frozen=True)
+class PreparedRow:
+    payload_json: str
+    schema_mode: str
+    event_uid: str
+    finding_uid: str
+
+
+def _normalize_bucket(raw_bucket: str) -> str:
+    bucket = raw_bucket.strip()
+    if not bucket:
+        raise ValueError("bucket must not be empty")
+    if not BUCKET_RE.fullmatch(bucket):
+        raise ValueError(f"invalid S3 bucket name `{bucket}`")
+    if ".." in bucket or ".-" in bucket or "-." in bucket:
+        raise ValueError(f"invalid S3 bucket name `{bucket}`")
+    return bucket
+
+
+def _normalize_prefix(raw_prefix: str) -> str:
+    prefix = raw_prefix.strip().strip("/")
+    if not prefix:
+        raise ValueError("prefix must not be empty")
+    parts = prefix.split("/")
+    for part in parts:
+        if not part or not PREFIX_SEGMENT_RE.fullmatch(part):
+            raise ValueError(f"invalid S3 prefix segment `{part or raw_prefix}`")
+    return "/".join(parts)
+
+
+def _extract_schema_mode(record: dict[str, Any]) -> str:
+    schema_mode = record.get("schema_mode")
+    if isinstance(schema_mode, str) and schema_mode.strip():
+        return schema_mode
+    if "class_uid" in record or "finding_info" in record or "metadata" in record:
+        return "ocsf"
+    return "raw"
+
+
+def _extract_event_uid(record: dict[str, Any]) -> str:
+    event_uid = record.get("event_uid")
+    if isinstance(event_uid, str):
+        return event_uid
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        metadata_uid = metadata.get("uid")
+        if isinstance(metadata_uid, str):
+            return metadata_uid
+    return ""
+
+
+def _extract_finding_uid(record: dict[str, Any]) -> str:
+    finding_uid = record.get("finding_uid")
+    if isinstance(finding_uid, str):
+        return finding_uid
+    finding_info = record.get("finding_info")
+    if isinstance(finding_info, dict):
+        finding_info_uid = finding_info.get("uid")
+        if isinstance(finding_info_uid, str):
+            return finding_info_uid
+    return ""
+
+
+def _prepare_rows(stdin: Iterable[str]) -> list[PreparedRow]:
+    rows: list[PreparedRow] = []
+    for line_number, raw_line in enumerate(stdin, start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number}: invalid JSON ({exc.msg})") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"line {line_number}: expected a JSON object")
+        rows.append(
+            PreparedRow(
+                payload_json=json.dumps(payload, separators=(",", ":"), sort_keys=True),
+                schema_mode=_extract_schema_mode(payload),
+                event_uid=_extract_event_uid(payload),
+                finding_uid=_extract_finding_uid(payload),
+            )
+        )
+    return rows
+
+
+def _object_key(prefix: str, rows: list[PreparedRow], now: datetime | None = None) -> str:
+    moment = now or datetime.now(UTC)
+    digest = hashlib.sha256(
+        "\n".join(row.payload_json for row in rows).encode("utf-8")
+    ).hexdigest()[:12]
+    return (
+        f"{prefix}/"
+        f"{moment:%Y/%m/%d}/"
+        f"{moment:%Y%m%dT%H%M%SZ}-{digest}.jsonl"
+    )
+
+
+def _body(rows: list[PreparedRow]) -> bytes:
+    return ("\n".join(row.payload_json for row in rows) + "\n").encode("utf-8")
+
+
+def _client() -> Any:
+    import boto3
+
+    region_name = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    kwargs: dict[str, str] = {}
+    if region_name:
+        kwargs["region_name"] = region_name
+    return boto3.client("s3", **kwargs)
+
+
+def _write_object(bucket: str, object_key: str, rows: list[PreparedRow]) -> int:
+    client = _client()
+    client.put_object(
+        Bucket=bucket,
+        Key=object_key,
+        Body=_body(rows),
+        ContentType="application/x-ndjson",
+    )
+    return len(rows)
+
+
+def _summary(
+    *,
+    bucket: str,
+    prefix: str,
+    object_key: str,
+    rows: list[PreparedRow],
+    dry_run: bool,
+    written_records: int,
+) -> dict[str, Any]:
+    schema_modes = Counter(row.schema_mode for row in rows)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": "v1",
+        "record_type": "sink_result",
+        "sink": "s3",
+        "bucket": bucket,
+        "prefix": prefix,
+        "object_key": object_key,
+        "dry_run": dry_run,
+        "input_records": len(rows),
+        "written_objects": 0 if dry_run else 1,
+        "written_records": written_records,
+        "would_write_objects": 1 if dry_run else 0,
+        "would_write_records": len(rows) if dry_run else 0,
+        "schema_modes": dict(sorted(schema_modes.items())),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Persist JSONL records into a new immutable S3 object.")
+    parser.add_argument("--bucket", required=True, help="Target S3 bucket.")
+    parser.add_argument("--prefix", required=True, help="Target S3 key prefix for new immutable objects.")
+    parser.add_argument(
+        "--output-format",
+        choices=("native",),
+        default="native",
+        help="Declared output rendering mode for the sink result.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="dry_run", action="store_true", help="Validate and summarize without writing.")
+    mode.add_argument("--apply", dest="dry_run", action="store_false", help="Write a new NDJSON object to S3.")
+    parser.set_defaults(dry_run=True)
+    args = parser.parse_args(argv)
+
+    try:
+        bucket = _normalize_bucket(args.bucket)
+        prefix = _normalize_prefix(args.prefix)
+        rows = _prepare_rows(sys.stdin)
+        if not rows:
+            raise ValueError("stdin did not contain any JSONL records")
+        object_key = _object_key(prefix, rows)
+        written_records = 0 if args.dry_run else _write_object(bucket, object_key, rows)
+        sys.stdout.write(
+            json.dumps(
+                _summary(
+                    bucket=bucket,
+                    prefix=prefix,
+                    object_key=object_key,
+                    rows=rows,
+                    dry_run=args.dry_run,
+                    written_records=written_records,
+                ),
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+    except Exception as exc:
+        print(f"[{SKILL_NAME}] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/sink-s3-jsonl/tests/test_sink.py
+++ b/skills/remediation/sink-s3-jsonl/tests/test_sink.py
@@ -1,0 +1,175 @@
+"""Tests for sink-s3-jsonl."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "sink.py"
+_SPEC = importlib.util.spec_from_file_location("sink_s3_jsonl", _SRC)
+assert _SPEC and _SPEC.loader
+_SINK = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SINK
+_SPEC.loader.exec_module(_SINK)
+
+_normalize_bucket = _SINK._normalize_bucket
+_normalize_prefix = _SINK._normalize_prefix
+_object_key = _SINK._object_key
+_prepare_rows = _SINK._prepare_rows
+_summary = _SINK._summary
+main = _SINK.main
+
+
+class _FakeClient:
+    def __init__(self, *, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self.calls = []
+
+    def put_object(self, **kwargs) -> None:
+        if self.should_fail:
+            raise RuntimeError("write failed")
+        self.calls.append(kwargs)
+
+
+class TestNormalizeNames:
+    def test_accepts_bucket_and_prefix(self):
+        assert _normalize_bucket("my-sec-lake") == "my-sec-lake"
+        assert _normalize_prefix("/findings/lateral-movement/") == "findings/lateral-movement"
+
+    def test_rejects_invalid_bucket(self):
+        try:
+            _normalize_bucket("BadBucket")
+        except ValueError as exc:
+            assert "invalid S3 bucket name" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_invalid_prefix(self):
+        try:
+            _normalize_prefix("findings/*")
+        except ValueError as exc:
+            assert "invalid S3 prefix segment" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestPrepareRowsAndKey:
+    def test_extracts_metadata_and_builds_deterministic_key(self):
+        rows = _prepare_rows(
+            [
+                '{"schema_mode":"native","event_uid":"evt-1","finding_uid":"f-1"}\n',
+                '{"metadata":{"uid":"evt-2"},"finding_info":{"uid":"f-2"}}\n',
+            ]
+        )
+
+        assert rows[0].schema_mode == "native"
+        assert rows[1].schema_mode == "ocsf"
+        key = _object_key("findings/lm", rows, datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC))
+        assert key.startswith("findings/lm/2026/04/15/20260415T120000Z-")
+        assert key.endswith(".jsonl")
+
+    def test_rejects_non_object_json(self):
+        try:
+            _prepare_rows(['["not","an","object"]\n'])
+        except ValueError as exc:
+            assert "expected a JSON object" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestWriteAndMain:
+    def test_apply_writes_one_object(self, monkeypatch):
+        fake = _FakeClient()
+        monkeypatch.setattr(_SINK, "_client", lambda: fake)
+
+        written = _SINK._write_object(
+            "my-sec-lake",
+            "findings/lm/2026/04/15/object.jsonl",
+            _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1","finding_uid":"f-1"}\n']),
+        )
+
+        assert written == 1
+        assert len(fake.calls) == 1
+        call = fake.calls[0]
+        assert call["Bucket"] == "my-sec-lake"
+        assert call["Key"] == "findings/lm/2026/04/15/object.jsonl"
+        assert call["ContentType"] == "application/x-ndjson"
+        assert call["Body"].endswith(b"\n")
+
+    def test_summary_reports_dry_run(self):
+        rows = _prepare_rows(['{"schema_mode":"native","event_uid":"evt-1"}\n'])
+        result = _summary(
+            bucket="my-sec-lake",
+            prefix="findings/lm",
+            object_key="findings/lm/2026/04/15/object.jsonl",
+            rows=rows,
+            dry_run=True,
+            written_records=0,
+        )
+
+        assert result["record_type"] == "sink_result"
+        assert result["sink"] == "s3"
+        assert result["would_write_objects"] == 1
+        assert result["would_write_records"] == 1
+
+    def test_main_defaults_to_dry_run(self, monkeypatch, capsys):
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"schema_mode":"native","event_uid":"evt-1"}\n'))
+        monkeypatch.setattr(
+            _SINK,
+            "_object_key",
+            lambda prefix, rows: "findings/lm/2026/04/15/object.jsonl",
+        )
+
+        exit_code = main(["--bucket", "my-sec-lake", "--prefix", "findings/lm"])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is True
+        assert payload["would_write_objects"] == 1
+        assert payload["object_key"] == "findings/lm/2026/04/15/object.jsonl"
+
+    def test_main_apply_writes_object(self, monkeypatch, capsys):
+        fake = _FakeClient()
+        monkeypatch.setattr(_SINK, "_client", lambda: fake)
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"metadata":{"uid":"evt-2"}}\n'))
+        monkeypatch.setattr(
+            _SINK,
+            "_object_key",
+            lambda prefix, rows: "evidence/ctrl/2026/04/15/object.jsonl",
+        )
+
+        exit_code = main(["--bucket", "my-sec-lake", "--prefix", "evidence/ctrl", "--apply"])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is False
+        assert payload["written_objects"] == 1
+        assert payload["written_records"] == 1
+        assert fake.calls
+
+    def test_main_apply_returns_error_when_write_fails(self, monkeypatch, capsys):
+        fake = _FakeClient(should_fail=True)
+        monkeypatch.setattr(_SINK, "_client", lambda: fake)
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO('{"metadata":{"uid":"evt-2"}}\n'))
+        monkeypatch.setattr(
+            _SINK,
+            "_object_key",
+            lambda prefix, rows: "evidence/ctrl/2026/04/15/object.jsonl",
+        )
+
+        exit_code = main(["--bucket", "my-sec-lake", "--prefix", "evidence/ctrl", "--apply"])
+
+        assert exit_code == 1
+        assert "write failed" in capsys.readouterr().err
+
+    def test_main_requires_records(self, monkeypatch, capsys):
+        monkeypatch.setattr(_SINK.sys, "stdin", io.StringIO(""))
+
+        exit_code = main(["--bucket", "my-sec-lake", "--prefix", "findings/lm"])
+
+        assert exit_code == 1
+        assert "stdin did not contain any JSONL records" in capsys.readouterr().err

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -61,6 +61,7 @@ class TestSkillValidationCommon:
         names = {skill.name for skill in skills}
         assert "source-databricks-query" in names
         assert "source-snowflake-query" in names
+        assert "sink-s3-jsonl" in names
         assert "sink-snowflake-jsonl" in names
         assert "sink-clickhouse-jsonl" in names
         assert "detect-lateral-movement" in names
@@ -229,6 +230,16 @@ class TestValidationScripts:
         assert sink.approval_model == "human_required"
         assert sink.execution_modes == ("jit", "mcp", "persistent")
         assert sink.side_effects == ("writes-database",)
+        assert sink.caller_roles == ("security_engineer", "platform_engineer")
+        assert sink.approver_roles == ("security_lead", "data_platform_owner")
+        assert sink.min_approvers == 1
+
+    def test_s3_sink_declares_human_approval(self):
+        skills = {skill.name: skill for skill in COMMON.discover_skill_contracts()}
+        sink = skills["sink-s3-jsonl"]
+        assert sink.approval_model == "human_required"
+        assert sink.execution_modes == ("jit", "mcp", "persistent")
+        assert sink.side_effects == ("writes-storage",)
         assert sink.caller_roles == ("security_engineer", "platform_engineer")
         assert sink.approver_roles == ("security_lead", "data_platform_owner")
         assert sink.min_approvers == 1


### PR DESCRIPTION
## Summary
- add an immutable S3 JSONL sink with the same HITL and dry-run envelope as the Snowflake and ClickHouse sinks
- persist one new NDJSON object per apply run under a validated bucket and prefix
- wire the new sink into framework coverage and MCP/tool-registry validation

## Validation
- uv run pytest /tmp/cloud-security-sink-s3/skills/remediation/sink-s3-jsonl/tests/test_sink.py /tmp/cloud-security-sink-s3/mcp-server/tests/test_tool_registry.py /tmp/cloud-security-sink-s3/tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- uv run ruff check /tmp/cloud-security-sink-s3/skills/remediation/sink-s3-jsonl/src/sink.py /tmp/cloud-security-sink-s3/skills/remediation/sink-s3-jsonl/tests/test_sink.py /tmp/cloud-security-sink-s3/mcp-server/tests/test_tool_registry.py /tmp/cloud-security-sink-s3/tests/integration/test_skill_validation_scripts.py --config /tmp/cloud-security-sink-s3/pyproject.toml
- python /tmp/cloud-security-sink-s3/scripts/validate_skill_contract.py && python /tmp/cloud-security-sink-s3/scripts/validate_framework_coverage.py && python /tmp/cloud-security-sink-s3/scripts/validate_dependency_consistency.py && python /tmp/cloud-security-sink-s3/scripts/validate_skill_integrity.py && python /tmp/cloud-security-sink-s3/scripts/validate_safe_skill_bar.py