### PR TITLE
docs: refresh top-level README visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Security skills for cloud and AI systems. Use source-specific ingest, discovery,
 
 Start here if you want the shortest true picture of the repo:
 
-![Repository architecture showing external sources feeding three action bands — Intake (Ingest and Discover), Analyze (Detect and Evaluate), and Act (View and Remediate) — that share one skill bundle contract, with edge persistence, warehouse query packs, and runtime surfaces wrapping the same skills.](docs/images/repo-architecture.svg)
+![Repository architecture showing a cleaner three-band model: external signals feed Intake through Ingest and Discover, flow into Analyze through Detect and Evaluate, and leave through Act via View or guarded Remediate, all on one shared skill bundle contract.](docs/images/repo-architecture.svg)
 
 The mental model:
 
@@ -50,7 +50,7 @@ For the full source, asset, framework, and runtime crosswalk, see [docs/USE_CASE
 
 Use this as the quick mental model for how data moves through the repo:
 
-![End-to-end skill compositions showing three shipped paths: raw logs through ingest, detect, and view; lake rows through source, detect, and sink; and live API or HR-driven paths through discovery or evaluation with optional guarded remediation.](docs/images/end-to-end-skill-flows.svg)
+![Common shipped flows showing three concrete lanes: raw payloads through ingest, detect, and view; warehouse rows through source, detect, and sink; and live state through discovery or evaluation with optional guarded remediation.](docs/images/end-to-end-skill-flows.svg)
 
 The visual is intentionally short. The exact examples live in markdown:
 
@@ -98,13 +98,13 @@ Each shipped skill is a bundle:
 - `src/` for the executable implementation
 - `tests/` for contract and regression coverage
 
-The Python file is the execution core. The full skill that agents use is the
-whole bundle.
+The execution core is only one part. The operational contract is the whole
+bundle.
 
 ### Use the skill name first
 
 The normal integration path is the skill name through MCP or an agent client,
-not a raw `python .../src/<entry>.py` invocation.
+not a raw subprocess command.
 
 For the Kubernetes example, the skill-level flow is:
 
@@ -161,10 +161,57 @@ Most flows reduce to one of these outcomes:
   - start from live state or HR events
   - end in evidence, audit records, or guarded writes
 
-The low-level execution-core examples still exist for debugging and wrapper
-authors, but they are intentionally moved out of the top-level entry path. See
+The low-level subprocess examples still exist for debugging and wrapper authors,
+but they are intentionally kept out of the main entry path. See
 [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md) and the individual `SKILL.md`
-files when you need wrapper-free subprocess examples.
+files when you need wrapper-free execution details.
+
+<details>
+<summary><b>Low-level execution core examples</b></summary>
+
+The same Kubernetes path can still be run directly when you are debugging a
+wrapper or developing around the raw subprocess surface:
+
+```bash
+python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
+  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
+  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
+  | python skills/view/convert-ocsf-to-sarif/src/convert.py \
+  > findings.sarif
+```
+
+If you want to inspect each stage separately, write local scratch files in the
+current directory:
+
+```bash
+python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
+  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
+  > k8s-events.ocsf.jsonl
+
+python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
+  k8s-events.ocsf.jsonl \
+  > k8s-findings.ocsf.jsonl
+
+python skills/view/convert-ocsf-to-sarif/src/convert.py \
+  k8s-findings.ocsf.jsonl \
+  > findings.sarif
+```
+
+Those intermediate files are only for debugging. The final output you usually
+keep is `findings.sarif`.
+
+If you want the repo-owned native wire format instead of OCSF:
+
+```bash
+python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
+  --output-format native \
+  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
+  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
+      --output-format native \
+  > findings.native.jsonl
+```
+
+</details>
 
 <details>
 <summary><b>Real input and output</b></summary>
@@ -232,7 +279,7 @@ what ships everywhere:
 
 The flagship example skill family is IAM departures remediation: a guarded, event-driven workflow with a dual audit trail and clear trust boundaries.
 
-![IAM departures workflow showing HR and identity inputs flowing through guarded approval and remediation steps into dual audit outputs.](docs/images/iam-departures-architecture.svg)
+![IAM departures remediation showing the flagship write path in three stages: select the actionable set first, run the guarded workflow with separate roles, then write a dual audit trail and verify drift later.](docs/images/iam-departures-architecture.svg)
 
 The diagram shows the flagship write path only: source events feed a guarded
 planner/worker flow, the reconciler writes an S3 manifest, EventBridge starts

--- a/docs/images/end-to-end-skill-flows.svg
+++ b/docs/images/end-to-end-skill-flows.svg
@@ -1,114 +1,124 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="1060" viewBox="0 0 1560 1060" role="img" aria-labelledby="title desc">
-  <title id="title">End-to-end skill flows</title>
-  <desc id="desc">Three real shipped paths are shown with the same structure: where the data starts, which skill families run, what the result becomes, and which guardrail matters most. The first path is raw logs through ingest, detect, and view. The second is warehouse or object rows through source, detect, and sink. The third is live state or HR events through discovery or evaluation into native outputs with optional guarded remediation.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="960" viewBox="0 0 1480 960" role="img" aria-labelledby="title desc">
+  <title id="title">Common shipped flows</title>
+  <desc id="desc">Three high-signal shipped paths. Raw payloads flow through ingest, detect, and view. Warehouse or object rows flow through source, detect, and sink. Live cloud, SaaS, or HR state flows through discovery or evaluation, then optionally through guarded remediation. The same skill bundle contract is used from CLI, MCP, CI, and runners.</desc>
+
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#07111e"/>
-      <stop offset="100%" stop-color="#0b1326"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#08111f"/>
+      <stop offset="100%" stop-color="#06111b"/>
     </linearGradient>
-    <style>
-      .title { fill: #f8fafc; font: 700 42px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .subtitle { fill: #cbd5e1; font: 400 21px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .eyebrow { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; letter-spacing: .08em; text-transform: uppercase; }
-      .lane { fill: #f8fafc; font: 700 32px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .body { fill: #e2e8f0; font: 400 18px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .head { fill: #93c5fd; font: 700 20px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .cardtitle { fill: #f8fafc; font: 700 28px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .cardbody { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .chip { fill: #dbeafe; font: 600 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .guard { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .guardlabel { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-    </style>
+    <linearGradient id="cyanStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#7dd3fc"/>
+    </linearGradient>
+    <linearGradient id="blueStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#93c5fd"/>
+    </linearGradient>
+    <linearGradient id="tealStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2dd4bf"/>
+      <stop offset="100%" stop-color="#67e8f9"/>
+    </linearGradient>
   </defs>
 
-  <rect width="1560" height="1060" fill="url(#bg)"/>
-  <rect x="28" y="28" width="1504" height="1004" rx="34" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+  <rect width="1480" height="960" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1424" height="904" rx="32" fill="#0f172a" stroke="#334155" stroke-width="2"/>
 
-  <g>
-    <text x="72" y="92" class="title">Common shipped flows</text>
-    <text x="72" y="126" class="subtitle">The same skill bundles show up in different lanes. What changes is the starting data, the output, and the guardrail around the path.</text>
+  <g font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="72" y="92" fill="#f8fafc" font-size="42" font-weight="800">Common shipped flows</text>
+    <text x="72" y="128" fill="#c7d2e3" font-size="22">The repo repeats the same skill bundles in different lanes. What changes is the input, output, and control boundary.</text>
 
-    <rect x="72" y="158" width="1416" height="54" rx="18" fill="#101929" stroke="#475569" stroke-width="2"/>
-    <text x="102" y="192" class="chip">Access surfaces</text>
-    <text x="262" y="192" class="chip">CLI</text>
-    <text x="320" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="344" y="192" class="chip">MCP / agents</text>
-    <text x="478" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="502" y="192" class="chip">CI</text>
-    <text x="542" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="566" y="192" class="chip">AWS / GCP / Azure runners</text>
-    <text x="878" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="902" y="192" class="chip">same underlying skill contract</text>
+    <rect x="72" y="158" width="1336" height="60" rx="18" fill="#111c34" stroke="#475569" stroke-width="2"/>
+    <text x="98" y="196" fill="#e5eefb" font-size="18" font-weight="800">Access surfaces</text>
+    <text x="240" y="196" fill="#dbe4f0" font-size="18">CLI • MCP / agents • CI • AWS / GCP / Azure runners • same underlying skill contract</text>
 
-    <text x="110" y="262" class="head">Start</text>
-    <text x="390" y="262" class="head">Skill flow</text>
-    <text x="930" y="262" class="head">Result</text>
-    <text x="1188" y="262" class="head">Guardrail</text>
+    <text x="126" y="274" fill="#93c5fd" font-size="17" font-weight="800">START</text>
+    <text x="452" y="274" fill="#93c5fd" font-size="17" font-weight="800">SKILL FLOW</text>
+    <text x="1042" y="274" fill="#93c5fd" font-size="17" font-weight="800">RESULT</text>
+    <text x="1284" y="274" fill="#93c5fd" font-size="17" font-weight="800">GUARDRAIL</text>
 
-    <rect x="72" y="282" width="1416" height="214" rx="28" fill="#0a2538" stroke="#22d3ee" stroke-width="2"/>
-    <text x="102" y="332" class="lane">1. Raw log detection and export</text>
-    <text x="102" y="364" class="body">Use when the repo starts from raw CloudTrail, Kubernetes audit, Okta, Entra, or other source-specific payloads.</text>
-    <rect x="102" y="390" width="230" height="78" rx="20" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
-    <text x="136" y="435" class="cardtitle">raw payloads</text>
-    <text x="136" y="458" class="cardbody">stdin, file, object, or queue message</text>
-    <rect x="372" y="390" width="150" height="78" rx="20" fill="#1d4ed8" stroke="#93c5fd" stroke-width="2"/>
-    <rect x="552" y="390" width="150" height="78" rx="20" fill="#0f766e" stroke="#5eead4" stroke-width="2"/>
-    <rect x="732" y="390" width="150" height="78" rx="20" fill="#7c3aed" stroke="#c4b5fd" stroke-width="2"/>
-    <text x="413" y="437" class="cardtitle">ingest-*</text>
-    <text x="592" y="437" class="cardtitle">detect-*</text>
-    <text x="783" y="437" class="cardtitle">view/*</text>
-    <path d="M332 429 L372 429" stroke="#38bdf8" stroke-width="5" fill="none"/>
-    <path d="M522 429 L552 429" stroke="#93c5fd" stroke-width="5" fill="none"/>
-    <path d="M702 429 L732 429" stroke="#5eead4" stroke-width="5" fill="none"/>
-    <rect x="922" y="390" width="220" height="78" rx="20" fill="#13253f" stroke="#7dd3fc" stroke-width="2"/>
-    <text x="956" y="434" fill="#f8fafc" font-size="24" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">export artifact</text>
-    <text x="956" y="458" class="cardbody">SARIF, Mermaid, or JSON output</text>
-    <rect x="1172" y="390" width="276" height="78" rx="20" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
-    <text x="1204" y="434" class="guardlabel">Guardrail</text>
-    <text x="1204" y="458" class="guard">read-only, deterministic, no hidden writes</text>
+    <g transform="translate(72,294)">
+      <rect x="0" y="0" width="1336" height="176" rx="26" fill="#0c2a3b" stroke="url(#cyanStroke)" stroke-width="2.5"/>
+      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">1. Raw log detection and export</text>
+      <text x="30" y="74" fill="#d7e9f0" font-size="18">Use when the repo starts from CloudTrail, Kubernetes audit, Okta, Entra, Workspace, or other source-native payloads.</text>
 
-    <rect x="72" y="526" width="1416" height="214" rx="28" fill="#10243a" stroke="#60a5fa" stroke-width="2"/>
-    <text x="102" y="576" class="lane">2. Warehouse or object analysis with persistence</text>
-    <text x="102" y="608" class="body">Use when data already lives in Snowflake, Databricks, ClickHouse, or object storage and you want analysis near the data.</text>
-    <rect x="102" y="634" width="230" height="78" rx="20" fill="#13253f" stroke="#38bdf8" stroke-width="2"/>
-    <text x="136" y="679" class="cardtitle">rows or objects</text>
-    <text x="136" y="702" class="cardbody">read-only table, view, or object rows</text>
-    <rect x="372" y="634" width="150" height="78" rx="20" fill="#155e75" stroke="#67e8f9" stroke-width="2"/>
-    <rect x="552" y="634" width="150" height="78" rx="20" fill="#0f766e" stroke="#5eead4" stroke-width="2"/>
-    <rect x="732" y="634" width="150" height="78" rx="20" fill="#5b21b6" stroke="#c084fc" stroke-width="2"/>
-    <text x="406" y="681" class="cardtitle">source-*</text>
-    <text x="592" y="681" class="cardtitle">detect-*</text>
-    <text x="792" y="681" class="cardtitle">sink-*</text>
-    <path d="M332 673 L372 673" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M522 673 L552 673" stroke="#67e8f9" stroke-width="5" fill="none"/>
-    <path d="M702 673 L732 673" stroke="#5eead4" stroke-width="5" fill="none"/>
-    <rect x="922" y="634" width="220" height="78" rx="20" fill="#13253f" stroke="#7dd3fc" stroke-width="2"/>
-    <text x="956" y="679" fill="#f8fafc" font-size="24" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">customer sink</text>
-    <text x="956" y="702" class="cardbody">Snowflake, ClickHouse, or S3 JSONL</text>
-    <rect x="1172" y="634" width="276" height="78" rx="20" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
-    <text x="1204" y="678" class="guardlabel">Guardrail</text>
-    <text x="1204" y="702" class="guard">read-only query side, validated sinks only</text>
+      <rect x="30" y="102" width="236" height="50" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="62" y="134" fill="#f8fafc" font-size="18" font-weight="800">raw payloads</text>
 
-    <rect x="72" y="770" width="1416" height="214" rx="28" fill="#083344" stroke="#2dd4bf" stroke-width="2"/>
-    <text x="102" y="820" class="lane">3. Live posture, discovery, and guarded action</text>
-    <text x="102" y="852" class="body">Use when the repo starts from live cloud APIs, SaaS APIs, or HR lifecycle events instead of a raw log stream.</text>
-    <rect x="102" y="878" width="230" height="78" rx="20" fill="#13253f" stroke="#14b8a6" stroke-width="2"/>
-    <text x="136" y="923" class="cardtitle">live state</text>
-    <text x="136" y="946" class="cardbody">cloud, SaaS, or HR event context</text>
-    <rect x="372" y="878" width="230" height="78" rx="20" fill="#0f766e" stroke="#5eead4" stroke-width="2"/>
-    <rect x="632" y="878" width="190" height="78" rx="20" fill="#4338ca" stroke="#a78bfa" stroke-width="2"/>
-    <rect x="852" y="878" width="190" height="78" rx="20" fill="#7f1d1d" stroke="#fca5a5" stroke-width="2"/>
-    <text x="404" y="925" fill="#f8fafc" font-size="23" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">discover / evaluate</text>
-    <text x="674" y="925" fill="#f8fafc" font-size="23" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">native outputs</text>
-    <text x="888" y="925" fill="#f8fafc" font-size="23" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">remediation/*</text>
-    <path d="M332 917 L372 917" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-    <path d="M602 917 L632 917" stroke="#5eead4" stroke-width="5" fill="none"/>
-    <path d="M822 917 L852 917" stroke="#a78bfa" stroke-width="5" fill="none"/>
-    <rect x="1072" y="878" width="180" height="78" rx="20" fill="#13253f" stroke="#2dd4bf" stroke-width="2"/>
-    <text x="1102" y="923" fill="#f8fafc" font-size="24" font-weight="700" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">evidence trail</text>
-    <text x="1102" y="946" class="cardbody">review and audit output</text>
-    <rect x="1272" y="878" width="176" height="78" rx="20" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
-    <text x="1304" y="923" class="guardlabel">Guardrail</text>
-    <text x="1304" y="946" class="guard">HITL, dry-run, audited writes</text>
+      <rect x="322" y="102" width="172" height="50" rx="18" fill="#2955d9" stroke="#9cc2ff" stroke-width="2"/>
+      <text x="376" y="134" fill="#f8fafc" font-size="18" font-weight="800">ingest-*</text>
+      <rect x="546" y="102" width="172" height="50" rx="18" fill="#16877b" stroke="#7ef0df" stroke-width="2"/>
+      <text x="600" y="134" fill="#f8fafc" font-size="18" font-weight="800">detect-*</text>
+      <rect x="770" y="102" width="172" height="50" rx="18" fill="#8b3dff" stroke="#d0b0ff" stroke-width="2"/>
+      <text x="830" y="134" fill="#f8fafc" font-size="18" font-weight="800">view/*</text>
+
+      <path d="M266 127 L322 127" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M494 127 L546 127" stroke="#8dc4ff" stroke-width="5" fill="none"/>
+      <path d="M718 127 L770 127" stroke="#77e6d7" stroke-width="5" fill="none"/>
+
+      <rect x="994" y="102" width="232" height="50" rx="18" fill="#17304f" stroke="#7dd3fc" stroke-width="2"/>
+      <text x="1036" y="134" fill="#f8fafc" font-size="18" font-weight="800">SARIF / Mermaid / JSON</text>
+
+      <rect x="1240" y="102" width="66" height="50" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+      <text x="1261" y="134" fill="#67e8f9" font-size="18" font-weight="800">RO</text>
+
+      <text x="30" y="168" fill="#8fd8e5" font-size="15">Example: ingest-cloudtrail-ocsf → detect-lateral-movement → convert-ocsf-to-sarif</text>
+    </g>
+
+    <g transform="translate(72,500)">
+      <rect x="0" y="0" width="1336" height="176" rx="26" fill="#13253f" stroke="url(#blueStroke)" stroke-width="2.5"/>
+      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">2. Warehouse or object analysis with persistence</text>
+      <text x="30" y="74" fill="#d7e3f0" font-size="18">Use when data already lives in Snowflake, Databricks, ClickHouse, or object storage and you want analysis near the data.</text>
+
+      <rect x="30" y="102" width="236" height="50" rx="18" fill="#17304f" stroke="#38bdf8" stroke-width="2"/>
+      <text x="66" y="134" fill="#f8fafc" font-size="18" font-weight="800">rows or objects</text>
+
+      <rect x="322" y="102" width="172" height="50" rx="18" fill="#155e75" stroke="#7dd3fc" stroke-width="2"/>
+      <text x="378" y="134" fill="#f8fafc" font-size="18" font-weight="800">source-*</text>
+      <rect x="546" y="102" width="172" height="50" rx="18" fill="#16877b" stroke="#7ef0df" stroke-width="2"/>
+      <text x="600" y="134" fill="#f8fafc" font-size="18" font-weight="800">detect-*</text>
+      <rect x="770" y="102" width="172" height="50" rx="18" fill="#6d28d9" stroke="#c4b5fd" stroke-width="2"/>
+      <text x="826" y="134" fill="#f8fafc" font-size="18" font-weight="800">sink-*</text>
+
+      <path d="M266 127 L322 127" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M494 127 L546 127" stroke="#7dd3fc" stroke-width="5" fill="none"/>
+      <path d="M718 127 L770 127" stroke="#7ef0df" stroke-width="5" fill="none"/>
+
+      <rect x="994" y="102" width="232" height="50" rx="18" fill="#17304f" stroke="#93c5fd" stroke-width="2"/>
+      <text x="1048" y="134" fill="#f8fafc" font-size="18" font-weight="800">customer sink edge</text>
+
+      <rect x="1240" y="102" width="66" height="50" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="1254" y="134" fill="#bfdbfe" font-size="18" font-weight="800">ROQ</text>
+
+      <text x="30" y="168" fill="#a8c8f2" font-size="15">Example: source-snowflake-query → detect-lateral-movement → sink-snowflake-jsonl</text>
+    </g>
+
+    <g transform="translate(72,706)">
+      <rect x="0" y="0" width="1336" height="176" rx="26" fill="#083344" stroke="url(#tealStroke)" stroke-width="2.5"/>
+      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">3. Live posture, discovery, and guarded action</text>
+      <text x="30" y="74" fill="#d1efe8" font-size="18">Use when the repo starts from live cloud APIs, SaaS APIs, or HR lifecycle events instead of a raw stream.</text>
+
+      <rect x="30" y="102" width="236" height="50" rx="18" fill="#17304f" stroke="#14b8a6" stroke-width="2"/>
+      <text x="74" y="134" fill="#f8fafc" font-size="18" font-weight="800">live state</text>
+
+      <rect x="322" y="102" width="248" height="50" rx="18" fill="#16877b" stroke="#7ef0df" stroke-width="2"/>
+      <text x="354" y="134" fill="#f8fafc" font-size="18" font-weight="800">discover-* / evaluation/*</text>
+      <rect x="616" y="102" width="192" height="50" rx="18" fill="#4f46e5" stroke="#a5b4fc" stroke-width="2"/>
+      <text x="654" y="134" fill="#f8fafc" font-size="18" font-weight="800">native outputs</text>
+      <rect x="854" y="102" width="202" height="50" rx="18" fill="#991b1b" stroke="#fca5a5" stroke-width="2"/>
+      <text x="900" y="134" fill="#f8fafc" font-size="18" font-weight="800">remediation/*</text>
+
+      <path d="M266 127 L322 127" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+      <path d="M570 127 L616 127" stroke="#7ef0df" stroke-width="5" fill="none"/>
+      <path d="M808 127 L854 127" stroke="#a5b4fc" stroke-width="5" fill="none"/>
+
+      <rect x="1088" y="102" width="138" height="50" rx="18" fill="#17304f" stroke="#2dd4bf" stroke-width="2"/>
+      <text x="1114" y="134" fill="#f8fafc" font-size="18" font-weight="800">evidence trail</text>
+
+      <rect x="1240" y="102" width="66" height="50" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+      <text x="1255" y="134" fill="#99f6e4" font-size="18" font-weight="800">HITL</text>
+
+      <text x="30" y="168" fill="#9ce9dd" font-size="15">Example: discover-control-evidence, cspm-aws-cis-benchmark, or iam-departures-remediation</text>
+    </g>
   </g>
 </svg>

--- a/docs/images/iam-departures-architecture.svg
+++ b/docs/images/iam-departures-architecture.svg
@@ -1,93 +1,123 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="980" viewBox="0 0 1560 980" role="img" aria-labelledby="title desc">
-  <title id="title">IAM departures remediation</title>
-  <desc id="desc">The flagship guarded write path begins with HR sources and a reconciler that decides which identities are actionable before exporting an S3 manifest. EventBridge starts a Step Function that invokes parser and worker Lambdas with separate roles. The worker applies scoped changes to AWS, Entra, GCP, Snowflake, and Databricks. Every action lands in DynamoDB and S3, then feeds back into later reconciliation and drift verification.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="920" viewBox="0 0 1480 920" role="img" aria-labelledby="title desc">
+  <title id="title">IAM departures remediation flagship path</title>
+  <desc id="desc">A cleaner three-stage view of the IAM departures workflow. HR systems feed a reconciler that filters rehires and grace-window exceptions before writing an S3 manifest. EventBridge starts a Step Function that gates a parser Lambda and a scoped worker Lambda. The workflow writes audited actions to DynamoDB and S3, then later verification and ingest-back close the loop.</desc>
+
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#07111e"/>
-      <stop offset="100%" stop-color="#0b1326"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#08111f"/>
+      <stop offset="100%" stop-color="#06111b"/>
     </linearGradient>
-    <style>
-      .title { fill: #f8fafc; font: 700 42px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .subtitle { fill: #cbd5e1; font: 400 21px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .chip { fill: #dbeafe; font: 600 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .eyebrow { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; letter-spacing: .08em; text-transform: uppercase; }
-      .stage { fill: #f8fafc; font: 700 30px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .body { fill: #e2e8f0; font: 400 18px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .cardtitle { fill: #f8fafc; font: 700 27px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .cardbody { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .guardlabel { fill: #67e8f9; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .guard { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-    </style>
+    <linearGradient id="scopeStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#67e8f9"/>
+    </linearGradient>
+    <linearGradient id="workflowStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#93c5fd"/>
+    </linearGradient>
+    <linearGradient id="auditStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2dd4bf"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+    <symbol id="aws" viewBox="0 0 24 24">
+      <path fill="#f59e0b" d="M6.763 10.036c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 0 1-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 0 1-.287-.375 6.18 6.18 0 0 1-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.391-.384-.59-.894-.59-1.533 0-.678.239-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.287 2.287 0 0 1-.28.104.488.488 0 0 1-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 0 1 .224-.167c.279-.144.614-.264 1.005-.36a4.84 4.84 0 0 1 1.246-.151c.95 0 1.644.216 2.091.647.439.43.662 1.085.662 1.963v2.586z"/>
+    </symbol>
+    <symbol id="azure" viewBox="0 0 24 24">
+      <path fill="#38bdf8" d="M22.379 23.343a1.62 1.62 0 0 0 1.536-2.14v.002L17.35 1.76A1.62 1.62 0 0 0 15.816.657H8.184A1.62 1.62 0 0 0 6.65 1.76L.086 21.204a1.62 1.62 0 0 0 1.536 2.139h4.741a1.62 1.62 0 0 0 1.535-1.103l.977-2.892 4.947 3.675c.28.208.618.32.966.32"/>
+    </symbol>
+    <symbol id="gcp" viewBox="0 0 24 24">
+      <path fill="#60a5fa" d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38z"/>
+    </symbol>
+    <symbol id="snowflake" viewBox="0 0 24 24">
+      <path fill="#7dd3fc" d="M12.358 11.981a.412.412 0 00-.114-.266l-.57-.571a.346.346 0 00-.267-.114.412.412 0 00-.266.114l-.571.57a.411.411 0 00-.114.267c0 .076.038.19.114.267l.57.57a.345.345 0 00.267.114c.076 0 .19-.038.266-.114l.571-.57a.412.412 0 00.114-.267zM13.956 12.514L11.94 14.53c-.039.038-.153.114-.229.114h-.608a.411.411 0 01-.267-.114L8.82 12.514a.408.408 0 01-.076-.229v-.608c0-.076.038-.19.114-.267l2.016-2.016a.41.41 0 01.267-.114h.608a.41.41 0 01.267.114l2.016 2.016a.347.347 0 01.114.267v.608c-.076.077-.114.19-.19.229z"/>
+    </symbol>
+    <symbol id="databricks" viewBox="0 0 24 24">
+      <path fill="#ef4444" d="M.95 14.184L12 20.403l9.919-5.55v2.21L12 22.662l-10.484-5.96-.565.308v.77L12 24l11.05-6.218v-4.317l-.515-.309L12 19.118l-9.867-5.653v-2.21L12 16.805l11.05-6.218V6.32l-.515-.308L12 11.974 2.647 6.681 12 1.388l7.76 4.368.668-.411v-.566L12 0 .95 6.27v.72L12 13.207l9.919-5.55v2.26L12 15.52 1.516 9.56l-.565.308Z"/>
+    </symbol>
   </defs>
 
-  <rect width="1560" height="980" fill="url(#bg)"/>
-  <rect x="28" y="28" width="1504" height="924" rx="34" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+  <rect width="1480" height="920" fill="url(#bg)"/>
+  <rect x="30" y="28" width="1420" height="864" rx="34" fill="#0f172a" stroke="#334155" stroke-width="2"/>
 
-  <g>
-    <text x="72" y="92" class="title">IAM departures remediation</text>
-    <text x="72" y="126" class="subtitle">Flagship guarded write path. The key control idea is simple: decide scope early, keep orchestration separate, keep writes scoped, and audit every action twice.</text>
+  <g font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="74" y="92" fill="#f8fafc" font-size="40" font-weight="800">IAM departures remediation</text>
+    <text x="74" y="128" fill="#c7d2e3" font-size="22">Flagship guarded write path. Decide scope early, keep orchestration separate, keep writes scoped, audit everything twice.</text>
 
-    <rect x="72" y="158" width="1416" height="54" rx="18" fill="#101929" stroke="#475569" stroke-width="2"/>
-    <text x="102" y="192" class="chip">Execution roles</text>
-    <text x="260" y="192" class="chip">EventBridge</text>
-    <text x="364" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="388" y="192" class="chip">Step Function</text>
-    <text x="520" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="544" y="192" class="chip">parser Lambda</text>
-    <text x="684" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="708" y="192" class="chip">worker Lambda</text>
-    <text x="854" y="192" fill="#38bdf8" font-size="20">•</text>
-    <text x="878" y="192" class="chip">cross-account remediation role</text>
+    <rect x="74" y="156" width="1332" height="56" rx="18" fill="#111c34" stroke="#475569" stroke-width="2"/>
+    <text x="102" y="192" fill="#f8fafc" font-size="18" font-weight="800">Execution roles</text>
+    <text x="268" y="192" fill="#dbe4f0" font-size="18">EventBridge • Step Function • parser Lambda • worker Lambda • cross-account remediation role</text>
 
-    <rect x="72" y="246" width="1416" height="180" rx="28" fill="#0a2538" stroke="#22d3ee" stroke-width="2"/>
-    <text x="102" y="294" class="stage">1. Select scope before anything can act</text>
-    <text x="102" y="326" class="body">Rehire and grace-period filtering happen in the reconciler, not in the worker. Only the actionable set gets exported.</text>
-    <rect x="102" y="348" width="260" height="58" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
-    <rect x="410" y="348" width="308" height="58" rx="18" fill="#155e75" stroke="#67e8f9" stroke-width="2"/>
-    <rect x="766" y="348" width="256" height="58" rx="18" fill="#13253f" stroke="#38bdf8" stroke-width="2"/>
-    <rect x="1070" y="348" width="320" height="58" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
-    <text x="136" y="384" class="cardtitle">HR sources</text>
-    <text x="444" y="384" class="cardtitle">reconciler</text>
-    <text x="800" y="384" class="cardtitle">S3 manifest</text>
-    <text x="1104" y="384" class="cardtitle">EventBridge rule</text>
-    <path d="M362 377 L410 377" stroke="#38bdf8" stroke-width="5" fill="none"/>
-    <path d="M718 377 L766 377" stroke="#67e8f9" stroke-width="5" fill="none"/>
-    <path d="M1022 377 L1070 377" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <text x="102" y="448" class="guardlabel">Guardrail</text>
-    <text x="190" y="448" class="guard">No direct Step Function entry, no rehire decisions later in the pipeline, no filtered identities written to the action manifest.</text>
+    <g transform="translate(74,244)">
+      <rect x="0" y="0" width="1332" height="182" rx="28" fill="#0b2538" stroke="url(#scopeStroke)" stroke-width="2.5"/>
+      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">1. Select scope before anything can act</text>
+      <text x="30" y="74" fill="#d8eaf0" font-size="18">Rehire and grace-window decisions happen in the reconciler. Only the actionable set is exported.</text>
 
-    <rect x="72" y="454" width="1416" height="190" rx="28" fill="#11233b" stroke="#60a5fa" stroke-width="2"/>
-    <text x="102" y="502" class="stage">2. Start the guarded workflow and re-check before write</text>
-    <text x="102" y="534" class="body">EventBridge starts the Step Function. The parser Lambda re-checks the manifest and runtime state before the worker can change anything.</text>
-    <rect x="102" y="556" width="264" height="60" rx="18" fill="#1e3a8a" stroke="#93c5fd" stroke-width="2"/>
-    <rect x="414" y="556" width="268" height="60" rx="18" fill="#1e3a8a" stroke="#93c5fd" stroke-width="2"/>
-    <rect x="730" y="556" width="268" height="60" rx="18" fill="#1e3a8a" stroke="#93c5fd" stroke-width="2"/>
-    <rect x="1046" y="556" width="344" height="60" rx="18" fill="#173056" stroke="#60a5fa" stroke-width="2"/>
-    <text x="136" y="594" class="cardtitle">Step Function</text>
-    <text x="448" y="594" class="cardtitle">parser Lambda</text>
-    <text x="764" y="594" class="cardtitle">worker Lambda</text>
-    <text x="1080" y="594" class="cardtitle">targets</text>
-    <path d="M366 586 L414 586" stroke="#60a5fa" stroke-width="5" fill="none"/>
-    <path d="M682 586 L730 586" stroke="#93c5fd" stroke-width="5" fill="none"/>
-    <path d="M998 586 L1046 586" stroke="#93c5fd" stroke-width="5" fill="none"/>
-    <text x="102" y="666" class="guardlabel">Guardrail</text>
-    <text x="190" y="666" class="guard">Separate roles, human-required approval, dry-run-first, and deny-listed identities keep the write edge narrow.</text>
+      <rect x="30" y="102" width="250" height="54" rx="18" fill="#16304e" stroke="#5eead4" stroke-width="2"/>
+      <text x="82" y="136" fill="#f8fafc" font-size="18" font-weight="800">HR sources</text>
+      <rect x="330" y="102" width="318" height="54" rx="18" fill="#19607a" stroke="#67e8f9" stroke-width="2"/>
+      <text x="398" y="136" fill="#f8fafc" font-size="18" font-weight="800">reconciler</text>
+      <rect x="698" y="102" width="250" height="54" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="780" y="136" fill="#f8fafc" font-size="18" font-weight="800">S3 manifest</text>
+      <rect x="998" y="102" width="278" height="54" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="1070" y="136" fill="#f8fafc" font-size="18" font-weight="800">EventBridge rule</text>
 
-    <rect x="72" y="672" width="1416" height="196" rx="28" fill="#083344" stroke="#2dd4bf" stroke-width="2"/>
-    <text x="102" y="720" class="stage">3. Apply scoped changes and write the audit trail</text>
-    <text x="102" y="752" class="body">The worker touches only the approved targets. Every action is recorded in DynamoDB and S3 as the system of record for later replay and review.</text>
-    <rect x="102" y="776" width="286" height="60" rx="18" fill="#1f4b61" stroke="#2dd4bf" stroke-width="2"/>
-    <rect x="436" y="776" width="250" height="60" rx="18" fill="#312e81" stroke="#a78bfa" stroke-width="2"/>
-    <rect x="734" y="776" width="250" height="60" rx="18" fill="#173056" stroke="#60a5fa" stroke-width="2"/>
-    <rect x="1032" y="776" width="306" height="60" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
-    <text x="136" y="814" class="cardtitle">scoped write set</text>
-    <text x="470" y="814" class="cardtitle">DynamoDB + S3</text>
-    <text x="768" y="814" class="cardtitle">ingest-back</text>
-    <text x="1066" y="814" class="cardtitle">later drift check</text>
-    <path d="M388 806 L436 806" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-    <path d="M686 806 L734 806" stroke="#a78bfa" stroke-width="5" fill="none"/>
-    <path d="M984 806 L1032 806" stroke="#22d3ee" stroke-width="5" fill="none"/>
-    <path d="M1326 860 C1326 918 286 918 286 348" stroke="#22d3ee" stroke-width="4" stroke-dasharray="10 10" fill="none"/>
-    <text x="780" y="914" fill="#22d3ee" font="italic 18px 'IBM Plex Sans', 'Segoe UI', sans-serif" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
+      <path d="M280 129 L330 129" stroke="#67e8f9" stroke-width="5" fill="none"/>
+      <path d="M648 129 L698 129" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M948 129 L998 129" stroke="#60a5fa" stroke-width="5" fill="none"/>
+
+      <text x="30" y="170" fill="#99f6e4" font-size="15" font-weight="800">Guardrail</text>
+      <text x="122" y="170" fill="#d9e3ef" font-size="15">No direct Step Function entry. No rehire logic later in the pipeline. No filtered identities written to the action set.</text>
+    </g>
+
+    <g transform="translate(74,452)">
+      <rect x="0" y="0" width="1332" height="182" rx="28" fill="#10243a" stroke="url(#workflowStroke)" stroke-width="2.5"/>
+      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">2. Start the guarded workflow and re-check before write</text>
+      <text x="30" y="74" fill="#dce6f4" font-size="18">EventBridge starts the Step Function. The parser Lambda re-checks runtime state before the worker can change anything.</text>
+
+      <rect x="30" y="102" width="256" height="54" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
+      <text x="92" y="136" fill="#f8fafc" font-size="18" font-weight="800">Step Function</text>
+      <rect x="338" y="102" width="256" height="54" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
+      <text x="404" y="136" fill="#f8fafc" font-size="18" font-weight="800">parser Lambda</text>
+      <rect x="646" y="102" width="256" height="54" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
+      <text x="710" y="136" fill="#f8fafc" font-size="18" font-weight="800">worker Lambda</text>
+      <rect x="954" y="102" width="292" height="54" rx="18" fill="#203d66" stroke="#60a5fa" stroke-width="2"/>
+      <text x="1048" y="136" fill="#f8fafc" font-size="18" font-weight="800">scoped targets</text>
+
+      <path d="M286 129 L338 129" stroke="#7db7ff" stroke-width="5" fill="none"/>
+      <path d="M594 129 L646 129" stroke="#93c5fd" stroke-width="5" fill="none"/>
+      <path d="M902 129 L954 129" stroke="#93c5fd" stroke-width="5" fill="none"/>
+
+      <g transform="translate(998,88)">
+        <use href="#aws" x="0" y="0" width="16" height="16"/>
+        <use href="#azure" x="28" y="0" width="16" height="16"/>
+        <use href="#gcp" x="56" y="0" width="16" height="16"/>
+        <use href="#snowflake" x="84" y="0" width="16" height="16"/>
+        <use href="#databricks" x="112" y="0" width="16" height="16"/>
+      </g>
+
+      <text x="30" y="170" fill="#bfdbfe" font-size="15" font-weight="800">Guardrail</text>
+      <text x="126" y="170" fill="#d9e3ef" font-size="15">Separate roles, human-required approval, dry-run-first, deny-listed identities, scoped principals, no direct bypass of orchestration.</text>
+    </g>
+
+    <g transform="translate(74,660)">
+      <rect x="0" y="0" width="1332" height="184" rx="28" fill="#083344" stroke="url(#auditStroke)" stroke-width="2.5"/>
+      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">3. Apply scoped changes and write the audit trail</text>
+      <text x="30" y="74" fill="#d4efe9" font-size="18">The worker touches only approved targets. The system of record is DynamoDB + S3, then later verification closes the loop.</text>
+
+      <rect x="30" y="104" width="250" height="54" rx="18" fill="#155e75" stroke="#5eead4" stroke-width="2"/>
+      <text x="78" y="138" fill="#f8fafc" font-size="18" font-weight="800">scoped write set</text>
+      <rect x="330" y="104" width="270" height="54" rx="18" fill="#4c1d95" stroke="#c4b5fd" stroke-width="2"/>
+      <text x="398" y="138" fill="#f8fafc" font-size="18" font-weight="800">DynamoDB + S3</text>
+      <rect x="650" y="104" width="246" height="54" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="724" y="138" fill="#f8fafc" font-size="18" font-weight="800">ingest-back</text>
+      <rect x="946" y="104" width="300" height="54" rx="18" fill="#17304f" stroke="#22d3ee" stroke-width="2"/>
+      <text x="1020" y="138" fill="#f8fafc" font-size="18" font-weight="800">later drift check</text>
+
+      <path d="M280 131 L330 131" stroke="#5eead4" stroke-width="5" fill="none"/>
+      <path d="M600 131 L650 131" stroke="#c4b5fd" stroke-width="5" fill="none"/>
+      <path d="M896 131 L946 131" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M1226 158 C 1238 192, 1160 206, 920 206 C 580 206, 332 184, 226 74" stroke="#22d3ee" stroke-width="4" stroke-dasharray="8 10" fill="none"/>
+      <text x="740" y="176" fill="#67e8f9" font-size="17" font-style="italic" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
+    </g>
   </g>
 </svg>

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -1,108 +1,129 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="980" viewBox="0 0 1480 980" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="920" viewBox="0 0 1440 920" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills repository architecture</title>
-  <desc id="desc">The repo is organized into three action bands. Intake contains Ingest and Discover. Analyze contains Detect and Evaluate. Act contains Remediate and View. All six lanes share one skill bundle contract, while sources and sinks, warehouse query packs, and runtime surfaces wrap the same underlying skills.</desc>
+  <desc id="desc">A cleaner three-band view of the repo. External signals enter Intake through Ingest and Discover, flow into Analyze through Detect and Evaluate, and leave through Act via View or Remediate. The same skill bundle contract is shared across all lanes, while source and sink edges, SQL query packs, and runtime surfaces wrap the same implementation.</desc>
+
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#07111e"/>
-      <stop offset="100%" stop-color="#0b1326"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#08111f"/>
+      <stop offset="100%" stop-color="#06101a"/>
     </linearGradient>
-    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="hero" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="100%" stop-color="#111c34"/>
+      <stop offset="100%" stop-color="#111f37"/>
     </linearGradient>
-    <linearGradient id="intake" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#162456"/>
-      <stop offset="100%" stop-color="#1d4ed8"/>
+    <linearGradient id="intakeStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#60a5fa"/>
     </linearGradient>
-    <linearGradient id="analyze" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#0f3a41"/>
-      <stop offset="100%" stop-color="#0f766e"/>
+    <linearGradient id="analyzeStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#34d399"/>
     </linearGradient>
-    <linearGradient id="act" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#4a1930"/>
-      <stop offset="100%" stop-color="#7c2d12"/>
+    <linearGradient id="actStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#c084fc"/>
     </linearGradient>
-    <style>
-      .title { fill: #f8fafc; font: 700 42px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .subtitle { fill: #cbd5e1; font: 400 21px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .micro { fill: #94a3b8; font: 400 15px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .section { fill: #f8fafc; font: 700 30px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .eyebrow { fill: #93c5fd; font: 700 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; letter-spacing: .08em; text-transform: uppercase; }
-      .cardtitle { fill: #f8fafc; font: 700 29px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .body { fill: #e2e8f0; font: 400 17px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .small { fill: #cbd5e1; font: 400 15px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .chip { fill: #dbeafe; font: 600 15px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-      .foot { fill: #cbd5e1; font: 400 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
-    </style>
+    <symbol id="aws" viewBox="0 0 24 24">
+      <path fill="#f59e0b" d="M6.763 10.036c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 0 1-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 0 1-.287-.375 6.18 6.18 0 0 1-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.391-.384-.59-.894-.59-1.533 0-.678.239-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.287 2.287 0 0 1-.28.104.488.488 0 0 1-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 0 1 .224-.167c.279-.144.614-.264 1.005-.36a4.84 4.84 0 0 1 1.246-.151c.95 0 1.644.216 2.091.647.439.43.662 1.085.662 1.963v2.586zm-3.24 1.214c.263 0 .534-.048.822-.144.287-.096.543-.271.758-.51.128-.152.224-.32.272-.512.047-.191.08-.423.08-.694v-.335a6.66 6.66 0 0 0-.735-.136 6.02 6.02 0 0 0-.75-.048c-.535 0-.926.104-1.19.32-.263.215-.39.518-.39.917 0 .375.095.655.295.846.191.2.47.296.838.296z"/>
+    </symbol>
+    <symbol id="gcp" viewBox="0 0 24 24">
+      <path fill="#60a5fa" d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38z"/>
+    </symbol>
+    <symbol id="azure" viewBox="0 0 24 24">
+      <path fill="#38bdf8" d="M22.379 23.343a1.62 1.62 0 0 0 1.536-2.14v.002L17.35 1.76A1.62 1.62 0 0 0 15.816.657H8.184A1.62 1.62 0 0 0 6.65 1.76L.086 21.204a1.62 1.62 0 0 0 1.536 2.139h4.741a1.62 1.62 0 0 0 1.535-1.103l.977-2.892 4.947 3.675c.28.208.618.32.966.32"/>
+    </symbol>
+    <symbol id="okta" viewBox="0 0 24 24">
+      <path fill="#3b82f6" d="M12 0C5.389 0 0 5.35 0 12s5.35 12 12 12 12-5.35 12-12S18.611 0 12 0zm0 18c-3.325 0-6-2.675-6-6s2.675-6 6-6 6 2.675 6 6-2.675 6-6 6z"/>
+    </symbol>
+    <symbol id="entra" viewBox="0 0 24 24">
+      <path fill="#60a5fa" d="M0 0v11.408h11.408V0zm12.594 0v11.408H24V0zM0 12.594V24h11.408V12.594zm12.594 0V24H24V12.594z"/>
+    </symbol>
   </defs>
 
-  <rect width="1480" height="980" fill="url(#bg)"/>
-  <rect x="28" y="28" width="1424" height="924" rx="34" fill="url(#panel)" stroke="#334155" stroke-width="2"/>
+  <rect width="1440" height="920" fill="url(#bg)"/>
+  <rect x="32" y="28" width="1376" height="864" rx="34" fill="url(#hero)" stroke="#334155" stroke-width="2"/>
 
-  <g>
-    <text x="72" y="92" class="title">cloud-ai-security-skills</text>
-    <text x="72" y="126" class="subtitle">Same skill bundle, any surface. OCSF 1.8 by default for streams, native where OCSF is thin.</text>
-    <text x="72" y="152" class="micro">Three action bands. Six shipped skill lanes. One shared contract. Support layers wrap the same skills instead of replacing them.</text>
+  <g font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="84" y="94" fill="#f8fafc" font-size="40" font-weight="800">cloud-ai-security-skills</text>
+    <text x="84" y="132" fill="#dbe4f0" font-size="22" font-weight="600">Same skill bundle, any surface. OCSF-first for streams. Native where fidelity matters.</text>
+    <text x="84" y="164" fill="#8fa1b9" font-size="17">One mental model: signal in, stable contract through, review or guarded action out.</text>
 
-    <rect x="72" y="186" width="1336" height="86" rx="22" fill="#101929" stroke="#475569" stroke-width="2"/>
-    <text x="102" y="220" class="eyebrow">External signals</text>
-    <rect x="102" y="234" width="150" height="26" rx="13" fill="#172136"/>
-    <rect x="266" y="234" width="132" height="26" rx="13" fill="#172136"/>
-    <rect x="412" y="234" width="154" height="26" rx="13" fill="#172136"/>
-    <rect x="580" y="234" width="158" height="26" rx="13" fill="#172136"/>
-    <rect x="752" y="234" width="148" height="26" rx="13" fill="#172136"/>
-    <rect x="914" y="234" width="148" height="26" rx="13" fill="#172136"/>
-    <text x="126" y="252" class="chip">cloud APIs</text>
-    <text x="298" y="252" class="chip">raw logs</text>
-    <text x="442" y="252" class="chip">identity feeds</text>
-    <text x="606" y="252" class="chip">Kubernetes audit</text>
-    <text x="785" y="252" class="chip">warehouses</text>
-    <text x="948" y="252" class="chip">MCP proxy</text>
+    <rect x="84" y="198" width="1272" height="88" rx="24" fill="#10192b" stroke="#41536f" stroke-width="2"/>
+    <text x="114" y="234" fill="#93c5fd" font-size="15" font-weight="800" letter-spacing="1.5">EXTERNAL SIGNALS</text>
+    <g transform="translate(108,248)">
+      <rect x="0" y="0" width="170" height="24" rx="12" fill="#17233a"/>
+      <use href="#aws" x="10" y="4" width="16" height="16"/>
+      <text x="34" y="17" fill="#e5eefb" font-size="13" font-weight="700">cloud APIs</text>
 
-    <rect x="72" y="308" width="1336" height="154" rx="28" fill="#0f1f3a" stroke="#3b82f6" stroke-width="2"/>
-    <text x="100" y="342" class="eyebrow">Intake</text>
-    <text x="100" y="380" class="section">Turn raw inputs or live state into stable repo data</text>
-    <rect x="100" y="404" width="610" height="44" rx="18" fill="url(#intake)" stroke="#93c5fd" stroke-width="2"/>
-    <rect x="770" y="404" width="610" height="44" rx="18" fill="url(#intake)" stroke="#93c5fd" stroke-width="2"/>
-    <text x="126" y="434" class="cardtitle">L1 Ingest</text>
-    <text x="796" y="434" class="cardtitle">L2 Discover</text>
-    <text x="126" y="490" class="body">source-specific normalization from CloudTrail, Azure Activity, GCP audit,</text>
-    <text x="126" y="514" class="body">Kubernetes audit, Okta, Entra, Workspace, VPC/NSG flows, and MCP proxy logs</text>
-    <text x="796" y="490" class="body">live inventory, AI BOM, control evidence, environment graph context,</text>
-    <text x="796" y="514" class="body">and repo-native outputs for posture, evidence, and discovery workflows</text>
+      <rect x="186" y="0" width="146" height="24" rx="12" fill="#17233a"/>
+      <text x="206" y="17" fill="#e5eefb" font-size="13" font-weight="700">raw logs</text>
 
-    <rect x="72" y="492" width="1336" height="154" rx="28" fill="#0a2d30" stroke="#14b8a6" stroke-width="2"/>
-    <text x="100" y="526" class="eyebrow" fill="#99f6e4">Analyze</text>
-    <text x="100" y="564" class="section">Turn events into findings and controls into benchmark results</text>
-    <rect x="100" y="588" width="610" height="44" rx="18" fill="url(#analyze)" stroke="#5eead4" stroke-width="2"/>
-    <rect x="770" y="588" width="610" height="44" rx="18" fill="url(#analyze)" stroke="#5eead4" stroke-width="2"/>
-    <text x="126" y="618" class="cardtitle">L3 Detect</text>
-    <text x="796" y="618" class="cardtitle">L4 Evaluate</text>
-    <text x="126" y="674" class="body">detectors for lateral movement, Kubernetes privilege escalation,</text>
-    <text x="126" y="698" class="body">Okta MFA fatigue, MCP tool drift, Workspace auth, and Entra identity abuse</text>
-    <text x="796" y="674" class="body">benchmarks and evaluation flows for AWS, Azure, GCP, Kubernetes,</text>
-    <text x="796" y="698" class="body">containers, model serving, and GPU cluster posture</text>
+      <rect x="348" y="0" width="180" height="24" rx="12" fill="#17233a"/>
+      <use href="#okta" x="358" y="4" width="16" height="16"/>
+      <use href="#entra" x="378" y="4" width="16" height="16"/>
+      <text x="400" y="17" fill="#e5eefb" font-size="13" font-weight="700">identity feeds</text>
 
-    <rect x="72" y="676" width="1336" height="154" rx="28" fill="#2b1a1a" stroke="#f97316" stroke-width="2"/>
-    <text x="100" y="710" class="eyebrow" fill="#fdba74">Act</text>
-    <text x="100" y="748" class="section">Present results or take approval-bound action</text>
-    <rect x="100" y="772" width="610" height="44" rx="18" fill="url(#act)" stroke="#f0abfc" stroke-width="2"/>
-    <rect x="770" y="772" width="610" height="44" rx="18" fill="url(#act)" stroke="#fb923c" stroke-width="2"/>
-    <text x="126" y="802" class="cardtitle">L5 Remediate</text>
-    <text x="796" y="802" class="cardtitle">L6 View</text>
-    <text x="126" y="858" class="body">flagship guarded write path for IAM departures: dry-run first,</text>
-    <text x="126" y="882" class="body">human approval, scoped roles, and dual audit to DynamoDB plus S3</text>
-    <text x="796" y="858" class="body">delivery and review formats such as SARIF and Mermaid attack flow</text>
-    <text x="796" y="882" class="body">for downstream triage, export, and security review workflows</text>
+      <rect x="544" y="0" width="182" height="24" rx="12" fill="#17233a"/>
+      <text x="564" y="17" fill="#e5eefb" font-size="13" font-weight="700">Kubernetes audit</text>
 
-    <rect x="72" y="850" width="1336" height="48" rx="18" fill="#182234" stroke="#64748b" stroke-width="2"/>
-    <text x="100" y="881" class="foot"><tspan font-weight="700" fill="#f8fafc">Shared contract</tspan><tspan dx="18">SKILL.md • REFERENCES.md • src/ • tests/ • native / canonical / OCSF / bridge modes</tspan></text>
+      <rect x="742" y="0" width="166" height="24" rx="12" fill="#17233a"/>
+      <text x="762" y="17" fill="#e5eefb" font-size="13" font-weight="700">warehouses</text>
 
-    <rect x="72" y="912" width="420" height="30" rx="15" fill="#121b2a"/>
-    <rect x="530" y="912" width="352" height="30" rx="15" fill="#121b2a"/>
-    <rect x="920" y="912" width="488" height="30" rx="15" fill="#121b2a"/>
-    <text x="96" y="932" class="small"><tspan font-weight="700" fill="#f8fafc">Edge layers</tspan><tspan dx="10">source-* and sink-*</tspan></text>
-    <text x="554" y="932" class="small"><tspan font-weight="700" fill="#f8fafc">Query packs</tspan><tspan dx="10">warehouse SQL mirrors</tspan></text>
-    <text x="944" y="932" class="small"><tspan font-weight="700" fill="#f8fafc">Runtime surfaces</tspan><tspan dx="10">CLI • CI • MCP • runners</tspan></text>
+      <rect x="924" y="0" width="150" height="24" rx="12" fill="#17233a"/>
+      <text x="946" y="17" fill="#e5eefb" font-size="13" font-weight="700">MCP proxy</text>
+    </g>
+    <text x="114" y="272" fill="#8fa1b9" font-size="14">AWS • Azure • GCP • Okta • Entra • Workspace • K8s • lakehouse and object-store paths</text>
+
+    <g transform="translate(84,322)">
+      <rect x="0" y="0" width="1272" height="158" rx="28" fill="#102241" stroke="url(#intakeStroke)" stroke-width="2.5"/>
+      <text x="30" y="34" fill="#93c5fd" font-size="15" font-weight="800" letter-spacing="1.5">INTAKE</text>
+      <text x="30" y="76" fill="#f8fafc" font-size="24" font-weight="800">Turn raw signals or live state into stable repo data</text>
+      <text x="30" y="104" fill="#a8b7cc" font-size="16">Parallel entry lanes, not a fake sequence: normalize streams with Ingest or read live state with Discover.</text>
+
+      <rect x="30" y="118" width="574" height="24" rx="12" fill="#18335d"/>
+      <rect x="638" y="118" width="604" height="24" rx="12" fill="#18335d"/>
+      <rect x="30" y="118" width="574" height="24" rx="12" fill="#2955d9" opacity="0.95"/>
+      <rect x="638" y="118" width="604" height="24" rx="12" fill="#3157d2" opacity="0.95"/>
+      <text x="50" y="136" fill="#f8fafc" font-size="16" font-weight="800">L1 Ingest</text>
+      <text x="658" y="136" fill="#f8fafc" font-size="16" font-weight="800">L2 Discover</text>
+      <text x="50" y="162" fill="#dbe7fb" font-size="14">CloudTrail, Azure Activity, GCP audit, K8s audit, Okta, Entra, Workspace, MCP proxy</text>
+      <text x="658" y="162" fill="#dbe7fb" font-size="14">discover-environment, AI BOM, control evidence, cloud-control evidence</text>
+    </g>
+
+    <g transform="translate(84,504)">
+      <rect x="0" y="0" width="1272" height="158" rx="28" fill="#0a2d31" stroke="url(#analyzeStroke)" stroke-width="2.5"/>
+      <text x="30" y="34" fill="#99f6e4" font-size="15" font-weight="800" letter-spacing="1.5">ANALYZE</text>
+      <text x="30" y="76" fill="#f8fafc" font-size="24" font-weight="800">Turn events into findings and controls into benchmark evidence</text>
+      <text x="30" y="104" fill="#a8c9c4" font-size="16">Detect and Evaluate consume the same stable contracts but answer different questions.</text>
+
+      <rect x="30" y="118" width="574" height="24" rx="12" fill="#114549"/>
+      <rect x="638" y="118" width="604" height="24" rx="12" fill="#114549"/>
+      <rect x="30" y="118" width="574" height="24" rx="12" fill="#1c8a80" opacity="0.95"/>
+      <rect x="638" y="118" width="604" height="24" rx="12" fill="#166f46" opacity="0.95"/>
+      <text x="50" y="136" fill="#f8fafc" font-size="16" font-weight="800">L3 Detect</text>
+      <text x="658" y="136" fill="#f8fafc" font-size="16" font-weight="800">L4 Evaluate</text>
+      <text x="50" y="162" fill="#d5fff6" font-size="14">lateral movement, K8s privilege escalation, Okta MFA fatigue, Entra, Workspace, MCP</text>
+      <text x="658" y="162" fill="#ddffe6" font-size="14">CIS AWS/GCP/Azure/K8s, container, GPU cluster, model-serving security</text>
+    </g>
+
+    <g transform="translate(84,686)">
+      <rect x="0" y="0" width="1272" height="158" rx="28" fill="#2a1717" stroke="url(#actStroke)" stroke-width="2.5"/>
+      <text x="30" y="34" fill="#fdba74" font-size="15" font-weight="800" letter-spacing="1.5">ACT</text>
+      <text x="30" y="76" fill="#f8fafc" font-size="24" font-weight="800">Render findings cleanly or take scoped action with audit around every write</text>
+      <text x="30" y="104" fill="#d4c0c0" font-size="16">View is the delivery edge. Remediate is the guarded write edge.</text>
+
+      <rect x="30" y="118" width="574" height="24" rx="12" fill="#4d193d"/>
+      <rect x="638" y="118" width="604" height="24" rx="12" fill="#4d2213"/>
+      <rect x="30" y="118" width="574" height="24" rx="12" fill="#8b2cbf" opacity="0.95"/>
+      <rect x="638" y="118" width="604" height="24" rx="12" fill="#b45309" opacity="0.95"/>
+      <text x="50" y="136" fill="#f8fafc" font-size="16" font-weight="800">L5 Remediate</text>
+      <text x="658" y="136" fill="#f8fafc" font-size="16" font-weight="800">L6 View</text>
+      <text x="50" y="162" fill="#f6e9ff" font-size="14">IAM departures: HITL approval, dry-run-first, dual audit in DynamoDB + S3</text>
+      <text x="658" y="162" fill="#fff0de" font-size="14">SARIF and Mermaid delivery for downstream review, CI, and incident handoff</text>
+    </g>
+
+    <rect x="84" y="856" width="1272" height="36" rx="18" fill="#1b2435" stroke="#55657f" stroke-width="1.5"/>
+    <text x="108" y="880" fill="#f8fafc" font-size="15" font-weight="800">Shared skill bundle contract</text>
+    <text x="354" y="880" fill="#d1d9e6" font-size="15">SKILL.md · REFERENCES.md · src/ · tests/ · native / canonical / OCSF / bridge modes</text>
   </g>
 </svg>


### PR DESCRIPTION
## What
- redraws the three top-level README SVGs from scratch
- makes the README more skill-first and MCP-first
- moves raw subprocess examples behind a low-level details block instead of leading with them

## Why
The previous visuals were technically accurate but visually dense, box-heavy, and too text-first for the top of the repo. This PR keeps the diagrams true to the shipped flows and guardrails while making them cleaner, more legible, and less subprocess-centric.

## Validation
- `xmllint --noout docs/images/repo-architecture.svg docs/images/end-to-end-skill-flows.svg docs/images/iam-departures-architecture.svg`
- `git diff --check`