### PR TITLE
docs: add stderr telemetry contract

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -132,7 +132,7 @@ Use `stderr` for:
 - environment or dependency errors
 - permission or approval failures
 - machine-readable telemetry when `SKILL_LOG_FORMAT=json` or
-  `AGENT_TELEMETRY=1` is enabled
+  `AGENT_TELEMETRY=1` is enabled; see [STDERR_TELEMETRY_CONTRACT.md](STDERR_TELEMETRY_CONTRACT.md)
 
 Do not use `stderr` for:
 

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -50,7 +50,7 @@ Expected controls:
 - no broad network egress outside documented API use
 - deterministic `stdout` output
 - warnings and skips only on `stderr`
-- optional structured `stderr` telemetry via `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1` for wrappers and operators that need machine-readable runtime hints
+- optional structured `stderr` telemetry via `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1` for wrappers and operators that need machine-readable runtime hints; see [STDERR_TELEMETRY_CONTRACT.md](STDERR_TELEMETRY_CONTRACT.md)
 - strict input validation before parse, convert, or cloud calls
 
 Current pilots:

--- a/docs/STDERR_TELEMETRY_CONTRACT.md
+++ b/docs/STDERR_TELEMETRY_CONTRACT.md
@@ -1,0 +1,110 @@
+# Stderr Telemetry Contract
+
+This document defines the repo-local structured `stderr` contract used by
+`skills/_shared/runtime_telemetry.py`.
+
+Use this doc when you need to:
+
+- understand the exact wire shape of skill diagnostics on `stderr`
+- parse machine-readable warnings or skip hints from a skill that opts into
+  structured telemetry
+- keep wrappers, tests, and downstream tooling aligned on the same event shape
+
+Read next:
+
+- [ERROR_CODES.md](ERROR_CODES.md)
+- [RUNTIME_ISOLATION.md](RUNTIME_ISOLATION.md)
+- [DEBUGGING.md](DEBUGGING.md)
+- [schemas/stderr-telemetry.schema.json](schemas/stderr-telemetry.schema.json)
+
+## Scope
+
+This contract applies to repo-owned skills and wrappers that call
+`emit_stderr_event(...)`.
+
+It does not:
+
+- change stdout payloads
+- define external telemetry shipping
+- replace skill-specific error handling or exit-code behavior
+- permit secrets, tokens, or raw credentials in diagnostics
+
+## Activation
+
+The shared helper emits one of two `stderr` forms:
+
+- plain text by default
+- JSONL when `SKILL_LOG_FORMAT=json` or `AGENT_TELEMETRY=1`
+
+In both modes the helper writes one line per event and flushes immediately.
+It never writes diagnostic data to stdout.
+
+## Plain Text Form
+
+When JSON mode is disabled, the helper emits a human-readable single line:
+
+`[skill-name] message`
+
+This mode is for operator readability and quick local debugging.
+
+## JSONL Form
+
+When JSON mode is enabled, each `stderr` line is a single JSON object with:
+
+- `timestamp`
+- `skill`
+- `level`
+- `event`
+- `message`
+- any additional fields passed by the caller, excluding `None`
+
+The helper sorts object keys before serializing them.
+
+### Field Semantics
+
+- `timestamp` is UTC ISO-8601 with millisecond precision and a trailing `Z`
+- `skill` is the stable skill name passed by the caller
+- `level` is a caller-supplied severity string such as `warning` or `error`
+- `event` is a machine-friendly identifier such as `json_parse_failed`
+- `message` is the human-readable explanation for operators
+- additional fields should carry compact machine data such as `line`,
+  `path`, `count`, or `error`
+
+## Contract Rules
+
+- keep messages actionable and safe to print
+- prefer structured fields for values that consumers may need to filter on
+- omit `None` fields rather than serializing null placeholders
+- keep stderr diagnostics short and single-line
+- treat stderr telemetry as advisory context, not the primary result payload
+- do not include secrets, session tokens, or raw credentials in any field
+
+## Consumer Guidance
+
+- If you enable structured mode, parse `stderr` as JSONL and expect one event
+  per line.
+- If you do not enable structured mode, treat `stderr` as plain operator text.
+- If a skill emits warnings or skip hints, the process may still exit `0`
+  when the underlying contract considers the invocation successful.
+
+## Current Implementation
+
+The shared helper lives in
+[`skills/_shared/runtime_telemetry.py`](../skills/_shared/runtime_telemetry.py).
+It currently recognizes `SKILL_LOG_FORMAT=json` and `AGENT_TELEMETRY=1` as the
+JSON switch and falls back to a bracketed plain-text line otherwise.
+
+Future helpers should preserve that backward-compatible behavior so wrappers
+and tests can rely on a single stderr contract.
+
+## JSON Schema
+
+The machine-readable schema for JSON mode lives at:
+
+- [schemas/stderr-telemetry.schema.json](schemas/stderr-telemetry.schema.json)
+
+That schema pins:
+
+- the required base fields
+- string typing for the shared fields
+- open additional properties for skill-specific metadata

--- a/docs/schemas/stderr-telemetry.schema.json
+++ b/docs/schemas/stderr-telemetry.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/msaad00/cloud-ai-security-skills/docs/schemas/stderr-telemetry.schema.json",
+  "title": "Skill stderr telemetry event",
+  "description": "JSONL event emitted by skills/_shared/runtime_telemetry.py when structured stderr mode is enabled.",
+  "type": "object",
+  "required": [
+    "timestamp",
+    "skill",
+    "level",
+    "event",
+    "message"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "description": "UTC ISO-8601 timestamp with millisecond precision and trailing Z."
+    },
+    "skill": {
+      "type": "string",
+      "description": "Stable skill name."
+    },
+    "level": {
+      "type": "string",
+      "description": "Caller-supplied severity such as warning or error."
+    },
+    "event": {
+      "type": "string",
+      "description": "Machine-friendly event identifier."
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable diagnostic summary."
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- add docs/STDERR_TELEMETRY_CONTRACT.md for the shared JSON/plain-text stderr behavior
- add docs/schemas/stderr-telemetry.schema.json for the machine-readable JSON mode contract
- link the new contract from ERROR_CODES and RUNTIME_ISOLATION

## Validation
- python scripts/validate_skill_contract.py