### PR TITLE
docs: clarify runner deployment verification status

### DIFF
--- a/runners/DEPLOYMENT_VERIFICATION.md
+++ b/runners/DEPLOYMENT_VERIFICATION.md
@@ -1,0 +1,90 @@
+# Runner Deployment Verification
+
+This page tracks the difference between:
+
+- a runner template that is shipped and CI-validated
+- a runner path that has also been deployed once end to end in a real cloud
+
+Read next:
+
+- [README.md](README.md)
+- [../docs/DATA_HANDLING.md](../docs/DATA_HANDLING.md)
+- [../docs/THREAT_MODEL.md](../docs/THREAT_MODEL.md)
+
+## Current Status
+
+| Runner | Template shipped | Handler tests | IaC validation in CI | Real deploy proof captured | Tracking issue |
+|---|---|---|---|---|---|
+| `aws-s3-sqs-detect` | yes | yes | yes | not yet | [#198](https://github.com/msaad00/cloud-ai-security-skills/issues/198) |
+| `gcp-gcs-pubsub-detect` | yes | yes | yes | not yet | [#198](https://github.com/msaad00/cloud-ai-security-skills/issues/198) |
+| `azure-blob-eventgrid-detect` | yes | yes | yes | not yet | [#198](https://github.com/msaad00/cloud-ai-security-skills/issues/198) |
+
+Current repo reality:
+
+- all three runner templates are shipped references
+- the handlers and infrastructure contracts are validated in CI
+- the repo does not yet claim a checked-in live deployment walkthrough for all three clouds
+
+That is the remaining work tracked in `#198`.
+
+## What Counts As Real Deploy Proof
+
+To close `#198`, each runner should have one captured deploy-and-first-event proof:
+
+1. package the runner handlers for the target cloud runtime
+2. deploy the infrastructure template
+3. configure one real `ingest-*` and one real `detect-*` skill command
+4. send one real source event through the trigger path
+5. confirm the downstream dedupe + publish path completes
+6. write the exact walkthrough and cloud-specific prerequisites back into the runner README
+
+## Cloud-Specific First-Event Checklist
+
+### AWS
+
+- deploy `template.yaml`
+- bind the source bucket notification
+- upload one object that the ingest handler can read
+- confirm:
+  - ingest Lambda invoked
+  - detect SQS message created
+  - detect Lambda invoked
+  - DynamoDB dedupe row written
+  - SNS publish succeeded
+
+### GCP
+
+- apply `main.tf`
+- package and deploy both Cloud Functions
+- finalize one object in the source GCS bucket
+- confirm:
+  - ingest function invoked
+  - Pub/Sub detect topic received messages
+  - detect function invoked
+  - Firestore dedupe document created
+  - findings topic publish succeeded
+
+### Azure
+
+- deploy `template.bicep`
+- package the handlers into the chosen Azure runtime
+- create one blob in the watched container/prefix
+- confirm:
+  - Event Grid routed the event
+  - ingest queue received the message
+  - ingest handler ran and enqueued detect work
+  - detect handler invoked
+  - Table Storage dedupe entity created
+  - Service Bus topic publish succeeded
+
+## Why This Page Exists
+
+This repo already has:
+
+- shipped runner templates
+- handler tests
+- IaC validation
+
+What it still needs is deployment evidence. This page keeps that distinction
+explicit so the repo does not imply a stronger operational claim than it can
+currently prove.

--- a/runners/README.md
+++ b/runners/README.md
@@ -12,11 +12,31 @@ They own:
 They do **not** change the skill contract. The same `SKILL.md + src/ + tests/`
 bundle should still run unchanged from the CLI, CI, MCP, or a persistent loop.
 
-## Shipped reference runner
+Read next:
 
-- [`aws-s3-sqs-detect`](aws-s3-sqs-detect/): S3 object create trigger → ingest
-  Lambda → SQS detect queue → detect Lambda → DynamoDB dedupe → SNS publish
+- [DEPLOYMENT_VERIFICATION.md](DEPLOYMENT_VERIFICATION.md)
+- [../docs/DATA_HANDLING.md](../docs/DATA_HANDLING.md)
+
+## Shipped reference runners
+
+- [`aws-s3-sqs-detect`](aws-s3-sqs-detect/): S3 object create trigger -> ingest
+  Lambda -> SQS detect queue -> detect Lambda -> DynamoDB dedupe -> SNS publish
+- [`gcp-gcs-pubsub-detect`](gcp-gcs-pubsub-detect/): GCS finalize trigger ->
+  ingest Cloud Function -> Pub/Sub detect topic -> detect Cloud Function ->
+  Firestore dedupe -> findings topic
+- [`azure-blob-eventgrid-detect`](azure-blob-eventgrid-detect/): Blob create ->
+  Event Grid -> ingest queue -> ingest handler -> detect queue -> detect
+  handler -> Table Storage dedupe -> Service Bus topic
 
 This is a reference template, not a multi-tenant managed service. Operators still
 own packaging, deployment, sink wiring, IAM review, and environment-specific
 controls.
+
+## Live Deployment Status
+
+All three runners are shipped and CI-validated.
+
+The repo does not yet claim a captured real-cloud deploy-and-first-event proof
+for all three templates. That remaining work is tracked in
+[`#198`](https://github.com/msaad00/cloud-ai-security-skills/issues/198) and
+summarized in [DEPLOYMENT_VERIFICATION.md](DEPLOYMENT_VERIFICATION.md).

--- a/runners/aws-s3-sqs-detect/README.md
+++ b/runners/aws-s3-sqs-detect/README.md
@@ -69,3 +69,29 @@ system.
 - SNS only sees deduped findings
 - operators should scope the Lambda roles to the specific source bucket, queue,
   topic, and table ARNs in their environment
+
+## Live Deploy Verification Status
+
+Current repo reality:
+
+- the template is shipped
+- handler behavior is covered in tests
+- infrastructure validation runs in CI
+- a checked-in real-cloud deploy-and-first-event walkthrough is still pending
+
+That remaining deployment proof is tracked in
+[`#198`](https://github.com/msaad00/cloud-ai-security-skills/issues/198).
+
+## First Event Proof Checklist
+
+When capturing the live walkthrough for this runner, record:
+
+1. the exact CloudFormation deploy command and parameters
+2. the source bucket notification binding
+3. one uploaded object that triggers the ingest path
+4. evidence that:
+   - ingest Lambda ran
+   - an SQS detect message was created
+   - detect Lambda ran
+   - a DynamoDB dedupe row was written
+   - an SNS publish succeeded

--- a/runners/azure-blob-eventgrid-detect/README.md
+++ b/runners/azure-blob-eventgrid-detect/README.md
@@ -86,3 +86,30 @@ unbounded.
 - dedupe prevents duplicate publishes on replay
 - operators should scope the Azure role assignments to the specific blob
   source, queue, topic, and table resources in their environment
+
+## Live Deploy Verification Status
+
+Current repo reality:
+
+- the Bicep template is shipped
+- handler behavior is covered in tests
+- template validation runs in CI
+- a checked-in real-cloud deploy-and-first-event walkthrough is still pending
+
+That remaining deployment proof is tracked in
+[`#198`](https://github.com/msaad00/cloud-ai-security-skills/issues/198).
+
+## First Event Proof Checklist
+
+When capturing the live walkthrough for this runner, record:
+
+1. the exact Bicep deployment inputs and provisioned resources
+2. the chosen Azure runtime packaging path for the handlers
+3. one blob created in the watched source path
+4. evidence that:
+   - Event Grid routed the event
+   - ingest queue received the message
+   - ingest handler ran and enqueued detect work
+   - detect handler ran
+   - Table Storage dedupe wrote a stable UID row
+   - Service Bus topic publish succeeded

--- a/runners/gcp-gcs-pubsub-detect/README.md
+++ b/runners/gcp-gcs-pubsub-detect/README.md
@@ -78,3 +78,29 @@ based on cost, quota, and downstream sink pressure for their environment.
 - Pub/Sub findings fan-out sees only deduped findings
 - operators should scope the service accounts to the specific bucket, topics,
   and Firestore collection for their environment
+
+## Live Deploy Verification Status
+
+Current repo reality:
+
+- the Terraform template is shipped
+- handler behavior is covered in tests
+- Terraform validation runs in CI
+- a checked-in real-cloud deploy-and-first-event walkthrough is still pending
+
+That remaining deployment proof is tracked in
+[`#198`](https://github.com/msaad00/cloud-ai-security-skills/issues/198).
+
+## First Event Proof Checklist
+
+When capturing the live walkthrough for this runner, record:
+
+1. the exact Terraform apply inputs and deployed resources
+2. the packaged Cloud Function artifacts and runtime binding
+3. one object finalized in the watched GCS bucket
+4. evidence that:
+   - ingest function ran
+   - the detect Pub/Sub topic received messages
+   - detect function ran
+   - a Firestore dedupe document was created
+   - findings topic publish succeeded


### PR DESCRIPTION
## Summary
- add a runner deployment verification page that separates shipped templates from live deploy proof
- update the runners index to list all three shipped reference runners instead of only AWS
- add per-runner live-deploy status and first-event proof checklists for AWS, GCP, and Azure

## Why
The repo now ships three runner templates, but the docs did not clearly distinguish between CI-validated templates and a fully captured real-cloud deploy walkthrough. This PR makes that boundary explicit and ties the remaining live-deploy work to `#198`.

## Validation
- `python scripts/validate_skill_contract.py`

## Notes
- this PR does not claim the real-cloud deploy proof is already done
- it makes the current state honest and ready for the follow-on capture work in `#198`