### PR TITLE
docs: tighten design and schema contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Read next:
 |---|---|---|
 | Runtime surfaces | CLI, CI, MCP, `runners/aws-s3-sqs-detect`, IAM departures workflow | more multi-cloud runner templates |
 | Audit sinks | IAM departures dual-write to DynamoDB + S3 | customer sinks like Snowflake, Security Lake, ClickHouse, BigQuery |
-| Schema modes | native, canonical, OCSF, bridge contract; ingest and detect are fully dual-mode | extend dual-mode patterns to more families where appropriate |
+| Schema modes | native, canonical, OCSF, and bridge are all shipped; ingest and detect are fully dual-mode, while discovery uses native/bridge and evaluation, sinks, and remediation stay native-first | extend OCSF or bridge only where it materially improves interoperability without losing operational clarity |
 | Remediation | IAM departures with HITL and audit | broader remediation families |
 
 <details>
@@ -175,6 +175,7 @@ High-signal visuals:
 Operator and contributor docs:
 - [AGENTS.md](AGENTS.md)
 - [CLAUDE.md](CLAUDE.md)
+- [docs/DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md)
 - [docs/agent-integrations.md](docs/agent-integrations.md)
 - [skills/README.md](skills/README.md)
 - [docs/DEBUGGING.md](docs/DEBUGGING.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,8 +5,9 @@ This document is the load-bearing design contract for `cloud-ai-security-skills`
 This file is the design contract. It explains how the repo is supposed to work and what future changes must preserve. [`DIAGRAMS.md`](./DIAGRAMS.md) is the visual companion: it indexes the small set of readable SVGs used in rendered docs.
 
 - **Wire format contract** — see [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
-- **Sink / persistence contract** — see [`./SINK_CONTRACT.md`](./SINK_CONTRACT.md) *(lands with PR T)*
-- **Runner / streaming contract** — see [`./RUNNER_CONTRACT.md`](./RUNNER_CONTRACT.md) *(lands with PR V)*
+- **Design rationale and product decisions** — see [`./DESIGN_DECISIONS.md`](./DESIGN_DECISIONS.md)
+- **Sink / persistence contract** — see [`./SINK_CONTRACT.md`](./SINK_CONTRACT.md)
+- **Runner / streaming contract** — see [`./RUNNER_CONTRACT.md`](./RUNNER_CONTRACT.md)
 - **Runtime isolation and trust boundaries** — see [`./RUNTIME_ISOLATION.md`](./RUNTIME_ISOLATION.md)
 - **SIEM indexing and dedupe guidance** — see [`./SIEM_INDEX_GUIDE.md`](./SIEM_INDEX_GUIDE.md)
 - **Canonical schema contract** — see [`./CANONICAL_SCHEMA.md`](./CANONICAL_SCHEMA.md)
@@ -36,16 +37,16 @@ This file is the design contract. It explains how the repo is supposed to work a
 
 These are the non-negotiables. Everything in §3–§8 exists to serve them.
 
-1. **Skills are pure functions.** Input JSONL → output JSONL. No side effects. No cloud API calls. No disk writes outside stdout. No hidden state.
+1. **Most skills are pure functions.** Input JSONL → output JSONL. No side effects. No cloud API calls. No disk writes outside stdout. No hidden state. Source, sink, and remediation skills are the explicit edge exceptions.
 2. **Side effects live at the edges.** Exactly four categories may have side effects: **L0 sources** (read raw), **L5 remediate** (write cloud APIs), **L7 sinks** (write storage), **runners** (drive loops). Everything else is pure.
 3. **The schema contract is the shared dependency.** Skills never import from each other. If two skills need the same logic, they each own a copy. Copy-paste beats coupling at this scale — the contract is the API, not the Python. For shared pipelines the contract may be OCSF; for stateful inventory and evidence it may be canonical or bridge mode.
 4. **Determinism.** Same input always produces the same output. Every finding UID is a content hash; no random UUIDs. Replayable ⇒ testable ⇒ idempotent sink merges.
 5. **Read-only by default.** A skill may only perform writes if it is prefixed `remediate-*` or `sink-*` and its `SKILL.md` carries an explicit "Do NOT use" clause describing the blast radius.
 6. **Least-privilege infra.** Every skill that talks to a cloud API ships the *minimum* IAM policy in `infra/iam_policies/`. Wildcard actions are a CI failure.
 7. **MCP-exposable by default.** Every skill must be wrappable as an MCP tool with zero code changes: stdin+args in, stdout out, non-zero exit on error, stderr for warnings. Skills that can't satisfy this don't ship.
-8. **Idempotent sinks.** Every sink does `MERGE ... ON finding_info.uid`. Re-runs converge. No blind-insert mode.
+8. **Replay-safe persistence.** Database sinks should be idempotent or transactionally safe; object-store sinks should use immutable new-object writes. Re-runs must converge operationally instead of surprising operators.
 9. **Dry-run everywhere writes happen.** `--dry-run` is mandatory for every `remediate-*` and `sink-*` skill. It prints the SQL / API calls it *would* make without making them.
-10. **Audit the auditor.** Every sink write and every remediation action emits *itself* as an OCSF Application Activity (6002) event, so the tool's own actions are findable in the same pipeline it feeds.
+10. **Machine-readable write summaries.** Every sink and remediation path must emit a deterministic machine-readable result summary to `stdout`. Some workflows may also feed those results back into an auditable event pipeline, but that is not yet universal across all write surfaces.
 
 ## 2.1 Validation, debugging, and API-drift policy
 
@@ -81,7 +82,7 @@ The repo is easiest to read as **six shipped skill layers**, plus **three edge/r
 | Layer | Role | Current state |
 |---|---|---|
 | L0 | external sources and vendor APIs | outside the repo boundary |
-| L7 | sinks and persistence edges | contract and patterns documented; generic sink family not fully shipped |
+| L7 | sinks and persistence edges | shipped in `skills/remediation/sink-*`; future re-home to top-level `sinks/` remains optional |
 | L8 | query packs and warehouse-native analytics | partial shipping |
 | L9 | agent/runtime surface (`mcp-server`, runners, wrappers) | shipped as thin wrappers around the same skill contract |
 
@@ -92,12 +93,17 @@ The repo operates across four schema modes:
 - **ocsf** for shared pipelines, SIEMs, and standard interoperability
 - **bridge** when OCSF transport helps but native or canonical detail still matters
 
-Most current ingest, detect, evaluate, view, and sink paths are still **OCSF-friendly JSONL**, but OCSF is no longer the only valid operating mode. Discovery and evidence paths may emit deterministic native or canonical artifacts, plus OCSF bridge events where that improves interoperability. The current discovery set already supports explicit bridge modes for `Cloud Resources Inventory Info [5023]` and `Live Evidence Info [5040]`.
+Most current ingest and detect paths are **fully dual-mode** and can emit either
+repo-native JSONL or OCSF JSONL. Discovery and evidence paths may emit
+deterministic native or canonical artifacts, plus OCSF bridge events where
+that improves interoperability. Evaluation, sink, and remediation outputs remain
+primarily native because they are repo-owned operational contracts rather than
+clean OCSF fits.
 
 Execution-mode note:
 - `execution_modes: persistent` means a skill is safe to embed in a persistent runner, queue consumer, scheduler, or serverless loop without changing the skill logic
 - it does **not** mean the repo already ships that runner, daemon, or sink for every skill
-- today, the broad runner/sink layer is still planned work; `iam-departures-remediation` is the main shipped exception with repo-owned event-driven infrastructure
+- today, the runner and sink layers are shipped as reference patterns, not as dedicated wrappers for every single skill family
 
 For the detailed contract, see:
 
@@ -119,14 +125,14 @@ For the detailed contract, see:
 | Layer | Status | Current shape |
 |---|---|---|
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
-| L1 ingest | shipping | 15+ source-specific ingesters plus `source-snowflake-query`; ingest and detect are now fully dual-mode |
+| L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
 | L3 detect | shipping | 9 shipped detectors across cloud, identity, Kubernetes, and MCP drift |
 | L4 evaluate | shipping | 8 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths |
 | L5 remediate | shipping | IAM departures is the current flagship write path |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |
-| L7 sinks | planned / partial patterns | customer-controlled persistence patterns are documented; generic sink family is not fully shipped |
-| L8 query packs | partial shipping | first Snowflake pack shipped under `packs/`; broader warehouse-native pack framework remains future work |
+| L7 sinks | shipping | `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`, and `sink-s3-jsonl` ship today under `skills/remediation/` |
+| L8 query packs | partial shipping | `packs/lateral-movement/` and `packs/privilege-escalation-k8s/` are shipped; broader pack coverage remains future work |
 | L9 agent/runtime surfaces | shipping | `mcp-server`, CLI, CI, and runners call the same skill contract |
 
 ## 4. Two execution modes
@@ -145,7 +151,7 @@ cat cloudtrail.json \
   > findings.sarif
 ```
 
-Used by: Claude Code ad-hoc analysis, CI, one-off investigations, compliance snapshots, `gh pr review` automation.
+Used by: Claude Code ad-hoc analysis, CI, one-off investigations, compliance snapshots, and local pipeline runs.
 
 Properties: zero infrastructure, no state, perfectly reproducible, no persistence, single-shot.
 
@@ -160,12 +166,14 @@ A **runner** (L9 driver, not a skill) drives the skills in a loop from a source 
                          └─ checkpoint state in DynamoDB / Snowflake STREAM
 ```
 
-Shipped reference runner:
+Shipped reference runners:
 ```
 runners/aws-s3-sqs-detect              # S3 -> ingest Lambda -> SQS -> detect Lambda -> DynamoDB dedupe -> SNS
+runners/gcp-gcs-pubsub-detect          # GCS -> ingest function -> Pub/Sub -> detect function -> Firestore dedupe
+runners/azure-blob-eventgrid-detect    # Blob -> Event Grid -> Service Bus -> handlers -> Table Storage dedupe
 ```
 
-Additional example runners:
+Future runner variants could follow the same contract:
 ```
 runners/runner-s3-to-snowflake          # S3 → skill → Snowflake COPY INTO
 runners/runner-eventbridge-to-security-lake   # EventBridge → skill → Parquet → Security Lake
@@ -226,10 +234,10 @@ cloud-ai-security-skills/
 │   ├── evaluation/           # L4
 │   ├── view/                 # L6
 │   └── remediation/          # L5
-├── sinks/                    # L7 — own top-level, side-effectful
-│   ├── sink-snowflake-ocsf/
-│   ├── sink-security-lake-ocsf/
-│   └── sink-clickhouse-ocsf/
+├── sinks/                    # optional future L7 re-home from skills/remediation/sink-*
+│   ├── sink-snowflake-jsonl/
+│   ├── sink-clickhouse-jsonl/
+│   └── sink-s3-jsonl/
 ├── runners/                  # Mode B drivers
 │   ├── runner-s3-to-snowflake/
 │   └── runner-eventbridge-to-security-lake/
@@ -250,6 +258,10 @@ cloud-ai-security-skills/
 ```
 
 **Rationale for separating `sinks/`, `runners/`, `mcp-server/`, and `packs/` from `skills/`:** the "skills are pure, edges have side effects" mental model becomes visible in the directory tree. A reviewer can tell at a glance whether a change touches pure code or effectful code. This is cheap documentation that pays for itself on every PR.
+
+Today, sinks still live under `skills/remediation/sink-*` for compatibility with
+the existing skill-discovery contract. The conceptual layer is already real even
+if the final directory re-home is deferred.
 
 The layered skill directories are now canonical. `skills/detection-engineering/`
 remains only as the shared OCSF contract and frozen-fixture namespace used by

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,0 +1,270 @@
+# Design Decisions
+
+This file explains the major product and architecture decisions behind
+`cloud-ai-security-skills`: what the repo is, why it is shaped this way, and
+what features enterprise security teams can rely on today.
+
+Use this doc when you want the rationale. Use [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+when you want the design contract. Use [`NATIVE_VS_OCSF.md`](./NATIVE_VS_OCSF.md)
+when you want the schema-mode decision tree.
+
+## What ships today
+
+Current repo surface on `main`:
+
+- `43` shipped skills across ingestion, discovery, detection, evaluation, view,
+  and remediation
+- `3` read-only source adapters:
+  - `source-snowflake-query`
+  - `source-databricks-query`
+  - `source-s3-select`
+- `3` write-capable sinks:
+  - `sink-snowflake-jsonl`
+  - `sink-clickhouse-jsonl`
+  - `sink-s3-jsonl`
+- `2` query-pack families under `packs/`:
+  - `lateral-movement`
+  - `privilege-escalation-k8s`
+- `3` reference persistent runners:
+  - AWS `aws-s3-sqs-detect`
+  - GCP `gcp-gcs-pubsub-detect`
+  - Azure `azure-blob-eventgrid-detect`
+- signed CycloneDX SBOM generation in CI and on releases
+- MCP exposure through the same `SKILL.md + src/ + tests/` contract
+
+## Product position
+
+This repo is not a SIEM, not a multi-tenant SaaS runtime, and not a monolithic
+security platform.
+
+It is a library of:
+
+- security skills
+- reference runners
+- reference sinks
+- query packs
+- trust and contract docs
+
+The goal is to let enterprise teams run the same detection, evaluation,
+inventory, and response logic:
+
+- from the CLI
+- in CI
+- behind MCP / agent workflows
+- inside serverless wrappers
+- inside customer-owned warehouses and lakes
+
+without forking the logic per runtime.
+
+## Decisions
+
+### 1. Keep the skill contract small and strict
+
+Every shipped skill is a standalone bundle:
+
+- `SKILL.md`
+- `src/`
+- `tests/`
+- `REFERENCES.md`
+
+The contract is:
+
+- stdin + args in
+- stdout out
+- stderr for warnings / telemetry
+- non-zero exit on contract-breaking failure
+
+Why:
+
+- MCP wrapping stays straightforward
+- CI execution stays reproducible
+- agent tooling does not need special integration paths
+- reviewers can audit a skill locally without booting extra infrastructure
+
+### 2. Keep side effects at the edges
+
+Pure skills are the default. Side effects are allowed only in a narrow set of
+places:
+
+- `source-*` reads external systems
+- `remediate-*` writes to cloud / identity systems
+- `sink-*` writes to storage
+- `runners/` own the long-lived loop and checkpoint behavior
+
+Why:
+
+- read-only analysis stays easy to trust
+- risky behavior is isolated and auditable
+- blast radius stays obvious in code review
+
+### 3. Treat OCSF as a first-class option, not a mandatory ceiling
+
+The repo operates across four schema modes:
+
+- `raw`
+- `native`
+- `canonical`
+- `ocsf`
+- `bridge`
+
+In practice:
+
+- `native` is the repo-owned external wire format
+- `canonical` is the stable internal normalization layer
+- `ocsf` is the interoperable external mode
+- `bridge` preserves repo or source detail alongside OCSF transport
+
+Why:
+
+- some artifacts fit OCSF cleanly
+- some do not
+- forcing everything into OCSF increases loss and confusion
+- enterprise teams need both interoperability and source fidelity
+
+### 4. Keep canonical internal, stable, and boring
+
+The repo normalizes different source families into a stable internal model
+before projecting outward.
+
+Why:
+
+- cross-cloud joins need stable internal keys
+- metrics, inventories, evidence, and state stores should not depend on a
+  lossy wire format
+- changing external transport should not require rethinking the whole repo
+
+### 5. Use repo-native mode for operational contracts
+
+`native` is the repo’s stable external format for:
+
+- native findings
+- evaluation results
+- sink summaries
+- remediation plans and audit artifacts
+
+Why:
+
+- these artifacts are part of the repo’s own product contract
+- they often need fields OCSF does not model well
+- enterprise operators need deterministic, explicit repo-owned output
+
+### 6. Use SQL packs where the warehouse is the runtime
+
+The repo now ships a `packs/` layer because not every useful execution path
+should move data through Python.
+
+Use a query pack when:
+
+- the data already lives in a warehouse
+- you want zero egress
+- the analytic is better run in SQL
+
+Why:
+
+- warehouse-native execution is often the right operational answer for large
+  enterprises
+- this keeps Python skills clean while still supporting in-lake detection
+
+### 7. Prefer additive platform layers over skill forks
+
+The repo adds:
+
+- `source-*` adapters
+- `sink-*` adapters
+- `packs/*`
+- `runners/*`
+
+instead of forking every detector per storage engine or cloud.
+
+Why:
+
+- `detect-lateral-movement` should stay a detection, not become a storage SDK
+- per-warehouse skill forks drift quickly
+- orthogonal layers compose better than runtime-specific clones
+
+### 8. Keep writes human-gated and dry-run first
+
+Write-capable skills carry an explicit HITL envelope:
+
+- `approval_model: human_required`
+- explicit caller and approver roles
+- `--dry-run` default for sinks and remediation paths
+
+Why:
+
+- enterprise security teams need reviewable intent
+- production response should be reversible and explainable
+- “agent-safe” is not credible without a visible approval model
+
+### 9. Make persistence idempotent and replay-safe
+
+Every persistence edge should converge safely on replay:
+
+- deterministic identifiers
+- append-only or merge-safe semantics
+- dedupe at the edge where needed
+
+Why:
+
+- queue retries and reruns are normal
+- operators should not fear replay
+- production-grade systems need convergence, not one-shot assumptions
+
+### 10. Prefer official vendors first, canonical OSS second
+
+Dependency policy is:
+
+1. official vendor SDKs first
+2. repo-owned code second
+3. canonical OSS only when needed
+
+Why:
+
+- provenance and maintenance matter in security tooling
+- enterprise reviewers ask where a dependency comes from and why it exists
+
+## Feature map
+
+| Need | Shipped surface |
+|---|---|
+| Normalize raw telemetry | `ingest-*` |
+| Detect attacks on event streams | `detect-*` |
+| Evaluate posture or benchmarks | `evaluation/*` |
+| Inventory cloud / AI assets | `discover-*` |
+| Persist findings or evidence | `sink-*` |
+| Run continuously | `runners/*` |
+| Run in a warehouse | `packs/*` |
+| Drive from agents | `mcp-server/` |
+
+## What enterprise teams can rely on
+
+Today the repo is credible for:
+
+- read-only analysis
+- benchmark and posture evaluation
+- agent-driven investigations
+- CI-driven policy and evidence pipelines
+- serverless continuous ingest -> detect -> notify patterns
+- customer-controlled sink persistence
+- warehouse-native detection where a pack exists
+
+What still requires more breadth, not a rethink:
+
+- more query packs
+- more sink vendors
+- more response families beyond IAM departures
+- stricter internal typing on every skill family
+
+## What this repo is not trying to do
+
+- replace a SIEM
+- own a hosted control plane
+- hide cloud-specific detail behind a fake universal schema
+- make every artifact OCSF whether it fits or not
+- turn every skill into a storage connector
+
+The design goal is narrower and more useful:
+
+build trustworthy, composable security skills and edge layers that enterprise
+teams can run in their own environments with clear contracts, explicit trust
+boundaries, and minimal surprises.

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -1,161 +1,276 @@
-# Native, Canonical, OCSF, and Bridge Modes
+# Native vs OCSF
 
-`cloud-ai-security-skills` must work **with or without OCSF**.
+`cloud-ai-security-skills` is **not OCSF-only**.
 
-That is not a soft preference. It is the repo contract.
+The repo supports:
 
-## The four schema modes
+- `raw` for unnormalized source data
+- `native` for the repo-owned external wire format
+- `canonical` for the internal normalization model
+- `ocsf` for interoperable external output
+- `bridge` when both OCSF transport and repo/source detail matter
 
-| Mode | Purpose | When to use it |
+The short version:
+
+- use `native` when you want the repo’s own stable operational contract
+- use `ocsf` when you want interoperability
+- use `bridge` when OCSF helps but would otherwise lose detail
+- remember that `canonical` is internal and `raw` is pre-normalized input
+
+## The five shapes
+
+| Shape | What it is | Where it shows up |
 |---|---|---|
-| **native** | Preserve the source payload shape and natural identifiers | source fidelity matters most, the vendor schema is the contract, or OCSF would be lossy |
-| **canonical** | Normalize into the repo's stable internal model | internal-only storage and join model; not emitted directly today. `native`, `ocsf`, and `bridge` are projections of canonical |
-| **ocsf** | Emit native OCSF classes, profiles, or extensions | SIEM interoperability, cross-vendor correlation, downstream OCSF consumers, or shared wire contracts between skills |
-| **bridge** | Emit an OCSF-friendly event while preserving the native or canonical artifact under `unmapped` or an explicit sidecar field | OCSF helps transport/search, but the source or evidence shape still carries important detail |
+| `raw` | source-native input with no repo normalization yet | source adapters, raw ingest inputs |
+| `native` | repo-owned external wire format | native findings, sink results, evaluation output, remediation plans, native ingest output |
+| `canonical` | stable internal normalization layer | implementation and storage design, not a public CLI default |
+| `ocsf` | interoperable external wire format | SIEM/lakehouse delivery, shared cross-tool pipelines, standard findings/events |
+| `bridge` | OCSF plus preserved repo/source detail | discovery and evidence paths where OCSF transport helps but detail still matters |
 
-The rule is simple:
+## Raw is not native
 
-1. **Keep source truth.**
-2. **Stabilize the repo around a canonical internal model.**
-3. **Use OCSF where it adds interoperability.**
-4. **Use bridge mode when both are needed.**
+This is the confusion to avoid:
 
-## Source-specific ingestion
+- `raw` = the source payload before normalization
+- `native` = the repo’s stable external contract after normalization
 
-Every source has its own:
+Example:
 
-- field names
-- event taxonomy
-- enum values
-- timestamps
-- pagination model
-- nested payloads
-- natural identifiers
-- ordering and retry behavior
+- a raw CloudTrail record is still the original AWS event
+- a native ingest output is a repo-owned JSONL event with stable repo fields
+- an OCSF ingest output is the OCSF projection of the same normalized event
 
-So ingest skills must never pretend all vendors look alike.
+## What native means in this repo
 
-The ingest contract is:
+`native` means the repo emits its own stable external schema with fields like:
 
-`raw source payload -> canonical internal model -> native | ocsf | bridge output`
+- `schema_mode`
+- `canonical_schema_version`
+- `record_type`
+- stable event or finding identifiers
+- normalized cloud / actor / resource / evidence fields
 
-That lets the repo stay accurate for Okta, Entra, Google Workspace, AWS, Azure, GCP, Kubernetes, AI service APIs, and any later vendor without flattening away source truth.
+It does **not** mean:
 
-## What stays stable across modes
+- raw vendor JSON
+- a lightly edited OCSF event
+- an unstable implementation detail
 
-No matter which mode a skill uses, the repo should preserve:
+## Event example
 
-- source-native identifiers when they exist
-- UTC timestamps and epoch-ms normalized time fields
-- actor, target, provider, tenant/account, and resource keys
-- deterministic event and finding identity
-- explicit lifecycle status where the source exposes it
-- enough raw context to explain how the normalized record was produced
+The same normalized event can be projected two ways.
 
-## Canonical model expectations
+### Native event shape
 
-The repo should treat the canonical internal model as the stable contract for:
+```json
+{
+  "schema_mode": "native",
+  "canonical_schema_version": "2026-04",
+  "record_type": "api_activity",
+  "event_uid": "evt-4c8d...",
+  "provider": "aws",
+  "account_uid": "123456789012",
+  "region": "us-east-1",
+  "time_ms": 1713206400000,
+  "actor": {
+    "user": {
+      "name": "alice"
+    }
+  },
+  "api": {
+    "service": "sts",
+    "operation": "AssumeRole"
+  },
+  "resource": {
+    "type": "iam_role",
+    "name": "prod-admin"
+  },
+  "source": {
+    "kind": "cloudtrail"
+  }
+}
+```
 
-- database tables and views
-- entity materialization
-- metrics
-- indexes
-- search filters
-- joins across vendors and clouds
-- UI or reporting surfaces
+### OCSF event shape
 
-That means:
+```json
+{
+  "metadata": {
+    "version": "1.8.0"
+  },
+  "category_uid": 6,
+  "class_uid": 6003,
+  "time": 1713206400000,
+  "activity_name": "AssumeRole",
+  "cloud": {
+    "provider": "aws",
+    "account": {
+      "uid": "123456789012"
+    },
+    "region": "us-east-1"
+  },
+  "actor": {
+    "user": {
+      "name": "alice"
+    }
+  },
+  "resources": [
+    {
+      "type": "iam_role",
+      "name": "prod-admin"
+    }
+  ]
+}
+```
 
-- do **not** make OCSF the only storage schema
-- do **not** let every skill invent its own internal column names
-- do **not** rename canonical fields casually
+## Finding example
 
-If the repo needs to change a canonical field, treat it like a migration:
+### Native finding shape
 
-- additive first
-- deprecate second
-- remove later
+```json
+{
+  "schema_mode": "native",
+  "canonical_schema_version": "2026-04",
+  "record_type": "detection_finding",
+  "finding_uid": "det-lm-1f45...",
+  "event_uid": "evt-4c8d...",
+  "provider": "aws",
+  "time_ms": 1713206460000,
+  "severity_id": 3,
+  "severity_label": "medium",
+  "status_id": 1,
+  "status": "new",
+  "title": "Possible lateral movement",
+  "description": "AssumeRole followed by accepted east-west traffic.",
+  "attacks": [
+    {
+      "technique": "T1021"
+    }
+  ],
+  "evidence": {
+    "matched_signals": 2
+  }
+}
+```
 
-## Skill contract requirements
+### OCSF finding shape
 
-Every shipped skill should document:
+```json
+{
+  "metadata": {
+    "version": "1.8.0"
+  },
+  "category_uid": 2,
+  "class_uid": 2004,
+  "finding_info": {
+    "uid": "det-lm-1f45...",
+    "title": "Possible lateral movement",
+    "desc": "AssumeRole followed by accepted east-west traffic."
+  },
+  "severity_id": 3,
+  "status_id": 1,
+  "time": 1713206460000,
+  "attack": {
+    "tactic": [],
+    "technique": [
+      {
+        "uid": "T1021"
+      }
+    ]
+  }
+}
+```
 
-- accepted input modes:
-  - `raw`
-  - `canonical`
-  - `ocsf`
-- supported output modes:
-  - `native`
-  - `ocsf`
-  - `bridge`
-- whether the mapping is lossless or lossy
-- which source-native fields are preserved
-- what the stable output identity fields are
+## Column-level mental model
 
-## Practical defaults by layer
+| Concern | Native | OCSF |
+|---|---|---|
+| Repo identity fields | explicit and repo-owned | mapped into OCSF fields where possible |
+| Interoperability with SIEMs | acceptable, repo-specific | strongest |
+| Fit for sink summaries / remediation results | strongest | weak |
+| Fit for evidence / inventory | often needs bridge or native | partial |
+| Fit for standard detections | good | good |
+| Fit for raw source fidelity | no; use `raw` or `bridge` | no; use `raw` or `bridge` |
 
-| Layer | Recommended default |
-|---|---|
-| **ingest** | `raw -> canonical`, plus optional `ocsf` or `bridge` output |
-| **discover** | `canonical` or `native`, plus optional OCSF inventory/evidence bridge |
-| **detect** | `canonical` or `ocsf` input; emit `ocsf` when it fits, or a documented canonical/native finding shape otherwise |
-| **evaluate** | `canonical` or `ocsf` input; keep framework outputs deterministic and machine-readable |
-| **view** | convert from canonical or OCSF into target formats such as SARIF, Mermaid, dashboards, or evidence exports |
-| **remediate** | prefer canonical plus preserved native identifiers; never depend only on a lossy transformed view |
+## Where OCSF fits well
 
-## OCSF policy
+OCSF is the right default when:
 
-The repo remains **OCSF-first for shared pipelines**, but **not OCSF-only**.
+- the event or finding maps cleanly to a standard class
+- the output is headed to a SIEM, lake, or standard downstream tool
+- you want consistent cross-vendor transport
+- a detector or view skill already expects OCSF on stdin
 
-Use OCSF when:
+In this repo, OCSF fits especially well for:
 
-- a native class/profile/extension fits cleanly
-- the output is headed to a SIEM, lake, MCP-delivered workflow, or cross-vendor detection pipeline
-- a downstream tool benefits from standard indexing and correlation
+- ingest event streams
+- detection findings
+- view/export conversions
+- shared event pipelines between skills
 
-Do not force OCSF when:
+## Where OCSF is still a partial fit
 
-- the source schema carries important semantics that would be lost
-- the artifact is inventory/evidence/BOM-shaped and OCSF does not model it cleanly enough yet
-- the canonical or native output is the more accurate operational contract
+These are the practical OCSF gaps in the current repo surface:
 
-## Compatibility guidance
+### 1. Benchmark and posture results
 
-The repo can support all three operational styles:
+Evaluation skills emit deterministic benchmark or control results. Those are
+better represented today as native artifacts than as forced OCSF findings.
 
-- **native-only** for source fidelity and vendor-native workflows
-- **canonical-first** for state stores, metrics, evidence, and stable internal consumers
-- **OCSF-first** for interoperability, SIEMs, and shared pipelines
+### 2. Inventory, evidence, and AI BOM outputs
 
-The correct choice depends on the skill and the downstream consumer, not on ideology.
+Discovery output often needs richer asset, evidence, graph, or BOM structure
+than a clean OCSF class provides. That is why discovery uses `native` and
+`bridge` rather than pretending all inventory is a perfect OCSF event.
 
-## Current rollout status
+### 3. Sink and remediation result contracts
 
-Implemented dual-mode skills today:
+Sink summaries and remediation plans are repo-owned operational artifacts.
+OCSF is not the clearest contract for:
 
-- `ingest-cloudtrail-ocsf`
-- `ingest-vpc-flow-logs-ocsf`
-- `ingest-k8s-audit-ocsf`
-- `ingest-mcp-proxy-ocsf`
-- `ingest-entra-directory-audit-ocsf`
-- `ingest-google-workspace-login-ocsf`
-- `ingest-okta-system-log-ocsf`
-- `detect-lateral-movement`
-- `detect-okta-mfa-fatigue`
-- `detect-privilege-escalation-k8s`
-- `detect-sensitive-secret-read-k8s`
-- `detect-mcp-tool-drift`
-- `detect-entra-credential-addition`
-- `detect-entra-role-grant-escalation`
-- `detect-google-workspace-suspicious-login`
+- `sink_result`
+- remediation dry-run plans
+- remediation audit/result summaries
 
-Implemented native-first with bridge skills today:
+### 4. Raw source adapters
 
-- `discover-environment`
-- `discover-control-evidence`
-- `discover-cloud-control-evidence`
+`source-*` adapters intentionally emit raw JSONL rows. They are data-retrieval
+edges, not normalizers.
 
-The remaining skills now declare their supported `input_formats` and
-`output_formats` explicitly in `SKILL.md`, even where only one format is
-implemented today. That keeps the contract honest while the rollout continues
-skill-by-skill.
+### 5. Warehouse-native query packs
+
+Query packs emit OCSF-compatible finding rows, but they also need warehouse
+specific type locking, result contracts, and SQL-level guarantees that are
+outside a pure OCSF schema decision.
+
+## Practical decision tree
+
+Choose the mode based on the consumer:
+
+- want the repo’s own operational contract:
+  - use `native`
+- want the standard transport format:
+  - use `ocsf`
+- want both transport and preserved detail:
+  - use `bridge`
+- starting from vendor payloads:
+  - use `raw` as input, then normalize
+
+## Current repo posture
+
+What the repo ships today:
+
+- ingest and detect are fully dual-mode across the shipped skill set
+- discovery is native-first with bridge where useful
+- evaluation is native
+- view skills convert OCSF into downstream artifacts
+- sinks emit native sink summaries
+- source adapters emit raw JSONL
+
+So the repo answer is not “OCSF or not OCSF.”
+
+It is:
+
+`raw -> canonical -> native | ocsf | bridge`
+
+with the projection chosen by the operational need, not by ideology.

--- a/docs/RUNNER_CONTRACT.md
+++ b/docs/RUNNER_CONTRACT.md
@@ -1,0 +1,64 @@
+# Runner Contract
+
+Runners are not skills. They are thin, side-effectful wrappers that drive the
+same skill contract continuously.
+
+Their job is:
+
+`source event -> invoke skill command(s) -> dedupe / checkpoint -> publish or persist`
+
+## What runners own
+
+- queue or event subscription wiring
+- checkpoint or dedupe state
+- cloud-native packaging and deployment shape
+- retry / DLQ / concurrency boundaries
+
+## What runners do not own
+
+- detection logic
+- normalization logic
+- skill-specific business rules
+- alternate implementations of a shipped skill
+
+If the skill logic changes, it changes in the skill, not in the runner.
+
+## Required design rules
+
+- skill commands are passed in as environment variables, not hardcoded in code
+- tokenized command execution only; no shell passthrough
+- skills remain unchanged and stateless
+- retry and replay behavior lives in the runner edge, not in the skill
+- dedupe and checkpoint state must be explicit
+
+## Packaging model
+
+The repo’s runner templates intentionally focus on event plumbing first. They
+may provision the queues, topics, subscriptions, and dedupe state without
+owning the final compute packaging layer for every cloud.
+
+That is deliberate:
+
+- AWS, GCP, and Azure package compute differently
+- enterprise teams often already have an internal deployment opinion
+- the runner template should stay portable and reviewable
+
+## Concurrency and cost
+
+Runners should document or enforce a concurrency ceiling where the platform
+supports it.
+
+Current shipped posture:
+
+- AWS template: queue-driven geometry and retry boundaries
+- GCP template: enforced `max_instance_count`
+- Azure template: exported `recommendedMaxInstances` operator contract
+
+## Current shipped runners
+
+- `runners/aws-s3-sqs-detect`
+- `runners/gcp-gcs-pubsub-detect`
+- `runners/azure-blob-eventgrid-detect`
+
+These are reference patterns, not a promise that every skill ships with a
+dedicated long-lived runtime.

--- a/docs/SINK_CONTRACT.md
+++ b/docs/SINK_CONTRACT.md
@@ -1,0 +1,84 @@
+# Sink Contract
+
+Sinks are the persistence edge of the repo. They are not detectors, not
+normalizers, and not remediation workflows. Their job is simple:
+
+`JSONL on stdin -> validated write to a destination -> native sink summary`
+
+## What a sink may do
+
+- read JSONL from `stdin`
+- validate destination identifiers and required arguments
+- persist records to a pre-provisioned destination
+- emit one native `sink_result` object to `stdout`
+- support `--dry-run` and explicit apply mode
+
+## What a sink may not do
+
+- create, alter, or drop schema unless the skill contract explicitly says so
+- run arbitrary SQL supplied by the caller
+- invent detections, evidence, or evaluation logic
+- hide writes behind a default “apply” mode
+
+## Required skill frontmatter
+
+Every shipped sink must declare:
+
+- `capability: write-sink`
+- `approval_model: human_required`
+- `side_effects: writes-database` or `writes-storage`
+- `input_formats`
+- `output_formats: native`
+- `execution_modes` including `persistent` if it is safe to run in a loop
+
+## Required CLI behavior
+
+Every sink must provide:
+
+- `--dry-run` as the default posture
+- an explicit apply flag
+- identifier validation before any network call
+- non-zero exit on write failure
+- stderr messaging for operator warnings and failure detail
+
+## Output contract
+
+Every sink writes one repo-native summary object to `stdout` with at least:
+
+- `schema_mode: "native"`
+- `record_type: "sink_result"`
+- destination identity such as `table`, `bucket`, or `object_key`
+- `dry_run`
+- input record count
+- written or would-write counts
+
+## Write-safety requirements
+
+### Snowflake / database-style sinks
+
+- pre-provisioned table only
+- parameterized inserts only
+- validated identifier path only
+- explicit transaction control where the client supports it
+
+### Object-store sinks
+
+- validated bucket and prefix
+- one-way writes to new objects unless overwrite is a documented contract
+- no object mutation disguised as append
+
+## Audit and approval expectations
+
+Sink skills are write-capable, so they must remain operator-reviewable:
+
+- caller role and approver role frontmatter
+- documented blast radius in `Do NOT use`
+- MCP exposure should mark the tool as destructive
+
+## Current shipped sinks
+
+- `sink-snowflake-jsonl`
+- `sink-clickhouse-jsonl`
+- `sink-s3-jsonl`
+
+These are the current reference implementations for future sink work.


### PR DESCRIPTION
## Summary
- add a design-decisions doc that explains the repo shape, features, and why the layers exist
- rewrite native-vs-OCSF guidance with concrete event/finding examples and explicit OCSF gap coverage
- fix architecture drift around shipped sinks, runners, and write-surface contracts

## Testing
- python scripts/validate_skill_contract.py
