### PR TITLE
docs: add data handling guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Read next:
 - [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md)
 - [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md)
 - [docs/DATA_FLOW.md](docs/DATA_FLOW.md)
+- [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md)
 - [docs/OCSF_CONTRACT.md](docs/OCSF_CONTRACT.md)
 
 </details>
@@ -158,6 +159,7 @@ The skill contract stays the same across runtime surfaces: `SKILL.md + src/ + te
 
 Read next:
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md)
 - [docs/RUNTIME_ISOLATION.md](docs/RUNTIME_ISOLATION.md)
 - [docs/DIAGRAMS.md](docs/DIAGRAMS.md)
 - [docs/images/runtime-surfaces.svg](docs/images/runtime-surfaces.svg)
@@ -168,6 +170,7 @@ Read next:
 <summary><b>More Diagrams And Docs</b></summary>
 
 High-signal visuals:
+- [Data handling paths](docs/images/data-handling-paths.svg)
 - [Start here guide](docs/images/start-here-guide.svg)
 - [Runtime surfaces](docs/images/runtime-surfaces.svg)
 - [Repository architecture](docs/images/repo-architecture.svg)
@@ -182,6 +185,7 @@ Operator and contributor docs:
 - [docs/SCHEMA_VERSIONING.md](docs/SCHEMA_VERSIONING.md)
 - [docs/LOSSY_MAPPINGS.md](docs/LOSSY_MAPPINGS.md)
 - [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)
+- [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md)
 - [docs/agent-integrations.md](docs/agent-integrations.md)
 - [skills/README.md](skills/README.md)
 - [docs/DEBUGGING.md](docs/DEBUGGING.md)

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -3,6 +3,10 @@
 This repo supports raw-source fidelity, a stable canonical model, and optional
 OCSF interoperability.
 
+For the scenario-by-scenario operator guide, including source adapters,
+warehouse paths, sinks, remediation edges, and the guardrails on each lane, see
+[DATA_HANDLING.md](DATA_HANDLING.md).
+
 ```mermaid
 flowchart LR
     RAW["Raw vendor payload\nCloudTrail / VPC Flow / Okta / Entra / Workspace / K8s"]

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -1,0 +1,251 @@
+# Data Handling
+
+This file explains how data is acquired, normalized, analyzed, persisted, and
+protected across the repo's main execution paths.
+
+Use this doc when you need to answer:
+
+- where data starts
+- which skill family should touch it first
+- which runtime or deployment shape is actually shipped today
+- what format it is in at each stage
+- when `native`, `ocsf`, `canonical`, or `bridge` matters
+- what security controls apply on each path
+
+Read next:
+
+- [DATA_FLOW.md](DATA_FLOW.md)
+- [RUNTIME_ISOLATION.md](RUNTIME_ISOLATION.md)
+- [NATIVE_VS_OCSF.md](NATIVE_VS_OCSF.md)
+- [images/data-handling-paths.svg](images/data-handling-paths.svg)
+
+## The Main Scenarios
+
+| Scenario | Start with | Typical path | Primary formats | Main controls |
+|---|---|---|---|---|
+| Point-in-time posture or inventory | live cloud or SaaS API | `discover-*` or `evaluation/*` | native, sometimes bridge | read-only creds, least privilege, no hidden writes |
+| Raw event logs on disk or stdin | vendor payloads | `ingest-* -> detect-* -> view/*` | native or OCSF | defensive parsing, deterministic IDs, fixture-tested transforms |
+| Read-only data lake or warehouse rows | `source-*` skill or direct SQL | `source-* -> detect-*` if already shaped | raw, native, or OCSF | query restrictions, read-only creds, no arbitrary shell |
+| Warehouse rows that still need normalization | `source-*` + ingester | `source-* -> ingest-* -> detect-*` | raw -> canonical -> native or OCSF | same ingest controls, plus read-only source adapter boundary |
+| Continuous detection or scheduled pipelines | runner or serverless wrapper | runner -> `ingest-* -> detect-* -> sink-*` | native, OCSF, sink results | dedupe, retries, isolated principals, append-only audit |
+| Guarded operational writes | remediation skill | event -> `remediation/*` -> audit trail | native operational result | HITL, `--dry-run`, explicit approval, blast-radius docs |
+
+## Available Today
+
+| Option | Shipped today | Start with | Use it when |
+|---|---|---|---|
+| Local CLI pipeline | yes | direct skill entrypoint | you want one-shot analysis, fixture testing, or debuggable local runs |
+| CI pipeline | yes | GitHub Actions or similar wrapper | you want repeatable checks, SARIF, snapshots, or release validation |
+| MCP tool calling | yes | `mcp-server/` | you want local agent composition with the same skill contracts |
+| Persistent AWS runner | yes | `runners/aws-s3-sqs-detect` | you want S3 -> ingest -> detect -> sink style event processing |
+| Persistent GCP runner template | yes | `runners/gcp-gcs-pubsub-detect` | you want GCS/PubSub style event-driven execution |
+| Persistent Azure runner template | yes | `runners/azure-blob-eventgrid-detect` | you want Blob/Event Grid style event-driven execution |
+| Warehouse source adapter | yes | `source-snowflake-query`, `source-databricks-query` | your data already lives in a lake or warehouse and you want read-only extraction |
+| Object-store source adapter | yes | `source-s3-select` | your source data lives in S3 and you want read-only extraction before analysis |
+| Warehouse-native analytics pack | yes, partial | `packs/` | you want the detection to run in Snowflake or Databricks instead of Python |
+| Sink / persistence edge | yes | `sink-*` | you want durable storage in Snowflake, ClickHouse, or S3 |
+
+## Ingestion And Selection Options
+
+| Data starts as... | Choose this first | Real path today |
+|---|---|---|
+| live cloud or SaaS state | `discover-*` or `evaluation/*` | API call -> native or bridge output |
+| raw file or stdin payload | `ingest-*` | raw -> canonical -> native or OCSF |
+| raw warehouse row | `source-*` then `ingest-*` | source adapter -> ingester -> detector |
+| already-shaped OCSF or native row | `detect-*` directly | source adapter or local file -> detector |
+| warehouse-scale historical analysis | `packs/` | warehouse table/view -> SQL pack -> OCSF-compatible result |
+| findings or evidence that must persist | `sink-*` | skill output -> sink result + customer-owned storage |
+| operational action request | `remediation/*` | approved event -> plan/action -> audit trail |
+
+## Data Lifecycle
+
+| Stage | What happens | Typical skill families | Formats | Security posture |
+|---|---|---|---|---|
+| Acquire | read cloud state, files, stdin, or warehouse rows | `source-*`, `discover-*`, `evaluation/*`, `ingest-*` | raw, native, canonical | read-only by default, scoped credentials, no generic shell passthrough |
+| Normalize | preserve source truth in a stable internal model | `ingest-*` | canonical internally, then native or OCSF outward | schema validation, lossiness documented, deterministic timestamps and IDs |
+| Analyze | correlate, benchmark, discover evidence, or convert | `detect-*`, `evaluation/*`, `discover-*`, `view/*` | native, OCSF, bridge, delivery artifact | deterministic outputs, fixture tests, no hidden writes |
+| Persist | store results in customer-owned systems | `sink-*`, runners, customer infrastructure | native sink result plus stored payload | append-only or idempotent writes, parameterized APIs, approval-gated write surfaces |
+| Act | execute guarded operational changes | `remediation/*` | native operational contract | human approval, dry-run-first, separate principals, audit trail |
+
+## Which Schema Shows Up Where
+
+| Shape | Where it appears | What it is for |
+|---|---|---|
+| `raw` | source payloads and source adapters | original vendor or warehouse row shape, before repo normalization |
+| `canonical` | internal only | repo-owned stable normalization model used before projection |
+| `native` | most operational outputs and some event/finding outputs | repo-owned external format with stable IDs and repo semantics |
+| `ocsf` | interoperable event and finding streams | standard external schema for SIEMs, analytics, and downstream tooling |
+| `bridge` | discovery and evidence paths that need both worlds | interoperable payload with repo context preserved |
+
+Short rule:
+
+- event and finding streams default to `ocsf`
+- operational artifacts default to `native`
+- `canonical` is internal
+- `bridge` exists when interoperability and repo context both matter
+
+## Security Controls By Path
+
+| Path | Main risk | Required guardrails |
+|---|---|---|
+| live API -> discover/evaluate | over-privileged cloud access | least-privilege roles, read-only defaults, secret-minimizing auth |
+| raw log -> ingest | malformed or adversarial input | defensive parsing, warnings on stderr, schema-mode contract |
+| source adapter -> detect | unsafe queries or broad lake access | read-only creds, query allow-lists, no multi-statement execution, no arbitrary SQL in sinks |
+| detect -> sink | duplicate or unsafe writes | append-only or idempotent writes, validated identifiers, dry-run default where applicable |
+| event -> remediation | rogue or destructive action | approval gates, explicit blast radius, dedicated principals, audit evidence |
+| MCP -> local skill | hidden side effects or tool misuse | fixed tool surface, inherited approval model, stdio wrapper, audit events |
+
+## Deployment And Runtime Selection
+
+| Runtime | Best fit | Notes that are true to the current code |
+|---|---|---|
+| CLI | local runs, fixtures, one-shot pipelines | every shipped skill remains a direct script entrypoint |
+| CI | regression tests, policy checks, exports | the same skills run inside workflows; CI adds validation and release controls |
+| MCP | local agent tooling | the wrapper exposes the same skill contracts; it does not create a second implementation |
+| Runner template | event-driven, queue-backed, scheduled processing | the repo ships concrete AWS, GCP, and Azure templates, but not a universal managed control plane |
+| Query pack | warehouse-native detection | currently partial shipping, not every detection exists as a SQL pack |
+| Sink | durable persistence edge | persistence is explicit and separate from pure detection logic |
+
+## Dev, Sandbox, And Production Guidance
+
+### Local development
+
+Use local development for:
+
+- fixture-based ingest and detect work
+- format validation
+- documentation examples
+- non-production sink dry runs
+
+Expected posture:
+
+- sandbox or dev credentials only
+- no production write credentials in an agent session unless the task truly requires them
+- `/tmp` scratch files are fine for debugging, not for durable retention
+
+### CI
+
+Use CI for:
+
+- lint, tests, contract checks, and coverage
+- SBOM generation and signing
+- IaC validation
+- advisory external scans such as `agent-bom`
+
+Expected posture:
+
+- ephemeral runners
+- short-lived credentials
+- no normal PR lane that performs live destructive writes
+
+### MCP and local agent workflows
+
+Use MCP for:
+
+- local tool composition
+- repeatable skill invocation through a fixed wrapper
+- approval-aware execution of write-capable skills
+
+Expected posture:
+
+- stdio transport, not an open unauthenticated listener
+- tool registry limits what can be called
+- approval context required for destructive flows
+
+### Persistent runners and serverless wrappers
+
+Use runners for:
+
+- continuous detection
+- scheduled batches
+- event-driven ingestion and sink paths
+
+Expected posture:
+
+- separate principals for read, detect, sink, and remediation roles where possible
+- checkpointing, dedupe, and bounded concurrency
+- append-only audit where feasible
+
+## Example Paths
+
+### 1. Live posture check
+
+```text
+cloud API -> evaluation/* -> native benchmark results
+```
+
+Use when:
+
+- you need a point-in-time benchmark or control result
+- the data does not already exist in a lake
+
+### 2. Raw log detection
+
+```text
+raw vendor payload -> ingest-* -> detect-* -> view/*
+```
+
+Use when:
+
+- you have raw CloudTrail, Okta, Entra, K8s audit, or similar payloads
+- you want a deterministic repo-owned transform before detection
+
+### 3. Lake detection on already-shaped rows
+
+```text
+source-* -> detect-*
+```
+
+Use when:
+
+- the warehouse already stores OCSF-shaped or repo-native rows
+- you want to skip the ingest step
+
+### 4. Lake detection on raw rows
+
+```text
+source-* -> ingest-* -> detect-*
+```
+
+Use when:
+
+- the warehouse stores raw vendor JSON
+- you still want the repo's tested normalization logic
+
+### 5. Persisting findings or evidence
+
+```text
+detect-* or discover-* -> sink-*
+```
+
+Use when:
+
+- you need durable storage in Snowflake, ClickHouse, S3, or a customer-owned sink
+- the sink path is append-only or otherwise explicitly documented
+
+### 6. Guarded action path
+
+```text
+event -> remediation/* -> audit trail -> re-verify
+```
+
+Use when:
+
+- the task is operational, not just analytical
+- a human approval and audit trail are part of the contract
+
+## What This Repo Does Not Assume
+
+This repo does not assume:
+
+- one central runtime for every skill
+- one mandatory schema for every artifact
+- that all data belongs in OCSF
+- that production credentials should be present in development by default
+- that wrappers are allowed to change the meaning of a skill
+
+The product contract is the opposite:
+
+- the skill logic stays stable
+- wrappers add transport or scheduling, not a second implementation model
+- security controls are explicit at each boundary

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -6,6 +6,7 @@ Keep markdown diagrams lightweight and reviewable, then pair them with polished 
 
 ## Visual set
 
