### PR TITLE
docs: tighten schema contracts and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Read next:
 - [docs/CREDENTIAL_PROVENANCE.md](docs/CREDENTIAL_PROVENANCE.md)
 - [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md)
 - [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md)
+- [docs/SCHEMA_VERSIONING.md](docs/SCHEMA_VERSIONING.md)
 
 ## Core Surfaces
 
@@ -176,6 +177,8 @@ Operator and contributor docs:
 - [AGENTS.md](AGENTS.md)
 - [CLAUDE.md](CLAUDE.md)
 - [docs/DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md)
+- [docs/SCHEMA_VERSIONING.md](docs/SCHEMA_VERSIONING.md)
+- [docs/LOSSY_MAPPINGS.md](docs/LOSSY_MAPPINGS.md)
 - [docs/agent-integrations.md](docs/agent-integrations.md)
 - [skills/README.md](skills/README.md)
 - [docs/DEBUGGING.md](docs/DEBUGGING.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,7 @@ This file is the design contract. It explains how the repo is supposed to work a
 
 - **Wire format contract** — see [`../skills/detection-engineering/OCSF_CONTRACT.md`](../skills/detection-engineering/OCSF_CONTRACT.md)
 - **Design rationale and product decisions** — see [`./DESIGN_DECISIONS.md`](./DESIGN_DECISIONS.md)
+- **Schema versioning and upgrade rules** — see [`./SCHEMA_VERSIONING.md`](./SCHEMA_VERSIONING.md)
 - **Sink / persistence contract** — see [`./SINK_CONTRACT.md`](./SINK_CONTRACT.md)
 - **Runner / streaming contract** — see [`./RUNNER_CONTRACT.md`](./RUNNER_CONTRACT.md)
 - **Runtime isolation and trust boundaries** — see [`./RUNTIME_ISOLATION.md`](./RUNTIME_ISOLATION.md)
@@ -108,6 +109,7 @@ Execution-mode note:
 For the detailed contract, see:
 
 - [`NATIVE_VS_OCSF.md`](./NATIVE_VS_OCSF.md)
+- [`SCHEMA_VERSIONING.md`](./SCHEMA_VERSIONING.md)
 - [`CANONICAL_SCHEMA.md`](./CANONICAL_SCHEMA.md)
 - [`DATA_FLOW.md`](./DATA_FLOW.md)
 - [`STATE_AND_TIMELINE_MODEL.md`](./STATE_AND_TIMELINE_MODEL.md)

--- a/docs/CANONICAL_SCHEMA.md
+++ b/docs/CANONICAL_SCHEMA.md
@@ -31,6 +31,9 @@ Current repo-wide canonical schema version:
 
 - `2026-04`
 
+See [`SCHEMA_VERSIONING.md`](./SCHEMA_VERSIONING.md) for bump rules, OCSF pin
+semantics, and upgrade guidance.
+
 ## Shared core fields
 
 These are the minimum fields every canonical record should preserve where the
@@ -213,10 +216,11 @@ canonical truth, multiple wire formats.
 
 ## Current implementation note
 
-The canonical model is fully piloted today in:
+The canonical model is now the repo-wide normalization contract:
 
-- `ingest-cloudtrail-ocsf`
-- `ingest-vpc-flow-logs-ocsf`
-- `detect-lateral-movement`
+- ingest and detect are fully dual-mode across the shipped skill set
+- discovery is native-first with bridge where useful
+- evaluation remains native-first
+- sinks and remediation use native repo-owned operational contracts
 
-The rest of the repo is being rolled into the same pattern skill-by-skill.
+The repo is no longer in a one-skill pilot stage for canonical-first design.

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -20,3 +20,4 @@ Keep markdown diagrams lightweight and reviewable, then pair them with polished 
 - Prefer 2-3 high-signal diagrams over a large diagram dump.
 - One diagram should answer one question. Do not mix repo structure, runtime surfaces, and roadmap detail in the same visual.
 - The flagship remediation diagram can be more detailed than the repo overview, but the repo overview should stay readable in GitHub preview without zooming.
+- Treat text overlap or zoom-dependent readability as a documentation bug, not a cosmetic issue.

--- a/docs/LOSSY_MAPPINGS.md
+++ b/docs/LOSSY_MAPPINGS.md
@@ -1,0 +1,105 @@
+# Lossy Mappings
+
+This file documents where a source payload loses detail when normalized for the
+repo’s native or OCSF projections.
+
+The goal is not to claim “OCSF always loses fields.” The honest questions are:
+
+- what is preserved from raw input
+- what is normalized
+- what is omitted entirely
+- what exists only in repo-native context
+
+Use this doc together with:
+
+- [`NATIVE_VS_OCSF.md`](./NATIVE_VS_OCSF.md)
+- [`CANONICAL_SCHEMA.md`](./CANONICAL_SCHEMA.md)
+- the affected skill’s `SKILL.md`
+
+## Reading the tables
+
+| Column | Meaning |
+|---|---|
+| Raw field / context | the original source field or structure |
+| Native behavior | what the repo-native projection keeps |
+| OCSF behavior | what the OCSF projection keeps |
+| Loss / impact | what is reduced, omitted, or flattened |
+
+## ingest-cloudtrail-ocsf
+
+This skill is intentionally selective. It preserves the fields most useful for
+cross-cloud activity analysis, but it does not try to serialize the full
+CloudTrail payload into either native or OCSF output.
+
+| Raw field / context | Native behavior | OCSF behavior | Loss / impact |
+|---|---|---|---|
+| `eventID`, `eventName`, `eventSource`, `eventTime`, `recipientAccountId`, `awsRegion` | preserved in normalized fields such as `event_uid`, `operation`, `service_name`, `time_ms`, `account_uid`, `region` | preserved under OCSF metadata, api, cloud, and time fields | mostly semantic remapping, not loss |
+| `requestParameters` top-level keys | projected into `resources[]` only at top level | same `resources[]` projection | nested request body detail is not preserved |
+| nested `requestParameters` objects | not preserved as structured payload | not preserved | deep request context is intentionally dropped |
+| `responseElements` | omitted | omitted | response payload detail is dropped |
+| `additionalEventData` | omitted | omitted | free-form supplemental context is dropped |
+| session creation time from `userIdentity.sessionContext.attributes.creationDate` | preserved in normalized actor/session context | preserved where mapped through actor/session context | low loss |
+| MFA/session flags beyond the current normalized actor/session projection | omitted | omitted | authentication nuance may be reduced |
+| repo-native envelope fields such as `canonical_schema_version`, `source.kind`, `source.request_id`, `source.event_id`, `activity_name` | preserved | not first-class OCSF fields | OCSF output loses some repo-owned envelope detail |
+
+### Example
+
+Raw CloudTrail can contain large nested request bodies. The current contract
+keeps only the normalized action and resource identity, not the full request.
+
+That is intentional for transport clarity, but it means CloudTrail OCSF/native
+output should not be treated as an archival substitute for raw CloudTrail.
+
+## ingest-okta-system-log-ocsf
+
+This skill preserves more vendor detail than the CloudTrail ingester because it
+keeps Okta-specific correlation data under `unmapped`.
+
+| Raw field / context | Native behavior | OCSF behavior | Loss / impact |
+|---|---|---|---|
+| `uuid`, `published`, `eventType`, outcome result | preserved as stable IDs, time, event type, status, and severity | preserved through OCSF metadata, time, status, and class/activity mapping | mostly semantic remapping |
+| `transaction.id` and `authenticationContext.rootSessionId` | preserved under `unmapped.okta.*` | preserved under `unmapped.okta.*` | no major native-vs-OCSF loss here |
+| `authenticationContext.externalSessionId` | preserved in native `session.uid` | preserved in OCSF `session.uid` | no major loss |
+| `client.ipAddress` and `client.userAgent.rawUserAgent` | preserved as `src_endpoint.ip` and `src_endpoint.svc_name` | preserved the same way | fine for transport, but normalized |
+| richer `client` structure such as browser / device detail | not preserved as a full object | not preserved as a full object | device/browser nuance is reduced |
+| `debugContext.debugData` | omitted | omitted | troubleshooting/debug context is dropped |
+| target entity profile detail beyond normalized user/resource/privilege fields | reduced to selected normalized fields | reduced to selected normalized fields | target metadata is flattened |
+| repo-native envelope fields such as `canonical_schema_version`, `record_type`, `source_skill`, `output_format` | preserved | not first-class OCSF fields | repo-owned native context is thinner in OCSF |
+
+### Example
+
+Okta session and transaction identifiers survive both modes because the skill
+keeps them under `unmapped.okta.*`. That means this skill is not a good example
+of “OCSF drops everything vendor-specific.” The real loss is from the raw Okta
+payload to the normalized contract, not mostly from native to OCSF.
+
+## ingest-entra-directory-audit-ocsf
+
+The Entra ingester also preserves a useful vendor-specific tail under
+`unmapped.entra`, but it still flattens some target and initiator detail.
+
+| Raw field / context | Native behavior | OCSF behavior | Loss / impact |
+|---|---|---|---|
+| `id`, `correlationId`, `activityDateTime`, `activityDisplayName`, `result` | preserved as event UID, correlation UID, time, operation, and status fields | preserved through metadata/api/time/status fields | mostly semantic remapping |
+| `additionalDetails` | preserved under `unmapped.entra.additional_details` | preserved under `unmapped.entra.additional_details` | no major native-vs-OCSF loss here |
+| `targetResources[]` primary IDs, names, and types | preserved in normalized `resources[]` | preserved in OCSF `resources[]` | good preservation of identity keys |
+| `targetResources[].modifiedProperties` and richer target internals | omitted from normalized resources | omitted | change-specific detail is dropped |
+| `initiatedBy.user` / `initiatedBy.app` primary identity fields | normalized into `actor.user` and `src_endpoint` | preserved the same way | mostly semantic remapping |
+| richer initiator object detail beyond normalized identity fields | reduced | reduced | some raw Graph detail is flattened |
+| repo-native envelope fields such as `canonical_schema_version`, `record_type`, `source_skill`, `output_format` | preserved | not first-class OCSF fields | repo-owned native context is thinner in OCSF |
+
+## Current scope
+
+This file starts with:
+
+- CloudTrail
+- Okta System Log
+- Entra directoryAudit
+
+Those are the highest-signal examples for the current repo because they cover:
+
+- a source where raw -> normalized is intentionally selective
+- two identity sources where vendor detail is partly preserved under `unmapped`
+
+More ingest skills should be added here over time, but the initial goal is to
+make the cost of normalization explicit instead of leaving it implicit.

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -17,6 +17,11 @@ The short version:
 - use `bridge` when OCSF helps but would otherwise lose detail
 - remember that `canonical` is internal and `raw` is pre-normalized input
 
+Related docs:
+
+- [`SCHEMA_VERSIONING.md`](./SCHEMA_VERSIONING.md)
+- [`LOSSY_MAPPINGS.md`](./LOSSY_MAPPINGS.md)
+
 ## The five shapes
 
 | Shape | What it is | Where it shows up |
@@ -242,6 +247,8 @@ edges, not normalizers.
 Query packs emit OCSF-compatible finding rows, but they also need warehouse
 specific type locking, result contracts, and SQL-level guarantees that are
 outside a pure OCSF schema decision.
+
+For source-by-source detail, see [`LOSSY_MAPPINGS.md`](./LOSSY_MAPPINGS.md).
 
 ## Practical decision tree
 

--- a/docs/SCHEMA_VERSIONING.md
+++ b/docs/SCHEMA_VERSIONING.md
@@ -1,0 +1,164 @@
+# Schema Versioning
+
+This repo has two related but different versioned contracts:
+
+- the repo-owned canonical/native schema version
+- the OCSF wire-contract version used by the repo
+
+They are pinned on purpose and should be bumped intentionally, not casually.
+
+## 1. Canonical and native schema version
+
+Canonical and native payloads use:
+
+- `canonical_schema_version`
+
+Current value:
+
+- `2026-04`
+
+## Format
+
+`canonical_schema_version` uses `YYYY-MM`, but it is **not** a calendar roll.
+
+It changes only when the canonical/native contract changes in a way downstream
+operators may need to review.
+
+That means:
+
+- the version may stay the same across many releases
+- the version does **not** change every month automatically
+- the month stamp is the first release month of that contract version
+
+## What counts as a schema change
+
+Bump `canonical_schema_version` when any of these happen:
+
+- a canonical or native field is added and downstream consumers may need to
+  materialize it
+- a canonical or native field is renamed
+- a field type changes
+- a field meaning changes materially
+- a record type changes its stable required keys
+- a sink, query pack, or native projection changes its documented stable output
+  contract
+
+Do **not** bump it for:
+
+- doc-only changes
+- test-only changes
+- new examples
+- internal refactors with identical emitted fields and semantics
+- new skills that reuse the existing canonical/native contract without changing
+  the contract itself
+
+## Bump policy
+
+When the canonical/native contract changes:
+
+1. add fields before removing old ones
+2. document the change in `CHANGELOG.md`
+3. update examples in:
+   - `NATIVE_VS_OCSF.md`
+   - `CANONICAL_SCHEMA.md`
+   - any affected `SKILL.md`
+4. bump `canonical_schema_version`
+5. update or re-freeze golden fixtures where the emitted shape changes
+
+## Stability promise
+
+If two payloads carry the same `canonical_schema_version`, they should be safe
+to treat as the same canonical/native contract for:
+
+- field names
+- field meanings
+- required identity keys
+- native output envelopes
+
+Additive optional fields are still schema changes in this repo because
+enterprise teams often pin downstream warehouse tables, transforms, and data
+dictionaries to the emitted shape.
+
+## 2. OCSF contract version
+
+The repo’s OCSF contract is pinned in:
+
+- `skills/detection-engineering/OCSF_CONTRACT.md`
+
+Current value:
+
+- `1.8.0+mcp.2026.04`
+
+This means:
+
+- `1.8.0` = upstream OCSF base version
+- `+mcp.2026.04` = repo-local profile / mapping / frozen-fixture contract
+
+The `+mcp.2026.04` suffix is the repo’s own compatibility marker for:
+
+- local mapping choices
+- profile / label conventions
+- pinned fixture expectations
+- repo-owned interoperability assumptions layered on top of OCSF 1.8
+
+## When to bump the OCSF contract suffix
+
+Bump the `+mcp.*` suffix when:
+
+- the repo changes an OCSF mapping materially
+- an OCSF projection changes class, field placement, or stable semantics
+- frozen OCSF golden fixtures are re-cut for contract reasons
+- the repo changes the pinned ATT&CK / metadata linkage in a way that affects
+  the OCSF contract
+
+Do **not** bump it for:
+
+- doc-only edits
+- code refactors with byte-for-byte identical OCSF output
+- adding a new skill that simply follows the already-pinned contract
+
+## 3. Relationship between the two versions
+
+The canonical/native version and the OCSF contract version are related, but not
+identical.
+
+Examples:
+
+- a native/canonical-only change may bump `canonical_schema_version` without
+  changing `1.8.0+mcp.2026.04`
+- an OCSF mapping change may require bumping the `+mcp.*` suffix even if the
+  canonical schema remains stable
+- a broad cross-mode change may require both
+
+## 4. Golden fixture versioning
+
+Today the repo versions fixture expectations through:
+
+- the release tag
+- the pinned OCSF contract version
+- the pinned canonical/native examples in docs and `SKILL.md`
+
+That is enough for now, but the repo does **not** yet ship a separate
+fixture-manifest version per skill family. If that becomes necessary later, it
+should extend this contract rather than replace it.
+
+## 5. Upgrade path
+
+When introducing a schema-impacting change:
+
+1. make the change additive first where possible
+2. document old and new behavior
+3. update examples and affected skill docs
+4. re-freeze fixtures
+5. cut the version bump in the same PR
+
+## 6. OCSF 2.0 note
+
+If the repo adopts OCSF 2.x later:
+
+- the base contract version changes from `1.8.0+...` to `2.x.y+...`
+- the migration should be documented as a deliberate upgrade path
+- old and new fixture sets should not be mixed invisibly in one contract
+
+Until then, the repo remains explicitly pinned to OCSF 1.8 plus the current
+repo-local `+mcp.*` suffix.

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,46 +1,46 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="480" viewBox="0 0 1280 480" role="img" aria-labelledby="title desc">
   <title id="title">Runtime surfaces use one shared skill contract</title>
   <desc id="desc">CLI, CI, MCP, and persistent runners call the same skill contract and implementation bundle.</desc>
-  <rect width="1280" height="460" fill="#08111f"/>
-  <rect x="24" y="24" width="1232" height="412" rx="28" fill="#0f172a" stroke="#334155"/>
+  <rect width="1280" height="480" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="432" rx="28" fill="#0f172a" stroke="#334155"/>
 
   <g font-family="Arial, sans-serif">
     <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">One skill contract, many runtime surfaces</text>
-    <text x="56" y="102" fill="#94a3b8" font-size="18">Runtimes add scheduling, gating, and transport. They do not create a second implementation model.</text>
+    <text x="56" y="102" fill="#94a3b8" font-size="18">Runtimes add scheduling and transport. They do not create a second skill implementation.</text>
 
-    <rect x="56" y="148" width="250" height="190" rx="22" fill="#172554" stroke="#60a5fa"/>
+    <rect x="56" y="148" width="254" height="190" rx="22" fill="#172554" stroke="#60a5fa"/>
     <text x="84" y="188" fill="#dbeafe" font-size="24" font-weight="700">Access paths</text>
     <text x="84" y="224" fill="#eff6ff" font-size="18" font-weight="700">CLI / Unix pipes</text>
     <text x="84" y="250" fill="#cbd5e1" font-size="16">local runs and pipelines</text>
-    <text x="84" y="282" fill="#eff6ff" font-size="18" font-weight="700">CI and MCP</text>
-    <text x="84" y="308" fill="#cbd5e1" font-size="16">checks, agents, guarded actions</text>
+    <text x="84" y="282" fill="#eff6ff" font-size="18" font-weight="700">CI / MCP / runners</text>
+    <text x="84" y="308" fill="#cbd5e1" font-size="16">checks, agents, queues, guarded actions</text>
 
-    <rect x="390" y="120" width="500" height="246" rx="24" fill="#111827" stroke="#94a3b8"/>
+    <rect x="374" y="120" width="532" height="246" rx="24" fill="#111827" stroke="#94a3b8"/>
     <text x="420" y="162" fill="#f8fafc" font-size="28" font-weight="700">Shared skill bundle</text>
     <text x="420" y="194" fill="#94a3b8" font-size="17">The same repo-owned contract and code path sits behind every wrapper.</text>
 
-    <rect x="424" y="226" width="180" height="102" rx="18" fill="#083344" stroke="#2dd4bf"/>
+    <rect x="408" y="226" width="188" height="102" rx="18" fill="#083344" stroke="#2dd4bf"/>
     <text x="450" y="258" fill="#ccfbf1" font-size="22" font-weight="700">Contract</text>
     <text x="450" y="286" fill="#ecfeff" font-size="15">SKILL.md</text>
     <text x="450" y="306" fill="#cbd5e1" font-size="14">approval, formats, side effects</text>
 
-    <rect x="646" y="226" width="210" height="102" rx="18" fill="#3b0764" stroke="#c084fc"/>
-    <text x="674" y="258" fill="#f3e8ff" font-size="22" font-weight="700">Implementation</text>
-    <text x="674" y="286" fill="#f8fafc" font-size="15">src/ + tests/ + REFERENCES.md</text>
-    <text x="674" y="306" fill="#ddd6fe" font-size="14">one code path, deterministic outputs</text>
+    <rect x="628" y="226" width="236" height="102" rx="18" fill="#3b0764" stroke="#c084fc"/>
+    <text x="652" y="258" fill="#f3e8ff" font-size="22" font-weight="700">Implementation</text>
+    <text x="652" y="286" fill="#f8fafc" font-size="15">src/ + tests/ + REFERENCES.md</text>
+    <text x="652" y="306" fill="#ddd6fe" font-size="14">one code path, deterministic outputs</text>
 
-    <rect x="974" y="148" width="250" height="190" rx="22" fill="#1f2937" stroke="#94a3b8"/>
-    <text x="1002" y="188" fill="#f8fafc" font-size="24" font-weight="700">Outputs</text>
-    <text x="1002" y="224" fill="#f8fafc" font-size="18" font-weight="700">repo-native, OCSF, bridge</text>
-    <text x="1002" y="250" fill="#cbd5e1" font-size="16">data streams and evidence</text>
-    <text x="1002" y="282" fill="#f8fafc" font-size="18" font-weight="700">SARIF, Mermaid, actions</text>
-    <text x="1002" y="308" fill="#cbd5e1" font-size="16">exports and audited write paths</text>
+    <rect x="956" y="148" width="268" height="190" rx="22" fill="#1f2937" stroke="#94a3b8"/>
+    <text x="984" y="188" fill="#f8fafc" font-size="24" font-weight="700">Outputs</text>
+    <text x="984" y="224" fill="#f8fafc" font-size="18" font-weight="700">repo-native / OCSF / bridge</text>
+    <text x="984" y="250" fill="#cbd5e1" font-size="16">events, findings, evidence</text>
+    <text x="984" y="282" fill="#f8fafc" font-size="18" font-weight="700">SARIF / Mermaid / actions</text>
+    <text x="984" y="308" fill="#cbd5e1" font-size="16">exports and audited write paths</text>
 
-    <path d="M306 244 L390 244" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M890 244 L974 244" stroke="#94a3b8" stroke-width="5" fill="none"/>
+    <path d="M310 244 L374 244" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M906 244 L956 244" stroke="#94a3b8" stroke-width="5" fill="none"/>
 
-    <rect x="56" y="376" width="1168" height="34" rx="12" fill="#111827" stroke="#475569"/>
-    <text x="84" y="399" fill="#f8fafc" font-size="16" font-weight="700">Rule:</text>
-    <text x="136" y="399" fill="#cbd5e1" font-size="16">wrappers may add gating, caller context, queues, or sinks; they must not fork the skill model.</text>
+    <rect x="56" y="386" width="1168" height="38" rx="12" fill="#111827" stroke="#475569"/>
+    <text x="84" y="411" fill="#f8fafc" font-size="16" font-weight="700">Rule:</text>
+    <text x="138" y="411" fill="#cbd5e1" font-size="16">wrappers may add gating, caller context, queues, or sinks; they must not fork the skill model.</text>
   </g>
 </svg>

--- a/docs/images/start-here-guide.svg
+++ b/docs/images/start-here-guide.svg
@@ -1,14 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="540" viewBox="0 0 1280 540" role="img" aria-labelledby="title desc">
   <title id="title">Start here guide for cloud-ai-security-skills</title>
   <desc id="desc">A simplified operator map showing inputs, skill layers, outputs, and runtime surfaces.</desc>
-  <rect width="1280" height="520" fill="#08111f"/>
-  <rect x="24" y="24" width="1232" height="472" rx="28" fill="#0f172a" stroke="#334155"/>
+  <rect width="1280" height="540" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="492" rx="28" fill="#0f172a" stroke="#334155"/>
 
   <g font-family="Arial, sans-serif">
     <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">Start here</text>
-    <text x="56" y="102" fill="#94a3b8" font-size="18">Pick an input, choose a skill layer, then decide whether you need repo-native or OCSF output.</text>
+    <text x="56" y="102" fill="#94a3b8" font-size="18">Pick an input, choose a layer, then decide whether you need repo-native or OCSF output.</text>
 
-    <rect x="56" y="144" width="300" height="240" rx="22" fill="#172554" stroke="#60a5fa"/>
+    <rect x="56" y="144" width="304" height="244" rx="22" fill="#172554" stroke="#60a5fa"/>
     <text x="84" y="184" fill="#dbeafe" font-size="24" font-weight="700">1. Inputs</text>
     <text x="84" y="220" fill="#eff6ff" font-size="18" font-weight="700">Raw logs</text>
     <text x="84" y="246" fill="#cbd5e1" font-size="16">CloudTrail, Azure Activity, GCP Audit</text>
@@ -16,7 +16,7 @@
     <text x="84" y="304" fill="#eff6ff" font-size="18" font-weight="700">Identity and inventory</text>
     <text x="84" y="330" fill="#cbd5e1" font-size="16">Okta, Entra, Workspace, cloud assets, AI services</text>
 
-    <rect x="490" y="120" width="300" height="288" rx="22" fill="#083344" stroke="#2dd4bf"/>
+    <rect x="488" y="120" width="304" height="292" rx="22" fill="#083344" stroke="#2dd4bf"/>
     <text x="518" y="160" fill="#ccfbf1" font-size="24" font-weight="700">2. Skill layers</text>
     <text x="518" y="198" fill="#f8fafc" font-size="18" font-weight="700">Ingest</text>
     <text x="518" y="222" fill="#cbd5e1" font-size="16">normalize one source</text>
@@ -24,9 +24,9 @@
     <text x="518" y="278" fill="#cbd5e1" font-size="16">inventory, findings, benchmarks, evidence</text>
     <text x="518" y="310" fill="#f8fafc" font-size="18" font-weight="700">View / remediate</text>
     <text x="518" y="334" fill="#cbd5e1" font-size="16">exports or guarded write workflows</text>
-    <text x="518" y="376" fill="#99f6e4" font-size="15">The same `SKILL.md + src/ + tests/` bundle runs everywhere.</text>
+    <text x="518" y="376" fill="#99f6e4" font-size="15">The same skill bundle runs everywhere: SKILL.md + src/ + tests/.</text>
 
-    <rect x="924" y="144" width="300" height="240" rx="22" fill="#3b0764" stroke="#c084fc"/>
+    <rect x="920" y="144" width="304" height="244" rx="22" fill="#3b0764" stroke="#c084fc"/>
     <text x="952" y="184" fill="#f3e8ff" font-size="24" font-weight="700">3. Outputs</text>
     <text x="952" y="220" fill="#f8fafc" font-size="18" font-weight="700">repo-native JSONL</text>
     <text x="952" y="246" fill="#ddd6fe" font-size="16">stable repo schema with deterministic UIDs</text>
@@ -35,19 +35,19 @@
     <text x="952" y="344" fill="#f8fafc" font-size="18" font-weight="700">Exports and actions</text>
     <text x="952" y="370" fill="#ddd6fe" font-size="16">SARIF, Mermaid, evidence, audited remediation</text>
 
-    <path d="M356 264 L490 264" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M790 264 L924 264" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+    <path d="M360 264 L488 264" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M792 264 L920 264" stroke="#2dd4bf" stroke-width="5" fill="none"/>
 
-    <rect x="56" y="426" width="1168" height="42" rx="14" fill="#111827" stroke="#475569"/>
-    <text x="84" y="453" fill="#f8fafc" font-size="17" font-weight="700">Run the same skill from:</text>
-    <text x="310" y="453" fill="#cbd5e1" font-size="17">CLI</text>
-    <text x="352" y="453" fill="#64748b" font-size="17">|</text>
-    <text x="372" y="453" fill="#cbd5e1" font-size="17">CI</text>
-    <text x="401" y="453" fill="#64748b" font-size="17">|</text>
-    <text x="421" y="453" fill="#cbd5e1" font-size="17">MCP</text>
-    <text x="468" y="453" fill="#64748b" font-size="17">|</text>
-    <text x="488" y="453" fill="#cbd5e1" font-size="17">persistent runner</text>
-    <text x="668" y="453" fill="#64748b" font-size="17">|</text>
-    <text x="688" y="453" fill="#cbd5e1" font-size="17">customer sink pattern</text>
+    <rect x="56" y="430" width="1168" height="46" rx="14" fill="#111827" stroke="#475569"/>
+    <text x="84" y="459" fill="#f8fafc" font-size="17" font-weight="700">Run the same skill from:</text>
+    <text x="310" y="459" fill="#cbd5e1" font-size="17">CLI</text>
+    <text x="352" y="459" fill="#64748b" font-size="17">|</text>
+    <text x="372" y="459" fill="#cbd5e1" font-size="17">CI</text>
+    <text x="401" y="459" fill="#64748b" font-size="17">|</text>
+    <text x="421" y="459" fill="#cbd5e1" font-size="17">MCP</text>
+    <text x="468" y="459" fill="#64748b" font-size="17">|</text>
+    <text x="488" y="459" fill="#cbd5e1" font-size="17">persistent runners</text>
+    <text x="670" y="459" fill="#64748b" font-size="17">|</text>
+    <text x="690" y="459" fill="#cbd5e1" font-size="17">customer sinks</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- add schema versioning guidance for canonical/native and OCSF contract pins
- add a source-by-source lossy mapping registry for CloudTrail, Okta, and Entra
- simplify the runtime and start-here SVGs for GitHub-preview readability

## Testing
- python scripts/validate_skill_contract.py
