### PR TITLE
docs: tighten remaining contract polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
+[![Coverage Gates](https://img.shields.io/badge/coverage-gated-0f766e)](docs/COVERAGE_MODEL.md)
 [![Scanned by agent-bom](https://img.shields.io/badge/scanned_by-agent--bom-164e63)](https://github.com/msaad00/agent-bom)
 
 Security skills for cloud and AI systems. Use source-specific ingest, discovery, detection, evaluation, view, and remediation skills from the CLI, CI, MCP, or persistent runners without changing the skill code.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,8 @@ or directly by email if a contact is listed on the maintainer profile. Include:
 
 - initial acknowledgment target: 48 hours
 - remediation triage target: 7 business days
+- critical or high-severity fix/mitigation target: 30 calendar days when a safe patch path exists
+- medium-severity fix/mitigation target: 90 calendar days or the next planned minor release, whichever comes first
 - coordinated disclosure after a fix or mitigation is available
 
 ## Secure Usage Requirements

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -12,8 +12,8 @@ when you want the schema-mode decision tree.
 
 Current repo surface on `main`:
 
-- `43` shipped skills across ingestion, discovery, detection, evaluation, view,
-  and remediation
+- shipped skills across ingestion, discovery, detection, evaluation, view, and
+  remediation
 - `3` read-only source adapters:
   - `source-snowflake-query`
   - `source-databricks-query`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -3,6 +3,13 @@
 This repo releases as one trust boundary. We do not version individual skills
 independently.
 
+## Cadence And Support
+
+- Releases are demand-driven, not calendar-driven.
+- During `0.x`, `main` and the most recent tagged release are the supported lines.
+- Older `0.x` tags are not long-term-support releases unless a release note says otherwise.
+- We do not publish a separate LTS line yet; if that changes, the release notes for that tag will state it explicitly.
+
 ## Semver Rules
 
 - `PATCH` (`0.4.1`)

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -39,6 +39,7 @@ Optional:
 
 Optional:
 - `network_egress`
+- `concurrency_safety`
 - `caller_roles`
 - `approver_roles`
 - `min_approvers`
@@ -86,6 +87,13 @@ Rules:
   - `ocsf`
   - `bridge`
 - every skill must declare the formats it supports today, even if only one mode is implemented
+- `concurrency_safety` must be one of:
+  - `stateless`
+  - `requires_consistent_sharding`
+  - `operator_coordinated`
+- `stateless` means the skill has no repo-local mutable state and can be parallelized safely on independent inputs
+- `requires_consistent_sharding` means the skill is safe to parallelize only when batching or sharding preserves the logical correlation window
+- `operator_coordinated` means concurrency is possible, but the caller should coordinate around remote quotas, writes, approvals, or append semantics
 - `network_egress`, when present, must be a comma-separated list of hostnames or wildcard hostnames such as:
   - `api.workday.com`
   - `*.snowflakecomputing.com`
@@ -113,6 +121,9 @@ operator anti-patterns that must never be bypassed.
 
 `REFERENCES.md` must point to the official documentation, schema, API, benchmark, or framework the skill relies on.
 
+Blogs, opinion posts, and vendor marketing pages may be helpful during authoring,
+but they are not authoritative references for shipped skills.
+
 Examples:
 
 - AWS / Azure / GCP official docs
@@ -130,6 +141,26 @@ Examples:
 - defensive parsing on untrusted input
 - explicit human-in-the-loop and runtime-mode declaration in frontmatter so agents know when they must stop for approval
 - preserve caller, approver, and execution identity context when the surrounding runtime provides it
+
+## How Code Blocks Work
+
+Code blocks in `SKILL.md` are documentation examples, not executable code.
+
+The relationship is:
+
+- YAML frontmatter:
+  - machine-readable metadata for validators, MCP tool registration, and wrappers
+- `SKILL.md` body:
+  - human-and-agent-readable guidance such as usage examples, composition paths, prerequisites, and schema notes
+- `src/<entry>.py`:
+  - the actual executable implementation
+
+This means:
+
+- shell examples show how to invoke a skill directly
+- composition examples show how skills chain together
+- SQL or infrastructure examples show prerequisites the skill expects
+- wrappers and MCP ignore `SKILL.md` code blocks at execution time and call the real Python entrypoint instead
 
 ## Required validation and error handling
 
@@ -164,6 +195,7 @@ CI currently validates:
 - `Use when` and `Do NOT use` are present
 - `approval_model`, `execution_modes`, and `side_effects` are present and valid
 - `input_formats` and `output_formats` are present and valid
+- `concurrency_safety` is present, valid, and in canonical frontmatter order
 - read-only skills do not use subprocess/shell execution
 - write-capable skills document and test dry-run behavior
 - write-capable skills explicitly require human approval

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -32,7 +32,26 @@ SIDE_EFFECT_VALUES = {
 }
 INPUT_FORMAT_VALUES = {"raw", "canonical", "native", "ocsf"}
 OUTPUT_FORMAT_VALUES = {"raw", "native", "ocsf", "bridge"}
+CONCURRENCY_SAFETY_VALUES = {"stateless", "requires_consistent_sharding", "operator_coordinated"}
 NETWORK_EGRESS_RE = re.compile(r"^(?:\*\.)?(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+$")
+FRONTMATTER_KEY_ORDER = (
+    "name",
+    "description",
+    "license",
+    "capability",
+    "approval_model",
+    "execution_modes",
+    "side_effects",
+    "input_formats",
+    "output_formats",
+    "concurrency_safety",
+    "network_egress",
+    "caller_roles",
+    "approver_roles",
+    "min_approvers",
+    "compatibility",
+    "metadata",
+)
 
 ENTRYPOINT_CANDIDATES = (
     "src/ingest.py",
@@ -123,6 +142,10 @@ class SkillContract:
         return parse_modes(self.frontmatter.get("network_egress"))
 
     @property
+    def concurrency_safety(self) -> str:
+        return self.frontmatter.get("concurrency_safety", "")
+
+    @property
     def caller_roles(self) -> tuple[str, ...]:
         return parse_modes(self.frontmatter.get("caller_roles"))
 
@@ -208,6 +231,18 @@ def parse_modes(raw_value: str | None) -> tuple[str, ...]:
     if not raw_value:
         return ()
     return tuple(part.strip() for part in raw_value.split(",") if part.strip())
+
+
+def extract_frontmatter_keys(frontmatter: str) -> tuple[str, ...]:
+    keys: list[str] = []
+    for line in frontmatter.splitlines():
+        if not line.strip() or line.startswith(" "):
+            continue
+        if ":" not in line:
+            continue
+        key, _ = line.split(":", 1)
+        keys.append(key.strip())
+    return tuple(keys)
 
 
 def resolve_entrypoint(skill_dir: Path) -> Path | None:

--- a/scripts/validate_skill_contract.py
+++ b/scripts/validate_skill_contract.py
@@ -4,7 +4,9 @@ import sys
 
 from skill_validation_common import (
     APPROVAL_MODE_VALUES,
+    CONCURRENCY_SAFETY_VALUES,
     EXECUTION_MODE_VALUES,
+    FRONTMATTER_KEY_ORDER,
     INPUT_FORMAT_VALUES,
     NAME_RE,
     NETWORK_EGRESS_RE,
@@ -12,6 +14,8 @@ from skill_validation_common import (
     ROOT,
     SIDE_EFFECT_VALUES,
     discover_skill_contracts,
+    extract_frontmatter,
+    extract_frontmatter_keys,
     iter_skill_like_dirs,
 )
 
@@ -33,6 +37,12 @@ def main() -> int:
             if not (skill.skill_dir / required).exists():
                 errors.append(f"{rel}: missing required path `{required}`")
 
+        frontmatter_keys = extract_frontmatter_keys(extract_frontmatter(skill.skill_dir / "SKILL.md"))
+        order_positions = {key: idx for idx, key in enumerate(FRONTMATTER_KEY_ORDER)}
+        present_positions = [order_positions[key] for key in frontmatter_keys if key in order_positions]
+        if present_positions != sorted(present_positions):
+            errors.append(f"{rel}: frontmatter fields must follow canonical order")
+
         for field in (
             "name",
             "description",
@@ -42,6 +52,7 @@ def main() -> int:
             "side_effects",
             "input_formats",
             "output_formats",
+            "concurrency_safety",
         ):
             if not skill.frontmatter.get(field):
                 errors.append(f"{rel}: frontmatter missing `{field}`")
@@ -92,6 +103,13 @@ def main() -> int:
                 errors.append(f"{rel}: invalid output_formats {unknown_output_formats}")
         elif output_formats:
             errors.append(f"{rel}: output_formats must not be empty")
+
+        concurrency_safety = skill.frontmatter.get("concurrency_safety", "").strip()
+        if concurrency_safety:
+            if concurrency_safety not in CONCURRENCY_SAFETY_VALUES:
+                errors.append(f"{rel}: invalid concurrency_safety `{concurrency_safety}`")
+        elif skill.frontmatter.get("concurrency_safety") is not None:
+            errors.append(f"{rel}: concurrency_safety must not be empty")
 
         network_egress = skill.frontmatter.get("network_egress")
         parsed_network_egress = tuple(

--- a/skills/detection/detect-entra-credential-addition/SKILL.md
+++ b/skills/detection/detect-entra-credential-addition/SKILL.md
@@ -19,6 +19,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: native, ocsf
+concurrency_safety: stateless
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-entra-credential-addition

--- a/skills/detection/detect-entra-role-grant-escalation/SKILL.md
+++ b/skills/detection/detect-entra-role-grant-escalation/SKILL.md
@@ -19,6 +19,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: native, ocsf
+concurrency_safety: stateless
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-entra-role-grant-escalation

--- a/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
+++ b/skills/detection/detect-google-workspace-suspicious-login/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: native, ocsf
+concurrency_safety: requires_consistent_sharding
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-google-workspace-suspicious-login

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: ocsf, native
+concurrency_safety: requires_consistent_sharding
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-lateral-movement

--- a/skills/detection/detect-mcp-tool-drift/SKILL.md
+++ b/skills/detection/detect-mcp-tool-drift/SKILL.md
@@ -21,6 +21,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: native, ocsf
+concurrency_safety: stateless
 ---
 
 # detect-mcp-tool-drift

--- a/skills/detection/detect-okta-mfa-fatigue/SKILL.md
+++ b/skills/detection/detect-okta-mfa-fatigue/SKILL.md
@@ -18,6 +18,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: native, ocsf
+concurrency_safety: requires_consistent_sharding
 metadata:
   homepage: https://github.com/msaad00/cloud-ai-security-skills
   source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-okta-mfa-fatigue

--- a/skills/detection/detect-privilege-escalation-k8s/SKILL.md
+++ b/skills/detection/detect-privilege-escalation-k8s/SKILL.md
@@ -17,6 +17,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical, native, ocsf
 output_formats: native, ocsf
+concurrency_safety: requires_consistent_sharding
 ---
 
 # detect-privilege-escalation-k8s

--- a/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
+++ b/skills/detection/detect-sensitive-secret-read-k8s/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: native, ocsf
 output_formats: native, ocsf
+concurrency_safety: stateless
 ---
 
 # detect-sensitive-secret-read-k8s

--- a/skills/discovery/discover-ai-bom/SKILL.md
+++ b/skills/discovery/discover-ai-bom/SKILL.md
@@ -17,6 +17,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw, canonical
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs required when inventory snapshots are
   already exported. Read-only — validates and normalizes inventory into a

--- a/skills/discovery/discover-cloud-control-evidence/SKILL.md
+++ b/skills/discovery/discover-cloud-control-evidence/SKILL.md
@@ -17,6 +17,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw, canonical
 output_formats: native, bridge
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. Read-only. Accepts raw cloud inventory JSON from
   stdin or a file path. Produces deterministic JSON evidence suitable for CLI,

--- a/skills/discovery/discover-control-evidence/SKILL.md
+++ b/skills/discovery/discover-control-evidence/SKILL.md
@@ -18,6 +18,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: canonical
 output_formats: native, bridge
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. Read-only. Accepts discovery-layer JSON from stdin or
   a file path. Produces deterministic JSON evidence suitable for CLI, CI, MCP,

--- a/skills/discovery/discover-environment/SKILL.md
+++ b/skills/discovery/discover-environment/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native, bridge
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. Cloud discovery needs respective SDKs (boto3 for AWS,
   google-cloud-* for GCP, azure-* for Azure). Static config mode needs no SDKs.

--- a/skills/evaluation/container-security/SKILL.md
+++ b/skills/evaluation/container-security/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No Docker daemon needed — works with config files.
   Optional: PyYAML for YAML parsing. Read-only — no image pulls or execution.

--- a/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+, boto3, and AWS credentials with SecurityAudit managed policy
   (read-only). No write permissions needed — assessment only.

--- a/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
@@ -14,6 +14,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+, azure-identity, azure-mgmt-storage, azure-mgmt-network.
   Service principal needs Reader role. No write permissions — assessment only.

--- a/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
@@ -14,6 +14,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-compute.
   Service account needs roles/viewer + roles/iam.securityReviewer.

--- a/skills/evaluation/gpu-cluster-security/SKILL.md
+++ b/skills/evaluation/gpu-cluster-security/SKILL.md
@@ -18,6 +18,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files
   (JSON/YAML). Optional: PyYAML for YAML parsing. Read-only — no write permissions,

--- a/skills/evaluation/k8s-security-benchmark/SKILL.md
+++ b/skills/evaluation/k8s-security-benchmark/SKILL.md
@@ -17,6 +17,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with exported JSON/YAML.
   Optional: kubectl for live cluster dumps. Read-only — no write permissions.

--- a/skills/evaluation/model-serving-security/SKILL.md
+++ b/skills/evaluation/model-serving-security/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native
+concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files.
   Optional: PyYAML for YAML config parsing. Read-only — no write permissions,

--- a/skills/ingestion/ingest-azure-activity-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-azure-activity-ocsf/SKILL.md
@@ -22,6 +22,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-azure-activity-ocsf

--- a/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-azure-defender-for-cloud-ocsf

--- a/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
@@ -19,6 +19,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-cloudtrail-ocsf

--- a/skills/ingestion/ingest-entra-directory-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-entra-directory-audit-ocsf/SKILL.md
@@ -17,6 +17,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native, ocsf
+concurrency_safety: stateless
 compatibility: >-
   Requires Python 3.11+. No Graph SDK required when directoryAudit payloads are
   already exported. Read-only — validates raw Entra audit shape and emits OCSF

--- a/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
@@ -21,6 +21,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-gcp-audit-ocsf

--- a/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-gcp-scc-ocsf

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/SKILL.md
@@ -18,6 +18,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native, ocsf
+concurrency_safety: stateless
 compatibility: >-
   Requires Python 3.11+. No Google SDK required when Admin SDK Reports payloads
   are already exported. Read-only — validates raw Workspace audit shape and

--- a/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-guardduty-ocsf

--- a/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native, ocsf
+concurrency_safety: stateless
 ---
 
 # ingest-k8s-audit-ocsf

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/SKILL.md
@@ -18,6 +18,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native, ocsf
+concurrency_safety: stateless
 ---
 
 # ingest-mcp-proxy-ocsf

--- a/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/SKILL.md
@@ -17,6 +17,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-nsg-flow-logs-azure-ocsf

--- a/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/SKILL.md
@@ -19,6 +19,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: native, ocsf
+concurrency_safety: stateless
 compatibility: >-
   Requires Python 3.11+. No Okta SDK required when System Log payloads are
   already exported. Read-only — validates raw Okta event shape and emits OCSF

--- a/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-security-hub-ocsf

--- a/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/SKILL.md
@@ -18,6 +18,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-vpc-flow-logs-gcp-ocsf

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/SKILL.md
@@ -21,6 +21,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: ocsf, native
+concurrency_safety: stateless
 ---
 
 # ingest-vpc-flow-logs-ocsf

--- a/skills/ingestion/source-databricks-query/SKILL.md
+++ b/skills/ingestion/source-databricks-query/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: raw
+concurrency_safety: stateless
 network_egress: "*.databricks.com"
 ---
 

--- a/skills/ingestion/source-s3-select/SKILL.md
+++ b/skills/ingestion/source-s3-select/SKILL.md
@@ -16,6 +16,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: raw
+concurrency_safety: stateless
 network_egress: "*.amazonaws.com"
 ---
 

--- a/skills/ingestion/source-snowflake-query/SKILL.md
+++ b/skills/ingestion/source-snowflake-query/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
 output_formats: raw
+concurrency_safety: stateless
 network_egress: "*.snowflakecomputing.com"
 ---
 

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, persistent
 side_effects: writes-identity, writes-storage, writes-database, writes-audit
 input_formats: raw, canonical
 output_formats: native
+concurrency_safety: operator_coordinated
 network_egress: api.workday.com, *.snowflakecomputing.com, *.databricks.com, *.clickhouse.cloud
 caller_roles: security_engineer, incident_responder
 approver_roles: security_lead, cis_officer

--- a/skills/remediation/sink-clickhouse-jsonl/SKILL.md
+++ b/skills/remediation/sink-clickhouse-jsonl/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, mcp, persistent
 side_effects: writes-database
 input_formats: raw, native, ocsf
 output_formats: native
+concurrency_safety: operator_coordinated
 network_egress: "*.clickhouse.cloud"
 caller_roles: security_engineer, platform_engineer
 approver_roles: security_lead, data_platform_owner

--- a/skills/remediation/sink-s3-jsonl/SKILL.md
+++ b/skills/remediation/sink-s3-jsonl/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, mcp, persistent
 side_effects: writes-storage
 input_formats: raw, native, ocsf
 output_formats: native
+concurrency_safety: operator_coordinated
 network_egress: "*.amazonaws.com"
 caller_roles: security_engineer, platform_engineer
 approver_roles: security_lead, data_platform_owner

--- a/skills/remediation/sink-snowflake-jsonl/SKILL.md
+++ b/skills/remediation/sink-snowflake-jsonl/SKILL.md
@@ -15,6 +15,7 @@ execution_modes: jit, mcp, persistent
 side_effects: writes-database
 input_formats: raw, native, ocsf
 output_formats: native
+concurrency_safety: operator_coordinated
 network_egress: "*.snowflakecomputing.com"
 caller_roles: security_engineer, platform_engineer
 approver_roles: security_lead, data_platform_owner

--- a/skills/view/convert-ocsf-to-mermaid-attack-flow/SKILL.md
+++ b/skills/view/convert-ocsf-to-mermaid-attack-flow/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: ocsf
 output_formats: native
+concurrency_safety: stateless
 ---
 
 # convert-ocsf-to-mermaid-attack-flow

--- a/skills/view/convert-ocsf-to-sarif/SKILL.md
+++ b/skills/view/convert-ocsf-to-sarif/SKILL.md
@@ -20,6 +20,7 @@ execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: ocsf
 output_formats: native
+concurrency_safety: stateless
 ---
 
 # convert-ocsf-to-sarif

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -85,6 +85,7 @@ class TestSkillValidationCommon:
         assert ingest.approval_model == "none"
         assert ingest.execution_modes == ("jit", "ci", "mcp", "persistent")
         assert ingest.side_effects == ("none",)
+        assert ingest.concurrency_safety == "stateless"
         assert ingest.caller_roles == ()
         assert ingest.approver_roles == ()
         assert ingest.min_approvers is None
@@ -211,6 +212,7 @@ class TestValidationScripts:
         assert remediation.approval_model == "human_required"
         assert remediation.execution_modes == ("jit", "persistent")
         assert "writes-identity" in remediation.side_effects
+        assert remediation.concurrency_safety == "operator_coordinated"
         assert remediation.caller_roles == ("security_engineer", "incident_responder")
         assert remediation.approver_roles == ("security_lead", "cis_officer")
         assert remediation.min_approvers == 1
@@ -221,6 +223,7 @@ class TestValidationScripts:
         assert sink.approval_model == "human_required"
         assert sink.execution_modes == ("jit", "mcp", "persistent")
         assert sink.side_effects == ("writes-database",)
+        assert sink.concurrency_safety == "operator_coordinated"
         assert sink.caller_roles == ("security_engineer", "platform_engineer")
         assert sink.approver_roles == ("security_lead", "data_platform_owner")
         assert sink.min_approvers == 1
@@ -231,6 +234,7 @@ class TestValidationScripts:
         assert sink.approval_model == "human_required"
         assert sink.execution_modes == ("jit", "mcp", "persistent")
         assert sink.side_effects == ("writes-database",)
+        assert sink.concurrency_safety == "operator_coordinated"
         assert sink.caller_roles == ("security_engineer", "platform_engineer")
         assert sink.approver_roles == ("security_lead", "data_platform_owner")
         assert sink.min_approvers == 1
@@ -241,6 +245,7 @@ class TestValidationScripts:
         assert sink.approval_model == "human_required"
         assert sink.execution_modes == ("jit", "mcp", "persistent")
         assert sink.side_effects == ("writes-storage",)
+        assert sink.concurrency_safety == "operator_coordinated"
         assert sink.caller_roles == ("security_engineer", "platform_engineer")
         assert sink.approver_roles == ("security_lead", "data_platform_owner")
         assert sink.min_approvers == 1


### PR DESCRIPTION
## Summary
- add repo-wide concurrency_safety guidance to every shipped skill and enforce canonical frontmatter order in validation
- tighten SKILL_CONTRACT with code-block semantics and a stricter REFERENCES policy
- add final readiness polish: coverage badge, CVE response targets, release cadence and support wording, and remove the last hardcoded skill-count drift point

## Validation
- python scripts/validate_skill_contract.py
- python -m pytest tests/integration/test_skill_validation_scripts.py -q -o addopts=''
- python -m ruff check scripts/skill_validation_common.py scripts/validate_skill_contract.py tests/integration/test_skill_validation_scripts.py --config pyproject.toml

## Notes
- direct local Python checks were used for test and lint because the repo currently has a uv dependency-resolution conflict between the OIDC and Snowflake extras