### PR TITLE
release: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ The format is loosely based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.5.0 - 2026-04-15
+
 ### Added
 
 - [`docs/NATIVE_VS_OCSF.md`](docs/NATIVE_VS_OCSF.md) and [`docs/STATE_AND_TIMELINE_MODEL.md`](docs/STATE_AND_TIMELINE_MODEL.md) to make `native`, `canonical`, `ocsf`, and `bridge` modes explicit and to pin historical-state, tombstone, and timeline expectations across just-in-time and persistent runs.
 - [`docs/DEBUGGING.md`](docs/DEBUGGING.md) and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) for operator-facing format, CI, and runtime troubleshooting.
+- [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md), [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md), [`docs/DATA_HANDLING.md`](docs/DATA_HANDLING.md), [`docs/COMPLIANCE_MAPPINGS.md`](docs/COMPLIANCE_MAPPINGS.md), [`docs/SCHEMA_VERSIONING.md`](docs/SCHEMA_VERSIONING.md), [`docs/LOSSY_MAPPINGS.md`](docs/LOSSY_MAPPINGS.md), [`docs/ERROR_CODES.md`](docs/ERROR_CODES.md), [`docs/STDERR_TELEMETRY_CONTRACT.md`](docs/STDERR_TELEMETRY_CONTRACT.md), [`docs/MCP_AUDIT_CONTRACT.md`](docs/MCP_AUDIT_CONTRACT.md), and [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md) to make the trust, schema, operator, procurement, and sizing story auditable from docs alone.
 - `ingest-okta-system-log-ocsf` as the first external identity-vendor ingestion skill, mapping verified Okta System Log session, user lifecycle, and membership events into OCSF Authentication (3002), Account Change (3001), and User Access Management (3005).
 - `detect-okta-mfa-fatigue` as the first Okta-native detection skill, emitting OCSF Detection Finding (2004) for repeated Okta Verify push challenge and denial bursts aligned to MITRE ATT&CK T1621.
 - `ingest-entra-directory-audit-ocsf` as the Microsoft Entra / Graph identity-audit ingestion skill, mapping verified `directoryAudit` application, service-principal, app-role-assignment, and federated-credential events into OCSF API Activity (6003).
@@ -30,7 +33,7 @@ The format is loosely based on Keep a Changelog.
 - extended the same opt-in structured `stderr` telemetry pilot to `ingest-okta-system-log-ocsf` and `detect-okta-mfa-fatigue`, covering the Okta identity ingest/detect path without changing stdout data contracts.
 - extended the same opt-in structured `stderr` telemetry pilot to `ingest-google-workspace-login-ocsf` and `detect-google-workspace-suspicious-login`, covering the Google Workspace identity ingest/detect path without changing stdout data contracts.
 - tightened the README and skill catalog entry path around use cases, skill selection, plug-in surfaces, and clearer layer guidance, plus added `docs/USE_CASES.md` as the practical crosswalk for sources, assets, frameworks, and starting skills.
-- clarified in the README and use-case guide that repo-owned remediation audit lands in DynamoDB + S3 today, while customer-controlled sinks such as Snowflake / Snowpipe belong to the planned sink / runner layer rather than the currently shipped generic path.
+- clarified in the README and use-case guide that repo-owned remediation audit lands in DynamoDB + S3 today, while generic sink skills now ship for Snowflake, ClickHouse, and S3; additional destinations such as Security Lake and BigQuery remain supported patterns rather than built-ins.
 - a new start-here visual and updated IAM departures data-flow visual so operators can see sources, layer choice, outputs, runtime surfaces, and the shipped-vs-optional sink boundary without reading the full architecture docs first.
 - a runtime-surfaces visual showing that CLI, CI, MCP, and persistent wrappers all call the same `SKILL.md + src/ + tests/` contract instead of creating parallel implementations.
 - expanded the vendor icon asset set with Okta plus Microsoft Entra and Google Workspace stand-ins so the visual system can represent shipped identity sources alongside cloud and data-platform vendors.
