### PR TITLE
docs: align visual captions and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,14 +366,16 @@ Read next:
 <details>
 <summary><b>More Diagrams And Docs</b></summary>
 
-High-signal visuals:
+Primary visuals:
+- [Repository architecture](docs/images/repo-architecture.svg)
+- [End-to-end skill flows](docs/images/end-to-end-skill-flows.svg)
+- [IAM departures workflow](docs/images/iam-departures-architecture.svg)
+
+Secondary visuals:
 - [Data handling paths](docs/images/data-handling-paths.svg)
 - [Start here guide](docs/images/start-here-guide.svg)
 - [Runtime surfaces](docs/images/runtime-surfaces.svg)
-- [Repository architecture](docs/images/repo-architecture.svg)
 - [Detection engineering pipeline](docs/images/detection-pipeline.svg)
-- [End-to-end skill flows](docs/images/end-to-end-skill-flows.svg)
-- [IAM departures workflow](docs/images/iam-departures-architecture.svg)
 - [IAM departures data flow](docs/images/iam-departures-data-flow.svg)
 
 Operator and contributor docs:

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -58,8 +58,7 @@ Read next:
 - [RUNTIME_ISOLATION.md](RUNTIME_ISOLATION.md)
 - [RUNTIME_PROFILES.md](RUNTIME_PROFILES.md)
 - [NATIVE_VS_OCSF.md](NATIVE_VS_OCSF.md)
-- [images/data-handling-paths.svg](images/data-handling-paths.svg)
-- [images/end-to-end-skill-flows.svg](images/end-to-end-skill-flows.svg)
+- [DIAGRAMS.md](DIAGRAMS.md)
 
 ## The Main Scenarios
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -6,14 +6,15 @@ Keep markdown diagrams lightweight and reviewable, then pair them with polished 
 
 ## Visual set
 
+- Primary visuals:
+  - [Repository architecture](images/repo-architecture.svg)
+  - [End-to-end skill flows](images/end-to-end-skill-flows.svg)
+  - [IAM departures cross-cloud workflow](images/iam-departures-architecture.svg)
 - [Data handling paths](images/data-handling-paths.svg)
 - [Start here guide](images/start-here-guide.svg)
 - [Runtime surfaces](images/runtime-surfaces.svg)
-- [IAM departures cross-cloud workflow](images/iam-departures-architecture.svg)
-- [Repository architecture](images/repo-architecture.svg)
 - [IAM departures data flow](images/iam-departures-data-flow.svg)
 - [Detection engineering pipeline](images/detection-pipeline.svg)
-- [End-to-end skill flows](images/end-to-end-skill-flows.svg)
 
 ## Diagram descriptions
 
@@ -23,7 +24,7 @@ review, and PR discussions where opening the SVG is inconvenient.
 - `data-handling-paths.svg`
   - Shows the main data-entry choices, the first skill family for each, the resulting outputs, and the control boundary that applies on each path.
 - `start-here-guide.svg`
-  - Shows the shortest decision tree for choosing a first layer: discover for inventory/evidence, ingest for raw logs, detect for normalized events, evaluate for posture, sink for persistence, and remediate for guarded writes.
+  - Shows the shortest operator decision tree for choosing the first layer: discover, ingest, detect, evaluate, sink, or remediate.
 - `runtime-surfaces.svg`
   - Shows that CLI, CI, MCP, and persistent runners are access paths around the same skill bundle and execution core rather than separate implementations.
 - `iam-departures-architecture.svg`


### PR DESCRIPTION
## Summary
- align the visual index and captions around the same primary diagram set
- simplify `DATA_HANDLING.md` read-next links so the doc points to the visual index instead of raw image paths
- tighten the wording in `docs/DIAGRAMS.md` so the current SVG set is described consistently

## Validation
- `python scripts/validate_skill_contract.py`