### PR TITLE
docs: clarify agent-first invocation and flagship flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,53 @@ Each shipped skill is a bundle:
 The Python file is the execution core. The full skill that agents use is the
 whole bundle.
 
-Why the README shows `python skills/.../src/<entry>.py`:
+### Agent or MCP path first
+
+The normal agent-facing integration path is the skill name through MCP, not a
+raw `python .../src/<entry>.py` call.
+
+For the Kubernetes example, an MCP client calls the skill bundle like this:
+
+```text
+tools/call name="ingest-k8s-audit-ocsf"
+arguments={
+  "args":["skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl"],
+  "output_format":"ocsf"
+}
+
+tools/call name="detect-privilege-escalation-k8s"
+arguments={
+  "input":"<stdout from ingest-k8s-audit-ocsf>",
+  "output_format":"ocsf"
+}
+
+tools/call name="convert-ocsf-to-sarif"
+arguments={
+  "input":"<stdout from detect-privilege-escalation-k8s>"
+}
+```
+
+That is the skill-level contract agents use today:
+
+- skill name from `SKILL.md`
+- `input`, `args`, and optional `output_format`
+- routing and guardrails from the skill bundle
+- the same runtime core underneath
+
+### Direct execution core
+
+The direct Python path is still shown because it is the wrapper-free execution
+surface the MCP server, CI, and runners call under the hood.
+
+Why the README still shows `python skills/.../src/<entry>.py`:
 
 - that is the direct execution path for the skill implementation
 - MCP, CI, and runners call the same skill code
 - agent clients add the `SKILL.md` contract, routing hints, and guardrails on top
 - the wrapper changes the access path, not the underlying skill implementation
 
