### PR TITLE
mcp: add per-skill mcp_timeout_seconds override

### DIFF
--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -43,6 +43,7 @@ Optional:
 - `caller_roles`
 - `approver_roles`
 - `min_approvers`
+- `mcp_timeout_seconds`
 
 Rules:
 
@@ -102,6 +103,7 @@ Rules:
 - `caller_roles`, when present, should name the human or agent roles allowed to invoke the skill
 - `approver_roles`, when present, should name the roles allowed to approve write-capable actions
 - `min_approvers`, when present, must be an integer greater than or equal to 1
+- `mcp_timeout_seconds`, when present, must be an integer between 1 and 900 and names the per-call subprocess timeout the MCP wrapper should apply to this skill. It is opt-in; skills that do not declare it inherit the global default (60 seconds) or whatever the operator sets via the `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` env var. The env var wins over the per-skill value so on-call can widen or tighten the window without editing `SKILL.md`
 - write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy
 - write-capable skills should preserve caller, approver, and request or session identifiers in their audit trail when the runtime provides them
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,6 +20,17 @@ Audit behavior:
 - the wrapper emits one JSON audit line per resolved tool call
 - the audit record contract lives in [../docs/MCP_AUDIT_CONTRACT.md](../docs/MCP_AUDIT_CONTRACT.md)
 - wrapper diagnostics stay on `stderr`; wrapped skill output stays on `stdout`
+- every audit event records the resolved `timeout_seconds` so operators can tell from the log whether a call was governed by the default, a per-skill override, or an env override
+
+Timeout behavior:
+
+Each tool call runs the skill in a subprocess with a hard timeout.
+
+- Default: `60` seconds (from `DEFAULT_TIMEOUT_SECONDS` in `src/server.py`).
+- Per-skill override: a skill's `SKILL.md` frontmatter may declare `mcp_timeout_seconds: <N>` (range `1`–`900`) when the skill's realistic runtime exceeds the default. No shipped skill sets this today; the field is opt-in and defaults to the global value.
+- Operator override: setting the `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` environment variable wins over both, so on-call can widen or tighten the window without editing any `SKILL.md`.
+
+Resolution order, highest wins: env override > per-skill value > default.
 
 Run locally:
 

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -14,7 +14,13 @@ CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
-from tool_registry import SkillSpec, build_command, repo_root, tool_definition, tool_map  # noqa: E402
+from tool_registry import (  # noqa: E402
+    SkillSpec,
+    build_command,
+    repo_root,
+    tool_definition,
+    tool_map,
+)
 
 SERVER_NAME = "cloud-ai-security-skills"
 SERVER_VERSION = "0.1.0"

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -14,12 +14,27 @@ CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
-from tool_registry import build_command, repo_root, tool_definition, tool_map  # noqa: E402
+from tool_registry import SkillSpec, build_command, repo_root, tool_definition, tool_map  # noqa: E402
 
 SERVER_NAME = "cloud-ai-security-skills"
 SERVER_VERSION = "0.1.0"
 PROTOCOL_VERSION = "2025-06-18"
 DEFAULT_TIMEOUT_SECONDS = 60
+
+
+def _resolve_timeout(skill: SkillSpec, env: dict[str, str]) -> int:
+    """Resolve the per-call subprocess timeout.
+
+    Priority: env override > skill-declared timeout > global default. The env
+    override is kept at the top so operators can widen or tighten the window
+    without editing every SKILL.md.
+    """
+    override = env.get("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", "").strip()
+    if override:
+        return int(override)
+    if skill.mcp_timeout_seconds is not None:
+        return skill.mcp_timeout_seconds
+    return DEFAULT_TIMEOUT_SECONDS
 
 
 def _now_iso() -> str:
@@ -176,7 +191,8 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
                 env["SKILL_APPROVAL_TICKET"] = approval_context["ticket_id"]
             if "approval_timestamp" in approval_context:
                 env["SKILL_APPROVAL_TIMESTAMP"] = approval_context["approval_timestamp"]
