### PR TITLE
docs: sharpen native and OCSF positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 Security skills for cloud and AI systems. Use source-specific ingest, discovery, detection, evaluation, view, and remediation skills from the CLI, CI, MCP, or persistent runners without changing the skill code.
 
-- OCSF is supported, not mandatory.
+- OCSF 1.8 is the default interoperable wire format for event and finding streams.
+- Native is the repo-owned operational format for evaluation, discovery, sinks, remediation, and domains where OCSF would be lossy.
 - Read-only by default; write paths stay HITL and audited.
 - Trust, schema, and runtime behavior are documented and validated in CI.
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -97,7 +97,7 @@ Why:
 - risky behavior is isolated and auditable
 - blast radius stays obvious in code review
 
-### 3. Treat OCSF as a first-class option, not a mandatory ceiling
+### 3. OCSF by default for streams, native-first for operational artifacts
 
 The repo operates across four schema modes:
 
@@ -116,10 +116,20 @@ In practice:
 
 Why:
 
-- some artifacts fit OCSF cleanly
-- some do not
+- event and finding streams benefit from a standard wire format, so OCSF is the
+  default there
+- operational artifacts such as evaluation results, discovery/evidence output,
+  sink summaries, and remediation plans are repo-owned contracts and stay
+  native-first
+- some source domains fit OCSF well, others need `bridge` or `unmapped` detail
 - forcing everything into OCSF increases loss and confusion
 - enterprise teams need both interoperability and source fidelity
+
+This is why the repo is neither “OCSF-only” nor “two equal random options.”
+The actual posture is:
+
+- OCSF-default for event and finding streams
+- native-first for operational artifacts
 
 ### 4. Keep canonical internal, stable, and boring
 
@@ -139,6 +149,7 @@ Why:
 
 - native findings
 - evaluation results
+- discovery and evidence artifacts
 - sink summaries
 - remediation plans and audit artifacts
 

--- a/docs/LOSSY_MAPPINGS.md
+++ b/docs/LOSSY_MAPPINGS.md
@@ -20,10 +20,11 @@ Use this doc together with:
 
 | Column | Meaning |
 |---|---|
-| Raw field / context | the original source field or structure |
-| Native behavior | what the repo-native projection keeps |
-| OCSF behavior | what the OCSF projection keeps |
-| Loss / impact | what is reduced, omitted, or flattened |
+| Field / context | the original source field or structure |
+| Lost at raw -> normalized | detail dropped before either native or OCSF output |
+| Preserved in `unmapped.*` | vendor detail kept, but not as first-class normalized fields |
+| Native-only | detail kept only in repo-native output |
+| Clean in OCSF | detail represented cleanly as standard OCSF fields |
 
 ## ingest-cloudtrail-ocsf
 
@@ -31,16 +32,15 @@ This skill is intentionally selective. It preserves the fields most useful for
 cross-cloud activity analysis, but it does not try to serialize the full
 CloudTrail payload into either native or OCSF output.
 
-| Raw field / context | Native behavior | OCSF behavior | Loss / impact |
-|---|---|---|---|
-| `eventID`, `eventName`, `eventSource`, `eventTime`, `recipientAccountId`, `awsRegion` | preserved in normalized fields such as `event_uid`, `operation`, `service_name`, `time_ms`, `account_uid`, `region` | preserved under OCSF metadata, api, cloud, and time fields | mostly semantic remapping, not loss |
-| `requestParameters` top-level keys | projected into `resources[]` only at top level | same `resources[]` projection | nested request body detail is not preserved |
-| nested `requestParameters` objects | not preserved as structured payload | not preserved | deep request context is intentionally dropped |
-| `responseElements` | omitted | omitted | response payload detail is dropped |
-| `additionalEventData` | omitted | omitted | free-form supplemental context is dropped |
-| session creation time from `userIdentity.sessionContext.attributes.creationDate` | preserved in normalized actor/session context | preserved where mapped through actor/session context | low loss |
-| MFA/session flags beyond the current normalized actor/session projection | omitted | omitted | authentication nuance may be reduced |
-| repo-native envelope fields such as `canonical_schema_version`, `source.kind`, `source.request_id`, `source.event_id`, `activity_name` | preserved | not first-class OCSF fields | OCSF output loses some repo-owned envelope detail |
+| Field / context | Lost at raw -> normalized | Preserved in `unmapped.*` | Native-only | Clean in OCSF |
+|---|---|---|---|---|
+| `eventID`, `eventName`, `eventSource`, `eventTime`, `recipientAccountId`, `awsRegion` | no | no | no | yes |
+| `requestParameters` top-level keys | partial | no | no | partial via `resources[]` |
+| nested `requestParameters` objects | yes | no | no | no |
+| `responseElements` | yes | no | no | no |
+| `additionalEventData` | yes | no | no | no |
+| session creation time from `sessionContext.attributes.creationDate` | no | no | no | yes, through normalized actor/session context |
+| repo-owned envelope fields such as `canonical_schema_version`, `source.kind`, `source.request_id`, `source.event_id`, `activity_name` | no | no | yes, some fields are native-first | partial |
 
 ### Example
 
