### PR TITLE
ci: sign source tarball and add SLSA attestations to release flow

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -12,9 +12,10 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
-  signed-sbom:
+  signed-release-assets:
     runs-on: ubuntu-latest
     steps:
       - name: Resolve release tag
@@ -43,6 +44,18 @@ jobs:
             --all-groups \
             --output-file cloud-ai-security-skills-full-lock.cdx.json
 
+      - name: Download signed source tarball from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.meta.outputs.tag }}"
+          out="cloud-ai-security-skills-${tag}-source.tar.gz"
+          curl -sSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/tarball/refs/tags/${tag}" \
+            -o "${out}"
+          ls -l "${out}"
+          echo "SOURCE_TARBALL=${out}" >> "$GITHUB_ENV"
+
       - uses: sigstore/cosign-installer@v3.8.1
 
       - name: Sign SBOM with GitHub OIDC
@@ -52,7 +65,30 @@ jobs:
             --output-certificate cloud-ai-security-skills-full-lock.cdx.json.pem \
             cloud-ai-security-skills-full-lock.cdx.json
 
-      - name: Upload signed SBOM set to release
+      - name: Sign source tarball with GitHub OIDC
+        run: |
+          cosign sign-blob --yes \
+            --output-signature "${SOURCE_TARBALL}.sig" \
+            --output-certificate "${SOURCE_TARBALL}.pem" \
+            "${SOURCE_TARBALL}"
+
+      - name: Generate SLSA build provenance attestation for SBOM
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: cloud-ai-security-skills-full-lock.cdx.json
+
+      - name: Generate SLSA build provenance attestation for source tarball
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ env.SOURCE_TARBALL }}
+
+      - name: Generate CycloneDX SBOM attestation
+        uses: actions/attest-sbom@v3
+        with:
+          subject-path: ${{ env.SOURCE_TARBALL }}
+          sbom-path: cloud-ai-security-skills-full-lock.cdx.json
+
+      - name: Upload signed SBOM and source-tarball set to release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -60,4 +96,7 @@ jobs:
             cloud-ai-security-skills-full-lock.cdx.json \
             cloud-ai-security-skills-full-lock.cdx.json.sig \
             cloud-ai-security-skills-full-lock.cdx.json.pem \
+            "${SOURCE_TARBALL}" \
+            "${SOURCE_TARBALL}.sig" \
+            "${SOURCE_TARBALL}.pem" \
             --clobber

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -75,10 +75,10 @@ git push origin vX.Y.Z
 3. Verify the tag points at the intended merge commit.
 4. Verify GitHub Actions passed on the tagged commit if a release workflow uses
    tag triggers.
-5. Verify the release workflow attached the signed CycloneDX SBOM set:
-   - `cloud-ai-security-skills-full-lock.cdx.json`
-   - `cloud-ai-security-skills-full-lock.cdx.json.sig`
-   - `cloud-ai-security-skills-full-lock.cdx.json.pem`
+5. Verify the release workflow attached the signed CycloneDX SBOM **and** the signed source tarball:
+   - SBOM: `cloud-ai-security-skills-full-lock.cdx.json` plus `.sig` and `.pem`
+   - Source tarball: `cloud-ai-security-skills-<tag>-source.tar.gz` plus `.sig` and `.pem`
+6. Verify the release workflow published SLSA build-provenance attestations for both the SBOM and the source tarball, plus a CycloneDX SBOM attestation binding the SBOM to the tarball. The attestations appear under the repo's GitHub attestation log and can be checked with `gh attestation verify <asset> --repo msaad00/cloud-ai-security-skills`.
 
 ## Post-Release
 

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -111,21 +111,46 @@ See:
 
 ## Release Distribution
 
-Published GitHub Releases now rebuild and attach the same signed CycloneDX
-artifact set that CI produces:
+Published GitHub Releases rebuild and attach both a signed CycloneDX SBOM and a
+signed source tarball, each with a SLSA build-provenance attestation and a
+CycloneDX SBOM attestation linking the tarball to its dependency graph:
 
-- `cloud-ai-security-skills-full-lock.cdx.json`
-- `cloud-ai-security-skills-full-lock.cdx.json.sig`
-- `cloud-ai-security-skills-full-lock.cdx.json.pem`
+- SBOM: `cloud-ai-security-skills-full-lock.cdx.json` plus the matching
+  `.sig` and `.pem` Sigstore materials
+- Source tarball: `cloud-ai-security-skills-<tag>-source.tar.gz` plus the
+  matching `.sig` and `.pem` Sigstore materials, downloaded from the
+  GitHub `tarball/refs/tags/<tag>` endpoint at release time and signed
+  keylessly via `cosign sign-blob` with GitHub OIDC
+- Attestations: `actions/attest-build-provenance@v2` publishes SLSA
+  provenance for both the SBOM and the source tarball to the repo's
+  GitHub attestation log, and `actions/attest-sbom@v3` binds the SBOM to
+  the source tarball so consumers can verify the dependency graph came
+  from the same release
 
 That keeps the release surface self-contained for buyers, auditors, and
