### PR TITLE
docs: rebuild data handling visual

### DIFF
--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -12,6 +12,16 @@ Use this doc when you need to answer:
 - when `native`, `ocsf`, `canonical`, or `bridge` matters
 - what security controls apply on each path
 
+## Quick Visual
+
+Start with the real input you have, then follow the first skill family, the
+output shape, and the control boundary:
+
+![Data handling paths showing live API paths, raw log paths, lake paths, and the separate guarded remediation path, with outputs and controls called out per lane.](images/data-handling-paths.svg)
+
+The visual is intentionally short. The details stay below in tables and worked
+examples.
+
 ## One Skill Bundle, Many Access Paths
 
 The repo ships skill bundles, not just standalone scripts.

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -21,7 +21,7 @@ Use these descriptions as the text companion for screen readers, plain-text
 review, and PR discussions where opening the SVG is inconvenient.
 
 - `data-handling-paths.svg`
-  - Shows the main runtime choices: live cloud posture, raw log ingest, OCSF-ready lake detection, raw lake detection through ingest, persistence via sinks, and guarded remediation.
+  - Shows the main data-entry choices, the first skill family for each, the resulting outputs, and the control boundary that applies on each path.
 - `start-here-guide.svg`
   - Shows the shortest decision tree for choosing a first layer: discover for inventory/evidence, ingest for raw logs, detect for normalized events, evaluate for posture, sink for persistence, and remediate for guarded writes.
 - `runtime-surfaces.svg`

--- a/docs/images/data-handling-paths.svg
+++ b/docs/images/data-handling-paths.svg
@@ -1,64 +1,88 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" role="img" aria-labelledby="title desc">
-  <title id="title">Data handling paths and guardrails</title>
-  <desc id="desc">A simplified view of how data enters cloud-ai-security-skills, which paths it can take, and which guardrails apply on each path.</desc>
-  <rect width="1280" height="760" fill="#08111f"/>
-  <rect x="24" y="24" width="1232" height="712" rx="28" fill="#0f172a" stroke="#334155"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="1060" viewBox="0 0 1480 1060" role="img" aria-labelledby="title desc">
+  <title id="title">Data handling paths and controls</title>
+  <desc id="desc">A staged view of how data enters the repo, which first skill family should touch it, what outputs are produced, and which controls apply. The diagram covers live API paths, raw log paths, ready lake rows, raw lake rows, and the separate guarded remediation path.</desc>
+  <rect width="1480" height="1060" fill="#08111f"/>
+  <rect x="24" y="24" width="1432" height="1012" rx="32" fill="#0f172a" stroke="#334155"/>
 
   <g font-family="Arial, sans-serif">
-    <text x="56" y="74" fill="#f8fafc" font-size="32" font-weight="700">How data moves and where controls apply</text>
-    <text x="56" y="106" fill="#94a3b8" font-size="18">One lane per real shipped scenario. Read-only analysis stays separate from sinks, runners, and remediation.</text>
+    <text x="64" y="86" fill="#f8fafc" font-size="40" font-weight="700">How data moves and where controls apply</text>
+    <text x="64" y="122" fill="#94a3b8" font-size="21">Start from the data you actually have, choose the first skill family, then follow the output and control boundary.</text>
 
-    <rect x="56" y="148" width="220" height="106" rx="18" fill="#172554" stroke="#60a5fa"/>
-    <text x="82" y="184" fill="#dbeafe" font-size="22" font-weight="700">Start here</text>
-    <text x="82" y="214" fill="#eff6ff" font-size="16">live cloud APIs</text>
-    <text x="82" y="236" fill="#eff6ff" font-size="16">raw logs and files</text>
+    <rect x="64" y="150" width="1352" height="68" rx="18" fill="#111c34" stroke="#475569"/>
+    <text x="94" y="192" fill="#cbd5e1" font-size="20" font-weight="700">Access paths:</text>
+    <text x="246" y="192" fill="#e2e8f0" font-size="19">CLI</text>
+    <text x="300" y="192" fill="#38bdf8" font-size="19">•</text>
+    <text x="324" y="192" fill="#e2e8f0" font-size="19">MCP / agents</text>
+    <text x="464" y="192" fill="#38bdf8" font-size="19">•</text>
+    <text x="488" y="192" fill="#e2e8f0" font-size="19">CI</text>
+    <text x="522" y="192" fill="#38bdf8" font-size="19">•</text>
+    <text x="546" y="192" fill="#e2e8f0" font-size="19">AWS / GCP / Azure runners</text>
+    <text x="866" y="192" fill="#38bdf8" font-size="19">•</text>
+    <text x="890" y="192" fill="#e2e8f0" font-size="19">same skill bundle contract</text>
 