@@ -55,16 +55,16 @@ output should not be treated as an archival substitute for raw CloudTrail.
 This skill preserves more vendor detail than the CloudTrail ingester because it
 keeps Okta-specific correlation data under `unmapped`.
 
-| Raw field / context | Native behavior | OCSF behavior | Loss / impact |
-|---|---|---|---|
-| `uuid`, `published`, `eventType`, outcome result | preserved as stable IDs, time, event type, status, and severity | preserved through OCSF metadata, time, status, and class/activity mapping | mostly semantic remapping |
-| `transaction.id` and `authenticationContext.rootSessionId` | preserved under `unmapped.okta.*` | preserved under `unmapped.okta.*` | no major native-vs-OCSF loss here |
-| `authenticationContext.externalSessionId` | preserved in native `session.uid` | preserved in OCSF `session.uid` | no major loss |
-| `client.ipAddress` and `client.userAgent.rawUserAgent` | preserved as `src_endpoint.ip` and `src_endpoint.svc_name` | preserved the same way | fine for transport, but normalized |
-| richer `client` structure such as browser / device detail | not preserved as a full object | not preserved as a full object | device/browser nuance is reduced |
-| `debugContext.debugData` | omitted | omitted | troubleshooting/debug context is dropped |
-| target entity profile detail beyond normalized user/resource/privilege fields | reduced to selected normalized fields | reduced to selected normalized fields | target metadata is flattened |
-| repo-native envelope fields such as `canonical_schema_version`, `record_type`, `source_skill`, `output_format` | preserved | not first-class OCSF fields | repo-owned native context is thinner in OCSF |
+| Field / context | Lost at raw -> normalized | Preserved in `unmapped.*` | Native-only | Clean in OCSF |
+|---|---|---|---|---|
+| `uuid`, `published`, `eventType`, outcome result | no | no | no | yes |
+| `transaction.id` and `authenticationContext.rootSessionId` | no | yes | no | not first-class |
+| `authenticationContext.externalSessionId` | no | no | no | yes via `session.uid` |
+| `client.ipAddress` and `client.userAgent.rawUserAgent` | no | no | no | yes via `src_endpoint.*` |
+| richer `client` browser / device structure | yes, flattened | no | no | no |
+| `debugContext.debugData` | yes | no | no | no |
+| target entity profile detail beyond normalized user/resource/privilege fields | partial | no | no | partial |
+| repo-owned envelope fields such as `canonical_schema_version`, `record_type`, `source_skill`, `output_format` | no | no | yes | no |
 
 ### Example
 
@@ -78,15 +78,15 @@ payload to the normalized contract, not mostly from native to OCSF.
 The Entra ingester also preserves a useful vendor-specific tail under
 `unmapped.entra`, but it still flattens some target and initiator detail.
 
-| Raw field / context | Native behavior | OCSF behavior | Loss / impact |
-|---|---|---|---|
-| `id`, `correlationId`, `activityDateTime`, `activityDisplayName`, `result` | preserved as event UID, correlation UID, time, operation, and status fields | preserved through metadata/api/time/status fields | mostly semantic remapping |
-| `additionalDetails` | preserved under `unmapped.entra.additional_details` | preserved under `unmapped.entra.additional_details` | no major native-vs-OCSF loss here |
-| `targetResources[]` primary IDs, names, and types | preserved in normalized `resources[]` | preserved in OCSF `resources[]` | good preservation of identity keys |
-| `targetResources[].modifiedProperties` and richer target internals | omitted from normalized resources | omitted | change-specific detail is dropped |
-| `initiatedBy.user` / `initiatedBy.app` primary identity fields | normalized into `actor.user` and `src_endpoint` | preserved the same way | mostly semantic remapping |
-| richer initiator object detail beyond normalized identity fields | reduced | reduced | some raw Graph detail is flattened |
-| repo-native envelope fields such as `canonical_schema_version`, `record_type`, `source_skill`, `output_format` | preserved | not first-class OCSF fields | repo-owned native context is thinner in OCSF |
+| Field / context | Lost at raw -> normalized | Preserved in `unmapped.*` | Native-only | Clean in OCSF |
+|---|---|---|---|---|
+| `id`, `correlationId`, `activityDateTime`, `activityDisplayName`, `result` | no | no | no | yes |
+| `additionalDetails` | no | yes | no | not first-class |
+| `targetResources[]` primary IDs, names, and types | no | no | no | yes |
+| `targetResources[].modifiedProperties` and richer target internals | yes | no | no | no |
+| `initiatedBy.user` / `initiatedBy.app` primary identity fields | no | no | no | yes via normalized actor/src fields |
+| richer initiator object detail beyond normalized identity fields | partial | no | no | partial |
+| repo-owned envelope fields such as `canonical_schema_version`, `record_type`, `source_skill`, `output_format` | no | no | yes | no |
 
 ## Current scope
 

--- a/docs/NATIVE_VS_OCSF.md
+++ b/docs/NATIVE_VS_OCSF.md
@@ -1,6 +1,11 @@
 # Native vs OCSF
 
