### PR TITLE
docs: clarify README quick run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,17 @@ For the full source, asset, framework, and runtime crosswalk, see [docs/USE_CASE
 
 ## Quick Run
 
-Start with the bundled Kubernetes audit fixture and generate SARIF in three clear steps:
+Start with the bundled Kubernetes audit fixture and generate SARIF in one shot:
+
+```bash
+python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
+  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
+  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
+  | python skills/view/convert-ocsf-to-sarif/src/convert.py \
+  > findings.sarif
+```
+
+If you want to inspect each stage separately, use throwaway files under `/tmp`:
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
@@ -44,6 +54,8 @@ python skills/view/convert-ocsf-to-sarif/src/convert.py \
   /tmp/k8s-findings.jsonl \
   > findings.sarif
 ```
+
+`/tmp` here just means scratch files for debugging. The final output you keep is `findings.sarif`.
 
 If you want the repo-owned native wire format instead of OCSF:
 


### PR DESCRIPTION
## Summary
- show the one-shot k8s quick-run pipeline first
- keep the step-by-step version as the debuggable path
- explain that /tmp files are scratch outputs, not required final artifacts

## Testing
- docs-only change