@@ -38,10 +41,15 @@ The format is loosely based on Keep a Changelog.
 - added a repo-aware `mypy` runner and CI lane that type-checks each skill `src/` directory in isolation plus `mcp-server/src/` and `scripts/`, so the repeated `ingest.py` / `detect.py` layout no longer blocks meaningful type enforcement.
 - `scripts/validate_test_coverage.py` plus a dedicated CI coverage lane that now enforces real repo-level thresholds: `overall >= 70%`, `detection >= 80%`, and `evaluation >= 60%`.
 - `runners/aws-s3-sqs-detect`, a repo-owned AWS reference runner template for `S3 -> ingest Lambda -> SQS -> detect Lambda -> DynamoDB dedupe -> SNS`, so persistent execution is no longer docs-only outside the IAM departures workflow.
+- `runners/gcp-gcs-pubsub-detect` and `runners/azure-blob-eventgrid-detect` as the matching GCP and Azure reference runners, so the persistent execution story now has a shipped template on all three major clouds.
+- `source-snowflake-query`, `source-databricks-query`, and `source-s3-select` as read-only source adapters for warehouse and object-store based pipelines.
+- `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`, and `sink-s3-jsonl` as write-capable persistence edges with dry-run-first contracts, explicit approval metadata, and auditable native result summaries.
+- `packs/lateral-movement/` and `packs/privilege-escalation-k8s/` as the first shipped query-pack families proving warehouse-native detection can stay aligned with the Python skill intent.
 - `docs/RELEASE_CHECKLIST.md` plus explicit repo-level semver bump rules, and aligned local pre-commit Bandit scope with the same `skills/`, `mcp-server/`, and `scripts/` surface enforced in CI.
 - `docs/CREDENTIAL_PROVENANCE.md` plus README / security-doc updates to make the repo's secret-minimizing credential posture explicit, document the remaining password/client-secret compatibility paths, and explain why direct Workday `httpx` access remains a narrow documented exception instead of a hidden supply-chain surprise.
 - `docs/CANONICAL_SCHEMA.md` and `docs/DATA_FLOW.md` to pin the repo-owned canonical model and the raw → canonical → native / ocsf / bridge flow.
 - `docs/SUPPLY_CHAIN.md` plus a new CI CycloneDX SBOM artifact, making the dependency-provenance, lockfile-ceiling, and runtime-surface story explicit for operators and auditors.
+- a release workflow that attaches the signed CycloneDX SBOM artifact set directly to GitHub Releases instead of leaving it only as a CI artifact.
 
 ### Changed
 
@@ -60,8 +68,11 @@ The format is loosely based on Keep a Changelog.
 - Extended the native/OCSF pilot to `ingest-google-workspace-login-ocsf` and `detect-google-workspace-suspicious-login`, so the Workspace login ingestion and suspicious-login detection path now supports native or OCSF input/output without changing the underlying detection semantics.
 - Extended the native/OCSF pilot to `ingest-entra-directory-audit-ocsf` and `detect-entra-credential-addition`, so Entra directory-audit ingestion and credential-addition detection now support native or OCSF input/output without changing the underlying detection semantics.
 - Extended the native/OCSF pilot to `ingest-okta-system-log-ocsf` and `detect-okta-mfa-fatigue`, so the Okta System Log ingestion and MFA-fatigue detection path now supports native or OCSF input/output without changing the underlying detection semantics.
+- Finished the native/OCSF rollout across the shipped ingest and detect layers, so event and finding pipelines are now fully dual-mode wherever the repo intends interoperability parity.
 - Made the README honest about current schema-mode rollout, required `input_formats` / `output_formats` for every shipped skill, and documented the native output fields on the currently dual-mode skills.
 - Added a runnable README hello-world path, clarified that the `DATA_FLOW.md` rollout list is now driven by README + `SKILL.md` frontmatter, and documented bounded-batch guidance for `detect-lateral-movement`.
