### PR TITLE
docs: stabilize post-v0.5.0 polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is loosely based on Keep a Changelog.
 
 ## Unreleased
 
+### Planned for v0.5.1
+
+- add parser-hardening follow-up tests on the highest-volume ingestion paths so malformed mixed-shape input keeps failing closed without breaking valid records in the same batch
+- improve visual accessibility and readability with diagram descriptions, clearer captions, and continued overlap cleanup in rendered SVGs
+- continue post-release quality work such as mutation/property-based parser testing where it adds measurable confidence without changing shipped contracts
+
 ## 0.5.0 - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ The flagship example skill family is IAM departures remediation: a guarded, even
 ![IAM departures workflow showing HR and identity inputs flowing through guarded approval and remediation steps into dual audit outputs.](docs/images/iam-departures-architecture.svg)
 
 The diagram shows the flagship write path only: source events feed a guarded
-planner/worker flow, human approval gates the write edge, and the final action
+planner/worker flow, the reconciler writes an S3 manifest, EventBridge starts
+the Step Function, human approval gates the write edge, and the final action
 trail lands in both operational storage and durable audit outputs.
 
 ## Trust, Security, And Supply Chain
@@ -273,6 +274,7 @@ High-signal visuals:
 - [Runtime surfaces](docs/images/runtime-surfaces.svg)
 - [Repository architecture](docs/images/repo-architecture.svg)
 - [Detection engineering pipeline](docs/images/detection-pipeline.svg)
+- [End-to-end skill flows](docs/images/end-to-end-skill-flows.svg)
 - [IAM departures workflow](docs/images/iam-departures-architecture.svg)
 - [IAM departures data flow](docs/images/iam-departures-data-flow.svg)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,11 @@ same skill bundle through a different access path.
 
 The flagship example skill family is IAM departures remediation: a guarded, event-driven workflow with a dual audit trail and clear trust boundaries.
 
-![IAM departures cross-cloud workflow](docs/images/iam-departures-architecture.svg)
+![IAM departures workflow showing HR and identity inputs flowing through guarded approval and remediation steps into dual audit outputs.](docs/images/iam-departures-architecture.svg)
+
+The diagram shows the flagship write path only: source events feed a guarded
+planner/worker flow, human approval gates the write edge, and the final action
+trail lands in both operational storage and durable audit outputs.
 
 ## Trust, Security, And Supply Chain
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,7 +66,11 @@ This is how the repo stays secure and reliable without turning every skill into 
 
 The repo is easiest to read as **six shipped skill layers**, plus **three edge/runtime layers** that sit around the pure skills.
 
-![Repository architecture](./images/repo-architecture.svg)
+![Repository architecture showing source inputs, shipped skill layers, persistence edges, query packs, and runtime wrappers around the same contract.](./images/repo-architecture.svg)
+
+The diagram is a layer index, not a second contract: sources feed ingest or
+discover paths, pure skills stay in the middle, and sinks/query packs/runtimes
+sit at the edges around the same bundle contract.
 
 ### Shipped skill layers
 

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -48,6 +48,7 @@ Read next:
 - [RUNTIME_PROFILES.md](RUNTIME_PROFILES.md)
 - [NATIVE_VS_OCSF.md](NATIVE_VS_OCSF.md)
 - [images/data-handling-paths.svg](images/data-handling-paths.svg)
+- [images/end-to-end-skill-flows.svg](images/end-to-end-skill-flows.svg)
 
 ## The Main Scenarios
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -14,6 +14,26 @@ Keep markdown diagrams lightweight and reviewable, then pair them with polished 
 - [IAM departures data flow](images/iam-departures-data-flow.svg)
 - [Detection engineering pipeline](images/detection-pipeline.svg)
 