+- [Data handling paths](images/data-handling-paths.svg)
 - [Start here guide](images/start-here-guide.svg)
 - [Runtime surfaces](images/runtime-surfaces.svg)
 - [IAM departures cross-cloud workflow](images/iam-departures-architecture.svg)

--- a/docs/images/data-handling-paths.svg
+++ b/docs/images/data-handling-paths.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" role="img" aria-labelledby="title desc">
+  <title id="title">Data handling paths and guardrails</title>
+  <desc id="desc">A simplified view of how data enters cloud-ai-security-skills, which paths it can take, and which guardrails apply on each path.</desc>
+  <rect width="1280" height="760" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="712" rx="28" fill="#0f172a" stroke="#334155"/>
+
+  <g font-family="Arial, sans-serif">
+    <text x="56" y="74" fill="#f8fafc" font-size="32" font-weight="700">How data moves and where controls apply</text>
+    <text x="56" y="106" fill="#94a3b8" font-size="18">One lane per real shipped scenario. Read-only analysis stays separate from sinks, runners, and remediation.</text>
+
+    <rect x="56" y="148" width="220" height="106" rx="18" fill="#172554" stroke="#60a5fa"/>
+    <text x="82" y="184" fill="#dbeafe" font-size="22" font-weight="700">Start here</text>
+    <text x="82" y="214" fill="#eff6ff" font-size="16">live cloud APIs</text>
+    <text x="82" y="236" fill="#eff6ff" font-size="16">raw logs and files</text>
+
+    <rect x="56" y="282" width="220" height="106" rx="18" fill="#172554" stroke="#60a5fa"/>
+    <text x="82" y="318" fill="#dbeafe" font-size="22" font-weight="700">Or start here</text>
+    <text x="82" y="348" fill="#eff6ff" font-size="16">warehouse rows</text>
+    <text x="82" y="370" fill="#eff6ff" font-size="16">lake objects</text>
+
+    <rect x="332" y="136" width="568" height="128" rx="22" fill="#083344" stroke="#2dd4bf"/>
+    <text x="364" y="174" fill="#ccfbf1" font-size="24" font-weight="700">Lane 1: live state and posture</text>
+    <text x="364" y="208" fill="#ecfeff" font-size="17">discover-* or evaluation/*</text>
+    <text x="364" y="234" fill="#cbd5e1" font-size="16">read-only APIs, least-privilege creds, native or bridge outputs</text>
+
+    <rect x="332" y="288" width="568" height="128" rx="22" fill="#083344" stroke="#2dd4bf"/>
+    <text x="364" y="326" fill="#ccfbf1" font-size="24" font-weight="700">Lane 2: raw event analysis</text>
+    <text x="364" y="360" fill="#ecfeff" font-size="17">ingest-* -&gt; detect-* -&gt; view/*</text>
+    <text x="364" y="386" fill="#cbd5e1" font-size="16">defensive parsing, canonical internal model, native or OCSF streams</text>
+
+    <rect x="332" y="440" width="568" height="128" rx="22" fill="#083344" stroke="#2dd4bf"/>
+    <text x="364" y="478" fill="#ccfbf1" font-size="24" font-weight="700">Lane 3: lake and warehouse paths</text>
+    <text x="364" y="512" fill="#ecfeff" font-size="17">source-* -&gt; detect-* or source-* -&gt; ingest-* -&gt; detect-*</text>
+    <text x="364" y="538" fill="#cbd5e1" font-size="16">read-only query adapters, query guardrails, skip ingest only when rows are already shaped</text>
+
+    <rect x="952" y="136" width="252" height="188" rx="22" fill="#3b0764" stroke="#c084fc"/>
+    <text x="982" y="174" fill="#f3e8ff" font-size="24" font-weight="700">Outputs</text>
+    <text x="982" y="210" fill="#f8fafc" font-size="18" font-weight="700">native</text>
+    <text x="982" y="234" fill="#ddd6fe" font-size="16">repo-owned operational format</text>
+    <text x="982" y="270" fill="#f8fafc" font-size="18" font-weight="700">ocsf</text>
+    <text x="982" y="294" fill="#ddd6fe" font-size="16">interoperable event and finding streams</text>
+
+    <rect x="952" y="352" width="252" height="216" rx="22" fill="#3b0764" stroke="#c084fc"/>
+    <text x="982" y="390" fill="#f3e8ff" font-size="24" font-weight="700">Write edges</text>
+    <text x="982" y="426" fill="#f8fafc" font-size="18" font-weight="700">sink-*</text>
+    <text x="982" y="450" fill="#ddd6fe" font-size="16">append-only or idempotent persistence</text>
+    <text x="982" y="486" fill="#f8fafc" font-size="18" font-weight="700">remediation/*</text>
+    <text x="982" y="510" fill="#ddd6fe" font-size="16">HITL, dry-run, audit trail</text>
+    <text x="982" y="546" fill="#f8fafc" font-size="18" font-weight="700">runners</text>
+    <text x="982" y="570" fill="#ddd6fe" font-size="16">queues, retries, dedupe, bounded concurrency</text>
+
+    <path d="M276 200 L332 200" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M276 334 L332 504" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M900 200 L952 200" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+    <path d="M900 352 L952 352" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+    <path d="M900 504 L952 504" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+
+    <rect x="56" y="616" width="1148" height="74" rx="16" fill="#111827" stroke="#475569"/>
+    <text x="84" y="646" fill="#f8fafc" font-size="18" font-weight="700">Available today</text>
+    <text x="246" y="646" fill="#cbd5e1" font-size="16">CLI · CI · MCP · AWS runner · GCP runner template · Azure runner template · source-* · sink-* · packs/</text>
+    <text x="84" y="676" fill="#f8fafc" font-size="18" font-weight="700">Guardrails</text>
+    <text x="186" y="676" fill="#cbd5e1" font-size="16">read-only by default · least-privilege credentials · no arbitrary shell passthrough · fixed schemas · explicit approval for destructive actions</text>
+  </g>
+</svg>


### PR DESCRIPTION
Summary
- add docs/DATA_HANDLING.md as the operator guide for real shipped data paths
- add docs/images/data-handling-paths.svg as a simplified visual for ingestion, lake, sink, and remediation lanes
- link the new guide from README.md, docs/DATA_FLOW.md, and docs/DIAGRAMS.md

Validation
- python scripts/validate_skill_contract.py