-        timeout_seconds = int(env.get("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+        timeout_seconds = _resolve_timeout(skill, env)
+        audit_event["timeout_seconds"] = timeout_seconds
         completed = subprocess.run(
             build_command(skill, args, output_format=output_format),
             input=stdin_text,

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -17,6 +17,10 @@ ENTRYPOINT_CANDIDATES = (
 )
 
 
+MIN_TIMEOUT_SECONDS = 1
+MAX_TIMEOUT_SECONDS = 900
+
+
 @dataclass(frozen=True)
 class SkillSpec:
     name: str
@@ -34,6 +38,7 @@ class SkillSpec:
     caller_roles: tuple[str, ...]
     approver_roles: tuple[str, ...]
     min_approvers: int | None
+    mcp_timeout_seconds: int | None
 
     @property
     def supported(self) -> bool:
@@ -153,9 +158,27 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 caller_roles=_parse_modes(metadata.get("caller_roles")),
                 approver_roles=_parse_modes(metadata.get("approver_roles")),
                 min_approvers=int(metadata["min_approvers"]) if metadata.get("min_approvers") else None,
+                mcp_timeout_seconds=_parse_mcp_timeout(metadata.get("mcp_timeout_seconds"), skill_dir),
             )
         )
     return specs
+
+
+def _parse_mcp_timeout(raw: str | None, skill_dir: Path) -> int | None:
+    if raw is None or not raw.strip():
+        return None
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{skill_dir}/SKILL.md: mcp_timeout_seconds must be an integer, got {raw!r}"
+        ) from exc
+    if value < MIN_TIMEOUT_SECONDS or value > MAX_TIMEOUT_SECONDS:
+        raise ValueError(
+            f"{skill_dir}/SKILL.md: mcp_timeout_seconds must be between "
+            f"{MIN_TIMEOUT_SECONDS} and {MAX_TIMEOUT_SECONDS}, got {value}"
+        )
+    return value
 
 
 def supported_skills(root: Path | None = None) -> list[SkillSpec]:

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -21,12 +21,18 @@ class _FakeCompleted:
 
 
 class _FakeSkill:
-    def __init__(self, read_only: bool = True, approver_roles: tuple[str, ...] = ()) -> None:
+    def __init__(
+        self,
+        read_only: bool = True,
+        approver_roles: tuple[str, ...] = (),
+        mcp_timeout_seconds: int | None = None,
+    ) -> None:
         self.name = "fake-skill"
         self.category = "detection"
         self.capability = "read-only" if read_only else "write-remediation"
         self.read_only = read_only
         self.approver_roles = approver_roles
+        self.mcp_timeout_seconds = mcp_timeout_seconds
 
 
 def test_call_tool_injects_caller_and_approval_context(monkeypatch):
@@ -102,3 +108,47 @@ def test_call_tool_requires_approval_context_for_write_skill(monkeypatch):
     assert audit_events[0]["error_type"] == "ValueError"
     assert audit_events[0]["args_hash"] == MODULE._stable_hash(["--dry-run"])
     assert audit_events[0]["approval_context_provided"] is False
+
+
+def test_resolve_timeout_prefers_env_override():
+    skill = _FakeSkill(mcp_timeout_seconds=45)
+    env = {"CLOUD_SECURITY_MCP_TIMEOUT_SECONDS": "300"}
+    assert MODULE._resolve_timeout(skill, env) == 300
+
+
+def test_resolve_timeout_uses_skill_value_when_no_env_override():
+    skill = _FakeSkill(mcp_timeout_seconds=120)
+    env: dict[str, str] = {}
+    assert MODULE._resolve_timeout(skill, env) == 120
+
+
+def test_resolve_timeout_falls_back_to_default_when_neither_set():
+    skill = _FakeSkill(mcp_timeout_seconds=None)
+    env: dict[str, str] = {}
+    assert MODULE._resolve_timeout(skill, env) == MODULE.DEFAULT_TIMEOUT_SECONDS
+
+
+def test_resolve_timeout_ignores_blank_env_override():
+    skill = _FakeSkill(mcp_timeout_seconds=90)
+    env = {"CLOUD_SECURITY_MCP_TIMEOUT_SECONDS": "   "}
+    assert MODULE._resolve_timeout(skill, env) == 90
+
+
+def test_call_tool_audit_records_resolved_timeout(monkeypatch):
+    audit_events: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        MODULE,
+        "tool_map",
+        lambda: {"fake-skill": _FakeSkill(mcp_timeout_seconds=150)},
+    )
+    monkeypatch.setattr(MODULE, "build_command", lambda skill, args, output_format=None: ["python", "fake.py"])
+    monkeypatch.setattr(MODULE, "_emit_audit_event", lambda event: audit_events.append(event))
+
+    def _fake_run(*args, **kwargs):
+        assert kwargs["timeout"] == 150
+        return _FakeCompleted()
+
+    monkeypatch.setattr(MODULE.subprocess, "run", _fake_run)
+    monkeypatch.delenv("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", raising=False)
+    MODULE._call_tool("fake-skill", {"args": []})
+    assert audit_events[0]["timeout_seconds"] == 150

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -177,3 +177,46 @@ class TestToolDefinition:
         skill = tool_map(REPO_ROOT)["ingest-cloudtrail-ocsf"]
         command = build_command(skill, [], output_format="native")
         assert command[-2:] == ["--output-format", "native"]