+## Diagram descriptions
+
+Use these descriptions as the text companion for screen readers, plain-text
+review, and PR discussions where opening the SVG is inconvenient.
+
+- `data-handling-paths.svg`
+  - Shows the main runtime choices: live cloud posture, raw log ingest, OCSF-ready lake detection, raw lake detection through ingest, persistence via sinks, and guarded remediation.
+- `start-here-guide.svg`
+  - Shows the shortest decision tree for choosing a first layer: discover for inventory/evidence, ingest for raw logs, detect for normalized events, evaluate for posture, sink for persistence, and remediate for guarded writes.
+- `runtime-surfaces.svg`
+  - Shows that CLI, CI, MCP, and persistent runners are access paths around the same skill bundle and execution core rather than separate implementations.
+- `iam-departures-architecture.svg`
+  - Shows the flagship write path: HR/IdP inputs, guarded orchestration, human approval, worker actions, and dual audit writes for reconciliation.
+- `repo-architecture.svg`
+  - Shows the six shipped skill layers plus the surrounding source, sink, query-pack, and runtime surfaces that compose around them.
+- `iam-departures-data-flow.svg`
+  - Shows the remediation workflow data path from source manifests through planning, approval, execution, and audit artifacts.
+- `detection-pipeline.svg`
+  - Shows the standard event path from raw input through normalization, detection, optional export, and downstream persistence.
+
 ## Rules
 
 - Keep ASCII or Mermaid diagrams in markdown for git-friendly diffs.

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -13,6 +13,7 @@ Keep markdown diagrams lightweight and reviewable, then pair them with polished 
 - [Repository architecture](images/repo-architecture.svg)
 - [IAM departures data flow](images/iam-departures-data-flow.svg)
 - [Detection engineering pipeline](images/detection-pipeline.svg)
+- [End-to-end skill flows](images/end-to-end-skill-flows.svg)
 
 ## Diagram descriptions
 
@@ -33,6 +34,8 @@ review, and PR discussions where opening the SVG is inconvenient.
   - Shows the remediation workflow data path from source manifests through planning, approval, execution, and audit artifacts.
 - `detection-pipeline.svg`
   - Shows the standard event path from raw input through normalization, detection, optional export, and downstream persistence.
+- `end-to-end-skill-flows.svg`
+  - Shows three concrete shipped compositions: raw logs through ingest/detect/export, warehouse rows through source/detect/sink, and live discovery/evaluation with native outputs and optional guarded action paths.
 
 ## Rules
 