-`cloud-ai-security-skills` is **not OCSF-only**.
+`cloud-ai-security-skills` is **not OCSF-only**, but it is also not undecided.
+
+The repo position is:
+
+- **OCSF 1.8 by default for event and finding streams**
+- **native by default for repo-owned operational artifacts**
 
 The repo supports:
 
@@ -12,8 +17,8 @@ The repo supports:
 
 The short version:
 
+- use `ocsf` when you want the default interoperable wire format for streams
 - use `native` when you want the repo’s own stable operational contract
-- use `ocsf` when you want interoperability
 - use `bridge` when OCSF helps but would otherwise lose detail
 - remember that `canonical` is internal and `raw` is pre-normalized input
 
@@ -60,6 +65,33 @@ It does **not** mean:
 - raw vendor JSON
 - a lightly edited OCSF event
 - an unstable implementation detail
+
+## Two rules, not one
+
+The repo is making two different decisions:
+
+### 1. For event and finding streams
+
+Use **OCSF by default** because it improves:
+
+- SIEM and lake interoperability
+- shared pipelines between skills
+- downstream correlation across tools
+
+Keep `native` available where OCSF is incomplete or unnecessarily lossy.
+
+### 2. For operational artifacts
+
+Use **native by default** because these outputs are repo-owned contracts, not
+clean OCSF event families:
+
+- evaluation results
+- discovery and evidence artifacts
+- sink results
+- remediation plans and audit summaries
+
+These were never strong OCSF fits, and forcing them into OCSF would make the
+contract less clear, not more standard.
 
 ## Event example
 
@@ -186,6 +218,64 @@ The same normalized event can be projected two ways.
 }
 ```
 
+## Example where OCSF is thinner
+
+Okta is a better example of the trade-off than CloudTrail because the skill
+preserves some vendor detail under `unmapped.okta.*` rather than pretending it
+cleanly fits first-class OCSF fields.
+
+### Native Okta event
+
+```json
+{
+  "schema_mode": "native",
+  "canonical_schema_version": "2026-04",
+  "record_type": "authentication",
+  "event_uid": "b9ab9263-a4ae-4780-9981-377ec8f2da86",
+  "provider": "Okta",
+  "event_type": "user.session.start",
+  "session": {
+    "uid": "sess-123"
+  },
+  "unmapped": {
+    "okta": {
+      "transaction_id": "trn-456",
+      "root_session_id": "root-789"
+    }
+  }
+}
+```
+
+### OCSF Okta event
+
+```json
+{
+  "category_uid": 3,
+  "class_uid": 3002,
+  "time": 1713206400000,
+  "metadata": {
+    "version": "1.8.0",
+    "uid": "b9ab9263-a4ae-4780-9981-377ec8f2da86"
+  },
+  "session": {
+    "uid": "sess-123"
+  },
+  "unmapped": {
+    "okta": {
+      "transaction_id": "trn-456",
+      "root_session_id": "root-789"
+    }
+  }
+}
+```
+
+What this shows:
+
+- the event is still usable in OCSF mode
+- the most vendor-specific correlation fields survive under `unmapped`
+- the loss is not “OCSF destroys everything”; it is that some detail is no
+  longer first-class standard schema
+
 ## Column-level mental model
 
 | Concern | Native | OCSF |
@@ -254,10 +344,10 @@ For source-by-source detail, see [`LOSSY_MAPPINGS.md`](./LOSSY_MAPPINGS.md).
 
 Choose the mode based on the consumer:
 
-- want the repo’s own operational contract:
-  - use `native`
 - want the standard transport format:
   - use `ocsf`
+- want the repo’s own operational contract:
+  - use `native`
 - want both transport and preserved detail:
   - use `bridge`
 - starting from vendor payloads:
@@ -267,7 +357,8 @@ Choose the mode based on the consumer:
 
 What the repo ships today:
 
-- ingest and detect are fully dual-mode across the shipped skill set
+- ingest and detect are fully dual-mode across the shipped skill set, with OCSF
+  as the default interoperable stream format
 - discovery is native-first with bridge where useful
 - evaluation is native
 - view skills convert OCSF into downstream artifacts

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,9 +2,14 @@
 
 ## Why does a skill name still end in `-ocsf` if OCSF is optional?
 
-`-ocsf` means OCSF is the default wire format for that skill family. It does
-not mean OCSF is the only supported mode. Check the skill's `output_formats`
-frontmatter for the current truth.
+`-ocsf` means OCSF is the default interoperable wire format for that skill
+family. It does not mean OCSF is the only supported mode. The repo uses:
+
+- OCSF by default for event and finding streams
+- native by default for evaluation, discovery/evidence, sinks, remediation,
+  and domains where OCSF would be lossy
+
+Check the skill's `output_formats` frontmatter for the current truth.
 
 ## Why doesn't every skill support `native` yet?
 


### PR DESCRIPTION
## Summary
- reframe the repo as OCSF-default for event and finding streams and native-first for operational artifacts
- add an Okta example that shows where OCSF is thinner but vendor detail survives in unmapped
- tighten lossy-mapping taxonomy around raw loss, unmapped preservation, native-only fields, and clean OCSF coverage

## Testing
- python scripts/validate_skill_contract.py