-    <rect x="56" y="282" width="220" height="106" rx="18" fill="#172554" stroke="#60a5fa"/>
-    <text x="82" y="318" fill="#dbeafe" font-size="22" font-weight="700">Or start here</text>
-    <text x="82" y="348" fill="#eff6ff" font-size="16">warehouse rows</text>
-    <text x="82" y="370" fill="#eff6ff" font-size="16">lake objects</text>
+    <rect x="64" y="244" width="1352" height="152" rx="28" fill="#111827" stroke="#475569"/>
+    <text x="94" y="286" fill="#f8fafc" font-size="28" font-weight="700">Start from what you have</text>
+    <rect x="94" y="308" width="240" height="60" rx="16" fill="#172554" stroke="#60a5fa"/>
+    <text x="128" y="344" fill="#eff6ff" font-size="23" font-weight="700">live cloud or SaaS APIs</text>
+    <rect x="366" y="308" width="220" height="60" rx="16" fill="#172554" stroke="#60a5fa"/>
+    <text x="414" y="344" fill="#eff6ff" font-size="23" font-weight="700">raw logs or files</text>
+    <rect x="618" y="308" width="238" height="60" rx="16" fill="#172554" stroke="#60a5fa"/>
+    <text x="654" y="344" fill="#eff6ff" font-size="23" font-weight="700">ready lake rows</text>
+    <rect x="888" y="308" width="238" height="60" rx="16" fill="#172554" stroke="#60a5fa"/>
+    <text x="924" y="344" fill="#eff6ff" font-size="23" font-weight="700">raw lake rows</text>
+    <rect x="1158" y="308" width="228" height="60" rx="16" fill="#3f1d1d" stroke="#f87171"/>
+    <text x="1200" y="344" fill="#fee2e2" font-size="23" font-weight="700">action request</text>
 
