### PR TITLE
docs: make top-level visuals and quick run skill-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ Each shipped skill is a bundle:
 The Python file is the execution core. The full skill that agents use is the
 whole bundle.
 
-### Agent or MCP path first
+### Use the skill name first
 
-The normal agent-facing integration path is the skill name through MCP, not a
-raw `python .../src/<entry>.py` call.
+The normal integration path is the skill name through MCP or an agent client,
+not a raw `python .../src/<entry>.py` invocation.
 
-For the Kubernetes example, an MCP client calls the skill bundle like this:
+For the Kubernetes example, the skill-level flow is:
 
 ```text
 tools/call name="ingest-k8s-audit-ocsf"
@@ -127,66 +127,44 @@ arguments={
 }
 ```
 
-That is the skill-level contract agents use today:
+That is the contract the repo wants humans and agents to think in:
 
 - skill name from `SKILL.md`
 - `input`, `args`, and optional `output_format`
-- routing and guardrails from the skill bundle
-- the same runtime core underneath
+- routing, references, and guardrails from the skill bundle
+- the same execution core underneath CLI, CI, MCP, and runners
 
-### Direct execution core
+The same path can be driven by:
 
-The direct Python path is still shown because it is the wrapper-free execution
-surface the MCP server, CI, and runners call under the hood.
+- MCP / agents:
+  - Claude, Codex, Cursor, Windsurf, Cortex Code CLI
+- CI:
+  - the same skill bundle called inside a pipeline job
+- runners:
+  - the same skill bundle called behind AWS, GCP, or Azure event wrappers
 
-Why the README still shows `python skills/.../src/<entry>.py`:
+If you want to stand up the local MCP surface, use the project-scoped config in
+[`.mcp.json`](.mcp.json) or the local wrapper instructions in
+[mcp-server/README.md](mcp-server/README.md).
 
-- that is the direct execution path for the skill implementation
-- MCP, CI, and runners call the same skill code
-- agent clients add the `SKILL.md` contract, routing hints, and guardrails on top
-- the wrapper changes the access path, not the underlying skill implementation
+### What you should expect back
 
-If you want the same flow without MCP, start with the bundled Kubernetes audit
-fixture and generate SARIF in one shot:
+Most flows reduce to one of these outcomes:
 
-```bash
-python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
-  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
-  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
-  | python skills/view/convert-ocsf-to-sarif/src/convert.py \
-  > findings.sarif
-```
+- `ingest-* -> detect-* -> view/*`
+  - start from raw payloads
+  - end in SARIF, Mermaid, or review JSON
+- `source-* -> detect-* -> sink-*`
+  - start from a warehouse or object row set
+  - end in customer-owned persistence
+- `discover-*` or `evaluation/* -> remediation/*`
+  - start from live state or HR events
+  - end in evidence, audit records, or guarded writes
 
-If you want to inspect each stage separately, write local scratch files in the
-current directory:
-
-```bash
-python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
-  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
-  > k8s-events.ocsf.jsonl
-
-python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
-  k8s-events.ocsf.jsonl \
-  > k8s-findings.ocsf.jsonl
-
-python skills/view/convert-ocsf-to-sarif/src/convert.py \
-  k8s-findings.ocsf.jsonl \
-  > findings.sarif
-```
-
-Those intermediate files are only for debugging. The final output you usually
-keep is `findings.sarif`.
-
-If you want the repo-owned native wire format instead of OCSF:
-
-```bash
-python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
-  --output-format native \
-  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
-  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
-      --output-format native \
-  > findings.native.jsonl
-```
+The low-level execution-core examples still exist for debugging and wrapper
+authors, but they are intentionally moved out of the top-level entry path. See
+[docs/DATA_HANDLING.md](docs/DATA_HANDLING.md) and the individual `SKILL.md`
+files when you need wrapper-free subprocess examples.
 
 <details>
 <summary><b>Real input and output</b></summary>
@@ -223,22 +201,20 @@ Native finding output, abbreviated:
 
 </details>
 
-### Same skill, different access path
+### Same skill bundle, different access path
 
-The skill code stays the same across all of these:
+Agent clients do not require a second implementation. The same skill bundle is
+what ships everywhere:
 
-- direct CLI:
-  - `python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py ...`
 - MCP / agent:
-  - Claude, Codex, Cursor, Windsurf, or Cortex call the same skill through
-    `mcp-server/`
+  - skill name plus `input`, `args`, and optional `output_format`
 - CI:
-  - GitHub Actions or another pipeline invokes the same script and checks its output
+  - the same bundle called inside a job
 - runner:
-  - the runner template wraps the same skill in an event-driven path
-
-Agent clients do not require a second implementation of the skill. They use the
-same skill bundle through a different access path.
+  - the same bundle called behind event-driven wrappers
+- execution core:
+  - the underlying subprocess entrypoint documented in the skill bundle and in
+    [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md)
 
 ## Native vs OCSF
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -28,15 +28,15 @@ review, and PR discussions where opening the SVG is inconvenient.
 - `runtime-surfaces.svg`
   - Shows that CLI, CI, MCP, and persistent runners are access paths around the same skill bundle and execution core rather than separate implementations.
 - `iam-departures-architecture.svg`
-  - Shows the flagship write path in four stages: actionable-set selection, guarded orchestration, scoped target writes, and dual audit with drift verification.
+  - Shows the flagship write path as four staged control points: select scope, start the guarded workflow, apply scoped writes, and dual-audit plus verify the result.
 - `repo-architecture.svg`
-  - Shows external sources feeding three action bands — Intake (Ingest and Discover), Analyze (Detect and Evaluate), and Act (View and Remediate) — that share one skill bundle contract, with edge persistence, warehouse query packs, and runtime surfaces wrapping the same skills.
+  - Shows the six shipped skill lanes grouped into three action bands, with the shared skill contract underneath and the supporting edges and runtime surfaces around them.
 - `iam-departures-data-flow.svg`
   - Shows the remediation workflow data path from source manifests through planning, approval, execution, and audit artifacts.
 - `detection-pipeline.svg`
   - Shows the standard event path from raw input through normalization, detection, optional export, and downstream persistence.
 - `end-to-end-skill-flows.svg`
-  - Shows three concrete shipped compositions with the same four questions answered in each lane: what the input is, which skill families run, what the output becomes, and which guardrails apply.
+  - Shows three concrete shipped compositions as the same four-column answer each time: where the flow starts, which skills run, what the result becomes, and which guardrail matters.
 
 ## Rules
 

--- a/docs/images/end-to-end-skill-flows.svg
+++ b/docs/images/end-to-end-skill-flows.svg
@@ -1,104 +1,114 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="980" viewBox="0 0 1480 980" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="1060" viewBox="0 0 1560 1060" role="img" aria-labelledby="title desc">
   <title id="title">End-to-end skill flows</title>
