### PR TITLE
feat: harden evaluation outputs and replay-safe remediation

### DIFF
--- a/skills/_shared/evaluation_ocsf.py
+++ b/skills/_shared/evaluation_ocsf.py
@@ -34,7 +34,7 @@ def findings_to_native(findings: list[Any]) -> list[dict[str, Any]]:
     """Render evaluation findings into plain dicts."""
     rendered: list[dict[str, Any]] = []
     for finding in findings:
-        if is_dataclass(finding):
+        if is_dataclass(finding) and not isinstance(finding, type):
             rendered.append(asdict(finding))
         elif isinstance(finding, dict):
             rendered.append(dict(finding))

--- a/skills/_shared/evaluation_ocsf.py
+++ b/skills/_shared/evaluation_ocsf.py
@@ -1,0 +1,206 @@
+"""Shared helpers for evaluation skills that emit OCSF Compliance Findings."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, is_dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+OCSF_VERSION = "1.8.0"
+
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_CLASS_UID = 2003
+FINDING_CLASS_NAME = "Compliance Finding"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+STATUS_SUCCESS = 1
+STATUS_FAILURE = 2
+
+_SEVERITY_TO_ID = {
+    "INFORMATIONAL": 1,
+    "LOW": 2,
+    "MEDIUM": 3,
+    "HIGH": 4,
+    "CRITICAL": 5,
+}
+
+
+def findings_to_native(findings: list[Any]) -> list[dict[str, Any]]:
+    """Render evaluation findings into plain dicts."""
+    rendered: list[dict[str, Any]] = []
+    for finding in findings:
+        if is_dataclass(finding):
+            rendered.append(asdict(finding))
+        elif isinstance(finding, dict):
+            rendered.append(dict(finding))
+        else:
+            raise TypeError(f"Unsupported finding type: {type(finding)!r}")
+    return rendered
+
+
+def findings_to_ocsf(
+    findings: list[Any],
+    *,
+    skill_name: str,
+    benchmark_name: str,
+    provider: str,
+    frameworks: list[str],
+) -> list[dict[str, Any]]:
+    """Convert native evaluation findings into OCSF Compliance Findings."""
+    native_findings = findings_to_native(findings)
+    return [
+        render_compliance_finding(
+            native_finding,
+            skill_name=skill_name,
+            benchmark_name=benchmark_name,
+            provider=provider,
+            frameworks=frameworks,
+        )
+        for native_finding in native_findings
+    ]
+
+
+def render_compliance_finding(
+    native_finding: dict[str, Any],
+    *,
+    skill_name: str,
+    benchmark_name: str,
+    provider: str,
+    frameworks: list[str],
+) -> dict[str, Any]:
+    """Project a repo-native evaluation result into OCSF class 2003."""
+    uid = _finding_uid(native_finding, skill_name=skill_name, provider=provider)
+    resources = _resource_names(native_finding)
+    now_ms = _now_ms()
+    severity_name = str(native_finding.get("severity") or "LOW").upper()
+    status_name = str(native_finding.get("status") or "UNKNOWN").upper()
+    title = str(native_finding.get("title") or benchmark_name)
+    detail = str(native_finding.get("detail") or "")
+    section = str(native_finding.get("section") or "")
+    rule_id = str(
+        native_finding.get("control_id")
+        or native_finding.get("check_id")
+        or native_finding.get("rule_id")
+        or title
+    )
+
+    remediation = str(native_finding.get("remediation") or "")
+    desc_parts = [detail] if detail else []
+    if remediation:
+        desc_parts.append(f"Remediation: {remediation}")
+
+    observables = [
+        {"name": "resource", "type": "Other", "value": resource}
+        for resource in resources
+    ]
+
+    evidence = {
+        "frameworks": frameworks,
+        "benchmark": benchmark_name,
+        "provider": provider,
+        "section": section,
+        "native_finding": native_finding,
+    }
+
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "activity_name": "Create",
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": _severity_id(severity_name),
+        "status_id": _status_id(status_name),
+        "time": now_ms,
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": uid,
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": skill_name},
+            },
+            "labels": ["evaluation", "compliance", provider.lower(), skill_name],
+        },
+        "finding_info": {
+            "uid": uid,
+            "title": title,
+            "desc": " ".join(desc_parts).strip(),
+            "types": [rule_id],
+            "first_seen_time": now_ms,
+            "last_seen_time": now_ms,
+        },
+        "compliance": {
+            "status": status_name,
+            "control": rule_id,
+            "frameworks": frameworks,
+            "requirements": [entry for entry in _framework_requirements(native_finding) if entry],
+        },
+        "cloud": {"provider": provider},
+        "resources": [{"name": resource, "type": "Other"} for resource in resources],
+        "observables": observables,
+        "evidence": evidence,
+    }
+
+
+def _framework_requirements(native_finding: dict[str, Any]) -> list[str]:
+    keys = (
+        "cis_docker",
+        "cis_control",
+        "cis_k8s",
+        "nist_csf",
+        "nist_ai_rmf",
+        "iso_27001",
+        "mitre_attack",
+        "mitre_atlas",
+    )
+    return [str(native_finding.get(key) or "") for key in keys]
+
+
+def _resource_names(native_finding: dict[str, Any]) -> list[str]:
+    resources = native_finding.get("resources") or []
+    names: list[str] = []
+    for resource in resources:
+        if isinstance(resource, str) and resource:
+            names.append(resource)
+    return names
+
+
+def _finding_uid(native_finding: dict[str, Any], *, skill_name: str, provider: str) -> str:
+    identifier = str(
+        native_finding.get("control_id")
+        or native_finding.get("check_id")
+        or native_finding.get("title")
+        or "finding"
+    )
+    resources = "|".join(sorted(_resource_names(native_finding)))
+    material = "|".join(
+        [
+            skill_name,
+            provider.lower(),
+            identifier,
+            str(native_finding.get("status") or ""),
+            str(native_finding.get("severity") or ""),
+            resources,
+        ]
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"eval-{skill_name}-{digest}"
+
+
+def _now_ms() -> int:
+    return int(datetime.now(UTC).timestamp() * 1000)
+
+
+def _severity_id(severity_name: str) -> int:
+    return _SEVERITY_TO_ID.get(severity_name.upper(), 2)
+
+
+def _status_id(status_name: str) -> int:
+    return STATUS_SUCCESS if status_name == "PASS" else STATUS_FAILURE

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -93,6 +93,11 @@ event family.
 
 Default 15 minutes post-anchor. Rationale: attackers tend to act fast after acquiring a more powerful cloud identity. A longer window catches more but produces more false positives on legitimate cross-service traffic.
 
+Operators can override the runtime thresholds without forking the skill:
+
+- `DETECT_LATERAL_MOVEMENT_WINDOW_MS`
+- `DETECT_LATERAL_MOVEMENT_MIN_BYTES`
+
 ### Batch sizing guidance
 
 This detector is designed for bounded batch windows, not as an infinite-stream

--- a/skills/detection/detect-lateral-movement/src/detect.py
+++ b/skills/detection/detect-lateral-movement/src/detect.py
@@ -17,6 +17,7 @@ import argparse
 import hashlib
 import ipaddress
 import json
+import os
 import sys
 from bisect import bisect_left
 from datetime import datetime, timezone
@@ -72,6 +73,8 @@ CORRELATION_WINDOW_MS = 15 * 60 * 1000
 # Byte threshold — filter out scan probes / 3-way handshake noise
 MIN_BYTES = 1024
 OUTPUT_FORMATS = ("ocsf", "native")
+WINDOW_ENV = "DETECT_LATERAL_MOVEMENT_WINDOW_MS"
+MIN_BYTES_ENV = "DETECT_LATERAL_MOVEMENT_MIN_BYTES"
 
 # Cloud identity-pivot operations we anchor on
 ASSUME_ROLE_OPERATIONS = {"AssumeRole", "AssumeRoleWithSAML", "AssumeRoleWithWebIdentity"}
@@ -354,13 +357,15 @@ def is_identity_pivot_anchor(event: dict[str, Any]) -> bool:
 
 def coverage_metadata() -> dict[str, object]:
     """Return machine-readable ATT&CK and provider coverage for the detector."""
+    correlation_window_ms = _correlation_window_ms()
+    min_bytes = _min_bytes()
     return {
         "frameworks": list(FRAMEWORKS),
         "providers": list(PROVIDERS),
         "asset_classes": list(ASSET_CLASSES),
         "attack_coverage": ATTACK_COVERAGE,
-        "correlation_window_seconds": CORRELATION_WINDOW_MS // 1000,
-        "min_flow_bytes": MIN_BYTES,
+        "correlation_window_seconds": correlation_window_ms // 1000,
+        "min_flow_bytes": min_bytes,
     }
 
 
@@ -386,6 +391,7 @@ def _build_native_finding(
     src_ip = str(flow_event["src_ip"])
     flow_bytes = _safe_int(flow_event["traffic_bytes"])
     operation = str(anchor_event["operation"])
+    correlation_window_ms = _correlation_window_ms()
 
     dst_key = f"{dst_ip}:{dst_port}"
     uid = f"det-lm-{_short(provider_key)}-{_short(session)}-{_short(dst_key)}"
@@ -393,7 +399,7 @@ def _build_native_finding(
     desc = (
         f"Principal '{principal}' triggered identity pivot operation '{operation}' "
         f"(session '{session}'), and within the "
-        f"{CORRELATION_WINDOW_MS // 60000}-minute correlation window an "
+        f"{correlation_window_ms // 60000}-minute correlation window an "
         f"accepted east-west flow moved {flow_bytes} bytes from "
         f"{src_instance or src_ip} to {dst_ip}:{dst_port}. This is the "
         f"canonical {provider} lateral movement pattern (MITRE T1021 Remote "
@@ -447,7 +453,7 @@ def _build_native_finding(
         "dst_ip": dst_ip,
         "dst_port": dst_port,
         "traffic_bytes": flow_bytes,
-        "window_seconds": CORRELATION_WINDOW_MS // 1000,
+        "window_seconds": correlation_window_ms // 1000,
         "rule_name": "cloud-lateral-movement",
     }
 
@@ -527,7 +533,7 @@ def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
 def _is_candidate_flow(event: dict[str, Any]) -> bool:
     if event["event_kind"] != "network_activity" or int(event["activity_id"]) != NET_ACTIVITY_ACCEPT:
         return False
-    if _safe_int(event["traffic_bytes"]) < MIN_BYTES:
+    if _safe_int(event["traffic_bytes"]) < _min_bytes():
         return False
     return is_rfc1918(str(event["dst_ip"]))
 
@@ -614,7 +620,7 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
 
     for anchor in identity_anchors:
         anchor_time = int(anchor["time_ms"])
-        window_end = anchor_time + CORRELATION_WINDOW_MS
+        window_end = anchor_time + _correlation_window_ms()
         anchor_provider = str(anchor["provider"])
         anchor_account = str(anchor["account_uid"])
         session = str(anchor["session_uid"])
@@ -641,6 +647,25 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
         )
     )
     yield from findings
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _correlation_window_ms() -> int:
+    return _env_int(WINDOW_ENV, CORRELATION_WINDOW_MS)
+
+
+def _min_bytes() -> int:
+    return _env_int(MIN_BYTES_ENV, MIN_BYTES)
 
 
 # ---------------------------------------------------------------------------

--- a/skills/detection/detect-lateral-movement/tests/test_detect.py
+++ b/skills/detection/detect-lateral-movement/tests/test_detect.py
@@ -241,6 +241,22 @@ class TestPositiveCases:
         findings = list(detect(events))
         assert len(findings) == 1
 
+
+class TestThresholdOverrides:
+    def test_min_bytes_env_override_allows_smaller_flows(self, monkeypatch):
+        events = [
+            _anchor_event(time_ms=1000),
+            _flow(time_ms=60_000, bytes_=800),
+        ]
+
+        assert list(detect(events)) == []
+
+        monkeypatch.setenv("DETECT_LATERAL_MOVEMENT_MIN_BYTES", "512")
+
+        findings = list(detect(events))
+        assert len(findings) == 1
+        assert findings[0]["severity_id"] == SEVERITY_HIGH
+
     def test_exact_window_boundary_is_included(self):
         events = [
             _anchor_event(time_ms=1000),

--- a/skills/detection/detect-okta-mfa-fatigue/SKILL.md
+++ b/skills/detection/detect-okta-mfa-fatigue/SKILL.md
@@ -65,6 +65,13 @@ authentication projection:
 The detector emits one finding per burst and suppresses repeat findings until
 there is a quiet period longer than the correlation window.
 
+Operators can tune the burst logic at runtime without forking the skill:
+
+- `DETECT_OKTA_MFA_FATIGUE_WINDOW_MS`
+- `DETECT_OKTA_MFA_FATIGUE_MIN_RELEVANT_EVENTS`
+- `DETECT_OKTA_MFA_FATIGUE_MIN_CHALLENGES`
+- `DETECT_OKTA_MFA_FATIGUE_MIN_DENIALS`
+
 ## Output contract
 
 Emits OCSF 1.8 Detection Finding (class `2004`) by default. With

--- a/skills/detection/detect-okta-mfa-fatigue/src/detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/src/detect.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,6 +48,10 @@ WINDOW_MS = 10 * 60 * 1000
 MIN_RELEVANT_EVENTS = 3
 MIN_CHALLENGES = 2
 MIN_DENIALS = 1
+WINDOW_ENV = "DETECT_OKTA_MFA_FATIGUE_WINDOW_MS"
+MIN_RELEVANT_ENV = "DETECT_OKTA_MFA_FATIGUE_MIN_RELEVANT_EVENTS"
+MIN_CHALLENGES_ENV = "DETECT_OKTA_MFA_FATIGUE_MIN_CHALLENGES"
+MIN_DENIALS_ENV = "DETECT_OKTA_MFA_FATIGUE_MIN_DENIALS"
 
 OKTA_INGEST_SKILL = "ingest-okta-system-log-ocsf"
 CHALLENGE_EVENT_TYPES = {"system.push.send_factor_verify_push"}
@@ -203,10 +208,11 @@ def _build_native_finding(user_uid: str, user_name: str, burst: list[dict[str, A
     source_ips = sorted({str((item["src_endpoint"] or {}).get("ip") or "") for item in burst if (item["src_endpoint"] or {}).get("ip")})
     session_uids = sorted({str((item["session"] or {}).get("uid") or "") for item in burst if (item["session"] or {}).get("uid")})
     event_uids = [item["event_uid"] for item in burst]
+    window_ms = _window_ms()
 
     description = (
         f"User '{user_name or user_uid}' received {challenge_count} Okta Verify push challenge events and "
-        f"{denial_count} denial or verification-failure events within {WINDOW_MS // 60000} minutes. "
+        f"{denial_count} denial or verification-failure events within {window_ms // 60000} minutes. "
         "This is a high-signal MFA fatigue pattern aligned to repeated push prompts and user rejection."
     )
 
@@ -302,6 +308,7 @@ def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
 
 
 def coverage_metadata() -> dict[str, Any]:
+    window_ms = _window_ms()
     return {
         "frameworks": ("OCSF 1.8.0", "MITRE ATT&CK v14"),
         "providers": ("okta",),
@@ -313,11 +320,11 @@ def coverage_metadata() -> dict[str, Any]:
                 "techniques": [MITRE_TECHNIQUE_UID],
             }
         },
-        "window_ms": WINDOW_MS,
+        "window_ms": window_ms,
         "thresholds": {
-            "min_relevant_events": MIN_RELEVANT_EVENTS,
-            "min_challenges": MIN_CHALLENGES,
-            "min_denials": MIN_DENIALS,
+            "min_relevant_events": _min_relevant_events(),
+            "min_challenges": _min_challenges(),
+            "min_denials": _min_denials(),
         },
     }
 
@@ -356,12 +363,13 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
         user_uid = item["user_uid"]
         current_time = item["time_ms"]
         burst = states.setdefault(user_uid, [])
+        window_ms = _window_ms()
 
-        if burst and current_time - burst[-1]["time_ms"] > WINDOW_MS:
+        if burst and current_time - burst[-1]["time_ms"] > window_ms:
             burst.clear()
             active_bursts.discard(user_uid)
 
-        cutoff = current_time - WINDOW_MS
+        cutoff = current_time - window_ms
         burst[:] = [entry for entry in burst if entry["time_ms"] >= cutoff]
         burst.append(item)
 
@@ -370,9 +378,9 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
         if user_uid in active_bursts:
             continue
         if (
-            len(burst) >= MIN_RELEVANT_EVENTS
-            and challenge_count >= MIN_CHALLENGES
-            and denial_count >= MIN_DENIALS
+            len(burst) >= _min_relevant_events()
+            and challenge_count >= _min_challenges()
+            and denial_count >= _min_denials()
         ):
             native_finding = _build_native_finding(user_uid, item["user_name"], burst)
             if output_format == "native":
@@ -380,6 +388,33 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
             else:
                 yield _render_ocsf_finding(native_finding)
             active_bursts.add(user_uid)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _window_ms() -> int:
+    return _env_int(WINDOW_ENV, WINDOW_MS)
+
+
+def _min_relevant_events() -> int:
+    return _env_int(MIN_RELEVANT_ENV, MIN_RELEVANT_EVENTS)
+
+
+def _min_challenges() -> int:
+    return _env_int(MIN_CHALLENGES_ENV, MIN_CHALLENGES)
+
+
+def _min_denials() -> int:
+    return _env_int(MIN_DENIALS_ENV, MIN_DENIALS)
 
 
 def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:

--- a/skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py
@@ -300,6 +300,26 @@ class TestDetection:
             raise AssertionError("expected unsupported output_format to raise")
 
 
+class TestThresholdOverrides:
+    def test_min_challenges_env_override_raises_threshold(self, monkeypatch):
+        events = [
+            _event(uid="evt-1", event_type="system.push.send_factor_verify_push", time_ms=1000),
+            _event(uid="evt-2", event_type="system.push.send_factor_verify_push", time_ms=2000),
+            _event(
+                uid="evt-3",
+                event_type="user.mfa.okta_verify.deny_push",
+                time_ms=3000,
+                status_id=STATUS_FAILURE,
+            ),
+        ]
+
+        assert len(list(detect(events))) == 1
+
+        monkeypatch.setenv("DETECT_OKTA_MFA_FATIGUE_MIN_CHALLENGES", "3")
+
+        assert list(detect(events)) == []
+
+
 class TestMetadata:
     def test_coverage_metadata(self):
         metadata = coverage_metadata()

--- a/skills/evaluation/container-security/SKILL.md
+++ b/skills/evaluation/container-security/SKILL.md
@@ -15,7 +15,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No Docker daemon needed — works with config files.
@@ -69,7 +69,7 @@ flowchart LR
 ```bash
 python src/checks.py container-config.json
 python src/checks.py config.yaml --section dockerfile
-python src/checks.py config.json --output json
+python src/checks.py config.json --output json --output-format ocsf
 ```
 
 ## Security Guardrails

--- a/skills/evaluation/container-security/src/checks.py
+++ b/skills/evaluation/container-security/src/checks.py
@@ -13,8 +13,19 @@ import argparse
 import json
 import re
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "container-security"
+BENCHMARK_NAME = "Container Security Benchmark"
+PROVIDER_NAME = "Containers"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 
 @dataclass
@@ -277,13 +288,25 @@ def main() -> None:
     parser.add_argument("config", help="Path to container config (JSON/YAML)")
     parser.add_argument("--section", choices=list(ALL_CHECKS.keys()))
     parser.add_argument("--output", choices=["console", "json"], default="console")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()
     p = Path(args.config)
     content = p.read_text()
     config = json.loads(content) if p.suffix == ".json" else __import__("yaml").safe_load(content)
     findings = run_benchmark(config, section=args.section)
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=["CIS Docker Benchmark", "NIST CSF 2.0"],
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
     sys.exit(1 if any(f.status == "FAIL" and f.severity in ("CRITICAL", "HIGH") for f in findings) else 0)

--- a/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
@@ -14,7 +14,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+, boto3, and AWS credentials with SecurityAudit managed policy
@@ -135,7 +135,7 @@ python src/checks.py --section logging
 python src/checks.py --section networking
 
 # Output JSON for SIEM/warehouse ingestion
-python src/checks.py --output json > cis-aws-results.json
+python src/checks.py --output json --output-format ocsf > cis-aws-results.json
 
 # Specific region
 python src/checks.py --region us-east-1

--- a/skills/evaluation/cspm-aws-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-aws-cis-benchmark/src/checks.py
@@ -17,12 +17,24 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "cspm-aws-cis-benchmark"
+BENCHMARK_NAME = "CIS AWS Foundations Benchmark v3.0"
+PROVIDER_NAME = "AWS"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -849,12 +861,29 @@ def main():
     parser.add_argument(
         "--output", choices=["console", "json"], default="console", help="Output format"
     )
+    parser.add_argument(
+        "--output-format",
+        choices=list(OUTPUT_FORMATS),
+        default="native",
+        help="Structured JSON format for --output json",
+    )
     args = parser.parse_args()
 
     findings = run_assessment(region=args.region, section=args.section)
 
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=["CIS AWS Foundations v3.0", "NIST CSF 2.0", "ISO/IEC 27001:2022"],
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
 

--- a/skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks.py
+++ b/skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks.py
@@ -34,6 +34,7 @@ check_3_4_cloudwatch_alarms = _CHECKS.check_3_4_cloudwatch_alarms
 check_4_1_no_unrestricted_ssh = _CHECKS.check_4_1_no_unrestricted_ssh
 check_4_2_no_unrestricted_rdp = _CHECKS.check_4_2_no_unrestricted_rdp
 check_4_3_vpc_flow_logs = _CHECKS.check_4_3_vpc_flow_logs
+findings_to_ocsf = _CHECKS.findings_to_ocsf
 
 
 @mock_aws
@@ -179,3 +180,31 @@ class TestRunnerRouting:
         assert finding.control_id == "3.4"
         clients["cw"].describe_alarms.assert_called_once()
         clients["iam"].describe_alarms.assert_not_called()
+
+
+class TestOcsfProjection:
+    def test_findings_can_render_as_compliance_findings(self):
+        finding = Finding(
+            control_id="1.1",
+            title="MFA on root account",
+            section="iam",
+            severity="CRITICAL",
+            status="FAIL",
+            detail="Root MFA disabled",
+            nist_csf="PR.AC-1",
+            iso_27001="A.8.5",
+            resources=["root"],
+        )
+
+        rendered = findings_to_ocsf(
+            [finding],
+            skill_name=_CHECKS.SKILL_NAME,
+            benchmark_name=_CHECKS.BENCHMARK_NAME,
+            provider=_CHECKS.PROVIDER_NAME,
+            frameworks=["CIS AWS Foundations v3.0", "NIST CSF 2.0", "ISO/IEC 27001:2022"],
+        )
+
+        assert rendered[0]["class_uid"] == 2003
+        assert rendered[0]["finding_info"]["types"] == ["1.1"]
+        assert rendered[0]["cloud"]["provider"] == "AWS"
+        assert "PR.AC-1" in rendered[0]["compliance"]["requirements"]

--- a/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
@@ -13,7 +13,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+, azure-identity, azure-mgmt-storage, azure-mgmt-network.
@@ -127,7 +127,7 @@ python src/checks.py --subscription-id SUB_ID --section identity
 python src/checks.py --subscription-id SUB_ID --section ai-foundry
 
 # Output JSON
-python src/checks.py --subscription-id SUB_ID --output json > cis-azure-results.json
+python src/checks.py --subscription-id SUB_ID --output json --output-format ocsf > cis-azure-results.json
 ```
 
 ## Remediation — Critical Findings

--- a/skills/evaluation/cspm-azure-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-azure-cis-benchmark/src/checks.py
@@ -16,7 +16,19 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "cspm-azure-cis-benchmark"
+BENCHMARK_NAME = "CIS Azure Foundations Benchmark v2.1"
+PROVIDER_NAME = "Azure"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -345,12 +357,24 @@ def main():
     parser.add_argument("--subscription-id", required=True, help="Azure subscription ID")
     parser.add_argument("--section", choices=["storage", "networking"], help="Run specific section")
     parser.add_argument("--output", choices=["console", "json"], default="console")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()
 
     findings = run_assessment(subscription_id=args.subscription_id, section=args.section)
 
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=["CIS Azure Foundations v2.1", "NIST CSF 2.0"],
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
 

--- a/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
@@ -13,7 +13,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+, google-cloud-iam, google-cloud-storage, google-cloud-compute.
@@ -140,7 +140,7 @@ python src/checks.py --project my-project-id --section iam
 python src/checks.py --project my-project-id --section vertex-ai
 
 # Output JSON
-python src/checks.py --project my-project-id --output json > cis-gcp-results.json
+python src/checks.py --project my-project-id --output json --output-format ocsf > cis-gcp-results.json
 ```
 
 ## Remediation — Critical Findings

--- a/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
@@ -16,8 +16,20 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "cspm-gcp-cis-benchmark"
+BENCHMARK_NAME = "CIS GCP Foundations Benchmark v3.0"
+PROVIDER_NAME = "GCP"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -366,12 +378,24 @@ def main():
     parser.add_argument("--project", required=True, help="GCP project ID")
     parser.add_argument("--section", choices=["iam", "storage", "networking"], help="Run specific section")
     parser.add_argument("--output", choices=["console", "json"], default="console")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()
 
     findings = run_assessment(project_id=args.project, section=args.section)
 
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=["CIS GCP Foundations v3.0", "NIST CSF 2.0"],
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
 

--- a/skills/evaluation/gpu-cluster-security/SKILL.md
+++ b/skills/evaluation/gpu-cluster-security/SKILL.md
@@ -17,7 +17,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files
@@ -154,7 +154,7 @@ python src/checks.py config.yaml --section driver
 python src/checks.py config.yaml --section tenant
 
 # JSON output
-python src/checks.py config.json --output json > gpu-security-results.json
+python src/checks.py config.json --output json --output-format ocsf > gpu-security-results.json
 ```
 
 ## Config Format

--- a/skills/evaluation/gpu-cluster-security/src/checks.py
+++ b/skills/evaluation/gpu-cluster-security/src/checks.py
@@ -22,8 +22,19 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "gpu-cluster-security"
+BENCHMARK_NAME = "GPU Cluster Security Benchmark"
+PROVIDER_NAME = "Multi"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 FRAMEWORKS = (
     "MITRE ATT&CK v14",
@@ -562,13 +573,25 @@ def main() -> None:
     parser.add_argument("config", help="Path to cluster config file (JSON/YAML)")
     parser.add_argument("--section", choices=list(ALL_CHECKS.keys()), help="Run specific section only")
     parser.add_argument("--output", choices=["console", "json"], default="console", help="Output format")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()
 
     config = load_config(args.config)
     findings = run_benchmark(config, section=args.section)
 
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=list(FRAMEWORKS),
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
 

--- a/skills/evaluation/k8s-security-benchmark/SKILL.md
+++ b/skills/evaluation/k8s-security-benchmark/SKILL.md
@@ -16,7 +16,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with exported JSON/YAML.
@@ -74,7 +74,7 @@ flowchart LR
 ```bash
 python src/checks.py cluster-config.json
 python src/checks.py config.yaml --section pod_security
-python src/checks.py config.json --output json
+python src/checks.py config.json --output json --output-format ocsf
 ```
 
 ## Security Guardrails

--- a/skills/evaluation/k8s-security-benchmark/src/checks.py
+++ b/skills/evaluation/k8s-security-benchmark/src/checks.py
@@ -12,8 +12,19 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "k8s-security-benchmark"
+BENCHMARK_NAME = "Kubernetes Security Benchmark"
+PROVIDER_NAME = "Kubernetes"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 
 @dataclass
@@ -327,13 +338,25 @@ def main() -> None:
     parser.add_argument("config", help="Path to K8s config (JSON/YAML)")
     parser.add_argument("--section", choices=list(ALL_CHECKS.keys()))
     parser.add_argument("--output", choices=["console", "json"], default="console")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()
     p = Path(args.config)
     content = p.read_text()
     config = json.loads(content) if p.suffix == ".json" else __import__("yaml").safe_load(content)
     findings = run_benchmark(config, section=args.section)
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=["CIS Kubernetes Benchmark", "NIST CSF 2.0"],
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
     sys.exit(1 if any(f.status == "FAIL" and f.severity in ("CRITICAL", "HIGH") for f in findings) else 0)

--- a/skills/evaluation/model-serving-security/SKILL.md
+++ b/skills/evaluation/model-serving-security/SKILL.md
@@ -19,7 +19,7 @@ approval_model: none
 execution_modes: jit, ci, mcp, persistent
 side_effects: none
 input_formats: raw
-output_formats: native
+output_formats: native, ocsf
 concurrency_safety: operator_coordinated
 compatibility: >-
   Requires Python 3.11+. No cloud SDKs needed — works with local config files.
@@ -131,7 +131,7 @@ python src/checks.py config.yaml --section auth
 python src/checks.py config.yaml --section safety
 
 # JSON output for pipeline integration
-python src/checks.py config.json --output json > results.json
+python src/checks.py config.json --output json --output-format ocsf > results.json
 
 # Scan additional paths for hardcoded secrets
 python src/checks.py config.yaml --scan-paths ./k8s/ ./helm/

--- a/skills/evaluation/model-serving-security/src/checks.py
+++ b/skills/evaluation/model-serving-security/src/checks.py
@@ -22,8 +22,19 @@ import argparse
 import json
 import re
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "model-serving-security"
+BENCHMARK_NAME = "Model Serving Security Benchmark"
+PROVIDER_NAME = "Multi"
+OUTPUT_FORMATS = ("native", "ocsf")
 
 FRAMEWORKS = (
     "MITRE ATLAS",
@@ -842,13 +853,25 @@ def main() -> None:
     parser.add_argument("--section", choices=list(ALL_CHECKS.keys()), help="Run specific section only")
     parser.add_argument("--scan-paths", nargs="*", help="Additional paths to scan for hardcoded secrets")
     parser.add_argument("--output", choices=["console", "json"], default="console", help="Output format")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()
 
     config = load_config(args.config)
     findings = run_benchmark(config, section=args.section, scan_paths=args.scan_paths)
 
     if args.output == "json":
-        print(json.dumps([asdict(f) for f in findings], indent=2))
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=list(FRAMEWORKS),
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
     else:
         print_summary(findings)
 

--- a/skills/evaluation/model-serving-security/tests/test_checks.py
+++ b/skills/evaluation/model-serving-security/tests/test_checks.py
@@ -8,6 +8,9 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from checks import (
+    BENCHMARK_NAME,
+    PROVIDER_NAME,
+    SKILL_NAME,
     Finding,
     benchmark_metadata,
     check_1_1_endpoint_auth_required,
@@ -29,6 +32,7 @@ from checks import (
     check_6_3_model_versioning,
     check_6_4_guardrails_attached,
     check_6_5_ai_endpoint_audit_logging,
+    findings_to_ocsf,
     run_benchmark,
 )
 
@@ -94,6 +98,36 @@ class TestAuthChecks:
         f = check_1_4_workload_identity_required(config)
         assert f.status == "PASS"
         assert f.nist_ai_rmf == "GOVERN, MANAGE"
+
+
+class TestOcsfProjection:
+    def test_findings_can_render_as_compliance_findings(self):
+        finding = Finding(
+            check_id="MOD-1.1",
+            title="Endpoint authentication required",
+            section="auth",
+            severity="CRITICAL",
+            status="FAIL",
+            detail="Public model endpoint has no authn control",
+            remediation="Require IAM, OAuth, or workload identity",
+            mitre_atlas="AML.TA0003",
+            nist_csf="PR.AC-1",
+            nist_ai_rmf="GOVERN",
+            resources=["inference-endpoint"],
+        )
+
+        rendered = findings_to_ocsf(
+            [finding],
+            skill_name=SKILL_NAME,
+            benchmark_name=BENCHMARK_NAME,
+            provider=PROVIDER_NAME,
+            frameworks=list(benchmark_metadata()["frameworks"]),
+        )
+
+        assert rendered[0]["class_uid"] == 2003
+        assert rendered[0]["finding_info"]["types"] == ["MOD-1.1"]
+        assert rendered[0]["metadata"]["product"]["feature"]["name"] == SKILL_NAME
+        assert "GOVERN" in rendered[0]["compliance"]["requirements"]
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
+++ b/skills/remediation/iam-departures-remediation/infra/cloudformation.yaml
@@ -277,6 +277,7 @@ Resources:
               - Sid: WriteAuditToDynamoDB
                 Effect: Allow
                 Action:
+                  - dynamodb:GetItem
                   - dynamodb:PutItem
                 Resource: !GetAtt AuditTable.Arn
               - Sid: WriteAuditToS3

--- a/skills/remediation/iam-departures-remediation/infra/iam_policies/worker_execution_role.json
+++ b/skills/remediation/iam-departures-remediation/infra/iam_policies/worker_execution_role.json
@@ -68,6 +68,7 @@
       "Sid": "WriteAuditToDynamoDB",
       "Effect": "Allow",
       "Action": [
+        "dynamodb:GetItem",
         "dynamodb:PutItem"
       ],
       "Resource": "arn:aws:dynamodb:*:*:table/${IAM_AUDIT_DYNAMODB_TABLE}"

--- a/skills/remediation/iam-departures-remediation/infra/terraform/main.tf
+++ b/skills/remediation/iam-departures-remediation/infra/terraform/main.tf
@@ -382,7 +382,7 @@ resource "aws_iam_role_policy" "worker" {
       {
         Sid      = "WriteAuditToDynamoDB"
         Effect   = "Allow"
-        Action   = ["dynamodb:PutItem"]
+        Action   = ["dynamodb:GetItem", "dynamodb:PutItem"]
         Resource = aws_dynamodb_table.audit.arn
       },
       {

--- a/skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py
+++ b/skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py
@@ -57,6 +57,7 @@ CROSS_ACCOUNT_ROLE = os.environ.get("IAM_CROSS_ACCOUNT_ROLE", "iam-remediation-r
 AUDIT_TABLE = os.environ.get("IAM_AUDIT_DYNAMODB_TABLE", "iam-remediation-audit")
 AUDIT_BUCKET = os.environ.get("IAM_REMEDIATION_BUCKET", "")
 ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
+CHECKPOINT_SK = "CURRENT"
 
 
 def handler(event: dict, context: Any) -> dict:
@@ -115,55 +116,51 @@ def handler(event: dict, context: Any) -> dict:
         email,
     )
 
-    actions_taken: list[dict] = []
+    checkpoint = _load_checkpoint(entry)
+    actions_taken: list[dict[str, Any]] = list(checkpoint["actions_taken"])
+    completed_steps: list[str] = list(checkpoint["completed_steps"])
+    completed_step_set = set(completed_steps)
+
+    if checkpoint["status"] == "remediated":
+        logger.info("Replay-safe short circuit for already remediated user %s in %s", iam_username, account_id)
+        return {
+            "email": email,
+            "iam_username": iam_username,
+            "account_id": account_id,
+            "status": "remediated",
+            "actions_taken": actions_taken,
+            "remediated_at": checkpoint["updated_at"],
+            "checkpoint_reused": True,
+        }
+
     try:
         iam = _get_iam_client(account_id)
 
-        # Step 1: Deactivate all access keys
-        _deactivate_access_keys(iam, iam_username, actions_taken)
-
-        # Step 2: Delete login profile (console access)
-        _delete_login_profile(iam, iam_username, actions_taken)
-
-        # Step 3: Remove from all groups
-        _remove_from_groups(iam, iam_username, actions_taken)
-
-        # Step 4: Detach all managed policies
-        _detach_managed_policies(iam, iam_username, actions_taken)
-
-        # Step 5: Delete all inline policies
-        _delete_inline_policies(iam, iam_username, actions_taken)
-
-        # Step 6: Deactivate and delete MFA devices
-        _delete_mfa_devices(iam, iam_username, actions_taken)
-
-        # Step 7: Delete signing certificates
-        _delete_signing_certificates(iam, iam_username, actions_taken)
-
-        # Step 8: Delete SSH public keys
-        _delete_ssh_keys(iam, iam_username, actions_taken)
-
-        # Step 9: Delete service-specific credentials
-        _delete_service_credentials(iam, iam_username, actions_taken)
-
-        # Step 10: Tag user with audit metadata before deletion
-        _tag_user_for_audit(iam, iam_username, entry, actions_taken)
-
-        # Step 11: DELETE the IAM user (all deps removed)
-        iam.delete_user(UserName=iam_username)
-        actions_taken.append(
-            {
-                "action": "delete_user",
-                "target": iam_username,
-                "timestamp": _now(),
-            }
-        )
+        for step_name, step_fn in _remediation_steps():
+            if step_name in completed_step_set:
+                continue
+            step_fn(iam, iam_username, entry, actions_taken)
+            completed_steps.append(step_name)
+            completed_step_set.add(step_name)
+            _save_checkpoint(
+                entry,
+                actions_taken,
+                completed_steps,
+                status="in_progress",
+            )
 
         logger.info("Successfully deleted IAM user: %s", iam_username)
 
         # Step 12: Write audit record
         audit_record = _build_audit_record(entry, actions_taken, "remediated", context=context)
         _write_audit(audit_record)
+        _save_checkpoint(
+            entry,
+            actions_taken,
+            completed_steps,
+            status="remediated",
+            audit_timestamp=audit_record["audit_timestamp"],
+        )
 
         return {
             "email": email,
@@ -176,6 +173,13 @@ def handler(event: dict, context: Any) -> dict:
 
     except Exception as exc:
         logger.exception("Remediation failed for %s in %s", iam_username, account_id)
+        _save_checkpoint(
+            entry,
+            actions_taken,
+            completed_steps,
+            status="error",
+            error=str(exc),
+        )
 
         # Still write audit — record the failure
         audit_record = _build_audit_record(entry, actions_taken, "error", error=str(exc), context=context)
@@ -192,6 +196,22 @@ def handler(event: dict, context: Any) -> dict:
 
 
 # ── IAM Remediation Steps ──────────────────────────────────────────
+
+
+def _remediation_steps() -> tuple[tuple[str, Any], ...]:
+    return (
+        ("deactivate_access_keys", lambda iam, username, _entry, actions: _deactivate_access_keys(iam, username, actions)),
+        ("delete_login_profile", lambda iam, username, _entry, actions: _delete_login_profile(iam, username, actions)),
+        ("remove_from_groups", lambda iam, username, _entry, actions: _remove_from_groups(iam, username, actions)),
+        ("detach_managed_policies", lambda iam, username, _entry, actions: _detach_managed_policies(iam, username, actions)),
+        ("delete_inline_policies", lambda iam, username, _entry, actions: _delete_inline_policies(iam, username, actions)),
+        ("delete_mfa_devices", lambda iam, username, _entry, actions: _delete_mfa_devices(iam, username, actions)),
+        ("delete_signing_certificates", lambda iam, username, _entry, actions: _delete_signing_certificates(iam, username, actions)),
+        ("delete_ssh_keys", lambda iam, username, _entry, actions: _delete_ssh_keys(iam, username, actions)),
+        ("delete_service_credentials", lambda iam, username, _entry, actions: _delete_service_credentials(iam, username, actions)),
+        ("tag_user_for_audit", lambda iam, username, entry, actions: _tag_user_for_audit(iam, username, entry, actions)),
+        ("delete_user", lambda iam, username, _entry, actions: _delete_user(iam, username, actions)),
+    )
 
 
 def _deactivate_access_keys(iam: Any, username: str, actions: list) -> None:
@@ -406,6 +426,17 @@ def _tag_user_for_audit(iam: Any, username: str, entry: dict, actions: list) -> 
         logger.warning("Failed to tag user %s before deletion", username)
 
 
+def _delete_user(iam: Any, username: str, actions: list[dict[str, Any]]) -> None:
+    iam.delete_user(UserName=username)
+    actions.append(
+        {
+            "action": "delete_user",
+            "target": username,
+            "timestamp": _now(),
+        }
+    )
+
+
 # ── Audit ───────────────────────────────────────────────────────────
 
 
@@ -487,6 +518,84 @@ def _write_audit(record: dict) -> None:
             logger.exception("Failed to write S3 audit record")
 
 
+def _load_checkpoint(entry: dict[str, Any]) -> dict[str, Any]:
+    checkpoint = {
+        "status": "new",
+        "actions_taken": [],
+        "completed_steps": [],
+        "updated_at": "",
+    }
+    if not AUDIT_TABLE:
+        return checkpoint
+    try:
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(AUDIT_TABLE)
+        response = table.get_item(
+            Key={
+                "pk": _checkpoint_pk(entry),
+                "sk": CHECKPOINT_SK,
+            }
+        )
+    except Exception:
+        logger.exception("Failed to read DynamoDB checkpoint")
+        return checkpoint
+
+    item = response.get("Item") or {}
+    actions_taken = item.get("actions_taken")
+    parsed_actions: list[dict[str, Any]] = []
+    if isinstance(actions_taken, str):
+        try:
+            decoded = json.loads(actions_taken)
+            if isinstance(decoded, list):
+                parsed_actions = [action for action in decoded if isinstance(action, dict)]
+        except json.JSONDecodeError:
+            parsed_actions = []
+
+    completed_steps = item.get("completed_steps")
+    if not isinstance(completed_steps, list):
+        completed_steps = []
+
+    checkpoint["status"] = str(item.get("status") or "new")
+    checkpoint["actions_taken"] = parsed_actions
+    checkpoint["completed_steps"] = [step for step in completed_steps if isinstance(step, str)]
+    checkpoint["updated_at"] = str(item.get("updated_at") or "")
+    return checkpoint
+
+
+def _save_checkpoint(
+    entry: dict[str, Any],
+    actions_taken: list[dict[str, Any]],
+    completed_steps: list[str],
+    *,
+    status: str,
+    error: str = "",
+    audit_timestamp: str = "",
+) -> None:
+    if not AUDIT_TABLE:
+        return
+    try:
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(AUDIT_TABLE)
+        table.put_item(
+            Item={
+                "pk": _checkpoint_pk(entry),
+                "sk": CHECKPOINT_SK,
+                "record_type": "remediation_checkpoint",
+                "status": status,
+                "email": entry.get("email", ""),
+                "iam_username": entry.get("iam_username", ""),
+                "account_id": entry.get("recipient_account_id", ""),
+                "completed_steps": completed_steps,
+                "updated_at": _now(),
+                "actions_taken": json.dumps(actions_taken),
+                "error": error,
+                "audit_timestamp": audit_timestamp,
+            }
+        )
+    except Exception:
+        logger.exception("Failed to write DynamoDB checkpoint")
+
+
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
@@ -521,3 +630,9 @@ def _require_non_empty_str(entry: dict[str, Any], field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"Missing required field: {field}")
     return value.strip()
+
+
+def _checkpoint_pk(entry: dict[str, Any]) -> str:
+    account_id = str(entry.get("recipient_account_id") or "")
+    iam_username = str(entry.get("iam_username") or "")
+    return f"CHECKPOINT#{account_id}#{iam_username}"

--- a/skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py
+++ b/skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from lambda_worker.handler import (
     _build_audit_record,
+    _checkpoint_pk,
     _deactivate_access_keys,
     _delete_inline_policies,
     _delete_login_profile,
@@ -146,9 +147,11 @@ class TestRemediationSteps:
 class TestWorkerHandler:
     """Test the full worker Lambda handler."""
 
+    @patch("lambda_worker.handler._save_checkpoint")
+    @patch("lambda_worker.handler._load_checkpoint", return_value={"status": "new", "actions_taken": [], "completed_steps": [], "updated_at": ""})
     @patch("lambda_worker.handler._write_audit")
     @patch("lambda_worker.handler._get_iam_client")
-    def test_successful_remediation(self, mock_iam, mock_audit):
+    def test_successful_remediation(self, mock_iam, mock_audit, _mock_load_checkpoint, mock_save_checkpoint):
         """Full remediation flow for a standard terminated employee."""
         iam = MagicMock()
         mock_iam.return_value = iam
@@ -189,10 +192,13 @@ class TestWorkerHandler:
         assert result["account_id"] == "123456789012"
         iam.delete_user.assert_called_once_with(UserName="jane")
         mock_audit.assert_called_once()
+        assert mock_save_checkpoint.call_count >= 2
 
+    @patch("lambda_worker.handler._save_checkpoint")
+    @patch("lambda_worker.handler._load_checkpoint", return_value={"status": "new", "actions_taken": [], "completed_steps": [], "updated_at": ""})
     @patch("lambda_worker.handler._write_audit")
     @patch("lambda_worker.handler._get_iam_client")
-    def test_remediation_failure_logged(self, mock_iam, mock_audit):
+    def test_remediation_failure_logged(self, mock_iam, mock_audit, _mock_load_checkpoint, mock_save_checkpoint):
         """If remediation fails, error is captured and audit still written."""
         mock_iam.side_effect = Exception("AssumeRole denied")
 
@@ -201,14 +207,17 @@ class TestWorkerHandler:
         assert result["status"] == "error"
         assert "AssumeRole denied" in result["error"]
         mock_audit.assert_called_once()  # Audit still written on failure
+        mock_save_checkpoint.assert_called()
 
+    @patch("lambda_worker.handler._save_checkpoint")
     @patch("lambda_worker.handler._write_audit")
-    def test_invalid_payload_rejected_before_remediation(self, mock_audit):
+    def test_invalid_payload_rejected_before_remediation(self, mock_audit, mock_save_checkpoint):
         result = handler(_make_event(account_id="not-an-account"), None)
 
         assert result["status"] == "error"
         assert result["error"] == "Invalid remediation payload"
         mock_audit.assert_called_once()
+        mock_save_checkpoint.assert_not_called()
 
     def test_audit_record_captures_caller_and_approval_context(self, monkeypatch):
         class _Context:
@@ -234,6 +243,71 @@ class TestWorkerHandler:
         assert record["approval_ticket"] == "SEC-123"
         assert record["approval_timestamp"] == "2026-04-14T12:00:00Z"
         assert record["lambda_request_id"] == "req-123"
+
+    @patch("lambda_worker.handler._save_checkpoint")
+    @patch(
+        "lambda_worker.handler._load_checkpoint",
+        return_value={
+            "status": "in_progress",
+            "actions_taken": [{"action": "delete_user", "target": "jane", "timestamp": "2026-04-17T00:00:00+00:00"}],
+            "completed_steps": [
+                "deactivate_access_keys",
+                "delete_login_profile",
+                "remove_from_groups",
+                "detach_managed_policies",
+                "delete_inline_policies",
+                "delete_mfa_devices",
+                "delete_signing_certificates",
+                "delete_ssh_keys",
+                "delete_service_credentials",
+                "tag_user_for_audit",
+                "delete_user",
+            ],
+            "updated_at": "2026-04-17T00:00:00+00:00",
+        },
+    )
+    @patch("lambda_worker.handler._write_audit")
+    @patch("lambda_worker.handler._get_iam_client")
+    def test_replay_after_delete_user_skips_delete_step(
+        self,
+        mock_iam,
+        mock_audit,
+        _mock_load_checkpoint,
+        mock_save_checkpoint,
+    ):
+        iam = MagicMock()
+        mock_iam.return_value = iam
+
+        result = handler(_make_event(), None)
+
+        assert result["status"] == "remediated"
+        iam.delete_user.assert_not_called()
+        mock_audit.assert_called_once()
+        mock_save_checkpoint.assert_called()
+
+    @patch("lambda_worker.handler._write_audit")
+    @patch("lambda_worker.handler._get_iam_client")
+    @patch(
+        "lambda_worker.handler._load_checkpoint",
+        return_value={
+            "status": "remediated",
+            "actions_taken": [{"action": "delete_user", "target": "jane", "timestamp": "2026-04-17T00:00:00+00:00"}],
+            "completed_steps": ["delete_user"],
+            "updated_at": "2026-04-17T00:00:00+00:00",
+        },
+    )
+    def test_remediated_checkpoint_short_circuits(self, mock_load_checkpoint, mock_iam, mock_audit):
+        result = handler(_make_event(), None)
+
+        assert result["status"] == "remediated"
+        assert result["checkpoint_reused"] is True
+        mock_iam.assert_not_called()
+        mock_audit.assert_not_called()
+
+
+class TestCheckpoints:
+    def test_checkpoint_pk_uses_account_and_username(self):
+        assert _checkpoint_pk(_make_event()["entry"]) == "CHECKPOINT#123456789012#jane"
 
 
 class TestSnowflakeIdentifierSafety:


### PR DESCRIPTION
## Summary
- add env-configurable thresholds for the lateral-movement and Okta MFA fatigue detectors
- make iam-departures remediation replay-safe with per-step DynamoDB checkpoints
- add shared OCSF 2003 Compliance Finding output for all evaluation skills while keeping native output intact

## Validation
- python -m pytest skills/detection/detect-lateral-movement/tests/test_detect.py -q -o addopts=''
- python -m pytest skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py -q -o addopts=''
- python -m pytest skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py -q -o addopts=''
- python -m pytest skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks.py -q -o addopts=''
- python -m pytest skills/evaluation/model-serving-security/tests/test_checks.py -q -o addopts=''
- python -m pytest skills/evaluation/k8s-security-benchmark/tests/test_checks.py -q -o addopts=''
- python scripts/validate_skill_contract.py
- python scripts/validate_safe_skill_bar.py
- python -m ruff check skills/_shared/evaluation_ocsf.py skills/detection/detect-lateral-movement/src/detect.py skills/detection/detect-okta-mfa-fatigue/src/detect.py skills/detection/detect-lateral-movement/tests/test_detect.py skills/detection/detect-okta-mfa-fatigue/tests/test_detect.py skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py skills/remediation/iam-departures-remediation/tests/test_worker_lambda.py skills/evaluation/cspm-aws-cis-benchmark/src/checks.py skills/evaluation/cspm-azure-cis-benchmark/src/checks.py skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py skills/evaluation/container-security/src/checks.py skills/evaluation/gpu-cluster-security/src/checks.py skills/evaluation/k8s-security-benchmark/src/checks.py skills/evaluation/model-serving-security/src/checks.py skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks.py skills/evaluation/model-serving-security/tests/test_checks.py --config pyproject.toml