+
+
+class TestMcpTimeoutParsing:
+    def test_missing_value_returns_none(self):
+        assert MODULE._parse_mcp_timeout(None, Path("/fake")) is None
+
+    def test_empty_value_returns_none(self):
+        assert MODULE._parse_mcp_timeout("", Path("/fake")) is None
+        assert MODULE._parse_mcp_timeout("   ", Path("/fake")) is None
+
+    def test_integer_value_parses(self):
+        assert MODULE._parse_mcp_timeout("120", Path("/fake")) == 120
+
+    def test_non_integer_value_errors(self):
+        try:
+            MODULE._parse_mcp_timeout("forever", Path("/fake"))
+        except ValueError as exc:
+            assert "must be an integer" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_out_of_range_value_errors(self):
+        try:
+            MODULE._parse_mcp_timeout("0", Path("/fake"))
+        except ValueError as exc:
+            assert "between 1 and 900" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+        try:
+            MODULE._parse_mcp_timeout("9999", Path("/fake"))
+        except ValueError as exc:
+            assert "between 1 and 900" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_default_shipped_skills_have_no_override(self):
+        for skill in discover_skills(REPO_ROOT):
+            assert skill.mcp_timeout_seconds is None, (
+                f"{skill.name} ships an mcp_timeout_seconds override; "
+                "make sure its SKILL.md declares the value explicitly and "
+                "that this test is updated to allowlist it"
+            )

--- a/scripts/generate_framework_coverage_doc.py
+++ b/scripts/generate_framework_coverage_doc.py
@@ -11,7 +11,7 @@ import json
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = REPO_ROOT / "docs" / "framework-coverage.json"
@@ -19,7 +19,10 @@ OUTPUT = REPO_ROOT / "docs" / "FRAMEWORK_COVERAGE.md"
 
 
 def _load_registry() -> dict[str, Any]:
-    return json.loads(REGISTRY.read_text())
+    decoded = json.loads(REGISTRY.read_text())
+    if not isinstance(decoded, dict):
+        raise ValueError("framework-coverage registry must be a JSON object")
+    return cast(dict[str, Any], decoded)
 
 
 def _render(data: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

**Pre-verify correction.** The earlier audit claimed the MCP server had no per-skill timeout. It actually does: \`server.py\` already applies a 60s subprocess timeout with an operator env override (\`CLOUD_SECURITY_MCP_TIMEOUT_SECONDS\`) and handles \`TimeoutExpired\` cleanly. Rate limits / concurrency caps are not meaningful on a single-threaded stdio server, so this PR does not add them.

What is actually missing is a **per-skill override** — the global 60s is tight for correlation detectors and loose for sub-second converters.

- Add opt-in \`mcp_timeout_seconds\` to \`SKILL.md\` frontmatter (int seconds, range 1-900).
- \`mcp-server/src/server.py\` gains \`_resolve_timeout(skill, env)\` with priority order: **env override > per-skill value > default**.
- Every audit event now records \`timeout_seconds\` so operators can tell which path governed a call.
- No shipped skill declares the override yet; a new test asserts that invariant so future additions are visible.

## Test plan

- [x] \`pytest mcp-server/tests\` — all 29 tests pass (5 new: env override, skill fallback, default fallback, blank env handling, audit-event timeout recording; \`TestMcpTimeoutParsing\` covers missing, empty, integer, non-integer, and out-of-range values).
- [x] \`python scripts/validate_skill_contract.py\` — 43 skills pass.
- [ ] Docs: \`docs/SKILL_CONTRACT.md\` lists the new field and resolution order; \`mcp-server/README.md\` explains the timeout behavior.

## Not in scope

- Rate limiting / concurrency caps on the MCP server (stdio transport is single-threaded; meaningful only if / when HTTP/SSE transport lands).
- Auto-tuning per-skill defaults based on benchmark profiles (follow-up once runtime-profiles regressions gate on main).