### PR TITLE
docs: simplify flagship remediation visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,16 @@ planner/worker flow, the reconciler writes an S3 manifest, EventBridge starts
 the Step Function, human approval gates the write edge, and the final action
 trail lands in both operational storage and durable audit outputs.
 
+The artwork is intentionally staged into:
+
+- actionable selection
+- guarded orchestration
+- scoped writes
+- dual audit and drift verification
+
+The detailed examples, failure notes, and role tables stay in markdown so the
+visual stays readable in GitHub preview.
+
 Important accuracy notes:
 
 - rehire and primary eligibility logic happen in the reconciler/export path before actionable entries are written to the S3 manifest

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -27,7 +27,7 @@ review, and PR discussions where opening the SVG is inconvenient.
 - `runtime-surfaces.svg`
   - Shows that CLI, CI, MCP, and persistent runners are access paths around the same skill bundle and execution core rather than separate implementations.
 - `iam-departures-architecture.svg`
-  - Shows the flagship write path: HR/IdP inputs, guarded orchestration, human approval, worker actions, and dual audit writes for reconciliation.
+  - Shows the flagship write path in four stages: actionable-set selection, guarded orchestration, scoped target writes, and dual audit with drift verification.
 - `repo-architecture.svg`
   - Shows the six shipped skill layers plus the surrounding source, sink, query-pack, and runtime surfaces that compose around them.
 - `iam-departures-data-flow.svg`

--- a/docs/images/iam-departures-architecture.svg
+++ b/docs/images/iam-departures-architecture.svg
@@ -1,229 +1,94 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 520" role="img" aria-label="IAM Departures Remediation — closed-loop, event-driven pipeline architecture">
-  <title>IAM Departures Remediation — closed-loop event-driven pipeline</title>
-  <desc>Six numbered stages across two deployment domains: HR sources and a rehire-aware reconciler inside the AWS Corporate Security OU, then an S3 manifest plus EventBridge trigger into Parser and Worker Lambdas inside a VPC-isolated Step Function, then five cloud targets and a dual-write audit trail. A dashed verification loop runs from the audit back to the reconciler for drift detection.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="940" viewBox="0 0 1480 940" role="img" aria-labelledby="title desc">
+  <title id="title">IAM departures remediation</title>
+  <desc id="desc">The flagship guarded write path. HR systems feed a reconciler that filters rehires and grace-period exceptions before writing an S3 manifest. EventBridge starts a Step Function that invokes parser and worker Lambdas with separate execution roles. The workflow applies scoped changes to AWS, Entra, GCP, Snowflake, and Databricks, then dual-writes audit records to DynamoDB and S3 with ingest-back to the warehouse and a later drift-verification loop.</desc>
+  <rect width="1480" height="940" fill="#08111f"/>
+  <rect x="24" y="24" width="1432" height="892" rx="32" fill="#0f172a" stroke="#334155"/>
 
-  <defs>
-    <!-- Canvas background -->
-    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0"   stop-color="#0b1120"/>
-      <stop offset="1"   stop-color="#050814"/>
-    </linearGradient>
+  <g font-family="Arial, sans-serif">
+    <text x="64" y="86" fill="#f8fafc" font-size="40" font-weight="700">IAM departures remediation</text>
+    <text x="64" y="122" fill="#94a3b8" font-size="21">Flagship guarded write path. One closed-loop workflow with staged filters, separate roles, and dual audit.</text>
 
-    <!-- Box gradients by subsystem -->
-    <linearGradient id="gCorp" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#155e75"/>
-      <stop offset="1" stop-color="#0c3947"/>
-    </linearGradient>
-    <linearGradient id="gVpc" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#1e3a8a"/>
-      <stop offset="1" stop-color="#0f1f4d"/>
-    </linearGradient>
-    <linearGradient id="gTgt" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#1e3a5f"/>
-      <stop offset="1" stop-color="#0e1f3a"/>
-    </linearGradient>
-    <linearGradient id="gAudit" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#4338ca"/>
-      <stop offset="1" stop-color="#1e1b4b"/>
-    </linearGradient>
+    <rect x="64" y="150" width="1352" height="70" rx="18" fill="#111c34" stroke="#475569"/>
+    <text x="94" y="193" fill="#cbd5e1" font-size="20" font-weight="700">Execution roles:</text>
+    <text x="266" y="193" fill="#e2e8f0" font-size="19">EventBridge</text>
+    <text x="372" y="193" fill="#38bdf8" font-size="19">•</text>
+    <text x="395" y="193" fill="#e2e8f0" font-size="19">Step Function</text>
+    <text x="529" y="193" fill="#38bdf8" font-size="19">•</text>
+    <text x="552" y="193" fill="#e2e8f0" font-size="19">parser Lambda</text>
+    <text x="686" y="193" fill="#38bdf8" font-size="19">•</text>
+    <text x="709" y="193" fill="#e2e8f0" font-size="19">worker Lambda</text>
+    <text x="847" y="193" fill="#38bdf8" font-size="19">•</text>
+    <text x="870" y="193" fill="#e2e8f0" font-size="19">cross-account remediation role</text>
 