-Start with the bundled Kubernetes audit fixture and generate SARIF in one shot:
+If you want the same flow without MCP, start with the bundled Kubernetes audit
+fixture and generate SARIF in one shot:
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
@@ -112,7 +151,8 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
   > findings.native.jsonl
 ```
 
-### Real input and output
+<details>
+<summary><b>Real input and output</b></summary>
 
 Input fixture line, abbreviated:
 
@@ -143,6 +183,8 @@ Native finding output, abbreviated:
 ```json
 {"schema_mode":"native","record_type":"detection_finding","title":"Service account enumerated and read a Kubernetes secret"}
 ```
+
+</details>
 
 ### Same skill, different access path
 
@@ -183,6 +225,29 @@ The diagram shows the flagship write path only: source events feed a guarded
 planner/worker flow, the reconciler writes an S3 manifest, EventBridge starts
 the Step Function, human approval gates the write edge, and the final action
 trail lands in both operational storage and durable audit outputs.
+
+Important accuracy notes:
+
+- rehire and primary eligibility logic happen in the reconciler/export path before actionable entries are written to the S3 manifest
+- the parser Lambda is a second safety gate that rechecks manifest validity, grace period, and current IAM state before the worker runs
+- EventBridge, Step Function, parser Lambda, and worker Lambda each use separate execution roles
+- the flagship orchestration is AWS-native on purpose; equivalent GCP and Azure workflows should keep the same control contract but use native event and orchestration services for those clouds
+
+## End-to-End Skill Flows
+
+The flagship remediation path is one family. The repo also ships standard
+end-to-end read paths across raw logs, warehouses, and live APIs.
+
+![End-to-end skill compositions showing raw logs through ingest and detection, warehouse rows through source and sink, and live discovery or evaluation through native outputs and optional guarded remediation.](docs/images/end-to-end-skill-flows.svg)
+
+Use this as the quick mental model:
+
+- raw logs:
+  - `ingest-* -> detect-* -> view/*`
+- warehouse or object rows:
+  - `source-* -> detect-* -> sink-*`
+- live cloud or SaaS state:
+  - `discover-*` or `evaluation/*`, with optional guarded `remediation/*` on approved write paths
 
 ## Trust, Security, And Supply Chain
 

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -38,6 +38,7 @@ Short rule:
 
 - these are agent-usable skills
 - they are not agent-only skills
+- the normal agent path is MCP tool calling by skill name
 - the direct Python entrypoint is the clearest wrapper-free execution example
 - the full skill contract still lives in the bundle, not just the script file
 
@@ -132,7 +133,7 @@ Short rule:
 |---|---|---|
 | CLI | local runs, fixtures, one-shot pipelines | every shipped skill remains a direct script entrypoint |
 | CI | regression tests, policy checks, exports | the same skills run inside workflows; CI adds validation and release controls |
-| MCP | local agent tooling | the wrapper exposes the same skill contracts; it does not create a second implementation |
+| MCP | local agent tooling | agents call skill names with `input`, `args`, and optional `output_format`; the wrapper exposes the same skill contracts and does not create a second implementation |
 | Runner template | event-driven, queue-backed, scheduled processing | the repo ships concrete AWS, GCP, and Azure templates, but not a universal managed control plane |
 | Query pack | warehouse-native detection | currently partial shipping, not every detection exists as a SQL pack |
 | Sink | durable persistence edge | persistence is explicit and separate from pure detection logic |
@@ -196,6 +197,13 @@ Expected posture:
 - separate principals for read, detect, sink, and remediation roles where possible
 - checkpointing, dedupe, and bounded concurrency
 - append-only audit where feasible
+
+Cross-cloud note:
+
+- keep the skill contract the same across clouds
+- do not force AWS EventBridge or Step Functions semantics onto GCP or Azure
+- use native services per cloud for triggers, orchestration, and durable state
+- same guardrails, different orchestration substrate
 
 ## Example Paths
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -32,6 +32,23 @@ Important clarification:
 - agent clients call those same skill bundles through MCP or other wrappers
 - agents do not require a separate implementation model to use them
 
+## What an agent actually calls
+
+The MCP wrapper exposes the skill by skill name and passes only the bounded
+runtime inputs the wrapper supports:
+
+- `args` for explicit CLI-style arguments
+- `input` for stdin payloads such as JSON or JSONL
+- `output_format` when the skill supports multiple output modes
+
+So an agent is not expected to invoke `python skills/.../src/detect.py`
+directly. The normal path is:
+
+1. read the skill bundle for routing and guardrails
+2. call `tools/call name="<skill-name>"`
+3. pass `args`, `input`, and optional `output_format`
+4. let the MCP wrapper execute the real entrypoint underneath
+
 ## Client quick map
 
 | Tool | Best integration path | What to rely on |

--- a/docs/images/iam-departures-architecture.svg
+++ b/docs/images/iam-departures-architecture.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 520" role="img" aria-label="IAM Departures Remediation — closed-loop, event-driven pipeline architecture">
   <title>IAM Departures Remediation — closed-loop event-driven pipeline</title>
-  <desc>Six numbered stages across two deployment domains: HR sources and Reconciler inside the AWS Corporate Security OU, then an S3 manifest plus EventBridge trigger into Parser and Worker Lambdas inside a VPC-isolated Step Function, then five cloud targets and a dual-write audit trail. A dashed verification loop runs from the audit back to the reconciler for drift detection.</desc>
+  <desc>Six numbered stages across two deployment domains: HR sources and a rehire-aware reconciler inside the AWS Corporate Security OU, then an S3 manifest plus EventBridge trigger into Parser and Worker Lambdas inside a VPC-isolated Step Function, then five cloud targets and a dual-write audit trail. A dashed verification loop runs from the audit back to the reconciler for drift detection.</desc>
 
   <defs>
     <!-- Canvas background -->
@@ -132,7 +132,7 @@
     <text x="262" y="184" class="step-n" fill="#22d3ee">2</text>
     <text x="286" y="186" class="box-t">Reconciler</text>
     <text x="258" y="216" class="box-b">SHA-256 row diff</text>
-    <text x="258" y="234" class="box-b">→ S3 manifest (KMS)</text>
+    <text x="258" y="234" class="box-b">rehire-aware → S3 manifest</text>
     <text x="258" y="282" class="box-i">schedule + EventBridge handoff</text>
   </g>
 
@@ -152,8 +152,8 @@
     <circle cx="482" cy="180" r="14" fill="#0b1120" stroke="#3b82f6" stroke-width="1.5"/>
     <text x="482" y="184" class="step-n" fill="#60a5fa">3</text>
     <text x="506" y="186" class="box-t">Parser λ</text>
-    <text x="478" y="216" class="box-b">validate · grace</text>
-    <text x="478" y="234" class="box-b">rehire filter</text>
+    <text x="478" y="216" class="box-b">validate manifest</text>
+    <text x="478" y="234" class="box-b">recheck grace + IAM</text>
     <text x="478" y="282" class="box-i">read-only</text>
   </g>
 

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -50,7 +50,8 @@ metadata:
 # IAM Departures Remediation
 
 Automated IAM cleanup for departed employees with rehire-safe logic, change-driven
-exports, and a 2-Lambda Step Function remediation pipeline.
+exports, and an AWS-native EventBridge -> Step Function -> 2-Lambda remediation
+pipeline.
 
 Read [reference.md](reference.md) for detailed architecture, framework mappings,
 IAM role ARN definitions, and security model. Read [examples.md](examples.md)
@@ -69,13 +70,13 @@ for deployment walkthroughs and usage scenarios.
 ```mermaid
 flowchart TD
     HR["HR Source<br/>Workday / Snowflake / Databricks / ClickHouse"]
-    REC{"Reconciler<br/>SHA-256 change detect"}
+    REC{"Reconciler<br/>rehire-aware SHA-256 change detect"}
     EXIT["EXIT — no changes"]
     S3["S3 Manifest<br/>KMS · versioned<br/>EventBridge enabled"]
     EB["EventBridge Rule<br/>Object Created<br/>prefix departures/"]
 
     subgraph SFN["Step Function — VPC isolated"]
-        L1["Lambda 1 — Parser<br/>validate, grace period,<br/>rehire filter"]
+        L1["Lambda 1 — Parser<br/>validate manifest,<br/>recheck grace + IAM state"]
         L2["Lambda 2 — Worker<br/>13-step IAM cleanup"]
     end
 
@@ -109,7 +110,7 @@ flowchart TD
 - **Dry-run first**: use the parser and cross-cloud worker dry-run paths before any real execution. Planning, examples, and validation should never start with a destructive path.
 - **Deny policies**: Root, `break-glass-*`, and `emergency-*` accounts are protected by explicit IAM deny — the pipeline cannot touch them.
 - **Grace period**: 7-day default window before remediation (configurable). HR corrections within this window prevent accidental deletion.
-- **Rehire safety**: 8 scenarios handled. Active employees with same IAM are always skipped.
+- **Rehire safety**: 8 scenarios handled. The reconciler/export path applies the primary rehire-aware `should_remediate()` filter before writing the S3 manifest; the parser Lambda rechecks before worker execution.
 - **Cross-account scoped**: STS AssumeRole limited by `aws:PrincipalOrgID` condition — cannot escape the AWS Organization.
 - **Encryption**: S3 manifests KMS-encrypted. DynamoDB encryption at rest. Lambda env vars encrypted.
 - **VPC isolation**: Both Lambdas run in VPC with no public internet (NAT gateway for AWS API calls only).
@@ -134,6 +135,9 @@ The pipeline handles 8 rehire scenarios. Key rules:
 
 See `src/reconciler/sources.py:DepartureRecord.should_remediate()` for the
 complete decision tree.
+
+The parser Lambda is intentionally a second safety gate, not the first place
+rehire decisions are made.
 
 ## IAM Deletion Order
 
@@ -170,6 +174,19 @@ for deployable templates.
 | Cross-Account | `iam-remediation-role` | IAM read/write in target accounts (StackSets) |
 | DLQ | `iam-departures-dlq` (SQS) | Captures Lambda async failures for replay (KMS encrypted) |
 | Alerts | `iam-departures-alerts` (SNS) | EventBridge fires on `Step Functions Execution Status Change` for `FAILED` / `TIMED_OUT` / `ABORTED` |
+
+## Cross-cloud workflow shape
+
+The shipped flagship control plane is AWS-native:
+
+- reconciler writes the actionable manifest to S3
+- EventBridge starts the Step Function
+- the Step Function invokes parser and worker Lambdas
+- audit artifacts land in DynamoDB + S3 and then ingest back into the warehouse
+
+Equivalent GCP or Azure workflows should keep the same guardrails and skill
+contract, but use native services for those clouds rather than pretending one
+orchestration stack fits every provider.
 
 ## Data Sources
 

--- a/skills/remediation/iam-departures-remediation/reference.md
+++ b/skills/remediation/iam-departures-remediation/reference.md
@@ -21,6 +21,15 @@ and cross-cloud roadmap.
 ## Architecture Diagram
 
 ```
+
+Cross-cloud note:
+
+- the shipped flagship workflow is AWS-native because the current remediation
+  control plane is deployed in AWS
+- keep the approval model, manifest contract, and audit semantics consistent
+  across clouds
+- use native orchestration services per cloud instead of forcing AWS
+  EventBridge or Step Functions semantics onto GCP or Azure
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                    AWS Organization — Security OU Account                    │
 │                                                                             │
@@ -38,7 +47,7 @@ and cross-cloud roadmap.
 │  │                                                                    │    │
 │  │  sources.py ─→ DepartureRecord[]                                   │    │
 │  │      │              │                                              │    │
-│  │      │         should_remediate()                                  │    │
+│  │      │   should_remediate() + rehire/grace handling                │    │
 │  │      │              │                                              │    │
 │  │      ▼              ▼                                              │    │
 │  │  change_detect.py ─── SHA-256 hash ─── changed? ──no──→ EXIT      │    │
@@ -79,9 +88,9 @@ and cross-cloud roadmap.
 │  │  │                                                          │      │    │
 │  │  │  1. Read S3 manifest                                     │      │    │
 │  │  │  2. Validate required fields (email, account_id, iam)    │      │    │
-│  │  │  3. Check grace period (IAM_GRACE_PERIOD_DAYS, def: 7)   │      │    │
-│  │  │  4. Filter rehires (same-IAM vs orphaned)                │      │    │
-│  │  │  5. Filter already-deleted IAMs                          │      │    │
+│  │  │  3. Recheck grace period (IAM_GRACE_PERIOD_DAYS, def: 7) │      │    │
+│  │  │  4. Revalidate manifest vs current IAM state             │      │    │
+│  │  │  5. Filter already-deleted or now-invalid IAMs          │      │    │
 │  │  │  6. STS AssumeRole → iam:GetUser (verify exists)         │      │    │
 │  │  │  Output: validated_entries[]                              │      │    │
 │  │  └────────────────────┬─────────────────────────────────────┘      │    │


### PR DESCRIPTION
## Summary
- clarify that agents call skill bundles by skill name through MCP and that direct Python is the execution core underneath
- correct the IAM departures flagship docs to show rehire filtering in the reconciler/export path and AWS-native EventBridge -> Step Function orchestration
- surface the end-to-end skill-flow visual in the README so the main page shows real shipped compositions

## Validation
- python scripts/validate_skill_contract.py