### PR TITLE
docs: clarify skill bundle vs execution core

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,22 @@ For the full source, asset, framework, and runtime crosswalk, see [docs/USE_CASE
 
 ## Quick Run
 
-These skills are plain executable Python entrypoints first, and agent-usable
-skills second.
+Each shipped skill is a bundle:
+
+- `SKILL.md` for routing, guardrails, and approval model
+- `REFERENCES.md` for the official source-of-truth docs
+- `src/` for the executable implementation
+- `tests/` for contract and regression coverage
+
+The Python file is the execution core. The full skill that agents use is the
+whole bundle.
 
 Why the README shows `python skills/.../src/<entry>.py`:
 
-- that is the direct shipped entrypoint
+- that is the direct execution path for the skill implementation
 - MCP, CI, and runners call the same skill code
-- the wrapper changes the access path, not the implementation
+- agent clients add the `SKILL.md` contract, routing hints, and guardrails on top
+- the wrapper changes the access path, not the underlying skill implementation
 
 Start with the bundled Kubernetes audit fixture and generate SARIF in one shot:
 
@@ -126,8 +134,8 @@ The skill code stays the same across all of these:
 - runner:
   - the runner template wraps the same skill in an event-driven path
 
-Agent clients do not require a second implementation of the skill. They call
-the same code through a different entrypoint.
+Agent clients do not require a second implementation of the skill. They use the
+same skill bundle through a different access path.
 
 ## Native vs OCSF
 

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -12,24 +12,34 @@ Use this doc when you need to answer:
 - when `native`, `ocsf`, `canonical`, or `bridge` matters
 - what security controls apply on each path
 
-## One Skill, Many Access Paths
+## One Skill Bundle, Many Access Paths
 
-The repo ships executable Python skills. Agent tools and wrappers call those
-same entrypoints; they do not replace them.
+The repo ships skill bundles, not just standalone scripts.
+
+Each bundle includes:
+
+- `SKILL.md`
+- `REFERENCES.md`
+- `src/`
+- `tests/`
+
+The executable Python entrypoint is the runtime core inside that bundle. Agent
+tools and wrappers call the same skill bundle; they do not replace it.
 
 | Access path | What is actually running |
 |---|---|
-| direct CLI | `python skills/<layer>/<skill>/src/<entry>.py` |
-| MCP | local wrapper in `mcp-server/` calling the same skill |
-| CI | workflow step invoking the same skill code |
-| runner | serverless or queue wrapper invoking the same skill code |
+| direct CLI | the skill's `src/<entry>.py` execution core |
+| MCP | local wrapper plus the skill bundle contract from `SKILL.md` |
+| CI | workflow step invoking the same skill bundle and validating its output |
+| runner | serverless or queue wrapper invoking the same skill bundle |
 | query pack | SQL equivalent for selected warehouse-native detections |
 
 Short rule:
 
 - these are agent-usable skills
 - they are not agent-only skills
-- the direct Python entrypoint is the most truthful wrapper-free example
+- the direct Python entrypoint is the clearest wrapper-free execution example
+- the full skill contract still lives in the bundle, not just the script file
 
 Read next:
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -27,8 +27,9 @@ Use the docs in this order:
 
 Important clarification:
 
-- the repo ships normal executable Python skills
-- agent clients call those skills through MCP or other wrappers
+- the repo ships skill bundles with `SKILL.md`, `REFERENCES.md`, `src/`, and `tests/`
+- the executable Python file is only one part of that bundle
+- agent clients call those same skill bundles through MCP or other wrappers
 - agents do not require a separate implementation model to use them
 
 ## Client quick map


### PR DESCRIPTION
Summary
- clarify that the shipped skill is the full bundle: SKILL.md, REFERENCES.md, src, and tests
- keep python entrypoints as the direct execution core, not the whole skill contract
- tighten README.md, docs/DATA_HANDLING.md, and docs/agent-integrations.md so agent clients are described as callers of the same skill bundle

Validation
- python scripts/validate_skill_contract.py