### PR TITLE
docs: clarify direct skill execution and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ For the full source, asset, framework, and runtime crosswalk, see [docs/USE_CASE
 
 ## Quick Run
 
+These skills are plain executable Python entrypoints first, and agent-usable
+skills second.
+
+Why the README shows `python skills/.../src/<entry>.py`:
+
+- that is the direct shipped entrypoint
+- MCP, CI, and runners call the same skill code
+- the wrapper changes the access path, not the implementation
+
 Start with the bundled Kubernetes audit fixture and generate SARIF in one shot:
 
 ```bash
@@ -40,23 +49,25 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
   > findings.sarif
 ```
 
-If you want to inspect each stage separately, use throwaway files under `/tmp`:
+If you want to inspect each stage separately, write local scratch files in the
+current directory:
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
   skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
-  > /tmp/k8s-events.jsonl
+  > k8s-events.ocsf.jsonl
 
 python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
-  /tmp/k8s-events.jsonl \
-  > /tmp/k8s-findings.jsonl
+  k8s-events.ocsf.jsonl \
+  > k8s-findings.ocsf.jsonl
 
 python skills/view/convert-ocsf-to-sarif/src/convert.py \
-  /tmp/k8s-findings.jsonl \
+  k8s-findings.ocsf.jsonl \
   > findings.sarif
 ```
 
-`/tmp` here just means scratch files for debugging. The final output you keep is `findings.sarif`.
+Those intermediate files are only for debugging. The final output you usually
+keep is `findings.sarif`.
 
 If you want the repo-owned native wire format instead of OCSF:
 
@@ -68,6 +79,55 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
       --output-format native \
   > findings.native.jsonl
 ```
+
+### Real input and output
+
+Input fixture line, abbreviated:
+
+```json
+{"kind":"Event","stage":"ResponseComplete","verb":"list","auditID":"k1-list-secrets","user":{"username":"system:serviceaccount:default:builder"}}
+```
+
+OCSF event output, abbreviated:
+
+```json
+{"class_uid":6003,"class_name":"API Activity","metadata":{"uid":"k1-list-secrets"},"api":{"operation":"list"},"resources":[{"type":"secrets","namespace":"default"}]}
+```
+
+Native event output, abbreviated:
+
+```json
+{"schema_mode":"native","record_type":"api_activity","event_uid":"k1-list-secrets","operation":"list","resources":[{"type":"secrets","namespace":"default"}]}
+```
+
+OCSF finding output, abbreviated:
+
+```json
+{"class_uid":2004,"class_name":"Detection Finding","finding_info":{"title":"Service account enumerated and read a Kubernetes secret"}}
+```
+
+Native finding output, abbreviated:
+
+```json
+{"schema_mode":"native","record_type":"detection_finding","title":"Service account enumerated and read a Kubernetes secret"}
+```
+
+### Same skill, different access path
+
+The skill code stays the same across all of these:
+
+- direct CLI:
+  - `python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py ...`
+- MCP / agent:
+  - Claude, Codex, Cursor, Windsurf, or Cortex call the same skill through
+    `mcp-server/`
+- CI:
+  - GitHub Actions or another pipeline invokes the same script and checks its output
+- runner:
+  - the runner template wraps the same skill in an event-driven path
+
+Agent clients do not require a second implementation of the skill. They call
+the same code through a different entrypoint.
 
 ## Native vs OCSF
 

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -12,6 +12,25 @@ Use this doc when you need to answer:
 - when `native`, `ocsf`, `canonical`, or `bridge` matters
 - what security controls apply on each path
 
+## One Skill, Many Access Paths
+
+The repo ships executable Python skills. Agent tools and wrappers call those
+same entrypoints; they do not replace them.
+
+| Access path | What is actually running |
+|---|---|
+| direct CLI | `python skills/<layer>/<skill>/src/<entry>.py` |
+| MCP | local wrapper in `mcp-server/` calling the same skill |
+| CI | workflow step invoking the same skill code |
+| runner | serverless or queue wrapper invoking the same skill code |
+| query pack | SQL equivalent for selected warehouse-native detections |
+
+Short rule:
+
+- these are agent-usable skills
+- they are not agent-only skills
+- the direct Python entrypoint is the most truthful wrapper-free example
+
 Read next:
 
 - [DATA_FLOW.md](DATA_FLOW.md)
@@ -179,6 +198,12 @@ Use when:
 - you need a point-in-time benchmark or control result
 - the data does not already exist in a lake
 
+Example shape:
+
+```json
+{"control_id":"1.1","status":"PASS","severity":"HIGH"}
+```
+
 ### 2. Raw log detection
 
 ```text
@@ -189,6 +214,26 @@ Use when:
 
 - you have raw CloudTrail, Okta, Entra, K8s audit, or similar payloads
 - you want a deterministic repo-owned transform before detection
+
+Example:
+
+Input:
+
+```json
+{"kind":"Event","stage":"ResponseComplete","verb":"list","auditID":"k1-list-secrets"}
+```
+
+OCSF event out:
+
+```json
+{"class_uid":6003,"metadata":{"uid":"k1-list-secrets"},"api":{"operation":"list"}}
+```
+
+Native finding out after detection:
+
+```json
+{"schema_mode":"native","record_type":"detection_finding","rule_name":"r1-secret-enum"}
+```
 
 ### 3. Lake detection on already-shaped rows
 
@@ -201,6 +246,12 @@ Use when:
 - the warehouse already stores OCSF-shaped or repo-native rows
 - you want to skip the ingest step
 
+Example:
+
+```text
+source-snowflake-query -> detect-lateral-movement
+```
+
 ### 4. Lake detection on raw rows
 
 ```text
@@ -211,6 +262,12 @@ Use when:
 
 - the warehouse stores raw vendor JSON
 - you still want the repo's tested normalization logic
+
+Example:
+
+```text
+source-databricks-query -> ingest-cloudtrail-ocsf -> detect-lateral-movement
+```
 
 ### 5. Persisting findings or evidence
 
@@ -223,6 +280,12 @@ Use when:
 - you need durable storage in Snowflake, ClickHouse, S3, or a customer-owned sink
 - the sink path is append-only or otherwise explicitly documented
 
+Example sink result:
+
+```json
+{"record_type":"sink_result","written_records":3,"written_objects":1}
+```
+
 ### 6. Guarded action path
 
 ```text
@@ -233,6 +296,12 @@ Use when:
 
 - the task is operational, not just analytical
 - a human approval and audit trail are part of the contract
+
+Example result:
+
+```json
+{"record_type":"remediation_result","status":"dry_run","actions_planned":13}
+```
 
 ## What This Repo Does Not Assume
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -25,6 +25,12 @@ Use the docs in this order:
 - A native local MCP server under [`mcp-server/`](../mcp-server/README.md)
 - Project-scoped MCP config in [`.mcp.json`](../.mcp.json) for Claude Code and similar clients
 
+Important clarification:
+
+- the repo ships normal executable Python skills
+- agent clients call those skills through MCP or other wrappers
+- agents do not require a separate implementation model to use them
+
 ## Client quick map
 
 | Tool | Best integration path | What to rely on |


### PR DESCRIPTION
Summary
- clarify that skills are executable Python entrypoints and agent-usable wrappers call the same code
- replace the tmp-heavy staged example with clearer local scratch-file examples
- add real abbreviated input and output examples for native and OCSF paths in README.md and docs/DATA_HANDLING.md
- tighten docs/agent-integrations.md so agents are described as callers of the same skills, not a second implementation model

Validation
- python scripts/validate_skill_contract.py
- verified direct python execution of the bundled Kubernetes fixture path