-    <!-- Arrow markers -->
-    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 12 6 L 0 12 z" fill="#60a5fa"/>
-    </marker>
-    <marker id="arrowDrift" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 12 6 L 0 12 z" fill="#22d3ee"/>
-    </marker>
+    <rect x="64" y="252" width="1352" height="248" rx="28" fill="#0b2538" stroke="#22d3ee"/>
+    <text x="92" y="296" fill="#ccfbf1" font-size="30" font-weight="700">1. Select and export the actionable set</text>
+    <text x="92" y="330" fill="#e2e8f0" font-size="18">The reconciler is the first control point. Rehire and eligibility logic happen here before anything is written to S3.</text>
 
-    <!-- Drop shadow -->
-    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
-      <feOffset dx="0" dy="3" result="blur"/>
-      <feComponentTransfer>
-        <feFuncA type="linear" slope="0.55"/>
-      </feComponentTransfer>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
+    <text x="92" y="372" fill="#67e8f9" font-size="18" font-weight="700">Inputs</text>
+    <rect x="92" y="388" width="238" height="88" rx="18" fill="#13253f" stroke="#22d3ee"/>
+    <text x="126" y="430" fill="#f8fafc" font-size="24" font-weight="700">HR sources</text>
+    <text x="126" y="454" fill="#cbd5e1" font-size="16">Workday, Snowflake, Databricks, ClickHouse</text>
 