--- a/docs/images/end-to-end-skill-flows.svg
+++ b/docs/images/end-to-end-skill-flows.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="620" viewBox="0 0 1280 620" role="img" aria-labelledby="title desc">
+  <title id="title">End-to-end skill flows</title>
+  <desc id="desc">Three concrete shipped end-to-end compositions: raw log ingest to detect to export, warehouse source to detect to sink, and live cloud discovery or evaluation to native evidence.</desc>
+  <rect width="1280" height="620" fill="#08111f"/>
+  <rect x="24" y="24" width="1232" height="572" rx="28" fill="#0f172a" stroke="#334155"/>
+
+  <g font-family="Arial, sans-serif">
+    <text x="56" y="72" fill="#f8fafc" font-size="32" font-weight="700">End-to-end skill flows</text>
+    <text x="56" y="104" fill="#94a3b8" font-size="18">Real shipped compositions. One lane per common path, with the skill families shown in order.</text>
+
+    <rect x="56" y="138" width="1168" height="126" rx="22" fill="#0b2538" stroke="#22d3ee"/>
+    <text x="86" y="174" fill="#ccfbf1" font-size="24" font-weight="700">1. Raw log detection and export</text>
+    <text x="86" y="204" fill="#e2e8f0" font-size="17">CloudTrail / K8s audit / Okta raw payload</text>
+    <rect x="372" y="160" width="176" height="58" rx="16" fill="#1d4ed8" stroke="#93c5fd"/>
+    <text x="420" y="196" fill="#eff6ff" font-size="19" font-weight="700">ingest-*</text>
+    <rect x="604" y="160" width="176" height="58" rx="16" fill="#0f766e" stroke="#5eead4"/>
+    <text x="654" y="196" fill="#ecfeff" font-size="19" font-weight="700">detect-*</text>
+    <rect x="836" y="160" width="176" height="58" rx="16" fill="#7c3aed" stroke="#c4b5fd"/>
+    <text x="892" y="196" fill="#f5f3ff" font-size="19" font-weight="700">view/*</text>
+    <text x="1044" y="204" fill="#e2e8f0" font-size="17">SARIF / Mermaid / JSON</text>
+    <path d="M250 188 L372 188" stroke="#67e8f9" stroke-width="4" fill="none"/>
+    <path d="M548 188 L604 188" stroke="#93c5fd" stroke-width="4" fill="none"/>
+    <path d="M780 188 L836 188" stroke="#5eead4" stroke-width="4" fill="none"/>
+    <text x="86" y="238" fill="#94a3b8" font-size="15">Example: ingest-cloudtrail-ocsf → detect-lateral-movement → convert-ocsf-to-sarif</text>
+
+    <rect x="56" y="286" width="1168" height="126" rx="22" fill="#10243a" stroke="#60a5fa"/>
+    <text x="86" y="322" fill="#dbeafe" font-size="24" font-weight="700">2. Lake or warehouse analysis with persistence</text>
+    <text x="86" y="352" fill="#e2e8f0" font-size="17">Snowflake / Databricks / S3 object rows</text>
+    <rect x="372" y="308" width="176" height="58" rx="16" fill="#155e75" stroke="#67e8f9"/>
+    <text x="418" y="344" fill="#ecfeff" font-size="19" font-weight="700">source-*</text>
+    <rect x="604" y="308" width="176" height="58" rx="16" fill="#0f766e" stroke="#5eead4"/>
+    <text x="654" y="344" fill="#ecfeff" font-size="19" font-weight="700">detect-*</text>
+    <rect x="836" y="308" width="176" height="58" rx="16" fill="#4c1d95" stroke="#c084fc"/>
+    <text x="889" y="344" fill="#f3e8ff" font-size="19" font-weight="700">sink-*</text>
+    <text x="1044" y="352" fill="#e2e8f0" font-size="17">Snowflake / ClickHouse / S3</text>
+    <path d="M268 336 L372 336" stroke="#60a5fa" stroke-width="4" fill="none"/>
+    <path d="M548 336 L604 336" stroke="#67e8f9" stroke-width="4" fill="none"/>
+    <path d="M780 336 L836 336" stroke="#5eead4" stroke-width="4" fill="none"/>
+    <text x="86" y="386" fill="#94a3b8" font-size="15">Example: source-snowflake-query → detect-lateral-movement → sink-snowflake-jsonl</text>
+
+    <rect x="56" y="434" width="1168" height="126" rx="22" fill="#083344" stroke="#2dd4bf"/>
+    <text x="86" y="470" fill="#ccfbf1" font-size="24" font-weight="700">3. Live posture, discovery, and guarded action</text>
+    <text x="86" y="500" fill="#e2e8f0" font-size="17">Cloud APIs / SaaS APIs / HR changes</text>
+    <rect x="372" y="456" width="176" height="58" rx="16" fill="#0f766e" stroke="#5eead4"/>
+    <text x="411" y="492" fill="#ecfeff" font-size="19" font-weight="700">discover-* / evaluation/*</text>
+    <rect x="604" y="456" width="176" height="58" rx="16" fill="#4338ca" stroke="#a78bfa"/>
+    <text x="650" y="492" fill="#eef2ff" font-size="19" font-weight="700">native outputs</text>
+    <rect x="836" y="456" width="176" height="58" rx="16" fill="#7f1d1d" stroke="#fca5a5"/>
+    <text x="876" y="492" fill="#fee2e2" font-size="19" font-weight="700">remediation/*</text>
+    <text x="1044" y="500" fill="#e2e8f0" font-size="17">audit trail + approval gate</text>
+    <path d="M254 484 L372 484" stroke="#2dd4bf" stroke-width="4" fill="none"/>
+    <path d="M548 484 L604 484" stroke="#5eead4" stroke-width="4" fill="none"/>
+    <path d="M780 484 L836 484" stroke="#a78bfa" stroke-width="4" fill="none"/>
+    <text x="86" y="534" fill="#94a3b8" font-size="15">Example: discover-control-evidence or cspm-aws-cis-benchmark; IAM departures is the flagship guarded write path</text>
+  </g>
+</svg>

--- a/docs/images/iam-departures-architecture.svg
+++ b/docs/images/iam-departures-architecture.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 520" role="img" aria-label="IAM Departures Remediation — closed-loop, event-driven pipeline architecture">
   <title>IAM Departures Remediation — closed-loop event-driven pipeline</title>
-  <desc>Six numbered stages across two deployment domains: HR sources and Reconciler inside the AWS Corporate Security OU, Parser and Worker Lambdas inside a VPC-isolated Step Function, then five cloud targets and a dual-write audit trail. A dashed verification loop runs from the audit back to the reconciler for drift detection.</desc>
+  <desc>Six numbered stages across two deployment domains: HR sources and Reconciler inside the AWS Corporate Security OU, then an S3 manifest plus EventBridge trigger into Parser and Worker Lambdas inside a VPC-isolated Step Function, then five cloud targets and a dual-write audit trail. A dashed verification loop runs from the audit back to the reconciler for drift detection.</desc>
 
   <defs>
     <!-- Canvas background -->
@@ -58,6 +58,8 @@
       .box-t  { font-size: 15px; font-weight: 600; fill: #e2e8f0; }
       .box-b  { font-size: 11px; fill: #cbd5e1; }
       .box-i  { font-size: 10px; fill: #64748b; font-style: italic; }
+      .mini   { font-size: 9px; fill: #cbd5e1; }
+      .mini-t { font-size: 10px; font-weight: 600; fill: #e2e8f0; }
       .step-n { font-size: 11px; font-weight: 700; text-anchor: middle; }
       .drift  { font-size: 11px; fill: #22d3ee; font-style: italic; }
       .foot   { font-size: 10px; fill: #475569; }
@@ -131,7 +133,17 @@
     <text x="286" y="186" class="box-t">Reconciler</text>
     <text x="258" y="216" class="box-b">SHA-256 row diff</text>
     <text x="258" y="234" class="box-b">→ S3 manifest (KMS)</text>
-    <text x="258" y="282" class="box-i">→ EventBridge rule</text>
+    <text x="258" y="282" class="box-i">schedule + EventBridge handoff</text>
+  </g>
+
+  <!-- ─── Handoff details: S3 manifest + EventBridge ───────── -->
+  <g filter="url(#shadow)" class="ttl">
+    <rect x="392" y="118" width="96" height="40" rx="9" fill="#111827" stroke="#22d3ee" stroke-width="1.2"/>
+    <text x="440" y="136" text-anchor="middle" class="mini-t">S3 manifest</text>
+    <text x="440" y="149" text-anchor="middle" class="mini">KMS object + row diff</text>
+
+    <rect x="410" y="246" width="126" height="34" rx="16" fill="#0b1120" stroke="#60a5fa" stroke-width="1.2"/>
+    <text x="473" y="267" text-anchor="middle" class="mini-t">EventBridge starts Step Function</text>
   </g>
 
   <!-- ─── Station 3 : Parser Lambda ───────────────────────── -->
@@ -194,6 +206,9 @@
     <line x1="623" y1="230" x2="657" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
     <line x1="823" y1="230" x2="857" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
     <line x1="1023" y1="230" x2="1037" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
+    <line x1="400" y1="190" x2="430" y2="156" stroke="#22d3ee" stroke-width="1.8" stroke-dasharray="5 4"/>
+    <line x1="446" y1="158" x2="468" y2="244" stroke="#60a5fa" stroke-width="1.8" stroke-dasharray="5 4"/>
+    <line x1="536" y1="263" x2="560" y2="230" stroke="#60a5fa" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
   </g>
 
   <!-- ─── Drift verification loop ─────────────────────────── -->

--- a/skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import os
+import random
+import string
 import sys
 from pathlib import Path
 
@@ -248,6 +250,18 @@ class TestIterRawEvents:
         assert payload["level"] == "warning"
         assert payload["event"] == "json_parse_failed"
         assert payload["line"] == 1
+
+    def test_mixed_random_garbage_keeps_valid_events(self, capsys):
+        rng = random.Random(7)
+        alphabet = string.ascii_letters + string.digits + "[]{}:,"
+        malformed = ["".join(rng.choice(alphabet) for _ in range(25)) for _ in range(20)]
+        lines = malformed + [json.dumps({"eventName": "StillGood"})]
+
+        out = list(iter_raw_events(lines))
+
+        assert out == [{"eventName": "StillGood"}]
+        stderr = capsys.readouterr().err
+        assert "skipping line" in stderr
 
 
 # ── Golden fixture parity ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- reopen Unreleased with concrete v0.5.1 quality bullets
- add readable diagram descriptions and clearer captions for the two embedded SVGs
- harden ingest-cloudtrail mixed-input parsing with a randomized malformed-line regression test

## Validation
- python scripts/validate_skill_contract.py
- python -m pytest skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py -q -o addopts=''
- python -m ruff check skills/ingestion/ingest-cloudtrail-ocsf/tests/test_ingest.py --config pyproject.toml