### PR TITLE
hardening: tighten source-query read-only guards

### DIFF
--- a/skills/_shared/read_only_sql.py
+++ b/skills/_shared/read_only_sql.py
@@ -1,0 +1,89 @@
+"""Shared validation for read-only warehouse source queries."""
+
+from __future__ import annotations
+
+import re
+
+ALLOWED_PREFIXES = ("SELECT", "WITH", "SHOW", "DESCRIBE")
+DISALLOWED_PATTERNS = (
+    re.compile(r"--"),
+    re.compile(r"/\*"),
+    re.compile(r"\*/"),
+    re.compile(
+        r"\b(?:"
+        r"ALTER|ANALYZE|CACHE|CALL|COPY\s+INTO|CREATE|DELETE|DROP|EXECUTE\s+IMMEDIATE|"
+        r"GET|GRANT|INSERT|MERGE|MSCK|OPTIMIZE|PUT|REFRESH|REPAIR|REVOKE|SET|TRUNCATE|"
+        r"UNCACHE|UNDROP|UNSET|UPDATE|USE|VACUUM"
+        r")\b"
+    ),
+    re.compile(r"\bIDENTIFIER\s*\("),
+    re.compile(r"\bSYSTEM\$"),
+)
+
+
+def normalize_read_only_query(query: str) -> str:
+    """Normalize and reject anything outside the repo's read-only SQL subset."""
+    cleaned = query.strip()
+    if not cleaned:
+        raise ValueError("query must not be empty")
+    while cleaned.endswith(";"):
+        cleaned = cleaned[:-1].rstrip()
+    if ";" in cleaned:
+        raise ValueError("multiple SQL statements are not allowed")
+
+    head = cleaned.lstrip("(\n\t ").upper()
+    if not any(head.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+        raise ValueError("only SELECT, WITH, SHOW, and DESCRIBE statements are allowed")
+
+    validate_read_only_shape(cleaned)
+    return cleaned
+
+
+def strip_quoted_sql(text: str) -> str:
+    """Mask quoted content before keyword scanning so string literals stay allowed."""
+    result: list[str] = []
+    quote: str | None = None
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote is None and char in ("'", '"', "`"):
+            quote = char
+            result.append(" ")
+            index += 1
+            continue
+        if quote is not None:
+            if char == quote:
+                if index + 1 < len(text) and text[index + 1] == quote:
+                    index += 2
+                    continue
+                quote = None
+            result.append(" ")
+            index += 1
+            continue
+        result.append(char)
+        index += 1
+    return "".join(result)
+
+
+def validate_read_only_shape(query: str) -> None:
+    stripped = strip_quoted_sql(query).upper()
+    validate_balanced_parentheses(stripped)
+    for pattern in DISALLOWED_PATTERNS:
+        if pattern.search(stripped):
+            raise ValueError(
+                "query contains comments, session controls, or write-oriented keywords; "
+                "only plain read-only SELECT, WITH, SHOW, and DESCRIBE queries are allowed"
+            )
+
+
+def validate_balanced_parentheses(text: str) -> None:
+    depth = 0
+    for char in text:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth < 0:
+                raise ValueError("query has unbalanced parentheses")
+    if depth != 0:
+        raise ValueError("query has unbalanced parentheses")

--- a/skills/ingestion/source-databricks-query/SKILL.md
+++ b/skills/ingestion/source-databricks-query/SKILL.md
@@ -5,11 +5,12 @@ description: >-
   rows for downstream ingestion, detection, or view skills. Accepts explicit
   `--query` SQL or reads the query from stdin when no `--query` is provided.
   Only `SELECT`, `WITH`, `SHOW`, and `DESCRIBE` statements are allowed, and
-  multiple statements, SQL comments, dynamic identifier helpers, and common
-  control/write keywords are rejected. Use when the user already has security
-  data in Databricks and wants to pipe lake rows into existing skills without
-  exporting files first. Do NOT use for writes, DDL, or admin changes. Do NOT
-  use as a detector or normalizer by itself.
+  multiple statements, SQL comments, session controls, optimizer/admin verbs,
+  dynamic identifier helpers, and common control/write keywords are rejected.
+  Use when the user already has security data in Databricks and wants to pipe
+  lake rows into existing skills without exporting files first. Do NOT use
+  for writes, DDL, or admin changes. Do NOT use as a detector or normalizer
+  by itself.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
@@ -54,8 +55,9 @@ Allowed statement families:
 - `SHOW`
 - `DESCRIBE`
 
-The skill rejects multiple statements, SQL comments, dynamic identifier
-helpers, and non-read-only verbs.
+The skill rejects multiple statements, SQL comments, session or optimizer
+controls, dynamic identifier helpers, unbalanced query shapes, and
+non-read-only verbs.
 
 ## Output
 

--- a/skills/ingestion/source-databricks-query/src/ingest.py
+++ b/skills/ingestion/source-databricks-query/src/ingest.py
@@ -5,20 +5,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import sys
 from typing import Any, Iterable
 
+from skills._shared.read_only_sql import normalize_read_only_query
+
 SKILL_NAME = "source-databricks-query"
-ALLOWED_PREFIXES = ("SELECT", "WITH", "SHOW", "DESCRIBE")
-DISALLOWED_PATTERNS = (
-    re.compile(r"--"),
-    re.compile(r"/\*"),
-    re.compile(r"\*/"),
-    re.compile(r"\b(?:ALTER|CALL|COPY\s+INTO|CREATE|DELETE|DROP|EXECUTE\s+IMMEDIATE|GET|GRANT|INSERT|MERGE|PUT|REVOKE|TRUNCATE|UPDATE|USE)\b"),
-    re.compile(r"\bIDENTIFIER\s*\("),
-    re.compile(r"\bSYSTEM\$"),
-)
 
 
 def _read_query(cli_query: str | None, stdin: Iterable[str]) -> str:
@@ -31,54 +23,7 @@ def _read_query(cli_query: str | None, stdin: Iterable[str]) -> str:
 
 
 def _normalize_query(query: str) -> str:
-    cleaned = query.strip()
-    if not cleaned:
-        raise ValueError("query must not be empty")
-    while cleaned.endswith(";"):
-        cleaned = cleaned[:-1].rstrip()
-    if ";" in cleaned:
-        raise ValueError("multiple SQL statements are not allowed")
-
-    head = cleaned.lstrip("(\n\t ").upper()
-    if not any(head.startswith(prefix) for prefix in ALLOWED_PREFIXES):
-        raise ValueError("only SELECT, WITH, SHOW, and DESCRIBE statements are allowed")
-    _validate_read_only_shape(cleaned)
-    return cleaned
-
-
-def _strip_quoted_sql(text: str) -> str:
-    result: list[str] = []
-    quote: str | None = None
-    index = 0
-    while index < len(text):
-        char = text[index]
-        if quote is None and char in ("'", '"', "`"):
-            quote = char
-            result.append(" ")
-            index += 1
-            continue
-        if quote is not None:
-            if char == quote:
-                if index + 1 < len(text) and text[index + 1] == quote:
-                    index += 2
-                    continue
-                quote = None
-            result.append(" ")
-            index += 1
-            continue
-        result.append(char)
-        index += 1
-    return "".join(result)
-
-
-def _validate_read_only_shape(query: str) -> None:
-    stripped = _strip_quoted_sql(query).upper()
-    for pattern in DISALLOWED_PATTERNS:
-        if pattern.search(stripped):
-            raise ValueError(
-                "query contains comments or disallowed control/write keywords; "
-                "only plain read-only SELECT, WITH, SHOW, and DESCRIBE queries are allowed"
-            )
+    return normalize_read_only_query(query)
 
 
 def _connect() -> Any:

--- a/skills/ingestion/source-databricks-query/tests/test_ingest.py
+++ b/skills/ingestion/source-databricks-query/tests/test_ingest.py
@@ -75,7 +75,7 @@ class TestNormalizeQuery:
         try:
             _normalize_query("SELECT * FROM foo /* nope */")
         except ValueError as exc:
-            assert "comments or disallowed control/write keywords" in str(exc)
+            assert "comments, session controls, or write-oriented keywords" in str(exc)
         else:
             raise AssertionError("expected ValueError")
 
@@ -87,12 +87,36 @@ class TestNormalizeQuery:
         try:
             _normalize_query("SELECT identifier('foo')")
         except ValueError as exc:
-            assert "comments or disallowed control/write keywords" in str(exc)
+            assert "comments, session controls, or write-oriented keywords" in str(exc)
         else:
             raise AssertionError("expected ValueError")
 
     def test_allows_keyword_inside_string_literal(self):
         assert _normalize_query("SELECT \"delete\" AS sample") == "SELECT \"delete\" AS sample"
+
+    def test_rejects_refresh_statement(self):
+        try:
+            _normalize_query("REFRESH TABLE foo")
+        except ValueError as exc:
+            assert "only SELECT, WITH, SHOW, and DESCRIBE" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_set_keyword_inside_read_path(self):
+        try:
+            _normalize_query("SELECT * FROM foo SET x = 1")
+        except ValueError as exc:
+            assert "comments, session controls, or write-oriented keywords" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_unbalanced_parentheses(self):
+        try:
+            _normalize_query("WITH t AS (SELECT 1 SELECT * FROM t")
+        except ValueError as exc:
+            assert "unbalanced parentheses" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
 
 
 class TestReadQuery:

--- a/skills/ingestion/source-snowflake-query/SKILL.md
+++ b/skills/ingestion/source-snowflake-query/SKILL.md
@@ -5,11 +5,12 @@ description: >-
   for downstream ingestion, detection, or view skills. Accepts explicit
   `--query` SQL or reads the query from stdin when no `--query` is provided.
   Only `SELECT`, `WITH`, `SHOW`, and `DESCRIBE` statements are allowed, and
-  multiple statements, SQL comments, dynamic identifier helpers, and common
-  control/write keywords are rejected. Use when the user already has security
-  data in Snowflake and wants to pipe lake rows into existing skills without
-  exporting files first. Do NOT use for writes, DDL, or admin changes. Do NOT
-  use as a detector or normalizer by itself.
+  multiple statements, SQL comments, session controls, optimizer/admin verbs,
+  dynamic identifier helpers, and common control/write keywords are rejected.
+  Use when the user already has security data in Snowflake and wants to pipe
+  lake rows into existing skills without exporting files first. Do NOT use
+  for writes, DDL, or admin changes. Do NOT use as a detector or normalizer
+  by itself.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
@@ -53,8 +54,9 @@ Allowed statement families:
 - `SHOW`
 - `DESCRIBE`
 
-The skill rejects multiple statements, SQL comments, dynamic identifier
-helpers, and non-read-only verbs.
+The skill rejects multiple statements, SQL comments, session or optimizer
+controls, dynamic identifier helpers, unbalanced query shapes, and
+non-read-only verbs.
 
 ## Output
 

--- a/skills/ingestion/source-snowflake-query/src/ingest.py
+++ b/skills/ingestion/source-snowflake-query/src/ingest.py
@@ -6,20 +6,12 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
 from typing import Any, Iterable
 
+from skills._shared.read_only_sql import normalize_read_only_query
+
 SKILL_NAME = "source-snowflake-query"
-ALLOWED_PREFIXES = ("SELECT", "WITH", "SHOW", "DESCRIBE")
-DISALLOWED_PATTERNS = (
-    re.compile(r"--"),
-    re.compile(r"/\*"),
-    re.compile(r"\*/"),
-    re.compile(r"\b(?:ALTER|CALL|COPY\s+INTO|CREATE|DELETE|DROP|EXECUTE\s+IMMEDIATE|GET|GRANT|INSERT|MERGE|PUT|REVOKE|TRUNCATE|UPDATE|USE)\b"),
-    re.compile(r"\bIDENTIFIER\s*\("),
-    re.compile(r"\bSYSTEM\$"),
-)
 
 
 def _configure_snowflake_logging() -> None:
@@ -36,54 +28,7 @@ def _read_query(cli_query: str | None, stdin: Iterable[str]) -> str:
 
 
 def _normalize_query(query: str) -> str:
-    cleaned = query.strip()
-    if not cleaned:
-        raise ValueError("query must not be empty")
-    while cleaned.endswith(";"):
-        cleaned = cleaned[:-1].rstrip()
-    if ";" in cleaned:
-        raise ValueError("multiple SQL statements are not allowed")
-
-    head = cleaned.lstrip("(\n\t ").upper()
-    if not any(head.startswith(prefix) for prefix in ALLOWED_PREFIXES):
-        raise ValueError("only SELECT, WITH, SHOW, and DESCRIBE statements are allowed")
-    _validate_read_only_shape(cleaned)
-    return cleaned
-
-
-def _strip_quoted_sql(text: str) -> str:
-    result: list[str] = []
-    quote: str | None = None
-    index = 0
-    while index < len(text):
-        char = text[index]
-        if quote is None and char in ("'", '"', "`"):
-            quote = char
-            result.append(" ")
-            index += 1
-            continue
-        if quote is not None:
-            if char == quote:
-                if index + 1 < len(text) and text[index + 1] == quote:
-                    index += 2
-                    continue
-                quote = None
-            result.append(" ")
-            index += 1
-            continue
-        result.append(char)
-        index += 1
-    return "".join(result)
-
-
-def _validate_read_only_shape(query: str) -> None:
-    stripped = _strip_quoted_sql(query).upper()
-    for pattern in DISALLOWED_PATTERNS:
-        if pattern.search(stripped):
-            raise ValueError(
-                "query contains comments or disallowed control/write keywords; "
-                "only plain read-only SELECT, WITH, SHOW, and DESCRIBE queries are allowed"
-            )
+    return normalize_read_only_query(query)
 
 
 def _connect() -> Any:

--- a/skills/ingestion/source-snowflake-query/tests/test_ingest.py
+++ b/skills/ingestion/source-snowflake-query/tests/test_ingest.py
@@ -73,7 +73,7 @@ class TestNormalizeQuery:
         try:
             _normalize_query("SELECT * FROM foo -- nope")
         except ValueError as exc:
-            assert "comments or disallowed control/write keywords" in str(exc)
+            assert "comments, session controls, or write-oriented keywords" in str(exc)
         else:
             raise AssertionError("expected ValueError")
 
@@ -81,12 +81,36 @@ class TestNormalizeQuery:
         try:
             _normalize_query("SELECT SYSTEM$ABORT_SESSION('x')")
         except ValueError as exc:
-            assert "comments or disallowed control/write keywords" in str(exc)
+            assert "comments, session controls, or write-oriented keywords" in str(exc)
         else:
             raise AssertionError("expected ValueError")
 
     def test_allows_keyword_inside_string_literal(self):
         assert _normalize_query("SELECT 'delete from foo' AS sample") == "SELECT 'delete from foo' AS sample"
+
+    def test_rejects_session_mutation_keyword(self):
+        try:
+            _normalize_query("SELECT * FROM foo SET x = 1")
+        except ValueError as exc:
+            assert "comments, session controls, or write-oriented keywords" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_optimizer_control_keyword(self):
+        try:
+            _normalize_query("OPTIMIZE foo")
+        except ValueError as exc:
+            assert "only SELECT, WITH, SHOW, and DESCRIBE" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_rejects_unbalanced_parentheses(self):
+        try:
+            _normalize_query("SELECT (1")
+        except ValueError as exc:
+            assert "unbalanced parentheses" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
 
 
 class TestReadQuery:


### PR DESCRIPTION
## Summary
- centralize read-only SQL validation for warehouse source adapters
- tighten blocked query shapes for Snowflake and Databricks source skills
- add explicit tests for comments, control verbs, and unbalanced shapes

## Validation
- python -m pytest skills/ingestion/source-snowflake-query/tests/test_ingest.py -q -o addopts=''
- python -m pytest skills/ingestion/source-databricks-query/tests/test_ingest.py -q -o addopts=''
- python scripts/validate_skill_contract.py
- python -m ruff check skills/_shared/read_only_sql.py skills/ingestion/source-snowflake-query/src/ingest.py skills/ingestion/source-snowflake-query/tests/test_ingest.py skills/ingestion/source-databricks-query/src/ingest.py skills/ingestion/source-databricks-query/tests/test_ingest.py --config pyproject.toml
- python -m py_compile skills/_shared/read_only_sql.py skills/ingestion/source-snowflake-query/src/ingest.py skills/ingestion/source-databricks-query/src/ingest.py