+- Tightened the public contract so the repo is positioned as OCSF-default for streams and native-first for operational artifacts, with explicit lossy-mapping and schema-versioning policy instead of vague "optional OCSF" wording.
+- Added `concurrency_safety` to every shipped skill plus validator enforcement for canonical frontmatter field order, making parallel-execution expectations explicit instead of tribal knowledge.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
 - `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is loosely based on Keep a Changelog.
 - Added a runnable README hello-world path, clarified that the `DATA_FLOW.md` rollout list is now driven by README + `SKILL.md` frontmatter, and documented bounded-batch guidance for `detect-lateral-movement`.
 - Tightened the public contract so the repo is positioned as OCSF-default for streams and native-first for operational artifacts, with explicit lossy-mapping and schema-versioning policy instead of vague "optional OCSF" wording.
 - Added `concurrency_safety` to every shipped skill plus validator enforcement for canonical frontmatter field order, making parallel-execution expectations explicit instead of tribal knowledge.
+- Clarified the install and trust model in the README so the repo is presented as a tagged source release with pinned dependency groups and signed SBOMs, not as a generic opaque package install.
 
 - `docs/COVERAGE_MODEL.md`, `docs/framework-coverage.json`, and `docs/ROADMAP.md` to make framework, provider, asset, and execution coverage measurable and auditable.
 - `scripts/validate_framework_coverage.py` so CI can reject undocumented or drifting coverage claims.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cloud-ai-security-skills
 
 [![CI](https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain)
-[![Version](https://img.shields.io/badge/version-0.4.0-0ea5e9)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.5.0-0ea5e9)](CHANGELOG.md)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![OCSF 1.8](https://img.shields.io/badge/OCSF-1.8-22d3ee)](https://schema.ocsf.io/1.8.0)
@@ -187,8 +187,9 @@ Read next:
 
 | Topic | Shipped today | Planned / supported pattern |
 |---|---|---|
-| Runtime surfaces | CLI, CI, MCP, `runners/aws-s3-sqs-detect`, IAM departures workflow | more multi-cloud runner templates |
-| Audit sinks | IAM departures dual-write to DynamoDB + S3 | customer sinks like Snowflake, Security Lake, ClickHouse, BigQuery |
+| Runtime surfaces | CLI, CI, MCP, AWS/GCP/Azure reference runners, IAM departures workflow | more specialized runners and dialect-specific wrappers where demand justifies them |
+| Persistence edges | `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`, `sink-s3-jsonl`, plus IAM departures dual-write to DynamoDB + S3 | additional customer-controlled destinations like Security Lake and BigQuery |
+| Query packs | `packs/lateral-movement/` and `packs/privilege-escalation-k8s/` | broader warehouse and dialect coverage |
 | Schema modes | native, canonical, OCSF, and bridge are all shipped; ingest and detect are fully dual-mode, while discovery uses native/bridge and evaluation, sinks, and remediation stay native-first | extend OCSF or bridge only where it materially improves interoperability without losing operational clarity |
 | Remediation | IAM departures with HITL and audit | broader remediation families |
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ Security skills for cloud and AI systems. Use source-specific ingest, discovery,
 
 For the full source, asset, framework, and runtime crosswalk, see [docs/USE_CASES.md](docs/USE_CASES.md).
 
+## Install And Trust Model
+
+This repo is not primarily distributed as a single PyPI-installed application.
+
+The intended trust and execution model is:
+
+- clone the repo at a tagged release
+- verify the signed tag and release-attached signed SBOM set
+- install only the dependency groups you actually need from `pyproject.toml`
+- run the skill bundles directly, through MCP, in CI, or behind the shipped runners
+
+In other words:
+
+- `uv.lock` is the full dependency ceiling
+- real operator installs are narrower and runtime-specific
+- the trust boundary is the repo release itself, not an opaque package wrapper
+
+See:
+
+- [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md)
+- [docs/CREDENTIAL_PROVENANCE.md](docs/CREDENTIAL_PROVENANCE.md)
+- [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md)
+
 ## Quick Run
 
 Each shipped skill is a bundle:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cloud-ai-security-skills"
-version = "0.4.0"
-description = "OCSF-native security skills for cloud and AI systems."
+version = "0.5.0"
+description = "Security skills for cloud and AI with repo-native and OCSF modes."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- cut the current Unreleased changelog into 0.5.0 with the shipped capability and docs surface
- bump the repo version to 0.5.0 in pyproject.toml and the README badge
- align the README shipped-vs-planned table with the actual shipped runners, sinks, and query packs
- clarify the install and trust model so the repo is presented as a tagged source release with pinned dependency groups and signed SBOMs

## Validation
- python scripts/validate_skill_contract.py