-downstream automation that reads release assets instead of CI artifacts.
+downstream automation that reads release assets instead of CI artifacts, and
+lets consumers verify with either `cosign verify-blob` against the Sigstore
+cert or `gh attestation verify` against the GitHub attestation log.
+
+Verification example (consumer side):
+
+```bash
+tag=vX.Y.Z
+tarball="cloud-ai-security-skills-${tag}-source.tar.gz"
+cosign verify-blob \
+  --certificate      "${tarball}.pem" \
+  --signature        "${tarball}.sig" \
+  --certificate-identity-regexp 'https://github.com/msaad00/cloud-ai-security-skills/' \
+  --certificate-oidc-issuer     'https://token.actions.githubusercontent.com' \
+  "${tarball}"
+
+gh attestation verify "${tarball}" \
+  --repo msaad00/cloud-ai-security-skills
+```
 
 ## Future Tightenings
 
 - export a runtime-group SBOM artifact once the repo's non-package group layout
   supports a clean grouped CycloneDX export without workarounds
-- add broader signed provenance or release attestations if the release flow
-  grows beyond the current repo-level tag process
 - emit SPDX alongside CycloneDX if a customer or procurement workflow requires
   both formats

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -60,14 +60,14 @@
     <text x="162" y="632" fill="#cbd5e1" font-size="15">findings to presentation · findings to approved remediation</text>
 
     <rect x="96" y="648" width="536" height="80" rx="16" fill="#581c87" stroke="#c084fc" stroke-width="2"/>
-    <text x="120" y="680" fill="#f3e8ff" font-size="22" font-weight="700">L5 View</text>
-    <text x="120" y="708" fill="#f3e8ff" font-size="15">convert-ocsf-to-sarif · convert-ocsf-to-mermaid-</text>
-    <text x="120" y="726" fill="#f3e8ff" font-size="15">attack-flow · downstream delivery formats</text>
+    <text x="120" y="680" fill="#f3e8ff" font-size="22" font-weight="700">L5 Remediate</text>
+    <text x="120" y="708" fill="#f3e8ff" font-size="15">iam-departures-remediation · HITL approval,</text>
+    <text x="120" y="726" fill="#f3e8ff" font-size="15">dry-run first, dual audit (DynamoDB + S3)</text>
 
     <rect x="648" y="648" width="560" height="80" rx="16" fill="#7c2d12" stroke="#fb923c" stroke-width="2"/>
-    <text x="672" y="680" fill="#ffedd5" font-size="22" font-weight="700">L6 Remediate</text>
-    <text x="672" y="708" fill="#ffedd5" font-size="15">iam-departures-remediation · HITL approval,</text>
-    <text x="672" y="726" fill="#ffedd5" font-size="15">dry-run first, dual audit (DynamoDB + S3)</text>
+    <text x="672" y="680" fill="#ffedd5" font-size="22" font-weight="700">L6 View</text>
+    <text x="672" y="708" fill="#ffedd5" font-size="15">convert-ocsf-to-sarif · convert-ocsf-to-mermaid-</text>
+    <text x="672" y="726" fill="#ffedd5" font-size="15">attack-flow · downstream delivery formats</text>
 
     <path d="M640 740 L640 762" stroke="#94a3b8" stroke-width="3" fill="none"/>
 

--- a/scripts/generate_framework_coverage_doc.py
+++ b/scripts/generate_framework_coverage_doc.py
@@ -11,7 +11,7 @@ import json
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = REPO_ROOT / "docs" / "framework-coverage.json"
@@ -19,7 +19,10 @@ OUTPUT = REPO_ROOT / "docs" / "FRAMEWORK_COVERAGE.md"
 
 
 def _load_registry() -> dict[str, Any]:
-    return json.loads(REGISTRY.read_text())
+    decoded = json.loads(REGISTRY.read_text())
+    if not isinstance(decoded, dict):
+        raise ValueError("framework-coverage registry must be a JSON object")
+    return cast(dict[str, Any], decoded)
 
 
 def _render(data: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

The release workflow already signed the CycloneDX SBOM with cosign keyless OIDC, but the GitHub-generated **source tarball** shipped without signatures or attestations. Operators who clone at a tagged release had no first-class way to verify the archive beyond the repo-level tag.

- Download the source tarball from the GitHub \`tarball/refs/tags/<tag>\` endpoint at release time.
- Sign it keylessly with cosign OIDC (mirroring the SBOM signing); attach \`.sig\` and \`.pem\` to the release.
- Publish SLSA build-provenance attestations with \`actions/attest-build-provenance@v2\` for **both** the SBOM and the source tarball.
- Publish a CycloneDX SBOM attestation with \`actions/attest-sbom@v3\` binding the SBOM to the source tarball so consumers can verify the dependency graph came from the same release.
- Renamed the job from \`signed-sbom\` to \`signed-release-assets\` to match the expanded scope.
- Docs: \`docs/SUPPLY_CHAIN.md\` gains a consumer-side verification example (\`cosign verify-blob\` + \`gh attestation verify\`); \`docs/RELEASE_CHECKLIST.md\` step 5 now lists both signed artifact sets; step 6 points at the attestation log.

## Permissions

Added \`attestations: write\` alongside existing \`contents: write\` and \`id-token: write\`. Scope is still release-only; no other workflow is affected.

## Test plan

- [ ] \`workflow_dispatch\` this job against a past tag and confirm the release now includes the tarball sig/cert, the attest-build-provenance step produces attestations, and \`gh attestation verify <asset> --repo msaad00/cloud-ai-security-skills\` passes from a clean checkout.
- [ ] \`cosign verify-blob\` against the tarball using the attached cert succeeds with the OIDC issuer and identity pinned to the repo.
- [ ] SBOM signing and upload remain unchanged by diffing the pre-existing asset names in the latest release against the new set.