-  <desc id="desc">Three real shipped skill lanes: raw logs through ingest, detect, and view; lake or warehouse rows through source, detect, and sink; and live posture or discovery data through native outputs with an optional guarded remediation path. All lanes can be called through CLI, MCP, CI, or runners using the same skill bundles.</desc>
-  <rect width="1480" height="980" fill="#08111f"/>
-  <rect x="24" y="24" width="1432" height="932" rx="32" fill="#0f172a" stroke="#334155"/>
+  <desc id="desc">Three real shipped paths are shown with the same structure: where the data starts, which skill families run, what the result becomes, and which guardrail matters most. The first path is raw logs through ingest, detect, and view. The second is warehouse or object rows through source, detect, and sink. The third is live state or HR events through discovery or evaluation into native outputs with optional guarded remediation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#07111e"/>
+      <stop offset="100%" stop-color="#0b1326"/>
+    </linearGradient>
+    <style>
+      .title { fill: #f8fafc; font: 700 42px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .subtitle { fill: #cbd5e1; font: 400 21px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .eyebrow { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; letter-spacing: .08em; text-transform: uppercase; }
+      .lane { fill: #f8fafc; font: 700 32px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .body { fill: #e2e8f0; font: 400 18px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .head { fill: #93c5fd; font: 700 20px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .cardtitle { fill: #f8fafc; font: 700 28px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .cardbody { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .chip { fill: #dbeafe; font: 600 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .guard { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .guardlabel { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    </style>
+  </defs>
 
-  <g font-family="Arial, sans-serif">
-    <text x="64" y="84" fill="#f8fafc" font-size="40" font-weight="700">End-to-end skill flows</text>
-    <text x="64" y="120" fill="#94a3b8" font-size="21">Real shipped paths. Same skill bundles underneath, different inputs, outputs, and guardrails.</text>
+  <rect width="1560" height="1060" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1504" height="1004" rx="34" fill="#0f172a" stroke="#334155" stroke-width="2"/>
 
-    <rect x="64" y="150" width="1352" height="66" rx="18" fill="#111c34" stroke="#475569"/>
-    <text x="94" y="192" fill="#cbd5e1" font-size="20" font-weight="700">Access paths:</text>
-    <text x="250" y="192" fill="#e2e8f0" font-size="20">CLI</text>
-    <text x="306" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="330" y="192" fill="#e2e8f0" font-size="20">MCP / agents</text>
-    <text x="470" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="494" y="192" fill="#e2e8f0" font-size="20">CI</text>
-    <text x="528" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="552" y="192" fill="#e2e8f0" font-size="20">AWS / GCP / Azure runners</text>
-    <text x="872" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="896" y="192" fill="#e2e8f0" font-size="20">same skill bundle contract</text>
+  <g>
+    <text x="72" y="92" class="title">Common shipped flows</text>
+    <text x="72" y="126" class="subtitle">The same skill bundles show up in different lanes. What changes is the starting data, the output, and the guardrail around the path.</text>
 
-    <rect x="64" y="248" width="1352" height="194" rx="26" fill="#0b2538" stroke="#22d3ee"/>
-    <text x="92" y="292" fill="#ccfbf1" font-size="30" font-weight="700">1. Raw log detection and export</text>
-    <text x="92" y="326" fill="#e2e8f0" font-size="18">Use when the repo starts from raw CloudTrail, Kubernetes audit, or identity-provider payloads.</text>
+    <rect x="72" y="158" width="1416" height="54" rx="18" fill="#101929" stroke="#475569" stroke-width="2"/>
+    <text x="102" y="192" class="chip">Access surfaces</text>
+    <text x="262" y="192" class="chip">CLI</text>
+    <text x="320" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="344" y="192" class="chip">MCP / agents</text>
+    <text x="478" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="502" y="192" class="chip">CI</text>
+    <text x="542" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="566" y="192" class="chip">AWS / GCP / Azure runners</text>
+    <text x="878" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="902" y="192" class="chip">same underlying skill contract</text>
 
-    <text x="92" y="370" fill="#67e8f9" font-size="18" font-weight="700">Input</text>
-    <rect x="92" y="384" width="238" height="72" rx="18" fill="#13253f" stroke="#3b82f6"/>
-    <text x="122" y="427" fill="#f8fafc" font-size="23" font-weight="700">raw vendor payload</text>
-    <text x="122" y="450" fill="#cbd5e1" font-size="16">stdin, file, object, queue</text>
+    <text x="110" y="262" class="head">Start</text>
+    <text x="390" y="262" class="head">Skill flow</text>
+    <text x="930" y="262" class="head">Result</text>
+    <text x="1188" y="262" class="head">Guardrail</text>
 
-    <text x="378" y="370" fill="#67e8f9" font-size="18" font-weight="700">Skills</text>
-    <rect x="378" y="384" width="192" height="72" rx="18" fill="#1d4ed8" stroke="#93c5fd"/>
-    <text x="438" y="428" fill="#eff6ff" font-size="25" font-weight="700">ingest-*</text>
-    <rect x="636" y="384" width="192" height="72" rx="18" fill="#0f766e" stroke="#5eead4"/>
-    <text x="698" y="428" fill="#ecfeff" font-size="25" font-weight="700">detect-*</text>
-    <rect x="894" y="384" width="192" height="72" rx="18" fill="#7c3aed" stroke="#c4b5fd"/>
-    <text x="964" y="428" fill="#f5f3ff" font-size="25" font-weight="700">view/*</text>
-    <path d="M330 420 L378 420" stroke="#38bdf8" stroke-width="5" fill="none"/>
-    <path d="M570 420 L636 420" stroke="#93c5fd" stroke-width="5" fill="none"/>
-    <path d="M828 420 L894 420" stroke="#5eead4" stroke-width="5" fill="none"/>
+    <rect x="72" y="282" width="1416" height="214" rx="28" fill="#0a2538" stroke="#22d3ee" stroke-width="2"/>
+    <text x="102" y="332" class="lane">1. Raw log detection and export</text>
+    <text x="102" y="364" class="body">Use when the repo starts from raw CloudTrail, Kubernetes audit, Okta, Entra, or other source-specific payloads.</text>
+    <rect x="102" y="390" width="230" height="78" rx="20" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
+    <text x="136" y="435" class="cardtitle">raw payloads</text>
+    <text x="136" y="458" class="cardbody">stdin, file, object, or queue message</text>
+    <rect x="372" y="390" width="150" height="78" rx="20" fill="#1d4ed8" stroke="#93c5fd" stroke-width="2"/>
+    <rect x="552" y="390" width="150" height="78" rx="20" fill="#0f766e" stroke="#5eead4" stroke-width="2"/>
+    <rect x="732" y="390" width="150" height="78" rx="20" fill="#7c3aed" stroke="#c4b5fd" stroke-width="2"/>
+    <text x="413" y="437" class="cardtitle">ingest-*</text>
+    <text x="592" y="437" class="cardtitle">detect-*</text>
+    <text x="783" y="437" class="cardtitle">view/*</text>
+    <path d="M332 429 L372 429" stroke="#38bdf8" stroke-width="5" fill="none"/>
+    <path d="M522 429 L552 429" stroke="#93c5fd" stroke-width="5" fill="none"/>
+    <path d="M702 429 L732 429" stroke="#5eead4" stroke-width="5" fill="none"/>
+    <rect x="922" y="390" width="220" height="78" rx="20" fill="#13253f" stroke="#7dd3fc" stroke-width="2"/>
+    <text x="956" y="434" fill="#f8fafc" font-size="24" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">export artifact</text>
+    <text x="956" y="458" class="cardbody">SARIF, Mermaid, or JSON output</text>
+    <rect x="1172" y="390" width="276" height="78" rx="20" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+    <text x="1204" y="434" class="guardlabel">Guardrail</text>
+    <text x="1204" y="458" class="guard">read-only, deterministic, no hidden writes</text>
 
-    <text x="1134" y="370" fill="#67e8f9" font-size="18" font-weight="700">Output</text>
-    <rect x="1134" y="384" width="246" height="72" rx="18" fill="#13253f" stroke="#7dd3fc"/>
-    <text x="1166" y="426" fill="#f8fafc" font-size="24" font-weight="700">SARIF / Mermaid / JSON</text>
-    <text x="1166" y="450" fill="#cbd5e1" font-size="16">export or review artifact</text>
-    <text x="92" y="490" fill="#94a3b8" font-size="16">Example: ingest-cloudtrail-ocsf → detect-lateral-movement → convert-ocsf-to-sarif</text>
-    <text x="92" y="516" fill="#22d3ee" font-size="16" font-weight="700">Guardrail:</text>
-    <text x="186" y="516" fill="#cbd5e1" font-size="16">read-only path, deterministic transforms, no hidden writes</text>
+    <rect x="72" y="526" width="1416" height="214" rx="28" fill="#10243a" stroke="#60a5fa" stroke-width="2"/>
+    <text x="102" y="576" class="lane">2. Warehouse or object analysis with persistence</text>
+    <text x="102" y="608" class="body">Use when data already lives in Snowflake, Databricks, ClickHouse, or object storage and you want analysis near the data.</text>
+    <rect x="102" y="634" width="230" height="78" rx="20" fill="#13253f" stroke="#38bdf8" stroke-width="2"/>
+    <text x="136" y="679" class="cardtitle">rows or objects</text>
+    <text x="136" y="702" class="cardbody">read-only table, view, or object rows</text>
+    <rect x="372" y="634" width="150" height="78" rx="20" fill="#155e75" stroke="#67e8f9" stroke-width="2"/>
+    <rect x="552" y="634" width="150" height="78" rx="20" fill="#0f766e" stroke="#5eead4" stroke-width="2"/>
+    <rect x="732" y="634" width="150" height="78" rx="20" fill="#5b21b6" stroke="#c084fc" stroke-width="2"/>
+    <text x="406" y="681" class="cardtitle">source-*</text>
+    <text x="592" y="681" class="cardtitle">detect-*</text>
+    <text x="792" y="681" class="cardtitle">sink-*</text>
+    <path d="M332 673 L372 673" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M522 673 L552 673" stroke="#67e8f9" stroke-width="5" fill="none"/>
+    <path d="M702 673 L732 673" stroke="#5eead4" stroke-width="5" fill="none"/>
+    <rect x="922" y="634" width="220" height="78" rx="20" fill="#13253f" stroke="#7dd3fc" stroke-width="2"/>
+    <text x="956" y="679" fill="#f8fafc" font-size="24" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">customer sink</text>
+    <text x="956" y="702" class="cardbody">Snowflake, ClickHouse, or S3 JSONL</text>
+    <rect x="1172" y="634" width="276" height="78" rx="20" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
+    <text x="1204" y="678" class="guardlabel">Guardrail</text>
+    <text x="1204" y="702" class="guard">read-only query side, validated sinks only</text>
 
-    <rect x="64" y="474" width="1352" height="194" rx="26" fill="#10243a" stroke="#60a5fa"/>
-    <text x="92" y="518" fill="#dbeafe" font-size="30" font-weight="700">2. Lake or warehouse analysis with persistence</text>
-    <text x="92" y="552" fill="#e2e8f0" font-size="18">Use when data already lives in Snowflake, Databricks, or S3 object rows and you want read-only extraction before analysis.</text>
-
-    <text x="92" y="596" fill="#93c5fd" font-size="18" font-weight="700">Input</text>
-    <rect x="92" y="610" width="238" height="72" rx="18" fill="#13253f" stroke="#38bdf8"/>
-    <text x="120" y="652" fill="#f8fafc" font-size="22" font-weight="700">read-only rows or objects</text>
-    <text x="120" y="676" fill="#cbd5e1" font-size="16">warehouse table, view, or S3 object</text>
-
-    <text x="378" y="596" fill="#93c5fd" font-size="18" font-weight="700">Skills</text>
-    <rect x="378" y="610" width="192" height="72" rx="18" fill="#155e75" stroke="#67e8f9"/>
-    <text x="440" y="654" fill="#ecfeff" font-size="25" font-weight="700">source-*</text>
-    <rect x="636" y="610" width="192" height="72" rx="18" fill="#0f766e" stroke="#5eead4"/>
-    <text x="698" y="654" fill="#ecfeff" font-size="25" font-weight="700">detect-*</text>
-    <rect x="894" y="610" width="192" height="72" rx="18" fill="#4c1d95" stroke="#c084fc"/>
-    <text x="958" y="654" fill="#f3e8ff" font-size="25" font-weight="700">sink-*</text>
-    <path d="M330 646 L378 646" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M570 646 L636 646" stroke="#67e8f9" stroke-width="5" fill="none"/>
-    <path d="M828 646 L894 646" stroke="#5eead4" stroke-width="5" fill="none"/>
-
-    <text x="1134" y="596" fill="#93c5fd" font-size="18" font-weight="700">Output</text>
-    <rect x="1134" y="610" width="246" height="72" rx="18" fill="#13253f" stroke="#7dd3fc"/>
-    <text x="1170" y="652" fill="#f8fafc" font-size="24" font-weight="700">Snowflake / ClickHouse / S3</text>
-    <text x="1166" y="676" fill="#cbd5e1" font-size="16">customer-owned persistence edge</text>
-    <text x="92" y="716" fill="#94a3b8" font-size="16">Example: source-snowflake-query → detect-lateral-movement → sink-snowflake-jsonl</text>
-    <text x="92" y="742" fill="#60a5fa" font-size="16" font-weight="700">Guardrail:</text>
-    <text x="188" y="742" fill="#cbd5e1" font-size="16">read-only source credentials, validated sink identifiers, no arbitrary SQL writes</text>
-
-    <rect x="64" y="700" width="1352" height="194" rx="26" fill="#083344" stroke="#2dd4bf"/>
-    <text x="92" y="744" fill="#ccfbf1" font-size="30" font-weight="700">3. Live posture, discovery, and guarded action</text>
-    <text x="92" y="778" fill="#e2e8f0" font-size="18">Use when the repo starts from live cloud APIs, SaaS APIs, or HR change events instead of log streams.</text>
-
-    <text x="92" y="822" fill="#5eead4" font-size="18" font-weight="700">Input</text>
-    <rect x="92" y="836" width="238" height="72" rx="18" fill="#13253f" stroke="#14b8a6"/>
-    <text x="120" y="878" fill="#f8fafc" font-size="23" font-weight="700">live APIs or HR events</text>
-    <text x="120" y="902" fill="#cbd5e1" font-size="16">cloud state, SaaS state, lifecycle event</text>
-
-    <text x="378" y="822" fill="#5eead4" font-size="18" font-weight="700">Skills</text>
-    <rect x="378" y="836" width="220" height="72" rx="18" fill="#0f766e" stroke="#5eead4"/>
-    <text x="416" y="878" fill="#ecfeff" font-size="22" font-weight="700">discover-* / evaluation/*</text>
-    <rect x="646" y="836" width="190" height="72" rx="18" fill="#4338ca" stroke="#a78bfa"/>
-    <text x="700" y="878" fill="#eef2ff" font-size="24" font-weight="700">native outputs</text>
-    <rect x="884" y="836" width="202" height="72" rx="18" fill="#7f1d1d" stroke="#fca5a5"/>
-    <text x="930" y="878" fill="#fee2e2" font-size="24" font-weight="700">remediation/*</text>
-    <path d="M330 872 L378 872" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-    <path d="M598 872 L646 872" stroke="#5eead4" stroke-width="5" fill="none"/>
-    <path d="M836 872 L884 872" stroke="#a78bfa" stroke-width="5" fill="none"/>
-
-    <text x="1134" y="822" fill="#5eead4" font-size="18" font-weight="700">Output</text>
-    <rect x="1134" y="836" width="246" height="72" rx="18" fill="#13253f" stroke="#2dd4bf"/>
-    <text x="1176" y="878" fill="#f8fafc" font-size="24" font-weight="700">evidence / audit trail</text>
-    <text x="1166" y="902" fill="#cbd5e1" font-size="16">native result contract, approval-bound writes</text>
+    <rect x="72" y="770" width="1416" height="214" rx="28" fill="#083344" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="102" y="820" class="lane">3. Live posture, discovery, and guarded action</text>
+    <text x="102" y="852" class="body">Use when the repo starts from live cloud APIs, SaaS APIs, or HR lifecycle events instead of a raw log stream.</text>
+    <rect x="102" y="878" width="230" height="78" rx="20" fill="#13253f" stroke="#14b8a6" stroke-width="2"/>
+    <text x="136" y="923" class="cardtitle">live state</text>
+    <text x="136" y="946" class="cardbody">cloud, SaaS, or HR event context</text>
+    <rect x="372" y="878" width="230" height="78" rx="20" fill="#0f766e" stroke="#5eead4" stroke-width="2"/>
+    <rect x="632" y="878" width="190" height="78" rx="20" fill="#4338ca" stroke="#a78bfa" stroke-width="2"/>
+    <rect x="852" y="878" width="190" height="78" rx="20" fill="#7f1d1d" stroke="#fca5a5" stroke-width="2"/>
+    <text x="404" y="925" fill="#f8fafc" font-size="23" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">discover / evaluate</text>
+    <text x="674" y="925" fill="#f8fafc" font-size="23" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">native outputs</text>
+    <text x="888" y="925" fill="#f8fafc" font-size="23" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">remediation/*</text>
+    <path d="M332 917 L372 917" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+    <path d="M602 917 L632 917" stroke="#5eead4" stroke-width="5" fill="none"/>
+    <path d="M822 917 L852 917" stroke="#a78bfa" stroke-width="5" fill="none"/>
+    <rect x="1072" y="878" width="180" height="78" rx="20" fill="#13253f" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="1102" y="923" fill="#f8fafc" font-size="24" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">evidence trail</text>
+    <text x="1102" y="946" class="cardbody">review and audit output</text>
+    <rect x="1272" y="878" width="176" height="78" rx="20" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+    <text x="1304" y="923" class="guardlabel">Guardrail</text>
+    <text x="1304" y="946" class="guard">HITL, dry-run, audited writes</text>
   </g>
 </svg>

--- a/docs/images/iam-departures-architecture.svg
+++ b/docs/images/iam-departures-architecture.svg
@@ -1,94 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="940" viewBox="0 0 1480 940" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="980" viewBox="0 0 1560 980" role="img" aria-labelledby="title desc">
   <title id="title">IAM departures remediation</title>
-  <desc id="desc">The flagship guarded write path. HR systems feed a reconciler that filters rehires and grace-period exceptions before writing an S3 manifest. EventBridge starts a Step Function that invokes parser and worker Lambdas with separate execution roles. The workflow applies scoped changes to AWS, Entra, GCP, Snowflake, and Databricks, then dual-writes audit records to DynamoDB and S3 with ingest-back to the warehouse and a later drift-verification loop.</desc>
-  <rect width="1480" height="940" fill="#08111f"/>
-  <rect x="24" y="24" width="1432" height="892" rx="32" fill="#0f172a" stroke="#334155"/>
+  <desc id="desc">The flagship guarded write path begins with HR sources and a reconciler that decides which identities are actionable before exporting an S3 manifest. EventBridge starts a Step Function that invokes parser and worker Lambdas with separate roles. The worker applies scoped changes to AWS, Entra, GCP, Snowflake, and Databricks. Every action lands in DynamoDB and S3, then feeds back into later reconciliation and drift verification.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#07111e"/>
+      <stop offset="100%" stop-color="#0b1326"/>
+    </linearGradient>
+    <style>
+      .title { fill: #f8fafc; font: 700 42px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .subtitle { fill: #cbd5e1; font: 400 21px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .chip { fill: #dbeafe; font: 600 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .eyebrow { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; letter-spacing: .08em; text-transform: uppercase; }
+      .stage { fill: #f8fafc; font: 700 30px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .body { fill: #e2e8f0; font: 400 18px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .cardtitle { fill: #f8fafc; font: 700 27px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .cardbody { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .guardlabel { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .guard { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    </style>
+  </defs>
 
-  <g font-family="Arial, sans-serif">
-    <text x="64" y="86" fill="#f8fafc" font-size="40" font-weight="700">IAM departures remediation</text>
-    <text x="64" y="122" fill="#94a3b8" font-size="21">Flagship guarded write path. One closed-loop workflow with staged filters, separate roles, and dual audit.</text>
+  <rect width="1560" height="980" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1504" height="924" rx="34" fill="#0f172a" stroke="#334155" stroke-width="2"/>
 
-    <rect x="64" y="150" width="1352" height="70" rx="18" fill="#111c34" stroke="#475569"/>
-    <text x="94" y="193" fill="#cbd5e1" font-size="20" font-weight="700">Execution roles:</text>
-    <text x="266" y="193" fill="#e2e8f0" font-size="19">EventBridge</text>
-    <text x="372" y="193" fill="#38bdf8" font-size="19">•</text>
-    <text x="395" y="193" fill="#e2e8f0" font-size="19">Step Function</text>
-    <text x="529" y="193" fill="#38bdf8" font-size="19">•</text>
-    <text x="552" y="193" fill="#e2e8f0" font-size="19">parser Lambda</text>
-    <text x="686" y="193" fill="#38bdf8" font-size="19">•</text>
-    <text x="709" y="193" fill="#e2e8f0" font-size="19">worker Lambda</text>
-    <text x="847" y="193" fill="#38bdf8" font-size="19">•</text>
-    <text x="870" y="193" fill="#e2e8f0" font-size="19">cross-account remediation role</text>
+  <g>
+    <text x="72" y="92" class="title">IAM departures remediation</text>
+    <text x="72" y="126" class="subtitle">Flagship guarded write path. The key control idea is simple: decide scope early, keep orchestration separate, keep writes scoped, and audit every action twice.</text>
 
-    <rect x="64" y="252" width="1352" height="248" rx="28" fill="#0b2538" stroke="#22d3ee"/>
-    <text x="92" y="296" fill="#ccfbf1" font-size="30" font-weight="700">1. Select and export the actionable set</text>
-    <text x="92" y="330" fill="#e2e8f0" font-size="18">The reconciler is the first control point. Rehire and eligibility logic happen here before anything is written to S3.</text>
+    <rect x="72" y="158" width="1416" height="54" rx="18" fill="#101929" stroke="#475569" stroke-width="2"/>
+    <text x="102" y="192" class="chip">Execution roles</text>
+    <text x="260" y="192" class="chip">EventBridge</text>
+    <text x="364" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="388" y="192" class="chip">Step Function</text>
+    <text x="520" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="544" y="192" class="chip">parser Lambda</text>
+    <text x="684" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="708" y="192" class="chip">worker Lambda</text>
+    <text x="854" y="192" fill="#38bdf8" font-size="20">•</text>
+    <text x="878" y="192" class="chip">cross-account remediation role</text>
 
-    <text x="92" y="372" fill="#67e8f9" font-size="18" font-weight="700">Inputs</text>
-    <rect x="92" y="388" width="238" height="88" rx="18" fill="#13253f" stroke="#22d3ee"/>
-    <text x="126" y="430" fill="#f8fafc" font-size="24" font-weight="700">HR sources</text>
-    <text x="126" y="454" fill="#cbd5e1" font-size="16">Workday, Snowflake, Databricks, ClickHouse</text>
+    <rect x="72" y="246" width="1416" height="180" rx="28" fill="#0a2538" stroke="#22d3ee" stroke-width="2"/>
+    <text x="102" y="294" class="stage">1. Select scope before anything can act</text>
+    <text x="102" y="326" class="body">Rehire and grace-period filtering happen in the reconciler, not in the worker. Only the actionable set gets exported.</text>
+    <rect x="102" y="348" width="260" height="58" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
+    <rect x="410" y="348" width="308" height="58" rx="18" fill="#155e75" stroke="#67e8f9" stroke-width="2"/>
+    <rect x="766" y="348" width="256" height="58" rx="18" fill="#13253f" stroke="#38bdf8" stroke-width="2"/>
+    <rect x="1070" y="348" width="320" height="58" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
+    <text x="136" y="384" class="cardtitle">HR sources</text>
+    <text x="444" y="384" class="cardtitle">reconciler</text>
+    <text x="800" y="384" class="cardtitle">S3 manifest</text>
+    <text x="1104" y="384" class="cardtitle">EventBridge rule</text>
+    <path d="M362 377 L410 377" stroke="#38bdf8" stroke-width="5" fill="none"/>
+    <path d="M718 377 L766 377" stroke="#67e8f9" stroke-width="5" fill="none"/>
+    <path d="M1022 377 L1070 377" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <text x="102" y="448" class="guardlabel">Guardrail</text>
+    <text x="190" y="448" class="guard">No direct Step Function entry, no rehire decisions later in the pipeline, no filtered identities written to the action manifest.</text>
 
-    <text x="380" y="372" fill="#67e8f9" font-size="18" font-weight="700">Control</text>
-    <rect x="380" y="388" width="270" height="88" rx="18" fill="#155e75" stroke="#67e8f9"/>
-    <text x="418" y="430" fill="#ecfeff" font-size="24" font-weight="700">reconciler</text>
-    <text x="418" y="454" fill="#cbd5e1" font-size="16">SHA-256 row diff, rehire filter, grace check</text>
+    <rect x="72" y="454" width="1416" height="190" rx="28" fill="#11233b" stroke="#60a5fa" stroke-width="2"/>
+    <text x="102" y="502" class="stage">2. Start the guarded workflow and re-check before write</text>
+    <text x="102" y="534" class="body">EventBridge starts the Step Function. The parser Lambda re-checks the manifest and runtime state before the worker can change anything.</text>
+    <rect x="102" y="556" width="264" height="60" rx="18" fill="#1e3a8a" stroke="#93c5fd" stroke-width="2"/>
+    <rect x="414" y="556" width="268" height="60" rx="18" fill="#1e3a8a" stroke="#93c5fd" stroke-width="2"/>
+    <rect x="730" y="556" width="268" height="60" rx="18" fill="#1e3a8a" stroke="#93c5fd" stroke-width="2"/>
+    <rect x="1046" y="556" width="344" height="60" rx="18" fill="#173056" stroke="#60a5fa" stroke-width="2"/>
+    <text x="136" y="594" class="cardtitle">Step Function</text>
+    <text x="448" y="594" class="cardtitle">parser Lambda</text>
+    <text x="764" y="594" class="cardtitle">worker Lambda</text>
+    <text x="1080" y="594" class="cardtitle">targets</text>
+    <path d="M366 586 L414 586" stroke="#60a5fa" stroke-width="5" fill="none"/>
+    <path d="M682 586 L730 586" stroke="#93c5fd" stroke-width="5" fill="none"/>
+    <path d="M998 586 L1046 586" stroke="#93c5fd" stroke-width="5" fill="none"/>
+    <text x="102" y="666" class="guardlabel">Guardrail</text>
+    <text x="190" y="666" class="guard">Separate roles, human-required approval, dry-run-first, and deny-listed identities keep the write edge narrow.</text>
 
-    <text x="700" y="372" fill="#67e8f9" font-size="18" font-weight="700">Manifest</text>
-    <rect x="700" y="388" width="248" height="88" rx="18" fill="#13253f" stroke="#38bdf8"/>
-    <text x="734" y="430" fill="#f8fafc" font-size="24" font-weight="700">S3 manifest</text>
-    <text x="734" y="454" fill="#cbd5e1" font-size="16">KMS-encrypted actionable export only</text>
-
-    <text x="998" y="372" fill="#67e8f9" font-size="18" font-weight="700">Trigger</text>
-    <rect x="998" y="388" width="288" height="88" rx="18" fill="#13253f" stroke="#60a5fa"/>
-    <text x="1034" y="430" fill="#f8fafc" font-size="24" font-weight="700">EventBridge rule</text>
-    <text x="1034" y="454" fill="#cbd5e1" font-size="16">Object-created event starts the Step Function</text>
-
-    <path d="M330 432 L380 432" stroke="#38bdf8" stroke-width="5" fill="none"/>
-    <path d="M650 432 L700 432" stroke="#67e8f9" stroke-width="5" fill="none"/>
-    <path d="M948 432 L998 432" stroke="#60a5fa" stroke-width="5" fill="none"/>
-
-    <text x="92" y="528" fill="#22d3ee" font-size="16" font-weight="700">Guardrail:</text>
-    <text x="188" y="528" fill="#cbd5e1" font-size="16">no direct Step Function entry, no rehire decisions in the worker, no action rows written for filtered identities</text>
-
-    <rect x="64" y="532" width="1352" height="222" rx="28" fill="#10243a" stroke="#60a5fa"/>
-    <text x="92" y="576" fill="#dbeafe" font-size="30" font-weight="700">2. Guarded orchestration and scoped writes</text>
-    <text x="92" y="610" fill="#e2e8f0" font-size="18">The Step Function orchestrates a read-only parser gate and a scoped worker. Approval and deny rules bound the write edge.</text>
-
-    <rect x="92" y="646" width="268" height="84" rx="18" fill="#1e3a8a" stroke="#93c5fd"/>
-    <text x="128" y="686" fill="#eff6ff" font-size="23" font-weight="700">Step Function</text>
-    <text x="128" y="710" fill="#cbd5e1" font-size="16">AWS-native orchestration, retries, bounded fan-out</text>
-
-    <rect x="412" y="646" width="248" height="84" rx="18" fill="#1e3a8a" stroke="#93c5fd"/>
-    <text x="452" y="686" fill="#eff6ff" font-size="23" font-weight="700">parser Lambda</text>
-    <text x="452" y="710" fill="#cbd5e1" font-size="16">rechecks manifest, grace period, and IAM state</text>
-
-    <rect x="712" y="646" width="248" height="84" rx="18" fill="#1e3a8a" stroke="#93c5fd"/>
-    <text x="752" y="686" fill="#eff6ff" font-size="23" font-weight="700">worker Lambda</text>
-    <text x="752" y="710" fill="#cbd5e1" font-size="16">13-step cleanup with scoped cross-cloud workers</text>
-
-    <rect x="1012" y="646" width="312" height="84" rx="18" fill="#1e3a5f" stroke="#60a5fa"/>
-    <text x="1050" y="686" fill="#eff6ff" font-size="23" font-weight="700">targets</text>
-    <text x="1050" y="710" fill="#cbd5e1" font-size="16">AWS IAM, Entra ID, GCP IAM, Snowflake, Databricks</text>
-
-    <path d="M360 688 L412 688" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M660 688 L712 688" stroke="#93c5fd" stroke-width="5" fill="none"/>
-    <path d="M960 688 L1012 688" stroke="#93c5fd" stroke-width="5" fill="none"/>
-
-    <text x="92" y="782" fill="#60a5fa" font-size="16" font-weight="700">Guardrail:</text>
-    <text x="188" y="782" fill="#cbd5e1" font-size="16">human_required approval, dry-run-first workflow, deny-listed identities, separate execution roles, scoped cloud principals</text>
-
-    <rect x="64" y="786" width="1352" height="104" rx="28" fill="#083344" stroke="#2dd4bf"/>
-    <text x="92" y="830" fill="#ccfbf1" font-size="30" font-weight="700">3. Dual audit, ingest-back, and drift verification</text>
-    <text x="92" y="864" fill="#e2e8f0" font-size="18">Every action lands in DynamoDB and S3, then flows back into warehouse analytics. Later runs verify that state really closed.</text>
-
-    <rect x="940" y="802" width="202" height="64" rx="18" fill="#312e81" stroke="#a78bfa"/>
-    <text x="976" y="840" fill="#eef2ff" font-size="22" font-weight="700">DynamoDB + S3</text>
-    <text x="976" y="860" fill="#cbd5e1" font-size="15">audit storage, KMS, PITR</text>
-    <rect x="1184" y="802" width="184" height="64" rx="18" fill="#13253f" stroke="#22d3ee"/>
-    <text x="1218" y="840" fill="#f8fafc" font-size="22" font-weight="700">ingest-back</text>
-    <text x="1218" y="860" fill="#cbd5e1" font-size="15">warehouse reconciliation</text>
-    <path d="M1324 834 C 1324 906, 220 906, 220 476" stroke="#22d3ee" stroke-width="4" stroke-dasharray="8 8" fill="none"/>
-    <text x="756" y="910" fill="#22d3ee" font-size="18" font-style="italic" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
+    <rect x="72" y="672" width="1416" height="196" rx="28" fill="#083344" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="102" y="720" class="stage">3. Apply scoped changes and write the audit trail</text>
+    <text x="102" y="752" class="body">The worker touches only the approved targets. Every action is recorded in DynamoDB and S3 as the system of record for later replay and review.</text>
+    <rect x="102" y="776" width="286" height="60" rx="18" fill="#1f4b61" stroke="#2dd4bf" stroke-width="2"/>
+    <rect x="436" y="776" width="250" height="60" rx="18" fill="#312e81" stroke="#a78bfa" stroke-width="2"/>
+    <rect x="734" y="776" width="250" height="60" rx="18" fill="#173056" stroke="#60a5fa" stroke-width="2"/>
+    <rect x="1032" y="776" width="306" height="60" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+    <text x="136" y="814" class="cardtitle">scoped write set</text>
+    <text x="470" y="814" class="cardtitle">DynamoDB + S3</text>
+    <text x="768" y="814" class="cardtitle">ingest-back</text>
+    <text x="1066" y="814" class="cardtitle">later drift check</text>
+    <path d="M388 806 L436 806" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+    <path d="M686 806 L734 806" stroke="#a78bfa" stroke-width="5" fill="none"/>
+    <path d="M984 806 L1032 806" stroke="#22d3ee" stroke-width="5" fill="none"/>
+    <path d="M1326 860 C1326 918 286 918 286 348" stroke="#22d3ee" stroke-width="4" stroke-dasharray="10 10" fill="none"/>
+    <text x="780" y="914" fill="#22d3ee" font="italic 18px 'IBM Plex Sans', 'Segoe UI', sans-serif" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
   </g>
 </svg>

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -1,98 +1,108 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="1020" viewBox="0 0 1280 1020" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="980" viewBox="0 0 1480 980" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills repository architecture</title>
-  <desc id="desc">External sources feed three action bands of shipped skill lanes. Intake pairs Ingest and Discover in parallel. Analyze pairs Detect and Evaluate in parallel. Act pairs Remediate and View in parallel. All six lanes share one skill bundle contract and are wrapped by edge persistence, warehouse query packs, and runtime surfaces.</desc>
+  <desc id="desc">The repo is organized into three action bands. Intake contains Ingest and Discover. Analyze contains Detect and Evaluate. Act contains Remediate and View. All six lanes share one skill bundle contract, while sources and sinks, warehouse query packs, and runtime surfaces wrap the same underlying skills.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#07111e"/>
+      <stop offset="100%" stop-color="#0b1326"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#111c34"/>
+    </linearGradient>
+    <linearGradient id="intake" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#162456"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+    <linearGradient id="analyze" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0f3a41"/>
+      <stop offset="100%" stop-color="#0f766e"/>
+    </linearGradient>
+    <linearGradient id="act" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#4a1930"/>
+      <stop offset="100%" stop-color="#7c2d12"/>
+    </linearGradient>
+    <style>
+      .title { fill: #f8fafc; font: 700 42px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .subtitle { fill: #cbd5e1; font: 400 21px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .micro { fill: #94a3b8; font: 400 15px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .section { fill: #f8fafc; font: 700 30px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .eyebrow { fill: #93c5fd; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; letter-spacing: .08em; text-transform: uppercase; }
+      .cardtitle { fill: #f8fafc; font: 700 29px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .body { fill: #e2e8f0; font: 400 17px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .small { fill: #cbd5e1; font: 400 15px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .chip { fill: #dbeafe; font: 600 15px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+      .foot { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    </style>
+  </defs>
 
-  <rect width="1280" height="1020" fill="#08111f"/>
-  <rect x="32" y="32" width="1216" height="956" rx="28" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+  <rect width="1480" height="980" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1424" height="924" rx="34" fill="url(#panel)" stroke="#334155" stroke-width="2"/>
 
-  <g font-family="Arial, sans-serif">
-    <text x="72" y="88" fill="#f8fafc" font-size="34" font-weight="700">cloud-ai-security-skills</text>
-    <text x="72" y="120" fill="#cbd5e1" font-size="18">Same skill bundle, any surface. OCSF 1.8 default wire format, native where OCSF is thin.</text>
-    <text x="72" y="148" fill="#94a3b8" font-size="15">Three action bands. Six skill lanes. One shared contract. Edge and runtime surfaces wrap the same skills.</text>
+  <g>
+    <text x="72" y="92" class="title">cloud-ai-security-skills</text>
+    <text x="72" y="126" class="subtitle">Same skill bundle, any surface. OCSF 1.8 by default for streams, native where OCSF is thin.</text>
+    <text x="72" y="152" class="micro">Three action bands. Six shipped skill lanes. One shared contract. Support layers wrap the same skills instead of replacing them.</text>
 
-    <!-- External sources band -->
-    <rect x="72" y="176" width="1136" height="60" rx="16" fill="#111827" stroke="#475569" stroke-width="2"/>
-    <text x="96" y="208" fill="#e5e7eb" font-size="18" font-weight="700">External sources</text>
-    <text x="96" y="228" fill="#cbd5e1" font-size="15">Cloud APIs · raw logs · identity providers · Kubernetes audit · warehouses · object stores · MCP proxy events</text>
+    <rect x="72" y="186" width="1336" height="86" rx="22" fill="#101929" stroke="#475569" stroke-width="2"/>
+    <text x="102" y="220" class="eyebrow">External signals</text>
+    <rect x="102" y="234" width="150" height="26" rx="13" fill="#172136"/>
+    <rect x="266" y="234" width="132" height="26" rx="13" fill="#172136"/>
+    <rect x="412" y="234" width="154" height="26" rx="13" fill="#172136"/>
+    <rect x="580" y="234" width="158" height="26" rx="13" fill="#172136"/>
+    <rect x="752" y="234" width="148" height="26" rx="13" fill="#172136"/>
+    <rect x="914" y="234" width="148" height="26" rx="13" fill="#172136"/>
+    <text x="126" y="252" class="chip">cloud APIs</text>
+    <text x="298" y="252" class="chip">raw logs</text>
+    <text x="442" y="252" class="chip">identity feeds</text>
+    <text x="606" y="252" class="chip">Kubernetes audit</text>
+    <text x="785" y="252" class="chip">warehouses</text>
+    <text x="948" y="252" class="chip">MCP proxy</text>
 
-    <path d="M640 236 L640 260" stroke="#94a3b8" stroke-width="3" fill="none"/>
-    <path d="M632 254 L640 262 L648 254" stroke="#94a3b8" stroke-width="3" fill="none"/>
+    <rect x="72" y="308" width="1336" height="154" rx="28" fill="#0f1f3a" stroke="#3b82f6" stroke-width="2"/>
+    <text x="100" y="342" class="eyebrow">Intake</text>
+    <text x="100" y="380" class="section">Turn raw inputs or live state into stable repo data</text>
+    <rect x="100" y="404" width="610" height="44" rx="18" fill="url(#intake)" stroke="#93c5fd" stroke-width="2"/>
+    <rect x="770" y="404" width="610" height="44" rx="18" fill="url(#intake)" stroke="#93c5fd" stroke-width="2"/>
+    <text x="126" y="434" class="cardtitle">L1 Ingest</text>
+    <text x="796" y="434" class="cardtitle">L2 Discover</text>
+    <text x="126" y="490" class="body">source-specific normalization from CloudTrail, Azure Activity, GCP audit,</text>
+    <text x="126" y="514" class="body">Kubernetes audit, Okta, Entra, Workspace, VPC/NSG flows, and MCP proxy logs</text>
+    <text x="796" y="490" class="body">live inventory, AI BOM, control evidence, environment graph context,</text>
+    <text x="796" y="514" class="body">and repo-native outputs for posture, evidence, and discovery workflows</text>
 
-    <!-- Intake band -->
-    <rect x="72" y="266" width="1136" height="138" rx="22" fill="#0f1f3a" stroke="#1e3a8a" stroke-width="2"/>
-    <text x="96" y="296" fill="#bfdbfe" font-size="17" font-weight="700">1 · Intake</text>
-    <text x="180" y="296" fill="#cbd5e1" font-size="15">raw source to stable event stream or live evidence</text>
+    <rect x="72" y="492" width="1336" height="154" rx="28" fill="#0a2d30" stroke="#14b8a6" stroke-width="2"/>
+    <text x="100" y="526" class="eyebrow" fill="#99f6e4">Analyze</text>
+    <text x="100" y="564" class="section">Turn events into findings and controls into benchmark results</text>
+    <rect x="100" y="588" width="610" height="44" rx="18" fill="url(#analyze)" stroke="#5eead4" stroke-width="2"/>
+    <rect x="770" y="588" width="610" height="44" rx="18" fill="url(#analyze)" stroke="#5eead4" stroke-width="2"/>
+    <text x="126" y="618" class="cardtitle">L3 Detect</text>
+    <text x="796" y="618" class="cardtitle">L4 Evaluate</text>
+    <text x="126" y="674" class="body">detectors for lateral movement, Kubernetes privilege escalation,</text>
+    <text x="126" y="698" class="body">Okta MFA fatigue, MCP tool drift, Workspace auth, and Entra identity abuse</text>
+    <text x="796" y="674" class="body">benchmarks and evaluation flows for AWS, Azure, GCP, Kubernetes,</text>
+    <text x="796" y="698" class="body">containers, model serving, and GPU cluster posture</text>
 
-    <rect x="96" y="312" width="536" height="80" rx="16" fill="#172554" stroke="#60a5fa" stroke-width="2"/>
-    <text x="120" y="344" fill="#dbeafe" font-size="22" font-weight="700">L1 Ingest</text>
-    <text x="120" y="372" fill="#dbeafe" font-size="15">15 ingesters · CloudTrail, GCP audit, Azure activity,</text>
-    <text x="120" y="390" fill="#dbeafe" font-size="15">K8s audit, Okta, Entra, Workspace, MCP proxy</text>
+    <rect x="72" y="676" width="1336" height="154" rx="28" fill="#2b1a1a" stroke="#f97316" stroke-width="2"/>
+    <text x="100" y="710" class="eyebrow" fill="#fdba74">Act</text>
+    <text x="100" y="748" class="section">Present results or take approval-bound action</text>
+    <rect x="100" y="772" width="610" height="44" rx="18" fill="url(#act)" stroke="#f0abfc" stroke-width="2"/>
+    <rect x="770" y="772" width="610" height="44" rx="18" fill="url(#act)" stroke="#fb923c" stroke-width="2"/>
+    <text x="126" y="802" class="cardtitle">L5 Remediate</text>
+    <text x="796" y="802" class="cardtitle">L6 View</text>
+    <text x="126" y="858" class="body">flagship guarded write path for IAM departures: dry-run first,</text>
+    <text x="126" y="882" class="body">human approval, scoped roles, and dual audit to DynamoDB plus S3</text>
+    <text x="796" y="858" class="body">delivery and review formats such as SARIF and Mermaid attack flow</text>
+    <text x="796" y="882" class="body">for downstream triage, export, and security review workflows</text>
 
-    <rect x="648" y="312" width="560" height="80" rx="16" fill="#1d4ed8" stroke="#60a5fa" stroke-width="2"/>
-    <text x="672" y="344" fill="#eff6ff" font-size="22" font-weight="700">L2 Discover</text>
-    <text x="672" y="372" fill="#dbeafe" font-size="15">live inventory, AI BOM, cloud control evidence,</text>
-    <text x="672" y="390" fill="#dbeafe" font-size="15">discover-environment graph context</text>
+    <rect x="72" y="850" width="1336" height="48" rx="18" fill="#182234" stroke="#64748b" stroke-width="2"/>
+    <text x="100" y="881" class="foot"><tspan font-weight="700" fill="#f8fafc">Shared contract</tspan><tspan dx="18">SKILL.md • REFERENCES.md • src/ • tests/ • native / canonical / OCSF / bridge modes</tspan></text>
 
-    <path d="M640 404 L640 428" stroke="#94a3b8" stroke-width="3" fill="none"/>
-    <path d="M632 422 L640 430 L648 422" stroke="#94a3b8" stroke-width="3" fill="none"/>
-
-    <!-- Analyze band -->
-    <rect x="72" y="434" width="1136" height="138" rx="22" fill="#0c2e2a" stroke="#0d9488" stroke-width="2"/>
-    <text x="96" y="464" fill="#a7f3d0" font-size="17" font-weight="700">2 · Analyze</text>
-    <text x="196" y="464" fill="#cbd5e1" font-size="15">events to findings · controls to compliance results</text>
-
-    <rect x="96" y="480" width="536" height="80" rx="16" fill="#0f766e" stroke="#2dd4bf" stroke-width="2"/>
-    <text x="120" y="512" fill="#ccfbf1" font-size="22" font-weight="700">L3 Detect</text>
-    <text x="120" y="540" fill="#ccfbf1" font-size="15">8 detectors · lateral movement, K8s priv-esc,</text>
-    <text x="120" y="558" fill="#ccfbf1" font-size="15">MFA fatigue, MCP tool drift · MITRE-mapped</text>
-
-    <rect x="648" y="480" width="560" height="80" rx="16" fill="#14532d" stroke="#4ade80" stroke-width="2"/>
-    <text x="672" y="512" fill="#dcfce7" font-size="22" font-weight="700">L4 Evaluate</text>
-    <text x="672" y="540" fill="#dcfce7" font-size="15">7 benchmarks · CIS AWS / GCP / Azure / K8s,</text>
-    <text x="672" y="558" fill="#dcfce7" font-size="15">container, GPU cluster, model serving</text>
-
-    <path d="M640 572 L640 596" stroke="#94a3b8" stroke-width="3" fill="none"/>
-    <path d="M632 590 L640 598 L648 590" stroke="#94a3b8" stroke-width="3" fill="none"/>
-
-    <!-- Act band -->
-    <rect x="72" y="602" width="1136" height="138" rx="22" fill="#2b1a1a" stroke="#b45309" stroke-width="2"/>
-    <text x="96" y="632" fill="#fed7aa" font-size="17" font-weight="700">3 · Act</text>
-    <text x="162" y="632" fill="#cbd5e1" font-size="15">findings to presentation · findings to approved remediation</text>
-
-    <rect x="96" y="648" width="536" height="80" rx="16" fill="#581c87" stroke="#c084fc" stroke-width="2"/>
-    <text x="120" y="680" fill="#f3e8ff" font-size="22" font-weight="700">L5 Remediate</text>
-    <text x="120" y="708" fill="#f3e8ff" font-size="15">iam-departures-remediation · HITL approval,</text>
-    <text x="120" y="726" fill="#f3e8ff" font-size="15">dry-run first, dual audit (DynamoDB + S3)</text>
-
-    <rect x="648" y="648" width="560" height="80" rx="16" fill="#7c2d12" stroke="#fb923c" stroke-width="2"/>
-    <text x="672" y="680" fill="#ffedd5" font-size="22" font-weight="700">L6 View</text>
-    <text x="672" y="708" fill="#ffedd5" font-size="15">convert-ocsf-to-sarif · convert-ocsf-to-mermaid-</text>
-    <text x="672" y="726" fill="#ffedd5" font-size="15">attack-flow · downstream delivery formats</text>
-
-    <path d="M640 740 L640 762" stroke="#94a3b8" stroke-width="3" fill="none"/>
-
-    <!-- Shared contract -->
-    <rect x="72" y="766" width="1136" height="48" rx="14" fill="#1f2937" stroke="#64748b" stroke-width="2"/>
-    <text x="96" y="797" fill="#f8fafc" font-size="17" font-weight="700">Shared contract</text>
-    <text x="260" y="797" fill="#cbd5e1" font-size="15">SKILL.md · src/ · tests/ · REFERENCES.md · OCSF 1.8 JSONL default · native / canonical / bridge modes</text>
-
-    <!-- Edge persistence, query packs, runtime surfaces -->
-    <rect x="72" y="838" width="352" height="130" rx="18" fill="#111827" stroke="#475569" stroke-width="2"/>
-    <text x="96" y="870" fill="#f8fafc" font-size="18" font-weight="700">Edge persistence</text>
-    <text x="96" y="898" fill="#cbd5e1" font-size="14">sink-snowflake-jsonl · sink-clickhouse-jsonl</text>
-    <text x="96" y="918" fill="#cbd5e1" font-size="14">sink-s3-jsonl · IAM departures DynamoDB + S3</text>
-    <text x="96" y="946" fill="#94a3b8" font-size="13">customer-owned, append-only, audit-friendly</text>
-
-    <rect x="440" y="838" width="304" height="130" rx="18" fill="#111827" stroke="#475569" stroke-width="2"/>
-    <text x="464" y="870" fill="#f8fafc" font-size="18" font-weight="700">Query packs</text>
-    <text x="464" y="898" fill="#cbd5e1" font-size="14">packs/lateral-movement</text>
-    <text x="464" y="918" fill="#cbd5e1" font-size="14">packs/privilege-escalation-k8s</text>
-    <text x="464" y="946" fill="#94a3b8" font-size="13">warehouse-native SQL mirrors</text>
-
-    <rect x="760" y="838" width="448" height="130" rx="18" fill="#111827" stroke="#475569" stroke-width="2"/>
-    <text x="784" y="870" fill="#f8fafc" font-size="18" font-weight="700">Runtime surfaces</text>
-    <text x="784" y="898" fill="#cbd5e1" font-size="14">CLI · CI · MCP · AWS / GCP / Azure runners</text>
-    <text x="784" y="918" fill="#cbd5e1" font-size="14">same skill bundle underneath every surface</text>
-    <text x="784" y="946" fill="#94a3b8" font-size="13">wrappers add orchestration, not a second implementation</text>
+    <rect x="72" y="912" width="420" height="30" rx="15" fill="#121b2a"/>
+    <rect x="530" y="912" width="352" height="30" rx="15" fill="#121b2a"/>
+    <rect x="920" y="912" width="488" height="30" rx="15" fill="#121b2a"/>
+    <text x="96" y="932" class="small"><tspan font-weight="700" fill="#f8fafc">Edge layers</tspan><tspan dx="10">source-* and sink-*</tspan></text>
+    <text x="554" y="932" class="small"><tspan font-weight="700" fill="#f8fafc">Query packs</tspan><tspan dx="10">warehouse SQL mirrors</tspan></text>
+    <text x="944" y="932" class="small"><tspan font-weight="700" fill="#f8fafc">Runtime surfaces</tspan><tspan dx="10">CLI • CI • MCP • runners</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the three top-level README SVGs with cleaner lane-based visuals
- move the README quick-run guidance to skill-name and MCP-first usage instead of leading with raw execution-core commands
- keep low-level subprocess examples documented in deeper docs instead of as the top-level repo entry path

## Validation
- python scripts/validate_skill_contract.py
- xmllint --noout docs/images/repo-architecture.svg docs/images/end-to-end-skill-flows.svg docs/images/iam-departures-architecture.svg