-    <rect x="332" y="136" width="568" height="128" rx="22" fill="#083344" stroke="#2dd4bf"/>
-    <text x="364" y="174" fill="#ccfbf1" font-size="24" font-weight="700">Lane 1: live state and posture</text>
-    <text x="364" y="208" fill="#ecfeff" font-size="17">discover-* or evaluation/*</text>
-    <text x="364" y="234" fill="#cbd5e1" font-size="16">read-only APIs, least-privilege creds, native or bridge outputs</text>
+    <rect x="64" y="426" width="1352" height="138" rx="26" fill="#083344" stroke="#2dd4bf"/>
+    <text x="92" y="466" fill="#ccfbf1" font-size="28" font-weight="700">1. Live posture, inventory, and evidence</text>
+    <text x="92" y="500" fill="#e2e8f0" font-size="18">Use when the repo starts from live APIs instead of pre-existing log streams.</text>
+    <rect x="360" y="452" width="236" height="62" rx="16" fill="#0f766e" stroke="#5eead4"/>
+    <text x="402" y="490" fill="#ecfeff" font-size="24" font-weight="700">discover-* / evaluation/*</text>
+    <rect x="668" y="452" width="236" height="62" rx="16" fill="#4338ca" stroke="#a78bfa"/>
+    <text x="736" y="490" fill="#eef2ff" font-size="24" font-weight="700">native / bridge</text>
+    <rect x="976" y="446" width="374" height="74" rx="18" fill="#13253f" stroke="#2dd4bf"/>
+    <text x="1008" y="482" fill="#f8fafc" font-size="22" font-weight="700">read-only credentials, least privilege, no hidden writes</text>
+    <text x="92" y="538" fill="#94a3b8" font-size="16">Examples: discover-environment, discover-control-evidence, cspm-aws-cis-benchmark</text>
+    <path d="M304 488 L360 488" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+    <path d="M596 488 L668 488" stroke="#5eead4" stroke-width="5" fill="none"/>
+    <path d="M904 488 L976 488" stroke="#a78bfa" stroke-width="5" fill="none"/>
 
-    <rect x="332" y="288" width="568" height="128" rx="22" fill="#083344" stroke="#2dd4bf"/>
-    <text x="364" y="326" fill="#ccfbf1" font-size="24" font-weight="700">Lane 2: raw event analysis</text>
-    <text x="364" y="360" fill="#ecfeff" font-size="17">ingest-* -&gt; detect-* -&gt; view/*</text>
-    <text x="364" y="386" fill="#cbd5e1" font-size="16">defensive parsing, canonical internal model, native or OCSF streams</text>
+    <rect x="64" y="590" width="1352" height="138" rx="26" fill="#0b2538" stroke="#22d3ee"/>
+    <text x="92" y="630" fill="#ccfbf1" font-size="28" font-weight="700">2. Raw event detection path</text>
+    <text x="92" y="664" fill="#e2e8f0" font-size="18">Use when the repo starts from raw CloudTrail, Kubernetes audit, Okta, Entra, or similar payloads.</text>
+    <rect x="360" y="616" width="180" height="62" rx="16" fill="#1d4ed8" stroke="#93c5fd"/>
+    <text x="412" y="654" fill="#eff6ff" font-size="24" font-weight="700">ingest-*</text>
+    <rect x="600" y="616" width="180" height="62" rx="16" fill="#0f766e" stroke="#5eead4"/>
+    <text x="652" y="654" fill="#ecfeff" font-size="24" font-weight="700">detect-*</text>
+    <rect x="840" y="616" width="180" height="62" rx="16" fill="#7c3aed" stroke="#c4b5fd"/>
+    <text x="904" y="654" fill="#f5f3ff" font-size="24" font-weight="700">view/*</text>
+    <rect x="1080" y="610" width="270" height="74" rx="18" fill="#13253f" stroke="#22d3ee"/>
+    <text x="1114" y="646" fill="#f8fafc" font-size="22" font-weight="700">defensive parsing, canonical internal model, native or OCSF out</text>
+    <text x="92" y="702" fill="#94a3b8" font-size="16">Example: ingest-cloudtrail-ocsf → detect-lateral-movement → convert-ocsf-to-sarif</text>
+    <path d="M586 646 L600 646" stroke="#93c5fd" stroke-width="5" fill="none"/>
+    <path d="M780 646 L840 646" stroke="#5eead4" stroke-width="5" fill="none"/>
+    <path d="M1020 646 L1080 646" stroke="#c4b5fd" stroke-width="5" fill="none"/>
 
-    <rect x="332" y="440" width="568" height="128" rx="22" fill="#083344" stroke="#2dd4bf"/>
-    <text x="364" y="478" fill="#ccfbf1" font-size="24" font-weight="700">Lane 3: lake and warehouse paths</text>
-    <text x="364" y="512" fill="#ecfeff" font-size="17">source-* -&gt; detect-* or source-* -&gt; ingest-* -&gt; detect-*</text>
-    <text x="364" y="538" fill="#cbd5e1" font-size="16">read-only query adapters, query guardrails, skip ingest only when rows are already shaped</text>
+    <rect x="64" y="754" width="1352" height="138" rx="26" fill="#10243a" stroke="#60a5fa"/>
+    <text x="92" y="794" fill="#dbeafe" font-size="28" font-weight="700">3. Lake and warehouse paths</text>
+    <text x="92" y="828" fill="#e2e8f0" font-size="18">Use source adapters first. Skip ingest only when the rows are already native or OCSF shaped.</text>
+    <rect x="332" y="780" width="180" height="62" rx="16" fill="#155e75" stroke="#67e8f9"/>
+    <text x="382" y="818" fill="#ecfeff" font-size="24" font-weight="700">source-*</text>
+    <rect x="572" y="780" width="180" height="62" rx="16" fill="#1d4ed8" stroke="#93c5fd"/>
+    <text x="624" y="818" fill="#eff6ff" font-size="24" font-weight="700">ingest-*</text>
+    <rect x="812" y="780" width="180" height="62" rx="16" fill="#0f766e" stroke="#5eead4"/>
+    <text x="864" y="818" fill="#ecfeff" font-size="24" font-weight="700">detect-*</text>
+    <rect x="1052" y="780" width="180" height="62" rx="16" fill="#4c1d95" stroke="#c084fc"/>
+    <text x="1114" y="818" fill="#f3e8ff" font-size="24" font-weight="700">sink-*</text>
+    <path d="M1126 338 C 1126 338, 422 338, 422 780" stroke="#60a5fa" stroke-width="4" stroke-dasharray="8 8" fill="none"/>
+    <path d="M856 338 C 856 338, 902 338, 902 780" stroke="#2dd4bf" stroke-width="4" stroke-dasharray="8 8" fill="none"/>
+    <text x="92" y="866" fill="#94a3b8" font-size="16">Examples: source-snowflake-query → detect-lateral-movement, or source-databricks-query → ingest-cloudtrail-ocsf → detect-lateral-movement</text>
+    <text x="92" y="892" fill="#60a5fa" font-size="16" font-weight="700">Guardrail:</text>
+    <text x="188" y="892" fill="#cbd5e1" font-size="16">read-only query adapters, no multi-statement execution, validated sink identifiers, customer-owned persistence</text>
 
-    <rect x="952" y="136" width="252" height="188" rx="22" fill="#3b0764" stroke="#c084fc"/>
-    <text x="982" y="174" fill="#f3e8ff" font-size="24" font-weight="700">Outputs</text>
-    <text x="982" y="210" fill="#f8fafc" font-size="18" font-weight="700">native</text>
-    <text x="982" y="234" fill="#ddd6fe" font-size="16">repo-owned operational format</text>
-    <text x="982" y="270" fill="#f8fafc" font-size="18" font-weight="700">ocsf</text>
-    <text x="982" y="294" fill="#ddd6fe" font-size="16">interoperable event and finding streams</text>
-
-    <rect x="952" y="352" width="252" height="216" rx="22" fill="#3b0764" stroke="#c084fc"/>
-    <text x="982" y="390" fill="#f3e8ff" font-size="24" font-weight="700">Write edges</text>
-    <text x="982" y="426" fill="#f8fafc" font-size="18" font-weight="700">sink-*</text>
-    <text x="982" y="450" fill="#ddd6fe" font-size="16">append-only or idempotent persistence</text>
-    <text x="982" y="486" fill="#f8fafc" font-size="18" font-weight="700">remediation/*</text>
-    <text x="982" y="510" fill="#ddd6fe" font-size="16">HITL, dry-run, audit trail</text>
-    <text x="982" y="546" fill="#f8fafc" font-size="18" font-weight="700">runners</text>
-    <text x="982" y="570" fill="#ddd6fe" font-size="16">queues, retries, dedupe, bounded concurrency</text>
-
-    <path d="M276 200 L332 200" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M276 334 L332 504" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M900 200 L952 200" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-    <path d="M900 352 L952 352" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-    <path d="M900 504 L952 504" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-
-    <rect x="56" y="616" width="1148" height="74" rx="16" fill="#111827" stroke="#475569"/>
-    <text x="84" y="646" fill="#f8fafc" font-size="18" font-weight="700">Available today</text>
-    <text x="246" y="646" fill="#cbd5e1" font-size="16">CLI · CI · MCP · AWS runner · GCP runner template · Azure runner template · source-* · sink-* · packs/</text>
-    <text x="84" y="676" fill="#f8fafc" font-size="18" font-weight="700">Guardrails</text>
-    <text x="186" y="676" fill="#cbd5e1" font-size="16">read-only by default · least-privilege credentials · no arbitrary shell passthrough · fixed schemas · explicit approval for destructive actions</text>
+    <rect x="64" y="918" width="1352" height="92" rx="24" fill="#3f1d1d" stroke="#f87171"/>
+    <text x="92" y="956" fill="#fee2e2" font-size="28" font-weight="700">4. Separate guarded action path</text>
+    <text x="92" y="988" fill="#fecaca" font-size="18">event → remediation/* → audit trail → next run verifies closure</text>
+    <text x="724" y="988" fill="#fca5a5" font-size="18" font-weight="700">HITL, dry-run-first, explicit approval, dedicated principals, dual audit</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- rebuild the data-handling SVG around the real start states, first skill family, outputs, and control boundaries
- move the visual into `docs/DATA_HANDLING.md` so the doc opens with the diagram instead of a file link
- keep the detailed tables and worked examples in markdown and keep the artwork short and readable

## Validation
- `python scripts/validate_skill_contract.py`