### PR TITLE
ci: extend validate-iac with tflint, Bicep, and shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
             cloud-ai-security-skills-full-lock.cdx.json.sig
             cloud-ai-security-skills-full-lock.cdx.json.pem
 
-  # ── IaC validation (CloudFormation + Terraform in one job) ─────
+  # ── IaC + shell validation (CloudFormation, Terraform, Bicep, Bash) ─
   validate-iac:
     runs-on: ubuntu-latest
     needs: [lint, skill-contract, type-check, safe-skill-bar]
@@ -289,13 +289,33 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.12.0"
+      - uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: v0.58.0
+      - name: Install Azure Bicep CLI
+        run: |
+          curl -sSL https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 -o /usr/local/bin/bicep
+          chmod +x /usr/local/bin/bicep
+          bicep --version
+      - name: Install shellcheck
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends shellcheck
       - name: cfn-lint — CloudFormation
         run: |
           cfn-lint skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
           cfn-lint skills/remediation/iam-departures-remediation/infra/cross_account_stackset.yaml
           cfn-lint runners/aws-s3-sqs-detect/template.yaml
-      - name: terraform validate
+      - name: terraform validate — iam-departures infra
         run: cd skills/remediation/iam-departures-remediation/infra/terraform && terraform init -backend=false && terraform validate
+      - name: terraform validate — gcp runner
+        run: cd runners/gcp-gcs-pubsub-detect && terraform init -backend=false && terraform validate
+      - name: tflint — iam-departures infra
+        run: cd skills/remediation/iam-departures-remediation/infra/terraform && tflint
+      - name: tflint — gcp runner
+        run: cd runners/gcp-gcs-pubsub-detect && tflint
+      - name: bicep build — azure runner
+        run: bicep build runners/azure-blob-eventgrid-detect/template.bicep --outfile /tmp/azure-runner.json
+      - name: shellcheck — scripts
+        run: shellcheck scripts/*.sh
 
   # ── agent-bom scans (code + skills + fs + IaC with SARIF upload) ─
   agent-bom:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,9 +294,11 @@ jobs:
           tflint_version: v0.58.0
       - name: Install Azure Bicep CLI
         run: |
-          curl -sSL https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 -o /usr/local/bin/bicep
-          chmod +x /usr/local/bin/bicep
-          bicep --version
+          mkdir -p "${HOME}/.local/bin"
+          curl -sSL https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 -o "${HOME}/.local/bin/bicep"
+          chmod +x "${HOME}/.local/bin/bicep"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          "${HOME}/.local/bin/bicep" --version
       - name: Install shellcheck
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends shellcheck
       - name: cfn-lint — CloudFormation

--- a/scripts/generate_framework_coverage_doc.py
+++ b/scripts/generate_framework_coverage_doc.py
@@ -11,7 +11,7 @@ import json
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = REPO_ROOT / "docs" / "framework-coverage.json"
@@ -19,7 +19,10 @@ OUTPUT = REPO_ROOT / "docs" / "FRAMEWORK_COVERAGE.md"
 
 
 def _load_registry() -> dict[str, Any]:
-    return json.loads(REGISTRY.read_text())
+    decoded = json.loads(REGISTRY.read_text())
+    if not isinstance(decoded, dict):
+        raise ValueError("framework-coverage registry must be a JSON object")
+    return cast(dict[str, Any], decoded)
 
 
 def _render(data: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

\`validate-iac\` covered \`cfn-lint\` and one \`terraform validate\` call. Three real gaps remained:

- **No tflint** on either Terraform tree, so style / deprecation / provider-argument bugs only surfaced at plan/apply time.
- \`terraform validate\` skipped \`runners/gcp-gcs-pubsub-detect/\` (Pub/Sub + Firestore reference runner) — it has been shipping unlinted.
- \`runners/azure-blob-eventgrid-detect/template.bicep\` never compiled in CI.
- \`scripts/run_mypy.sh\` had no shellcheck gate.

- Install tflint, the Azure Bicep CLI, and shellcheck in the \`validate-iac\` job.
- Run tflint on both Terraform trees (iam-departures infra + gcp runner).
- Run \`terraform validate\` on the gcp runner tree alongside the iam-departures one.
- Run \`bicep build\` against the Azure runner template.
- Run \`shellcheck\` on every \`scripts/*.sh\`.

No existing steps were removed. cfn-lint and the iam-departures \`terraform validate\` keep running as before.

## Not in scope

- Running the \`Runtime Benchmarks\` workflow on PR — it already exits non-zero on regression (via \`scripts/check_runtime_profile_regressions.py\`) on scheduled runs; moving it to PR incurs macOS-14 runner cost on every PR and is worth a separate discussion.
- \`checkov\` / policy-as-code. tflint catches provider-level bugs; checkov is a broader opinionated scanner best added in its own PR with agreed severity thresholds.

## Test plan

- [ ] \`validate-iac\` in CI passes on this branch.
- [ ] Temporarily breaking a \`.tf\` file (e.g. wrong attribute) should fail tflint; reverting should pass.
- [ ] Temporarily breaking the \`.bicep\` file should fail \`bicep build\`.
- [ ] Temporarily adding a shellcheck violation in \`scripts/run_mypy.sh\` should fail the job.