### PR TITLE
tests: harden mixed-batch ingest parsing

### DIFF
--- a/skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py
@@ -256,6 +256,28 @@ class TestIngestStream:
         assert first["record_type"] == "api_activity"
         assert "class_uid" not in first
 
+    def test_mixed_malformed_batch_keeps_valid_entries(self, capsys):
+        read_event = json.dumps(
+            {
+                "protoPayload": {"@type": AUDIT_LOG_TYPE, "methodName": "x.y.GetThing"},
+                "insertId": "good-read",
+                "timestamp": "2026-04-10T05:00:00Z",
+            }
+        )
+        delete_event = json.dumps(
+            {
+                "protoPayload": {"@type": AUDIT_LOG_TYPE, "methodName": "x.y.DeleteThing"},
+                "insertId": "good-delete",
+                "timestamp": "2026-04-10T05:01:00Z",
+            }
+        )
+        out = list(ingest([read_event, '{"bad"', "[]", delete_event]))
+        assert len(out) == 2
+        assert [event["activity_id"] for event in out] == [ACTIVITY_READ, ACTIVITY_DELETE]
+        stderr = capsys.readouterr().err
+        assert "skipping line 2: json parse failed" in stderr
+        assert "skipping line 3: not a JSON object" in stderr
+
 
 # ── Golden fixture parity ──────────────────────────────────────────────
 

--- a/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py
@@ -314,3 +314,34 @@ class TestStderrTelemetry:
         assert payload["level"] == "warning"
         assert payload["event"] == "json_parse_failed"
         assert payload["line"] == 1
+
+    def test_mixed_batch_keeps_valid_events(self, capsys, monkeypatch):
+        monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+        read_event = {
+            "kind": "Event",
+            "apiVersion": "audit.k8s.io/v1",
+            "stage": "ResponseComplete",
+            "auditID": "k8s-read",
+            "verb": "list",
+            "user": {"username": "system:serviceaccount:default:builder"},
+            "objectRef": {"resource": "secrets", "namespace": "default"},
+            "responseStatus": {"code": 200},
+            "requestReceivedTimestamp": "2026-04-10T05:00:00Z",
+        }
+        delete_event = {
+            "kind": "Event",
+            "apiVersion": "audit.k8s.io/v1",
+            "stage": "ResponseComplete",
+            "auditID": "k8s-delete",
+            "verb": "delete",
+            "user": {"username": "system:serviceaccount:default:builder"},
+            "objectRef": {"resource": "deployments", "namespace": "default"},
+            "responseStatus": {"code": 403, "reason": "Forbidden"},
+            "requestReceivedTimestamp": "2026-04-10T05:01:00Z",
+        }
+        out = list(ingest([json.dumps(read_event), '{"bad": ', "[]", json.dumps(delete_event)]))
+        assert len(out) == 2
+        assert [event["metadata"]["uid"] for event in out] == ["k8s-read", "k8s-delete"]
+        stderr_lines = [json.loads(line) for line in capsys.readouterr().err.splitlines() if line.strip()]
+        assert [payload["event"] for payload in stderr_lines] == ["json_parse_failed", "invalid_json_shape"]
+        assert [payload["line"] for payload in stderr_lines] == [2, 3]

--- a/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py
@@ -345,6 +345,14 @@ class TestIterRawEvents:
         assert payload["event"] == "json_parse_failed"
         assert payload["line"] == 1
 
+    def test_mixed_batch_keeps_valid_events(self, capsys, monkeypatch):
+        monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+        out = list(ingest([json.dumps(_event(uuid="okta-good-1")), '{"bad"', "[]", json.dumps(_event(uuid="okta-good-2"))]))
+        assert [event["metadata"]["uid"] for event in out] == ["okta-good-1", "okta-good-2"]
+        stderr_lines = [json.loads(line) for line in capsys.readouterr().err.splitlines() if line.strip()]
+        assert [payload["event"] for payload in stderr_lines] == ["json_parse_failed", "invalid_json_shape"]
+        assert [payload["line"] for payload in stderr_lines] == [2, 3]
+
 
 class TestGoldenFixture:
     def test_golden_fixture(self):


### PR DESCRIPTION
## Summary
- add mixed malformed-batch survivor coverage for GCP audit, Kubernetes audit, and Okta ingest skills
- assert valid records still emit when malformed JSON and invalid non-object rows appear in the same batch
- keep assertions aligned to each skill's current stderr contract (plain stderr for GCP, structured JSON telemetry for Kubernetes and Okta)

## Testing
- python -m pytest /tmp/cloud-security-release-v0.5.0/skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py -q -o addopts=''
- python -m pytest /tmp/cloud-security-release-v0.5.0/skills/ingestion/ingest-k8s-audit-ocsf/tests/test_ingest.py -q -o addopts=''
- python -m pytest /tmp/cloud-security-release-v0.5.0/skills/ingestion/ingest-okta-system-log-ocsf/tests/test_ingest.py -q -o addopts=''
- python /tmp/cloud-security-release-v0.5.0/scripts/validate_skill_contract.py

Closes #197