-    <!-- Reusable text styles via class selectors live in a style block -->
-    <style>
-      .ttl    { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif; }
-      .h1     { font-size: 22px; font-weight: 700; fill: #e2e8f0; }
-      .h2     { font-size: 13px; fill: #94a3b8; }
-      .group  { font-size: 11px; font-weight: 600; fill: #94a3b8; letter-spacing: 1.8px; }
-      .box-t  { font-size: 15px; font-weight: 600; fill: #e2e8f0; }
-      .box-b  { font-size: 11px; fill: #cbd5e1; }
-      .box-i  { font-size: 10px; fill: #64748b; font-style: italic; }
-      .mini   { font-size: 9px; fill: #cbd5e1; }
-      .mini-t { font-size: 10px; font-weight: 600; fill: #e2e8f0; }
-      .step-n { font-size: 11px; font-weight: 700; text-anchor: middle; }
-      .drift  { font-size: 11px; fill: #22d3ee; font-style: italic; }
-      .foot   { font-size: 10px; fill: #475569; }
-    </style>
-  
-    <!-- ─── Vendor icons (Simple Icons v13, CC0) + generic HR glyph ─── -->
-    <symbol id="icon-aws" viewBox="0 0 24 24">
-      <path d="M6.763 10.036c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 0 1-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 0 1-.287-.375 6.18 6.18 0 0 1-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.391-.384-.59-.894-.59-1.533 0-.678.239-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.287 2.287 0 0 1-.28.104.488.488 0 0 1-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 0 1 .224-.167c.279-.144.614-.264 1.005-.36a4.84 4.84 0 0 1 1.246-.151c.95 0 1.644.216 2.091.647.439.43.662 1.085.662 1.963v2.586zm-3.24 1.214c.263 0 .534-.048.822-.144.287-.096.543-.271.758-.51.128-.152.224-.32.272-.512.047-.191.08-.423.08-.694v-.335a6.66 6.66 0 0 0-.735-.136 6.02 6.02 0 0 0-.75-.048c-.535 0-.926.104-1.19.32-.263.215-.39.518-.39.917 0 .375.095.655.295.846.191.2.47.296.838.296zm6.41.862c-.144 0-.24-.024-.304-.08-.064-.048-.12-.16-.168-.311L7.586 5.55a1.398 1.398 0 0 1-.072-.32c0-.128.064-.2.191-.2h.783c.151 0 .255.025.31.08.065.048.113.16.16.312l1.342 5.284 1.245-5.284c.04-.16.088-.264.151-.312a.549.549 0 0 1 .32-.08h.638c.152 0 .256.025.32.08.063.048.12.16.151.312l1.261 5.348 1.381-5.348c.048-.16.104-.264.16-.312a.52.52 0 0 1 .311-.08h.743c.127 0 .2.065.2.2 0 .04-.009.08-.017.128a1.137 1.137 0 0 1-.056.2l-1.923 6.17c-.048.16-.104.263-.168.311a.51.51 0 0 1-.303.08h-.687c-.151 0-.255-.024-.32-.08-.063-.056-.119-.16-.15-.32l-1.238-5.148-1.23 5.14c-.04.16-.087.264-.15.32-.065.056-.177.08-.32.08zm10.256.215c-.415 0-.83-.048-1.229-.143-.399-.096-.71-.2-.918-.32-.128-.071-.215-.151-.247-.223a.563.563 0 0 1-.048-.224v-.407c0-.167.064-.247.183-.247.048 0 .096.008.144.024.048.016.12.048.2.08.271.12.566.215.878.279.319.064.63.096.95.096.502 0 .894-.088 1.165-.264a.86.86 0 0 0 .415-.758.777.777 0 0 0-.215-.559c-.144-.151-.416-.287-.807-.415l-1.157-.36c-.583-.183-1.014-.454-1.277-.813a1.902 1.902 0 0 1-.4-1.158c0-.335.073-.63.216-.886.144-.255.335-.479.575-.654.24-.184.51-.32.83-.415.32-.096.655-.136 1.006-.136.175 0 .359.008.535.032.183.024.35.056.518.088.16.04.312.08.455.127.144.048.256.096.336.144a.69.69 0 0 1 .24.2.43.43 0 0 1 .071.263v.375c0 .168-.064.256-.184.256a.83.83 0 0 1-.303-.096 3.652 3.652 0 0 0-1.532-.311c-.455 0-.815.071-1.062.223-.248.152-.375.383-.375.71 0 .224.08.416.24.567.159.152.454.304.877.44l1.134.358c.574.184.99.44 1.237.767.247.327.367.702.367 1.117 0 .343-.072.655-.207.926-.144.272-.336.511-.583.703-.248.2-.543.343-.886.447-.36.111-.734.167-1.142.167zM21.698 16.207c-2.626 1.94-6.442 2.969-9.722 2.969-4.598 0-8.74-1.7-11.87-4.526-.247-.223-.024-.527.272-.351 3.384 1.963 7.559 3.153 11.877 3.153 2.914 0 6.114-.607 9.06-1.852.439-.2.814.287.383.607zM22.792 14.961c-.336-.43-2.22-.207-3.074-.103-.255.032-.295-.192-.063-.36 1.5-1.053 3.967-.75 4.254-.399.287.36-.08 2.826-1.485 4.007-.215.184-.423.088-.327-.151.32-.79 1.03-2.57.695-2.994z"/>
-    </symbol>
-    <symbol id="icon-azure" viewBox="0 0 24 24">
-      <path d="M22.379 23.343a1.62 1.62 0 0 0 1.536-2.14v.002L17.35 1.76A1.62 1.62 0 0 0 15.816.657H8.184A1.62 1.62 0 0 0 6.65 1.76L.086 21.204a1.62 1.62 0 0 0 1.536 2.139h4.741a1.62 1.62 0 0 0 1.535-1.103l.977-2.892 4.947 3.675c.28.208.618.32.966.32m-3.084-12.531 3.624 10.739a.54.54 0 0 1-.51.713v-.001h-.03a.54.54 0 0 1-.322-.106l-9.287-6.9h4.853m6.313 7.006c.116-.326.13-.694.007-1.058L9.79 1.76a1.722 1.722 0 0 0-.007-.02h6.034a.54.54 0 0 1 .512.366l6.562 19.445a.54.54 0 0 1-.338.684"/>
-    </symbol>
-    <symbol id="icon-gcp" viewBox="0 0 24 24">
-      <path d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38zm-.358 4.146c1.244-.04 2.518.368 3.486 1.15a5.186 5.186 0 0 1 1.862 4.078v.518c3.53-.07 3.53 5.262 0 5.193h-5.193l-.008.009v-.04H6.785a2.59 2.59 0 0 1-1.067-.23h.001a2.597 2.597 0 1 1 3.437-3.437l3.013-3.012A6.747 6.747 0 0 0 8.11 8.24c.018-.01.04-.026.054-.023a5.186 5.186 0 0 1 3.67-1.69z"/>
-    </symbol>
-    <symbol id="icon-snowflake" viewBox="0 0 24 24">
-      <path d="M24 3.459c0 .646-.418 1.18-1.141 1.18-.723 0-1.142-.534-1.142-1.18 0-.647.419-1.18 1.142-1.18.723 0 1.141.533 1.141 1.18zm-.228 0c0-.533-.38-.951-.913-.951s-.913.38-.913.95c0 .533.38.952.913.952.57 0 .913-.419.913-.951zm-1.37-.533h.495c.266 0 .456.152.456.38 0 .153-.076.229-.19.305l.19.266v.038h-.266l-.19-.266h-.229v.266h-.266zm.495.228h-.229v.267h.229c.114 0 .152-.038.152-.114.038-.077-.038-.153-.152-.153zM7.602 12.4c.038-.151.076-.304.076-.456 0-.114-.038-.228-.038-.342-.114-.343-.304-.647-.646-.838l-4.87-2.777c-.685-.38-1.56-.152-1.94.533-.381.685-.153 1.56.532 1.94l2.701 1.56-2.701 1.56c-.685.38-.913 1.256-.533 1.94.38.685 1.256.914 1.94.533l4.832-2.777c.343-.267.571-.533.647-.876zm1.332 2.626c-.266-.038-.57.038-.837.19l-4.832 2.777c-.685.38-.913 1.256-.532 1.94.38.686 1.255.914 1.94.533l2.701-1.56v3.12c0 .8.647 1.408 1.446 1.408.799 0 1.407-.647 1.407-1.408v-5.592c0-.761-.57-1.37-1.293-1.408zm4.946-6.088c.266.038.57-.038.837-.19l4.832-2.777c.685-.38.913-1.256.532-1.94-.38-.686-1.255-.914-1.94-.533l-2.701 1.56V1.975c0-.799-.647-1.408-1.446-1.408-.799 0-1.446.609-1.446 1.408V7.53c0 .76.609 1.37 1.332 1.407zM3.265 5.97l4.832 2.777c.266.152.533.19.837.19.723-.038 1.331-.684 1.331-1.407V1.975c0-.799-.646-1.408-1.407-1.408-.799 0-1.446.647-1.446 1.408v3.12l-2.701-1.56c-.685-.38-1.56-.152-1.94.533-.419.646-.19 1.521.494 1.902zm9.093 6.011a.412.412 0 00-.114-.266l-.57-.571a.346.346 0 00-.267-.114.412.412 0 00-.266.114l-.571.57a.411.411 0 00-.114.267c0 .076.038.19.114.267l.57.57a.345.345 0 00.267.114c.076 0 .19-.038.266-.114l.571-.57a.412.412 0 00.114-.267zm1.598.533L11.94 14.53c-.039.038-.153.114-.229.114h-.608a.411.411 0 01-.267-.114L8.82 12.514a.408.408 0 01-.076-.229v-.608c0-.076.038-.19.114-.267l2.016-2.016a.41.41 0 01.267-.114h.608a.41.41 0 01.267.114l2.016 2.016a.347.347 0 01.114.267v.608c-.076.077-.114.19-.19.229zm5.593 5.44l-4.832-2.777c-.266-.152-.57-.19-.837-.152-.723.038-1.332.684-1.332 1.408v5.554c0 .8.647 1.408 1.408 1.408.799 0 1.446-.647 1.446-1.408v-3.12l2.7 1.56c.686.38 1.561.152 1.941-.533.419-.646.19-1.521-.494-1.94zm2.549-7.533l-2.701 1.56 2.7 1.56c.686.38.914 1.256.533 1.94-.38.685-1.255.913-1.94.533l-4.832-2.778a1.644 1.644 0 01-.647-.798c-.037-.153-.076-.305-.076-.457 0-.114.039-.228.039-.342.114-.343.342-.647.646-.837l4.832-2.778c.685-.38 1.56-.152 1.94.533.457.609.19 1.484-.494 1.864"/>
-    </symbol>
-    <symbol id="icon-databricks" viewBox="0 0 24 24">
-      <path d="M.95 14.184L12 20.403l9.919-5.55v2.21L12 22.662l-10.484-5.96-.565.308v.77L12 24l11.05-6.218v-4.317l-.515-.309L12 19.118l-9.867-5.653v-2.21L12 16.805l11.05-6.218V6.32l-.515-.308L12 11.974 2.647 6.681 12 1.388l7.76 4.368.668-.411v-.566L12 0 .95 6.27v.72L12 13.207l9.919-5.55v2.26L12 15.52 1.516 9.56l-.565.308Z"/>
-    </symbol>
-    <symbol id="icon-clickhouse" viewBox="0 0 24 24">
-      <path d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z"/>
-    </symbol>
-    <symbol id="icon-workday" viewBox="0 0 24 24">
-      <path d="M12 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8zm0 10c4.42 0 8 2.69 8 6v2H4v-2c0-3.31 3.58-6 8-6z"/>
-    </symbol>
-  </defs>
+    <text x="380" y="372" fill="#67e8f9" font-size="18" font-weight="700">Control</text>
+    <rect x="380" y="388" width="270" height="88" rx="18" fill="#155e75" stroke="#67e8f9"/>
+    <text x="418" y="430" fill="#ecfeff" font-size="24" font-weight="700">reconciler</text>
+    <text x="418" y="454" fill="#cbd5e1" font-size="16">SHA-256 row diff, rehire filter, grace check</text>
 
-  <!-- ─── Background ───────────────────────────────────────── -->
-  <rect width="1240" height="520" fill="url(#bg)"/>
+    <text x="700" y="372" fill="#67e8f9" font-size="18" font-weight="700">Manifest</text>
+    <rect x="700" y="388" width="248" height="88" rx="18" fill="#13253f" stroke="#38bdf8"/>
+    <text x="734" y="430" fill="#f8fafc" font-size="24" font-weight="700">S3 manifest</text>
+    <text x="734" y="454" fill="#cbd5e1" font-size="16">KMS-encrypted actionable export only</text>
 
-  <!-- ─── Title ────────────────────────────────────────────── -->
-  <g class="ttl">
-    <text x="620" y="42" text-anchor="middle" class="h1">IAM Departures Remediation</text>
-    <text x="620" y="68" text-anchor="middle" class="h2">Closed-loop, event-driven pipeline — HR change → cloud deactivation → audit → verify</text>
-  </g>
+    <text x="998" y="372" fill="#67e8f9" font-size="18" font-weight="700">Trigger</text>
+    <rect x="998" y="388" width="288" height="88" rx="18" fill="#13253f" stroke="#60a5fa"/>
+    <text x="1034" y="430" fill="#f8fafc" font-size="24" font-weight="700">EventBridge rule</text>
+    <text x="1034" y="454" fill="#cbd5e1" font-size="16">Object-created event starts the Step Function</text>
 
-  <!-- ─── Subsystem groups (drawn behind boxes) ───────────── -->
-  <g class="ttl">
-    <rect x="20"  y="100" width="400" height="260" rx="14" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="4 5"/>
-    <text x="220" y="126" text-anchor="middle" class="group">AWS CORPORATE  ·  SECURITY OU</text>
+    <path d="M330 432 L380 432" stroke="#38bdf8" stroke-width="5" fill="none"/>
+    <path d="M650 432 L700 432" stroke="#67e8f9" stroke-width="5" fill="none"/>
+    <path d="M948 432 L998 432" stroke="#60a5fa" stroke-width="5" fill="none"/>
 
-    <rect x="440" y="100" width="400" height="260" rx="14" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="4 5"/>
-    <text x="640" y="126" text-anchor="middle" class="group">VPC-ISOLATED  ·  STEP FUNCTION</text>
-  </g>
+    <text x="92" y="528" fill="#22d3ee" font-size="16" font-weight="700">Guardrail:</text>
+    <text x="188" y="528" fill="#cbd5e1" font-size="16">no direct Step Function entry, no rehire decisions in the worker, no action rows written for filtered identities</text>
 
-  <!-- ─── Station 1 : HR sources ──────────────────────────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="40" y="160" width="160" height="140" rx="10" fill="url(#gCorp)" stroke="#22d3ee" stroke-width="1.5"/>
-    <circle cx="62" cy="180" r="14" fill="#0b1120" stroke="#22d3ee" stroke-width="1.5"/>
-    <text x="62" y="184" class="step-n" fill="#22d3ee">1</text>
-    <text x="86" y="186" class="box-t">HR sources</text>
-    <!-- vendor icons: Simple Icons v13 (CC0) + generic HR glyph for Workday -->
-    <use href="#icon-workday"   x="52" y="205" width="12" height="12" fill="#F38B00"/>
-    <text x="70" y="215" class="box-b">Workday</text>
-    <use href="#icon-snowflake" x="52" y="221" width="12" height="12" fill="#29B5E8"/>
-    <text x="70" y="231" class="box-b">Snowflake</text>
-    <use href="#icon-databricks" x="52" y="237" width="12" height="12" fill="#FF3621"/>
-    <text x="70" y="247" class="box-b">Databricks</text>
-    <use href="#icon-clickhouse" x="52" y="253" width="12" height="12" fill="#FAFF69"/>
-    <text x="70" y="263" class="box-b">ClickHouse</text>
-    <text x="58" y="288" class="box-i">pull on schedule</text>
-  </g>
+    <rect x="64" y="532" width="1352" height="222" rx="28" fill="#10243a" stroke="#60a5fa"/>
+    <text x="92" y="576" fill="#dbeafe" font-size="30" font-weight="700">2. Guarded orchestration and scoped writes</text>
+    <text x="92" y="610" fill="#e2e8f0" font-size="18">The Step Function orchestrates a read-only parser gate and a scoped worker. Approval and deny rules bound the write edge.</text>
 
-  <!-- ─── Station 2 : Reconciler ──────────────────────────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="240" y="160" width="160" height="140" rx="10" fill="url(#gCorp)" stroke="#22d3ee" stroke-width="1.5"/>
-    <circle cx="262" cy="180" r="14" fill="#0b1120" stroke="#22d3ee" stroke-width="1.5"/>
-    <text x="262" y="184" class="step-n" fill="#22d3ee">2</text>
-    <text x="286" y="186" class="box-t">Reconciler</text>
-    <text x="258" y="216" class="box-b">SHA-256 row diff</text>
-    <text x="258" y="234" class="box-b">rehire-aware → S3 manifest</text>
-    <text x="258" y="282" class="box-i">schedule + EventBridge handoff</text>
-  </g>
+    <rect x="92" y="646" width="268" height="84" rx="18" fill="#1e3a8a" stroke="#93c5fd"/>
+    <text x="128" y="686" fill="#eff6ff" font-size="23" font-weight="700">Step Function</text>
+    <text x="128" y="710" fill="#cbd5e1" font-size="16">AWS-native orchestration, retries, bounded fan-out</text>
 
-  <!-- ─── Handoff details: S3 manifest + EventBridge ───────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="392" y="118" width="96" height="40" rx="9" fill="#111827" stroke="#22d3ee" stroke-width="1.2"/>
-    <text x="440" y="136" text-anchor="middle" class="mini-t">S3 manifest</text>
-    <text x="440" y="149" text-anchor="middle" class="mini">KMS object + row diff</text>
+    <rect x="412" y="646" width="248" height="84" rx="18" fill="#1e3a8a" stroke="#93c5fd"/>
+    <text x="452" y="686" fill="#eff6ff" font-size="23" font-weight="700">parser Lambda</text>
+    <text x="452" y="710" fill="#cbd5e1" font-size="16">rechecks manifest, grace period, and IAM state</text>
 
-    <rect x="410" y="246" width="126" height="34" rx="16" fill="#0b1120" stroke="#60a5fa" stroke-width="1.2"/>
-    <text x="473" y="267" text-anchor="middle" class="mini-t">EventBridge starts Step Function</text>
-  </g>
+    <rect x="712" y="646" width="248" height="84" rx="18" fill="#1e3a8a" stroke="#93c5fd"/>
+    <text x="752" y="686" fill="#eff6ff" font-size="23" font-weight="700">worker Lambda</text>
+    <text x="752" y="710" fill="#cbd5e1" font-size="16">13-step cleanup with scoped cross-cloud workers</text>
 
-  <!-- ─── Station 3 : Parser Lambda ───────────────────────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="460" y="160" width="160" height="140" rx="10" fill="url(#gVpc)" stroke="#3b82f6" stroke-width="1.5"/>
-    <circle cx="482" cy="180" r="14" fill="#0b1120" stroke="#3b82f6" stroke-width="1.5"/>
-    <text x="482" y="184" class="step-n" fill="#60a5fa">3</text>
-    <text x="506" y="186" class="box-t">Parser λ</text>
-    <text x="478" y="216" class="box-b">validate manifest</text>
-    <text x="478" y="234" class="box-b">recheck grace + IAM</text>
-    <text x="478" y="282" class="box-i">read-only</text>
-  </g>
+    <rect x="1012" y="646" width="312" height="84" rx="18" fill="#1e3a5f" stroke="#60a5fa"/>
+    <text x="1050" y="686" fill="#eff6ff" font-size="23" font-weight="700">targets</text>
+    <text x="1050" y="710" fill="#cbd5e1" font-size="16">AWS IAM, Entra ID, GCP IAM, Snowflake, Databricks</text>
 
-  <!-- ─── Station 4 : Worker Lambda ───────────────────────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="660" y="160" width="160" height="140" rx="10" fill="url(#gVpc)" stroke="#3b82f6" stroke-width="1.5"/>
-    <circle cx="682" cy="180" r="14" fill="#0b1120" stroke="#3b82f6" stroke-width="1.5"/>
-    <text x="682" y="184" class="step-n" fill="#60a5fa">4</text>
-    <text x="706" y="186" class="box-t">Worker λ</text>
-    <text x="678" y="216" class="box-b">13-step IAM cleanup</text>
-    <text x="678" y="234" class="box-b">map · parallel 10</text>
-    <text x="678" y="282" class="box-i">scoped write</text>
-  </g>
+    <path d="M360 688 L412 688" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M660 688 L712 688" stroke="#93c5fd" stroke-width="5" fill="none"/>
+    <path d="M960 688 L1012 688" stroke="#93c5fd" stroke-width="5" fill="none"/>
 
-  <!-- ─── Station 5 : Cloud targets ───────────────────────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="860" y="160" width="160" height="140" rx="10" fill="url(#gTgt)" stroke="#60a5fa" stroke-width="1.5"/>
-    <circle cx="882" cy="180" r="14" fill="#0b1120" stroke="#60a5fa" stroke-width="1.5"/>
-    <text x="882" y="184" class="step-n" fill="#60a5fa">5</text>
-    <text x="906" y="186" class="box-t">5 targets</text>
-    <!-- vendor icons: Simple Icons v13 (CC0) -->
-    <use href="#icon-aws"        x="872" y="205" width="12" height="12" fill="#FF9900"/>
-    <text x="890" y="215" class="box-b">AWS IAM</text>
-    <use href="#icon-azure"      x="872" y="221" width="12" height="12" fill="#00A4EF"/>
-    <text x="890" y="231" class="box-b">Entra ID</text>
-    <use href="#icon-gcp"        x="872" y="237" width="12" height="12" fill="#4285F4"/>
-    <text x="890" y="247" class="box-b">GCP IAM</text>
-    <use href="#icon-snowflake"  x="872" y="253" width="12" height="12" fill="#29B5E8"/>
-    <text x="890" y="263" class="box-b">Snowflake</text>
-    <use href="#icon-databricks" x="872" y="269" width="12" height="12" fill="#FF3621"/>
-    <text x="890" y="279" class="box-b">Databricks</text>
-    <text x="878" y="294" class="box-i">STS OrgID-scoped</text>
-  </g>
+    <text x="92" y="782" fill="#60a5fa" font-size="16" font-weight="700">Guardrail:</text>
+    <text x="188" y="782" fill="#cbd5e1" font-size="16">human_required approval, dry-run-first workflow, deny-listed identities, separate execution roles, scoped cloud principals</text>
 
-  <!-- ─── Station 6 : Audit trail ─────────────────────────── -->
-  <g filter="url(#shadow)" class="ttl">
-    <rect x="1040" y="160" width="160" height="140" rx="10" fill="url(#gAudit)" stroke="#a78bfa" stroke-width="1.5"/>
-    <circle cx="1062" cy="180" r="14" fill="#0b1120" stroke="#a78bfa" stroke-width="1.5"/>
-    <text x="1062" y="184" class="step-n" fill="#a78bfa">6</text>
-    <text x="1086" y="186" class="box-t">Audit</text>
-    <text x="1058" y="216" class="box-b">DynamoDB + S3</text>
-    <text x="1058" y="234" class="box-b">warehouse ingest</text>
-    <text x="1058" y="282" class="box-i">KMS · PITR</text>
-  </g>
+    <rect x="64" y="786" width="1352" height="104" rx="28" fill="#083344" stroke="#2dd4bf"/>
+    <text x="92" y="830" fill="#ccfbf1" font-size="30" font-weight="700">3. Dual audit, ingest-back, and drift verification</text>
+    <text x="92" y="864" fill="#e2e8f0" font-size="18">Every action lands in DynamoDB and S3, then flows back into warehouse analytics. Later runs verify that state really closed.</text>
 
-  <!-- ─── Forward flow arrows ─────────────────────────────── -->
-  <g>
-    <line x1="203" y1="230" x2="237" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
-    <line x1="403" y1="230" x2="457" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
-    <line x1="623" y1="230" x2="657" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
-    <line x1="823" y1="230" x2="857" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
-    <line x1="1023" y1="230" x2="1037" y2="230" stroke="#60a5fa" stroke-width="2.2" marker-end="url(#arrow)"/>
-    <line x1="400" y1="190" x2="430" y2="156" stroke="#22d3ee" stroke-width="1.8" stroke-dasharray="5 4"/>
-    <line x1="446" y1="158" x2="468" y2="244" stroke="#60a5fa" stroke-width="1.8" stroke-dasharray="5 4"/>
-    <line x1="536" y1="263" x2="560" y2="230" stroke="#60a5fa" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
-  </g>
-
-  <!-- ─── Drift verification loop ─────────────────────────── -->
-  <!-- Start at Audit bottom-center (1120, 300), curve down-left, end at Reconciler bottom-center (320, 300) -->
-  <path d="M 1120 300 C 1120 430, 320 430, 320 300"
-        fill="none" stroke="#22d3ee" stroke-width="2" stroke-dasharray="6 6" marker-end="url(#arrowDrift)"/>
-
-  <!-- Drift loop label (sits on the curve's lowest point ~y=397) -->
-  <g class="ttl">
-    <rect x="620" y="390" width="200" height="24" rx="12" fill="#0b1120" stroke="#22d3ee" stroke-width="1.2"/>
-    <text x="720" y="407" text-anchor="middle" class="drift">drift detected → re-run</text>
-  </g>
-
-  <!-- ─── Footer note ─────────────────────────────────────── -->
-  <g class="ttl">
-    <text x="620" y="480" text-anchor="middle" class="foot">Failure path (DLQ → SNS → on-call) and replay semantics documented in SKILL.md — omitted here for clarity</text>
+    <rect x="940" y="802" width="202" height="64" rx="18" fill="#312e81" stroke="#a78bfa"/>
+    <text x="976" y="840" fill="#eef2ff" font-size="22" font-weight="700">DynamoDB + S3</text>
+    <text x="976" y="860" fill="#cbd5e1" font-size="15">audit storage, KMS, PITR</text>
+    <rect x="1184" y="802" width="184" height="64" rx="18" fill="#13253f" stroke="#22d3ee"/>
+    <text x="1218" y="840" fill="#f8fafc" font-size="22" font-weight="700">ingest-back</text>
+    <text x="1218" y="860" fill="#cbd5e1" font-size="15">warehouse reconciliation</text>
+    <path d="M1324 834 C 1324 906, 220 906, 220 476" stroke="#22d3ee" stroke-width="4" stroke-dasharray="8 8" fill="none"/>
+    <text x="756" y="910" fill="#22d3ee" font-size="18" font-style="italic" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
   </g>
 </svg>

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -69,40 +69,42 @@ for deployment walkthroughs and usage scenarios.
 
 ```mermaid
 flowchart TD
-    HR["HR Source<br/>Workday / Snowflake / Databricks / ClickHouse"]
-    REC{"Reconciler<br/>rehire-aware SHA-256 change detect"}
-    EXIT["EXIT — no changes"]
-    S3["S3 Manifest<br/>KMS · versioned<br/>EventBridge enabled"]
-    EB["EventBridge Rule<br/>Object Created<br/>prefix departures/"]
+    HR["HR source<br/>Workday / Snowflake / Databricks / ClickHouse"]
+    REC["Reconciler<br/>rehire filter + grace check + SHA-256 diff"]
+    EXIT["No actionable change"]
+    S3["S3 manifest<br/>KMS-encrypted actionable set"]
+    EB["EventBridge rule"]
 
-    subgraph SFN["Step Function — VPC isolated"]
-        L1["Lambda 1 — Parser<br/>validate manifest,<br/>recheck grace + IAM state"]
-        L2["Lambda 2 — Worker<br/>13-step IAM cleanup"]
+    subgraph SFN["Step Function"]
+        L1["Parser Lambda<br/>recheck manifest + IAM state"]
+        L2["Worker Lambda<br/>13-step cleanup"]
     end
 
-    AUDIT["Audit Trail<br/>DynamoDB + S3"]
-    WH["Warehouse Ingest-Back<br/>remediation_log table"]
-    VERIFY["Next Reconciler Run<br/>verify state == closed<br/>flag drift"]
-    DLQ["DLQ + SNS<br/>Lambda async failures<br/>SFN ExecutionFailed"]
+    TGT["Targets<br/>AWS IAM / Entra / GCP / Snowflake / Databricks"]
+    AUDIT["Audit<br/>DynamoDB + S3"]
+    WH["Warehouse ingest-back"]
+    VERIFY["Next reconciler run"]
+    FAIL["DLQ + SNS"]
 
     HR --> REC
-    REC -->|no change| EXIT
-    REC -->|change detected| S3
+    REC -->|no changes| EXIT
+    REC -->|actionable rows only| S3
     S3 --> EB
-    EB --> L1
+    EB --> SFN
+    SFN --> L1
     L1 --> L2
-    L2 --> AUDIT
+    L2 --> TGT
+    TGT --> AUDIT
     AUDIT --> WH
     WH --> VERIFY
-    VERIFY -. drift .-> REC
-    SFN -. failure .-> DLQ
-    DLQ -. replay .-> EB
+    VERIFY -. drift check .-> REC
+    SFN -. failure .-> FAIL
 
     style SFN fill:#172554,stroke:#3b82f6,color:#e2e8f0
     style REC fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
     style EB fill:#172554,stroke:#3b82f6,color:#e2e8f0
     style VERIFY fill:#1a2e35,stroke:#2dd4bf,color:#e2e8f0
-    style DLQ fill:#3f1d1d,stroke:#f87171,color:#fecaca
+    style FAIL fill:#3f1d1d,stroke:#f87171,color:#fecaca
 ```
 
 ## Security Guardrails


### PR DESCRIPTION
## Summary
- rebuild the flagship IAM departures SVG around the real staged control flow instead of a crowded architecture dump
- simplify the skill's Mermaid diagram to the same orchestration path so the visual story stays consistent
- tighten the README and diagrams copy so the artwork stays readable and the detailed notes stay in markdown

## Validation
- `python scripts/validate_skill_contract.py`