### PR TITLE
docs: elevate readme architecture visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,61 @@ Security skills for cloud and AI systems. Use source-specific ingest, discovery,
 
 Start here if you want the shortest true picture of the repo:
 
+```mermaid
+flowchart TB
+    subgraph Signals[External Signals]
+        cloud[Cloud APIs]
+        logs[Raw Logs]
+        idp[Identity Feeds]
+        k8s[Kubernetes Audit]
+        mcp[MCP Proxy]
+        lake[Warehouses]
+    end
+
+    subgraph Intake[Intake]
+        ingest[L1 Ingest]
+        discover[L2 Discover]
+    end
+
+    subgraph Analyze[Analyze]
+        detect[L3 Detect]
+        evaluate[L4 Evaluate]
+    end
+
+    subgraph Act[Act]
+        remediate[L5 Remediate]
+        view[L6 View]
+    end
+
+    contract[(Shared Skill Bundle)]
+    support[Source / Sink / Packs / Runners]
+
+    cloud --> ingest
+    logs --> ingest
+    idp --> ingest
+    k8s --> ingest
+    mcp --> ingest
+    lake --> ingest
+    cloud --> discover
+    idp --> discover
+
+    ingest --> detect
+    discover --> detect
+    discover --> evaluate
+    detect --> view
+    evaluate --> view
+    discover --> remediate
+    evaluate --> remediate
+
+    contract --- ingest
+    contract --- discover
+    contract --- detect
+    contract --- evaluate
+    contract --- remediate
+    contract --- view
+    support --- contract
+```
+
 ![Repository architecture showing a cleaner three-band model: external signals feed Intake through Ingest and Discover, flow into Analyze through Detect and Evaluate, and leave through Act via View or guarded Remediate, all on one shared skill bundle contract.](docs/images/repo-architecture.svg)
 
 The mental model:
@@ -49,6 +104,30 @@ For the full source, asset, framework, and runtime crosswalk, see [docs/USE_CASE
 ## Common Shipped Flows
 
 Use this as the quick mental model for how data moves through the repo:
+
+```mermaid
+flowchart TB
+    subgraph Lane1[Raw Log Detection And Export]
+        raw[Raw Payloads] --> ingest1[ingest-*]
+        ingest1 --> detect1[detect-*]
+        detect1 --> view1[view/*]
+        view1 --> artifact[Export Artifact]
+    end
+
+    subgraph Lane2[Warehouse Or Object Analysis]
+        rows[Rows Or Objects] --> source[source-*]
+        source --> detect2[detect-*]
+        detect2 --> sink[sink-*]
+        sink --> persistence[Customer Sink]
+    end
+
+    subgraph Lane3[Live Posture And Guarded Action]
+        live[Live State] --> discover_eval[discover-* / evaluation/*]
+        discover_eval --> native[Native Outputs]
+        native --> remediation[remediation/*]
+        remediation --> audit[Evidence Trail]
+    end
+```
 
 ![Common shipped flows showing three concrete lanes: raw payloads through ingest, detect, and view; warehouse rows through source, detect, and sink; and live state through discovery or evaluation with optional guarded remediation.](docs/images/end-to-end-skill-flows.svg)
 
@@ -278,6 +357,19 @@ what ships everywhere:
 ## Flagship Example
 
 The flagship example skill family is IAM departures remediation: a guarded, event-driven workflow with a dual audit trail and clear trust boundaries.
+
+```mermaid
+flowchart LR
+    hr[HR Sources] --> reconciler[Reconciler]
+    reconciler --> manifest[S3 Manifest]
+    manifest --> eventbridge[EventBridge Rule]
+    eventbridge --> stepfn[Step Function]
+    stepfn --> parser[Parser Lambda]
+    parser --> worker[Worker Lambda]
+    worker --> targets[Scoped Targets]
+    worker --> audit[DynamoDB + S3 Audit]
+    audit -. later drift verification .-> reconciler
+```
 
 ![IAM departures remediation showing the flagship write path in three stages: select the actionable set first, run the guarded workflow with separate roles, then write a dual audit trail and verify drift later.](docs/images/iam-departures-architecture.svg)
 

--- a/docs/images/end-to-end-skill-flows.svg
+++ b/docs/images/end-to-end-skill-flows.svg
@@ -1,124 +1,131 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="960" viewBox="0 0 1480 960" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1040" viewBox="0 0 1600 1040" role="img" aria-labelledby="title desc">
   <title id="title">Common shipped flows</title>
-  <desc id="desc">Three high-signal shipped paths. Raw payloads flow through ingest, detect, and view. Warehouse or object rows flow through source, detect, and sink. Live cloud, SaaS, or HR state flows through discovery or evaluation, then optionally through guarded remediation. The same skill bundle contract is used from CLI, MCP, CI, and runners.</desc>
+  <desc id="desc">A polished flow poster showing three shipped paths: raw payloads through ingest, detect, and view; warehouse or object rows through source, detect, and sink; and live cloud or HR state through discovery or evaluation with optional guarded remediation. Each lane highlights its start, skill path, result, and guardrail.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#08111f"/>
-      <stop offset="100%" stop-color="#06111b"/>
+      <stop offset="0%" stop-color="#06111d"/>
+      <stop offset="100%" stop-color="#091524"/>
     </linearGradient>
-    <linearGradient id="cyanStroke" x1="0" y1="0" x2="1" y2="0">
+    <linearGradient id="frame" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f1a31"/>
+      <stop offset="100%" stop-color="#0c172c"/>
+    </linearGradient>
+    <linearGradient id="cyan" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#22d3ee"/>
       <stop offset="100%" stop-color="#7dd3fc"/>
     </linearGradient>
-    <linearGradient id="blueStroke" x1="0" y1="0" x2="1" y2="0">
+    <linearGradient id="blue" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#60a5fa"/>
       <stop offset="100%" stop-color="#93c5fd"/>
     </linearGradient>
-    <linearGradient id="tealStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#2dd4bf"/>
-      <stop offset="100%" stop-color="#67e8f9"/>
+    <linearGradient id="teal" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#5eead4"/>
     </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="20" flood-color="#020617" flood-opacity="0.42"/>
+    </filter>
   </defs>
 
-  <rect width="1480" height="960" fill="url(#bg)"/>
-  <rect x="28" y="28" width="1424" height="904" rx="32" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+  <rect width="1600" height="1040" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1544" height="984" rx="34" fill="url(#frame)" stroke="#334155" stroke-width="2"/>
 
   <g font-family="Inter, Segoe UI, Arial, sans-serif">
-    <text x="72" y="92" fill="#f8fafc" font-size="42" font-weight="800">Common shipped flows</text>
-    <text x="72" y="128" fill="#c7d2e3" font-size="22">The repo repeats the same skill bundles in different lanes. What changes is the input, output, and control boundary.</text>
+    <text x="84" y="98" fill="#f8fafc" font-size="50" font-weight="800">Common shipped flows</text>
+    <text x="84" y="138" fill="#dbe4f0" font-size="22">The same skill bundles keep reappearing. What changes is the start state, the output edge, and the guardrail around the path.</text>
 
-    <rect x="72" y="158" width="1336" height="60" rx="18" fill="#111c34" stroke="#475569" stroke-width="2"/>
-    <text x="98" y="196" fill="#e5eefb" font-size="18" font-weight="800">Access surfaces</text>
-    <text x="240" y="196" fill="#dbe4f0" font-size="18">CLI • MCP / agents • CI • AWS / GCP / Azure runners • same underlying skill contract</text>
+    <rect x="84" y="170" width="1432" height="64" rx="20" fill="#111c34" stroke="#475569" stroke-width="2"/>
+    <text x="116" y="210" fill="#f8fafc" font-size="18" font-weight="800">Access surfaces</text>
+    <text x="268" y="210" fill="#d7e2f2" font-size="18">CLI • MCP / agents • CI • AWS / GCP / Azure runners • same underlying skill bundle contract</text>
 
-    <text x="126" y="274" fill="#93c5fd" font-size="17" font-weight="800">START</text>
-    <text x="452" y="274" fill="#93c5fd" font-size="17" font-weight="800">SKILL FLOW</text>
-    <text x="1042" y="274" fill="#93c5fd" font-size="17" font-weight="800">RESULT</text>
-    <text x="1284" y="274" fill="#93c5fd" font-size="17" font-weight="800">GUARDRAIL</text>
+    <text x="120" y="292" fill="#93c5fd" font-size="16" font-weight="800" letter-spacing="1.5">START</text>
+    <text x="470" y="292" fill="#93c5fd" font-size="16" font-weight="800" letter-spacing="1.5">SKILL FLOW</text>
+    <text x="1078" y="292" fill="#93c5fd" font-size="16" font-weight="800" letter-spacing="1.5">RESULT</text>
+    <text x="1318" y="292" fill="#93c5fd" font-size="16" font-weight="800" letter-spacing="1.5">GUARDRAIL</text>
 
-    <g transform="translate(72,294)">
-      <rect x="0" y="0" width="1336" height="176" rx="26" fill="#0c2a3b" stroke="url(#cyanStroke)" stroke-width="2.5"/>
-      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">1. Raw log detection and export</text>
-      <text x="30" y="74" fill="#d7e9f0" font-size="18">Use when the repo starts from CloudTrail, Kubernetes audit, Okta, Entra, Workspace, or other source-native payloads.</text>
+    <g transform="translate(84,314)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="206" rx="30" fill="#0b3040" stroke="url(#cyan)" stroke-width="2.5"/>
+      <text x="36" y="48" fill="#f8fafc" font-size="32" font-weight="800">1. Raw log detection and export</text>
+      <text x="36" y="82" fill="#d7e9f0" font-size="18">Start from CloudTrail, Kubernetes audit, Okta, Entra, Workspace, or other source-native payloads that need normalization first.</text>
 
-      <rect x="30" y="102" width="236" height="50" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
-      <text x="62" y="134" fill="#f8fafc" font-size="18" font-weight="800">raw payloads</text>
+      <rect x="36" y="112" width="250" height="58" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="78" y="147" fill="#f8fafc" font-size="18" font-weight="800">raw payloads</text>
 
-      <rect x="322" y="102" width="172" height="50" rx="18" fill="#2955d9" stroke="#9cc2ff" stroke-width="2"/>
-      <text x="376" y="134" fill="#f8fafc" font-size="18" font-weight="800">ingest-*</text>
-      <rect x="546" y="102" width="172" height="50" rx="18" fill="#16877b" stroke="#7ef0df" stroke-width="2"/>
-      <text x="600" y="134" fill="#f8fafc" font-size="18" font-weight="800">detect-*</text>
-      <rect x="770" y="102" width="172" height="50" rx="18" fill="#8b3dff" stroke="#d0b0ff" stroke-width="2"/>
-      <text x="830" y="134" fill="#f8fafc" font-size="18" font-weight="800">view/*</text>
+      <rect x="332" y="112" width="178" height="58" rx="18" fill="#2955d9" stroke="#bfdbfe" stroke-width="2"/>
+      <text x="390" y="147" fill="#ffffff" font-size="18" font-weight="800">ingest-*</text>
+      <rect x="560" y="112" width="178" height="58" rx="18" fill="#14877f" stroke="#99f6e4" stroke-width="2"/>
+      <text x="618" y="147" fill="#ffffff" font-size="18" font-weight="800">detect-*</text>
+      <rect x="788" y="112" width="178" height="58" rx="18" fill="#8b3dff" stroke="#ddd6fe" stroke-width="2"/>
+      <text x="846" y="147" fill="#ffffff" font-size="18" font-weight="800">view/*</text>
 
-      <path d="M266 127 L322 127" stroke="#60a5fa" stroke-width="5" fill="none"/>
-      <path d="M494 127 L546 127" stroke="#8dc4ff" stroke-width="5" fill="none"/>
-      <path d="M718 127 L770 127" stroke="#77e6d7" stroke-width="5" fill="none"/>
+      <path d="M286 141 L332 141" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M510 141 L560 141" stroke="#8dc4ff" stroke-width="5" fill="none"/>
+      <path d="M738 141 L788 141" stroke="#7ef0df" stroke-width="5" fill="none"/>
 
-      <rect x="994" y="102" width="232" height="50" rx="18" fill="#17304f" stroke="#7dd3fc" stroke-width="2"/>
-      <text x="1036" y="134" fill="#f8fafc" font-size="18" font-weight="800">SARIF / Mermaid / JSON</text>
+      <rect x="1020" y="112" width="238" height="58" rx="18" fill="#17304f" stroke="#7dd3fc" stroke-width="2"/>
+      <text x="1070" y="147" fill="#f8fafc" font-size="18" font-weight="800">export artifact</text>
 
-      <rect x="1240" y="102" width="66" height="50" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
-      <text x="1261" y="134" fill="#67e8f9" font-size="18" font-weight="800">RO</text>
+      <rect x="1280" y="112" width="116" height="58" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+      <text x="1311" y="147" fill="#67e8f9" font-size="18" font-weight="800">read-only</text>
 
-      <text x="30" y="168" fill="#8fd8e5" font-size="15">Example: ingest-cloudtrail-ocsf → detect-lateral-movement → convert-ocsf-to-sarif</text>
+      <text x="36" y="194" fill="#9fe8f0" font-size="15">Example: ingest-cloudtrail-ocsf → detect-lateral-movement → convert-ocsf-to-sarif</text>
     </g>
 
-    <g transform="translate(72,500)">
-      <rect x="0" y="0" width="1336" height="176" rx="26" fill="#13253f" stroke="url(#blueStroke)" stroke-width="2.5"/>
-      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">2. Warehouse or object analysis with persistence</text>
-      <text x="30" y="74" fill="#d7e3f0" font-size="18">Use when data already lives in Snowflake, Databricks, ClickHouse, or object storage and you want analysis near the data.</text>
+    <g transform="translate(84,548)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="206" rx="30" fill="#12253f" stroke="url(#blue)" stroke-width="2.5"/>
+      <text x="36" y="48" fill="#f8fafc" font-size="32" font-weight="800">2. Warehouse or object analysis with persistence</text>
+      <text x="36" y="82" fill="#d7e3f0" font-size="18">Start when data already lives in Snowflake, Databricks, ClickHouse, or object storage and analysis should stay near the data.</text>
 
-      <rect x="30" y="102" width="236" height="50" rx="18" fill="#17304f" stroke="#38bdf8" stroke-width="2"/>
-      <text x="66" y="134" fill="#f8fafc" font-size="18" font-weight="800">rows or objects</text>
+      <rect x="36" y="112" width="250" height="58" rx="18" fill="#17304f" stroke="#38bdf8" stroke-width="2"/>
+      <text x="82" y="147" fill="#f8fafc" font-size="18" font-weight="800">rows or objects</text>
 
-      <rect x="322" y="102" width="172" height="50" rx="18" fill="#155e75" stroke="#7dd3fc" stroke-width="2"/>
-      <text x="378" y="134" fill="#f8fafc" font-size="18" font-weight="800">source-*</text>
-      <rect x="546" y="102" width="172" height="50" rx="18" fill="#16877b" stroke="#7ef0df" stroke-width="2"/>
-      <text x="600" y="134" fill="#f8fafc" font-size="18" font-weight="800">detect-*</text>
-      <rect x="770" y="102" width="172" height="50" rx="18" fill="#6d28d9" stroke="#c4b5fd" stroke-width="2"/>
-      <text x="826" y="134" fill="#f8fafc" font-size="18" font-weight="800">sink-*</text>
+      <rect x="332" y="112" width="178" height="58" rx="18" fill="#155e75" stroke="#7dd3fc" stroke-width="2"/>
+      <text x="390" y="147" fill="#ffffff" font-size="18" font-weight="800">source-*</text>
+      <rect x="560" y="112" width="178" height="58" rx="18" fill="#14877f" stroke="#99f6e4" stroke-width="2"/>
+      <text x="618" y="147" fill="#ffffff" font-size="18" font-weight="800">detect-*</text>
+      <rect x="788" y="112" width="178" height="58" rx="18" fill="#6d28d9" stroke="#c4b5fd" stroke-width="2"/>
+      <text x="850" y="147" fill="#ffffff" font-size="18" font-weight="800">sink-*</text>
 
-      <path d="M266 127 L322 127" stroke="#60a5fa" stroke-width="5" fill="none"/>
-      <path d="M494 127 L546 127" stroke="#7dd3fc" stroke-width="5" fill="none"/>
-      <path d="M718 127 L770 127" stroke="#7ef0df" stroke-width="5" fill="none"/>
+      <path d="M286 141 L332 141" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M510 141 L560 141" stroke="#7dd3fc" stroke-width="5" fill="none"/>
+      <path d="M738 141 L788 141" stroke="#7ef0df" stroke-width="5" fill="none"/>
 
-      <rect x="994" y="102" width="232" height="50" rx="18" fill="#17304f" stroke="#93c5fd" stroke-width="2"/>
-      <text x="1048" y="134" fill="#f8fafc" font-size="18" font-weight="800">customer sink edge</text>
+      <rect x="1020" y="112" width="238" height="58" rx="18" fill="#17304f" stroke="#93c5fd" stroke-width="2"/>
+      <text x="1070" y="147" fill="#f8fafc" font-size="18" font-weight="800">customer sink edge</text>
 
-      <rect x="1240" y="102" width="66" height="50" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
-      <text x="1254" y="134" fill="#bfdbfe" font-size="18" font-weight="800">ROQ</text>
+      <rect x="1280" y="112" width="116" height="58" rx="18" fill="#13253f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="1307" y="147" fill="#bfdbfe" font-size="18" font-weight="800">validated</text>
 
-      <text x="30" y="168" fill="#a8c8f2" font-size="15">Example: source-snowflake-query → detect-lateral-movement → sink-snowflake-jsonl</text>
+      <text x="36" y="194" fill="#bfdcff" font-size="15">Example: source-snowflake-query → detect-lateral-movement → sink-snowflake-jsonl</text>
     </g>
 
-    <g transform="translate(72,706)">
-      <rect x="0" y="0" width="1336" height="176" rx="26" fill="#083344" stroke="url(#tealStroke)" stroke-width="2.5"/>
-      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">3. Live posture, discovery, and guarded action</text>
-      <text x="30" y="74" fill="#d1efe8" font-size="18">Use when the repo starts from live cloud APIs, SaaS APIs, or HR lifecycle events instead of a raw stream.</text>
+    <g transform="translate(84,782)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="206" rx="30" fill="#083344" stroke="url(#teal)" stroke-width="2.5"/>
+      <text x="36" y="48" fill="#f8fafc" font-size="32" font-weight="800">3. Live posture, discovery, and guarded action</text>
+      <text x="36" y="82" fill="#d5efe9" font-size="18">Start from live cloud APIs, SaaS control planes, or HR lifecycle events where the repo needs current state, not just stored logs.</text>
 
-      <rect x="30" y="102" width="236" height="50" rx="18" fill="#17304f" stroke="#14b8a6" stroke-width="2"/>
-      <text x="74" y="134" fill="#f8fafc" font-size="18" font-weight="800">live state</text>
+      <rect x="36" y="112" width="250" height="58" rx="18" fill="#17304f" stroke="#2dd4bf" stroke-width="2"/>
+      <text x="96" y="147" fill="#f8fafc" font-size="18" font-weight="800">live state</text>
 
-      <rect x="322" y="102" width="248" height="50" rx="18" fill="#16877b" stroke="#7ef0df" stroke-width="2"/>
-      <text x="354" y="134" fill="#f8fafc" font-size="18" font-weight="800">discover-* / evaluation/*</text>
-      <rect x="616" y="102" width="192" height="50" rx="18" fill="#4f46e5" stroke="#a5b4fc" stroke-width="2"/>
-      <text x="654" y="134" fill="#f8fafc" font-size="18" font-weight="800">native outputs</text>
-      <rect x="854" y="102" width="202" height="50" rx="18" fill="#991b1b" stroke="#fca5a5" stroke-width="2"/>
-      <text x="900" y="134" fill="#f8fafc" font-size="18" font-weight="800">remediation/*</text>
+      <rect x="332" y="112" width="264" height="58" rx="18" fill="#14877f" stroke="#99f6e4" stroke-width="2"/>
+      <text x="368" y="147" fill="#ffffff" font-size="18" font-weight="800">discover-* / evaluation/*</text>
+      <rect x="628" y="112" width="196" height="58" rx="18" fill="#4f46e5" stroke="#c7d2fe" stroke-width="2"/>
+      <text x="674" y="147" fill="#ffffff" font-size="18" font-weight="800">native outputs</text>
+      <rect x="856" y="112" width="220" height="58" rx="18" fill="#991b1b" stroke="#fca5a5" stroke-width="2"/>
+      <text x="908" y="147" fill="#ffffff" font-size="18" font-weight="800">remediation/*</text>
 
-      <path d="M266 127 L322 127" stroke="#2dd4bf" stroke-width="5" fill="none"/>
-      <path d="M570 127 L616 127" stroke="#7ef0df" stroke-width="5" fill="none"/>
-      <path d="M808 127 L854 127" stroke="#a5b4fc" stroke-width="5" fill="none"/>
+      <path d="M286 141 L332 141" stroke="#2dd4bf" stroke-width="5" fill="none"/>
+      <path d="M596 141 L628 141" stroke="#99f6e4" stroke-width="5" fill="none"/>
+      <path d="M824 141 L856 141" stroke="#c7d2fe" stroke-width="5" fill="none"/>
 
-      <rect x="1088" y="102" width="138" height="50" rx="18" fill="#17304f" stroke="#2dd4bf" stroke-width="2"/>
-      <text x="1114" y="134" fill="#f8fafc" font-size="18" font-weight="800">evidence trail</text>
+      <rect x="1110" y="112" width="148" height="58" rx="18" fill="#17304f" stroke="#2dd4bf" stroke-width="2"/>
+      <text x="1134" y="147" fill="#f8fafc" font-size="18" font-weight="800">evidence trail</text>
 
-      <rect x="1240" y="102" width="66" height="50" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
-      <text x="1255" y="134" fill="#99f6e4" font-size="18" font-weight="800">HITL</text>
+      <rect x="1280" y="112" width="116" height="58" rx="18" fill="#13253f" stroke="#22d3ee" stroke-width="2"/>
+      <text x="1312" y="147" fill="#99f6e4" font-size="18" font-weight="800">HITL</text>
 
-      <text x="30" y="168" fill="#9ce9dd" font-size="15">Example: discover-control-evidence, cspm-aws-cis-benchmark, or iam-departures-remediation</text>
+      <text x="36" y="194" fill="#a7f3d0" font-size="15">Example: discover-control-evidence, cspm-aws-cis-benchmark, or iam-departures-remediation</text>
     </g>
   </g>
 </svg>

--- a/docs/images/iam-departures-architecture.svg
+++ b/docs/images/iam-departures-architecture.svg
@@ -1,123 +1,147 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="920" viewBox="0 0 1480 920" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">IAM departures remediation flagship path</title>
-  <desc id="desc">A cleaner three-stage view of the IAM departures workflow. HR systems feed a reconciler that filters rehires and grace-window exceptions before writing an S3 manifest. EventBridge starts a Step Function that gates a parser Lambda and a scoped worker Lambda. The workflow writes audited actions to DynamoDB and S3, then later verification and ingest-back close the loop.</desc>
+  <desc id="desc">A polished workflow poster for the IAM departures remediation family. HR systems feed a reconciler that filters rehires and grace-window exceptions before writing an S3 manifest. EventBridge starts a Step Function, the parser Lambda re-checks runtime state, the worker Lambda executes only scoped changes, and the workflow records a dual audit trail before later drift verification closes the loop.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#08111f"/>
-      <stop offset="100%" stop-color="#06111b"/>
+      <stop offset="0%" stop-color="#06111d"/>
+      <stop offset="100%" stop-color="#091523"/>
     </linearGradient>
-    <linearGradient id="scopeStroke" x1="0" y1="0" x2="1" y2="0">
+    <linearGradient id="frame" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#101b31"/>
+      <stop offset="100%" stop-color="#0c172b"/>
+    </linearGradient>
+    <linearGradient id="scope" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#22d3ee"/>
       <stop offset="100%" stop-color="#67e8f9"/>
     </linearGradient>
-    <linearGradient id="workflowStroke" x1="0" y1="0" x2="1" y2="0">
+    <linearGradient id="workflow" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#60a5fa"/>
       <stop offset="100%" stop-color="#93c5fd"/>
     </linearGradient>
-    <linearGradient id="auditStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#2dd4bf"/>
+    <linearGradient id="audit" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#14b8a6"/>
       <stop offset="100%" stop-color="#a78bfa"/>
     </linearGradient>
-    <symbol id="aws" viewBox="0 0 24 24">
-      <path fill="#f59e0b" d="M6.763 10.036c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 0 1-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 0 1-.287-.375 6.18 6.18 0 0 1-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.391-.384-.59-.894-.59-1.533 0-.678.239-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.287 2.287 0 0 1-.28.104.488.488 0 0 1-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 0 1 .224-.167c.279-.144.614-.264 1.005-.36a4.84 4.84 0 0 1 1.246-.151c.95 0 1.644.216 2.091.647.439.43.662 1.085.662 1.963v2.586z"/>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="20" flood-color="#020617" flood-opacity="0.42"/>
+    </filter>
+
+    <symbol id="aws" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#f59e0b" d="M18 35c7 5 18 6 28 1 1-1 3 1 1 2-4 4-12 6-20 6-5 0-10-1-13-4-1-1 0-4 4-5zm24-16c2 1 3 4 2 8-1 2-2 4-4 6 3 0 7 1 9 3 1 1 1 3-1 2-3-1-7-1-11-1-4 0-8 0-11 2-1 0-2-1-1-2 2-2 5-3 8-4-1-1-2-3-3-5-1-5 1-8 4-10 2-1 6-1 8 1z"/>
     </symbol>
-    <symbol id="azure" viewBox="0 0 24 24">
-      <path fill="#38bdf8" d="M22.379 23.343a1.62 1.62 0 0 0 1.536-2.14v.002L17.35 1.76A1.62 1.62 0 0 0 15.816.657H8.184A1.62 1.62 0 0 0 6.65 1.76L.086 21.204a1.62 1.62 0 0 0 1.536 2.139h4.741a1.62 1.62 0 0 0 1.535-1.103l.977-2.892 4.947 3.675c.28.208.618.32.966.32"/>
+    <symbol id="azure" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#38bdf8" d="M31 13h12l8 30H39l-4-12-7 12H14l17-30zm-3 18 5 8h10l-4-13-11 5z"/>
     </symbol>
-    <symbol id="gcp" viewBox="0 0 24 24">
-      <path fill="#60a5fa" d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38z"/>
+    <symbol id="gcp" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#60a5fa" d="M24 17c-5 2-9 8-9 15 0 9 7 17 17 17 6 0 10-2 14-6l-6-5c-2 2-4 3-8 3-5 0-9-4-9-9s4-9 9-9c2 0 5 1 7 3l6-5c-4-4-9-6-14-6-2 0-5 1-7 2z"/>
+      <path fill="#34d399" d="M46 26h-14v7h14c-1 5-5 8-11 8l4 6c9-2 15-8 15-18 0-1 0-2-1-3h-7z"/>
     </symbol>
-    <symbol id="snowflake" viewBox="0 0 24 24">
-      <path fill="#7dd3fc" d="M12.358 11.981a.412.412 0 00-.114-.266l-.57-.571a.346.346 0 00-.267-.114.412.412 0 00-.266.114l-.571.57a.411.411 0 00-.114.267c0 .076.038.19.114.267l.57.57a.345.345 0 00.267.114c.076 0 .19-.038.266-.114l.571-.57a.412.412 0 00.114-.267zM13.956 12.514L11.94 14.53c-.039.038-.153.114-.229.114h-.608a.411.411 0 01-.267-.114L8.82 12.514a.408.408 0 01-.076-.229v-.608c0-.076.038-.19.114-.267l2.016-2.016a.41.41 0 01.267-.114h.608a.41.41 0 01.267.114l2.016 2.016a.347.347 0 01.114.267v.608c-.076.077-.114.19-.19.229z"/>
+    <symbol id="snowflake" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path stroke="#7dd3fc" stroke-width="4" stroke-linecap="round" d="M32 14v36M16 23l32 18M16 41l32-18"/>
+      <path stroke="#7dd3fc" stroke-width="4" stroke-linecap="round" d="M22 14l20 36M42 14L22 50"/>
     </symbol>
-    <symbol id="databricks" viewBox="0 0 24 24">
-      <path fill="#ef4444" d="M.95 14.184L12 20.403l9.919-5.55v2.21L12 22.662l-10.484-5.96-.565.308v.77L12 24l11.05-6.218v-4.317l-.515-.309L12 19.118l-9.867-5.653v-2.21L12 16.805l11.05-6.218V6.32l-.515-.308L12 11.974 2.647 6.681 12 1.388l7.76 4.368.668-.411v-.566L12 0 .95 6.27v.72L12 13.207l9.919-5.55v2.26L12 15.52 1.516 9.56l-.565.308Z"/>
+    <symbol id="dbx" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#ef4444" d="M13 22l19-11 19 11-19 11zm0 10 19 11 19-11v8L32 51 13 40zm0-7 19 11 19-11v4L32 40 13 29z"/>
     </symbol>
   </defs>
 
-  <rect width="1480" height="920" fill="url(#bg)"/>
-  <rect x="30" y="28" width="1420" height="864" rx="34" fill="#0f172a" stroke="#334155" stroke-width="2"/>
+  <rect width="1600" height="980" fill="url(#bg)"/>
+  <rect x="28" y="26" width="1544" height="928" rx="34" fill="url(#frame)" stroke="#334155" stroke-width="2"/>
 
   <g font-family="Inter, Segoe UI, Arial, sans-serif">
-    <text x="74" y="92" fill="#f8fafc" font-size="40" font-weight="800">IAM departures remediation</text>
-    <text x="74" y="128" fill="#c7d2e3" font-size="22">Flagship guarded write path. Decide scope early, keep orchestration separate, keep writes scoped, audit everything twice.</text>
+    <text x="84" y="98" fill="#f8fafc" font-size="50" font-weight="800">IAM departures remediation</text>
+    <text x="84" y="138" fill="#dbe4f0" font-size="22">Flagship guarded write path. Decide scope before act, re-check before write, record every action twice, and verify later drift.</text>
 
-    <rect x="74" y="156" width="1332" height="56" rx="18" fill="#111c34" stroke="#475569" stroke-width="2"/>
-    <text x="102" y="192" fill="#f8fafc" font-size="18" font-weight="800">Execution roles</text>
-    <text x="268" y="192" fill="#dbe4f0" font-size="18">EventBridge • Step Function • parser Lambda • worker Lambda • cross-account remediation role</text>
+    <rect x="84" y="172" width="1432" height="64" rx="20" fill="#111c34" stroke="#475569" stroke-width="2"/>
+    <text x="118" y="212" fill="#f8fafc" font-size="18" font-weight="800">Execution roles</text>
+    <text x="278" y="212" fill="#d7e2f2" font-size="18">EventBridge • Step Function • parser Lambda • worker Lambda • cross-account remediation role</text>
 
-    <g transform="translate(74,244)">
-      <rect x="0" y="0" width="1332" height="182" rx="28" fill="#0b2538" stroke="url(#scopeStroke)" stroke-width="2.5"/>
-      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">1. Select scope before anything can act</text>
-      <text x="30" y="74" fill="#d8eaf0" font-size="18">Rehire and grace-window decisions happen in the reconciler. Only the actionable set is exported.</text>
+    <g transform="translate(84,270)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="198" rx="30" fill="#0b3040" stroke="url(#scope)" stroke-width="2.5"/>
+      <text x="36" y="48" fill="#f8fafc" font-size="32" font-weight="800">1. Select scope before anything can act</text>
+      <text x="36" y="82" fill="#d7e9f0" font-size="18">The reconciler is the first real control gate. Rehire and grace-period rules happen here before any actionable set is written.</text>
 
-      <rect x="30" y="102" width="250" height="54" rx="18" fill="#16304e" stroke="#5eead4" stroke-width="2"/>
-      <text x="82" y="136" fill="#f8fafc" font-size="18" font-weight="800">HR sources</text>
-      <rect x="330" y="102" width="318" height="54" rx="18" fill="#19607a" stroke="#67e8f9" stroke-width="2"/>
-      <text x="398" y="136" fill="#f8fafc" font-size="18" font-weight="800">reconciler</text>
-      <rect x="698" y="102" width="250" height="54" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
-      <text x="780" y="136" fill="#f8fafc" font-size="18" font-weight="800">S3 manifest</text>
-      <rect x="998" y="102" width="278" height="54" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
-      <text x="1070" y="136" fill="#f8fafc" font-size="18" font-weight="800">EventBridge rule</text>
+      <rect x="36" y="114" width="258" height="62" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="102" y="152" fill="#f8fafc" font-size="18" font-weight="800">HR sources</text>
 
-      <path d="M280 129 L330 129" stroke="#67e8f9" stroke-width="5" fill="none"/>
-      <path d="M648 129 L698 129" stroke="#60a5fa" stroke-width="5" fill="none"/>
-      <path d="M948 129 L998 129" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <rect x="348" y="114" width="342" height="62" rx="18" fill="#19607a" stroke="#67e8f9" stroke-width="2"/>
+      <text x="448" y="152" fill="#f8fafc" font-size="18" font-weight="800">reconciler</text>
 
-      <text x="30" y="170" fill="#99f6e4" font-size="15" font-weight="800">Guardrail</text>
-      <text x="122" y="170" fill="#d9e3ef" font-size="15">No direct Step Function entry. No rehire logic later in the pipeline. No filtered identities written to the action set.</text>
+      <rect x="744" y="114" width="258" height="62" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="826" y="152" fill="#f8fafc" font-size="18" font-weight="800">S3 manifest</text>
+
+      <rect x="1056" y="114" width="320" height="62" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="1142" y="152" fill="#f8fafc" font-size="18" font-weight="800">EventBridge rule</text>
+
+      <path d="M294 145 L348 145" stroke="#67e8f9" stroke-width="5" fill="none"/>
+      <path d="M690 145 L744 145" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M1002 145 L1056 145" stroke="#60a5fa" stroke-width="5" fill="none"/>
+
+      <text x="36" y="190" fill="#99f6e4" font-size="15" font-weight="800">Guardrail</text>
+      <text x="132" y="190" fill="#dbe4f0" font-size="15">No direct Step Function entry, no rehire logic later in the flow, no filtered identities written to the action manifest.</text>
     </g>
 
-    <g transform="translate(74,452)">
-      <rect x="0" y="0" width="1332" height="182" rx="28" fill="#10243a" stroke="url(#workflowStroke)" stroke-width="2.5"/>
-      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">2. Start the guarded workflow and re-check before write</text>
-      <text x="30" y="74" fill="#dce6f4" font-size="18">EventBridge starts the Step Function. The parser Lambda re-checks runtime state before the worker can change anything.</text>
+    <g transform="translate(84,498)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="206" rx="30" fill="#11263d" stroke="url(#workflow)" stroke-width="2.5"/>
+      <text x="36" y="48" fill="#f8fafc" font-size="32" font-weight="800">2. Start the guarded workflow and re-check before write</text>
+      <text x="36" y="82" fill="#dce6f4" font-size="18">EventBridge starts the Step Function. The parser Lambda re-checks the manifest and current state before the worker touches any target.</text>
 
-      <rect x="30" y="102" width="256" height="54" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
-      <text x="92" y="136" fill="#f8fafc" font-size="18" font-weight="800">Step Function</text>
-      <rect x="338" y="102" width="256" height="54" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
-      <text x="404" y="136" fill="#f8fafc" font-size="18" font-weight="800">parser Lambda</text>
-      <rect x="646" y="102" width="256" height="54" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
-      <text x="710" y="136" fill="#f8fafc" font-size="18" font-weight="800">worker Lambda</text>
-      <rect x="954" y="102" width="292" height="54" rx="18" fill="#203d66" stroke="#60a5fa" stroke-width="2"/>
-      <text x="1048" y="136" fill="#f8fafc" font-size="18" font-weight="800">scoped targets</text>
+      <rect x="36" y="114" width="266" height="62" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
+      <text x="98" y="152" fill="#f8fafc" font-size="18" font-weight="800">Step Function</text>
 
-      <path d="M286 129 L338 129" stroke="#7db7ff" stroke-width="5" fill="none"/>
-      <path d="M594 129 L646 129" stroke="#93c5fd" stroke-width="5" fill="none"/>
-      <path d="M902 129 L954 129" stroke="#93c5fd" stroke-width="5" fill="none"/>
+      <rect x="356" y="114" width="266" height="62" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
+      <text x="422" y="152" fill="#f8fafc" font-size="18" font-weight="800">parser Lambda</text>
 
-      <g transform="translate(998,88)">
-        <use href="#aws" x="0" y="0" width="16" height="16"/>
-        <use href="#azure" x="28" y="0" width="16" height="16"/>
-        <use href="#gcp" x="56" y="0" width="16" height="16"/>
-        <use href="#snowflake" x="84" y="0" width="16" height="16"/>
-        <use href="#databricks" x="112" y="0" width="16" height="16"/>
+      <rect x="676" y="114" width="266" height="62" rx="18" fill="#2942a4" stroke="#93c5fd" stroke-width="2"/>
+      <text x="740" y="152" fill="#f8fafc" font-size="18" font-weight="800">worker Lambda</text>
+
+      <rect x="996" y="114" width="380" height="62" rx="18" fill="#203d66" stroke="#60a5fa" stroke-width="2"/>
+      <text x="1120" y="152" fill="#f8fafc" font-size="18" font-weight="800">scoped targets</text>
+
+      <path d="M302 145 L356 145" stroke="#93c5fd" stroke-width="5" fill="none"/>
+      <path d="M622 145 L676 145" stroke="#93c5fd" stroke-width="5" fill="none"/>
+      <path d="M942 145 L996 145" stroke="#93c5fd" stroke-width="5" fill="none"/>
+
+      <g transform="translate(1038,96)">
+        <use href="#aws" width="42" height="42"/>
+        <use href="#azure" x="50" width="42" height="42"/>
+        <use href="#gcp" x="100" width="42" height="42"/>
+        <use href="#snowflake" x="150" width="42" height="42"/>
+        <use href="#dbx" x="200" width="42" height="42"/>
       </g>
 
-      <text x="30" y="170" fill="#bfdbfe" font-size="15" font-weight="800">Guardrail</text>
-      <text x="126" y="170" fill="#d9e3ef" font-size="15">Separate roles, human-required approval, dry-run-first, deny-listed identities, scoped principals, no direct bypass of orchestration.</text>
+      <text x="36" y="198" fill="#bfdbfe" font-size="15" font-weight="800">Guardrail</text>
+      <text x="132" y="198" fill="#dbe4f0" font-size="15">Separate roles, human-required approval, dry-run-first, scoped principals, deny-listed identities, and no direct orchestration bypass.</text>
     </g>
 
-    <g transform="translate(74,660)">
-      <rect x="0" y="0" width="1332" height="184" rx="28" fill="#083344" stroke="url(#auditStroke)" stroke-width="2.5"/>
-      <text x="30" y="42" fill="#f8fafc" font-size="28" font-weight="800">3. Apply scoped changes and write the audit trail</text>
-      <text x="30" y="74" fill="#d4efe9" font-size="18">The worker touches only approved targets. The system of record is DynamoDB + S3, then later verification closes the loop.</text>
+    <g transform="translate(84,734)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="190" rx="30" fill="#083344" stroke="url(#audit)" stroke-width="2.5"/>
+      <text x="36" y="48" fill="#f8fafc" font-size="32" font-weight="800">3. Apply scoped changes and write the audit trail</text>
+      <text x="36" y="82" fill="#d5efe9" font-size="18">The worker touches only approved targets. The system of record is DynamoDB plus S3, then later ingest-back and verification close the loop.</text>
 
-      <rect x="30" y="104" width="250" height="54" rx="18" fill="#155e75" stroke="#5eead4" stroke-width="2"/>
-      <text x="78" y="138" fill="#f8fafc" font-size="18" font-weight="800">scoped write set</text>
-      <rect x="330" y="104" width="270" height="54" rx="18" fill="#4c1d95" stroke="#c4b5fd" stroke-width="2"/>
-      <text x="398" y="138" fill="#f8fafc" font-size="18" font-weight="800">DynamoDB + S3</text>
-      <rect x="650" y="104" width="246" height="54" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
-      <text x="724" y="138" fill="#f8fafc" font-size="18" font-weight="800">ingest-back</text>
-      <rect x="946" y="104" width="300" height="54" rx="18" fill="#17304f" stroke="#22d3ee" stroke-width="2"/>
-      <text x="1020" y="138" fill="#f8fafc" font-size="18" font-weight="800">later drift check</text>
+      <rect x="36" y="112" width="260" height="62" rx="18" fill="#155e75" stroke="#5eead4" stroke-width="2"/>
+      <text x="92" y="150" fill="#f8fafc" font-size="18" font-weight="800">scoped write set</text>
 
-      <path d="M280 131 L330 131" stroke="#5eead4" stroke-width="5" fill="none"/>
-      <path d="M600 131 L650 131" stroke="#c4b5fd" stroke-width="5" fill="none"/>
-      <path d="M896 131 L946 131" stroke="#60a5fa" stroke-width="5" fill="none"/>
-      <path d="M1226 158 C 1238 192, 1160 206, 920 206 C 580 206, 332 184, 226 74" stroke="#22d3ee" stroke-width="4" stroke-dasharray="8 10" fill="none"/>
-      <text x="740" y="176" fill="#67e8f9" font-size="17" font-style="italic" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
+      <rect x="352" y="112" width="286" height="62" rx="18" fill="#4c1d95" stroke="#c4b5fd" stroke-width="2"/>
+      <text x="432" y="150" fill="#f8fafc" font-size="18" font-weight="800">DynamoDB + S3</text>
+
+      <rect x="694" y="112" width="250" height="62" rx="18" fill="#17304f" stroke="#60a5fa" stroke-width="2"/>
+      <text x="770" y="150" fill="#f8fafc" font-size="18" font-weight="800">ingest-back</text>
+
+      <rect x="1000" y="112" width="344" height="62" rx="18" fill="#17304f" stroke="#22d3ee" stroke-width="2"/>
+      <text x="1100" y="150" fill="#f8fafc" font-size="18" font-weight="800">later drift check</text>
+
+      <path d="M296 143 L352 143" stroke="#5eead4" stroke-width="5" fill="none"/>
+      <path d="M638 143 L694 143" stroke="#c4b5fd" stroke-width="5" fill="none"/>
+      <path d="M944 143 L1000 143" stroke="#60a5fa" stroke-width="5" fill="none"/>
+      <path d="M1324 174 C 1298 214, 1180 220, 976 220 C 662 220, 434 201, 264 68" stroke="#22d3ee" stroke-width="4" stroke-dasharray="10 10" fill="none"/>
+      <text x="846" y="205" fill="#67e8f9" font-size="17" font-style="italic" text-anchor="middle">drift detected → next reconciler run closes or flags it</text>
     </g>
   </g>
 </svg>

--- a/docs/images/repo-architecture.svg
+++ b/docs/images/repo-architecture.svg
@@ -1,129 +1,159 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="920" viewBox="0 0 1440 920" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills repository architecture</title>
-  <desc id="desc">A cleaner three-band view of the repo. External signals enter Intake through Ingest and Discover, flow into Analyze through Detect and Evaluate, and leave through Act via View or Remediate. The same skill bundle contract is shared across all lanes, while source and sink edges, SQL query packs, and runtime surfaces wrap the same implementation.</desc>
+  <desc id="desc">A polished architecture poster showing the repo as three action bands. External signals enter through ingest and discover, move into detect and evaluate, and exit through view or guarded remediation. The same skill bundle contract sits underneath every lane, with source and sink edges, warehouse query packs, and runtime surfaces wrapped around it.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#08111f"/>
-      <stop offset="100%" stop-color="#06101a"/>
+      <stop offset="0%" stop-color="#050b15"/>
+      <stop offset="100%" stop-color="#081525"/>
     </linearGradient>
-    <linearGradient id="hero" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="100%" stop-color="#111f37"/>
+    <linearGradient id="frame" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#101b31"/>
+      <stop offset="100%" stop-color="#0d172b"/>
     </linearGradient>
-    <linearGradient id="intakeStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#3b82f6"/>
-      <stop offset="100%" stop-color="#60a5fa"/>
+    <linearGradient id="intake" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#38bdf8"/>
     </linearGradient>
-    <linearGradient id="analyzeStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#14b8a6"/>
+    <linearGradient id="analyze" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0f766e"/>
       <stop offset="100%" stop-color="#34d399"/>
     </linearGradient>
-    <linearGradient id="actStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#f97316"/>
-      <stop offset="100%" stop-color="#c084fc"/>
+    <linearGradient id="act" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#c2410c"/>
+      <stop offset="100%" stop-color="#a855f7"/>
     </linearGradient>
-    <symbol id="aws" viewBox="0 0 24 24">
-      <path fill="#f59e0b" d="M6.763 10.036c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 0 1-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 0 1-.287-.375 6.18 6.18 0 0 1-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.391-.384-.59-.894-.59-1.533 0-.678.239-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.287 2.287 0 0 1-.28.104.488.488 0 0 1-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 0 1 .224-.167c.279-.144.614-.264 1.005-.36a4.84 4.84 0 0 1 1.246-.151c.95 0 1.644.216 2.091.647.439.43.662 1.085.662 1.963v2.586zm-3.24 1.214c.263 0 .534-.048.822-.144.287-.096.543-.271.758-.51.128-.152.224-.32.272-.512.047-.191.08-.423.08-.694v-.335a6.66 6.66 0 0 0-.735-.136 6.02 6.02 0 0 0-.75-.048c-.535 0-.926.104-1.19.32-.263.215-.39.518-.39.917 0 .375.095.655.295.846.191.2.47.296.838.296z"/>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="20" flood-color="#020617" flood-opacity="0.42"/>
+    </filter>
+    <filter id="innerGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#60a5fa" flood-opacity="0.20"/>
+    </filter>
+
+    <symbol id="aws" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#f59e0b" d="M18 35c7 5 18 6 28 1 1-1 3 1 1 2-4 4-12 6-20 6-5 0-10-1-13-4-1-1 0-4 4-5zm24-16c2 1 3 4 2 8-1 2-2 4-4 6 3 0 7 1 9 3 1 1 1 3-1 2-3-1-7-1-11-1-4 0-8 0-11 2-1 0-2-1-1-2 2-2 5-3 8-4-1-1-2-3-3-5-1-5 1-8 4-10 2-1 6-1 8 1z"/>
     </symbol>
-    <symbol id="gcp" viewBox="0 0 24 24">
-      <path fill="#60a5fa" d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38z"/>
+    <symbol id="gcp" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#60a5fa" d="M24 17c-5 2-9 8-9 15 0 9 7 17 17 17 6 0 10-2 14-6l-6-5c-2 2-4 3-8 3-5 0-9-4-9-9s4-9 9-9c2 0 5 1 7 3l6-5c-4-4-9-6-14-6-2 0-5 1-7 2z"/>
+      <path fill="#34d399" d="M46 26h-14v7h14c-1 5-5 8-11 8l4 6c9-2 15-8 15-18 0-1 0-2-1-3h-7z"/>
     </symbol>
-    <symbol id="azure" viewBox="0 0 24 24">
-      <path fill="#38bdf8" d="M22.379 23.343a1.62 1.62 0 0 0 1.536-2.14v.002L17.35 1.76A1.62 1.62 0 0 0 15.816.657H8.184A1.62 1.62 0 0 0 6.65 1.76L.086 21.204a1.62 1.62 0 0 0 1.536 2.139h4.741a1.62 1.62 0 0 0 1.535-1.103l.977-2.892 4.947 3.675c.28.208.618.32.966.32"/>
+    <symbol id="azure" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#38bdf8" d="M31 13h12l8 30H39l-4-12-7 12H14l17-30zm-3 18 5 8h10l-4-13-11 5z"/>
     </symbol>
-    <symbol id="okta" viewBox="0 0 24 24">
-      <path fill="#3b82f6" d="M12 0C5.389 0 0 5.35 0 12s5.35 12 12 12 12-5.35 12-12S18.611 0 12 0zm0 18c-3.325 0-6-2.675-6-6s2.675-6 6-6 6 2.675 6 6-2.675 6-6 6z"/>
+    <symbol id="k8s" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <circle cx="32" cy="32" r="16" fill="#60a5fa"/>
+      <circle cx="32" cy="32" r="6" fill="#e0f2fe"/>
+      <path d="M32 12v9M32 43v9M12 32h9M43 32h9M18 18l6 6M40 40l6 6M46 18l-6 6M18 46l6-6" stroke="#e0f2fe" stroke-width="3" stroke-linecap="round"/>
     </symbol>
-    <symbol id="entra" viewBox="0 0 24 24">
-      <path fill="#60a5fa" d="M0 0v11.408h11.408V0zm12.594 0v11.408H24V0zM0 12.594V24h11.408V12.594zm12.594 0V24H24V12.594z"/>
+    <symbol id="okta" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <circle cx="32" cy="32" r="18" fill="none" stroke="#3b82f6" stroke-width="8"/>
+    </symbol>
+    <symbol id="dbx" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path fill="#ef4444" d="M13 22l19-11 19 11-19 11zm0 10 19 11 19-11v8L32 51 13 40zm0-7 19 11 19-11v4L32 40 13 29z"/>
+    </symbol>
+    <symbol id="snowflake" viewBox="0 0 64 64">
+      <rect x="4" y="4" width="56" height="56" rx="16" fill="#111827"/>
+      <path stroke="#7dd3fc" stroke-width="4" stroke-linecap="round" d="M32 14v36M16 23l32 18M16 41l32-18"/>
+      <path stroke="#7dd3fc" stroke-width="4" stroke-linecap="round" d="M22 14l20 36M42 14L22 50"/>
     </symbol>
   </defs>
 
-  <rect width="1440" height="920" fill="url(#bg)"/>
-  <rect x="32" y="28" width="1376" height="864" rx="34" fill="url(#hero)" stroke="#334155" stroke-width="2"/>
+  <rect width="1600" height="980" fill="url(#bg)"/>
+  <rect x="28" y="26" width="1544" height="928" rx="34" fill="url(#frame)" stroke="#334155" stroke-width="2"/>
 
   <g font-family="Inter, Segoe UI, Arial, sans-serif">
-    <text x="84" y="94" fill="#f8fafc" font-size="40" font-weight="800">cloud-ai-security-skills</text>
-    <text x="84" y="132" fill="#dbe4f0" font-size="22" font-weight="600">Same skill bundle, any surface. OCSF-first for streams. Native where fidelity matters.</text>
-    <text x="84" y="164" fill="#8fa1b9" font-size="17">One mental model: signal in, stable contract through, review or guarded action out.</text>
+    <text x="84" y="102" fill="#f8fafc" font-size="52" font-weight="800">cloud-ai-security-skills</text>
+    <text x="84" y="145" fill="#d7e2f2" font-size="24" font-weight="600">One skill bundle contract, multiple runtime surfaces, cloud and AI signals in one repo-native security flow.</text>
+    <text x="84" y="179" fill="#8ea1bb" font-size="18">OCSF-first for event streams. Native where operational fidelity matters. Same skills underneath CLI, MCP, CI, and runners.</text>
 
-    <rect x="84" y="198" width="1272" height="88" rx="24" fill="#10192b" stroke="#41536f" stroke-width="2"/>
-    <text x="114" y="234" fill="#93c5fd" font-size="15" font-weight="800" letter-spacing="1.5">EXTERNAL SIGNALS</text>
-    <g transform="translate(108,248)">
-      <rect x="0" y="0" width="170" height="24" rx="12" fill="#17233a"/>
-      <use href="#aws" x="10" y="4" width="16" height="16"/>
-      <text x="34" y="17" fill="#e5eefb" font-size="13" font-weight="700">cloud APIs</text>
+    <rect x="84" y="216" width="1432" height="120" rx="28" fill="#0e172a" stroke="#41536f" stroke-width="2"/>
+    <text x="118" y="255" fill="#93c5fd" font-size="16" font-weight="800" letter-spacing="2">EXTERNAL SIGNALS</text>
 
-      <rect x="186" y="0" width="146" height="24" rx="12" fill="#17233a"/>
-      <text x="206" y="17" fill="#e5eefb" font-size="13" font-weight="700">raw logs</text>
-
-      <rect x="348" y="0" width="180" height="24" rx="12" fill="#17233a"/>
-      <use href="#okta" x="358" y="4" width="16" height="16"/>
-      <use href="#entra" x="378" y="4" width="16" height="16"/>
-      <text x="400" y="17" fill="#e5eefb" font-size="13" font-weight="700">identity feeds</text>
-
-      <rect x="544" y="0" width="182" height="24" rx="12" fill="#17233a"/>
-      <text x="564" y="17" fill="#e5eefb" font-size="13" font-weight="700">Kubernetes audit</text>
-
-      <rect x="742" y="0" width="166" height="24" rx="12" fill="#17233a"/>
-      <text x="762" y="17" fill="#e5eefb" font-size="13" font-weight="700">warehouses</text>
-
-      <rect x="924" y="0" width="150" height="24" rx="12" fill="#17233a"/>
-      <text x="946" y="17" fill="#e5eefb" font-size="13" font-weight="700">MCP proxy</text>
-    </g>
-    <text x="114" y="272" fill="#8fa1b9" font-size="14">AWS • Azure • GCP • Okta • Entra • Workspace • K8s • lakehouse and object-store paths</text>
-
-    <g transform="translate(84,322)">
-      <rect x="0" y="0" width="1272" height="158" rx="28" fill="#102241" stroke="url(#intakeStroke)" stroke-width="2.5"/>
-      <text x="30" y="34" fill="#93c5fd" font-size="15" font-weight="800" letter-spacing="1.5">INTAKE</text>
-      <text x="30" y="76" fill="#f8fafc" font-size="24" font-weight="800">Turn raw signals or live state into stable repo data</text>
-      <text x="30" y="104" fill="#a8b7cc" font-size="16">Parallel entry lanes, not a fake sequence: normalize streams with Ingest or read live state with Discover.</text>
-
-      <rect x="30" y="118" width="574" height="24" rx="12" fill="#18335d"/>
-      <rect x="638" y="118" width="604" height="24" rx="12" fill="#18335d"/>
-      <rect x="30" y="118" width="574" height="24" rx="12" fill="#2955d9" opacity="0.95"/>
-      <rect x="638" y="118" width="604" height="24" rx="12" fill="#3157d2" opacity="0.95"/>
-      <text x="50" y="136" fill="#f8fafc" font-size="16" font-weight="800">L1 Ingest</text>
-      <text x="658" y="136" fill="#f8fafc" font-size="16" font-weight="800">L2 Discover</text>
-      <text x="50" y="162" fill="#dbe7fb" font-size="14">CloudTrail, Azure Activity, GCP audit, K8s audit, Okta, Entra, Workspace, MCP proxy</text>
-      <text x="658" y="162" fill="#dbe7fb" font-size="14">discover-environment, AI BOM, control evidence, cloud-control evidence</text>
+    <g transform="translate(118,276)" filter="url(#softShadow)">
+      <g transform="translate(0,0)">
+        <use href="#aws" width="48" height="48"/>
+        <text x="58" y="22" fill="#f8fafc" font-size="18" font-weight="700">Cloud APIs</text>
+        <text x="58" y="40" fill="#94a3b8" font-size="13">AWS, GCP, Azure</text>
+      </g>
+      <g transform="translate(250,0)">
+        <use href="#k8s" width="48" height="48"/>
+        <text x="58" y="22" fill="#f8fafc" font-size="18" font-weight="700">Raw and audit logs</text>
+        <text x="58" y="40" fill="#94a3b8" font-size="13">CloudTrail, K8s, object feeds</text>
+      </g>
+      <g transform="translate(560,0)">
+        <use href="#okta" width="48" height="48"/>
+        <text x="58" y="22" fill="#f8fafc" font-size="18" font-weight="700">Identity feeds</text>
+        <text x="58" y="40" fill="#94a3b8" font-size="13">Okta, Entra, Workspace</text>
+      </g>
+      <g transform="translate(844,0)">
+        <use href="#dbx" width="48" height="48"/>
+        <text x="58" y="22" fill="#f8fafc" font-size="18" font-weight="700">Warehouses</text>
+        <text x="58" y="40" fill="#94a3b8" font-size="13">Snowflake, Databricks, ClickHouse</text>
+      </g>
+      <g transform="translate(1128,0)">
+        <use href="#azure" width="48" height="48"/>
+        <text x="58" y="22" fill="#f8fafc" font-size="18" font-weight="700">Agent runtime events</text>
+        <text x="58" y="40" fill="#94a3b8" font-size="13">MCP proxy and tool metadata</text>
+      </g>
     </g>
 
-    <g transform="translate(84,504)">
-      <rect x="0" y="0" width="1272" height="158" rx="28" fill="#0a2d31" stroke="url(#analyzeStroke)" stroke-width="2.5"/>
-      <text x="30" y="34" fill="#99f6e4" font-size="15" font-weight="800" letter-spacing="1.5">ANALYZE</text>
-      <text x="30" y="76" fill="#f8fafc" font-size="24" font-weight="800">Turn events into findings and controls into benchmark evidence</text>
-      <text x="30" y="104" fill="#a8c9c4" font-size="16">Detect and Evaluate consume the same stable contracts but answer different questions.</text>
+    <g transform="translate(84,376)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="160" rx="32" fill="#0d2342" stroke="url(#intake)" stroke-width="2.5"/>
+      <text x="34" y="38" fill="#93c5fd" font-size="16" font-weight="800" letter-spacing="1.8">INTAKE</text>
+      <text x="34" y="78" fill="#f8fafc" font-size="30" font-weight="800">Turn raw signals and live state into stable repo-owned contracts</text>
+      <text x="34" y="108" fill="#b7c5d8" font-size="17">Ingest normalizes source-specific payloads. Discover reads live cloud or AI state directly. Both feed the same downstream contract surface.</text>
 
-      <rect x="30" y="118" width="574" height="24" rx="12" fill="#114549"/>
-      <rect x="638" y="118" width="604" height="24" rx="12" fill="#114549"/>
-      <rect x="30" y="118" width="574" height="24" rx="12" fill="#1c8a80" opacity="0.95"/>
-      <rect x="638" y="118" width="604" height="24" rx="12" fill="#166f46" opacity="0.95"/>
-      <text x="50" y="136" fill="#f8fafc" font-size="16" font-weight="800">L3 Detect</text>
-      <text x="658" y="136" fill="#f8fafc" font-size="16" font-weight="800">L4 Evaluate</text>
-      <text x="50" y="162" fill="#d5fff6" font-size="14">lateral movement, K8s privilege escalation, Okta MFA fatigue, Entra, Workspace, MCP</text>
-      <text x="658" y="162" fill="#ddffe6" font-size="14">CIS AWS/GCP/Azure/K8s, container, GPU cluster, model-serving security</text>
+      <rect x="34" y="120" width="660" height="24" rx="12" fill="#1e40af"/>
+      <rect x="738" y="120" width="660" height="24" rx="12" fill="#3157d2"/>
+      <text x="58" y="138" fill="#ffffff" font-size="16" font-weight="800">L1 Ingest</text>
+      <text x="762" y="138" fill="#ffffff" font-size="16" font-weight="800">L2 Discover</text>
+      <text x="58" y="160" fill="#dbeafe" font-size="15">CloudTrail • Azure Activity • GCP audit • K8s audit • Okta • Entra • Workspace • MCP proxy</text>
+      <text x="762" y="160" fill="#dbeafe" font-size="15">environment graph • AI BOM • control evidence • cloud control evidence • live inventory</text>
     </g>
 
-    <g transform="translate(84,686)">
-      <rect x="0" y="0" width="1272" height="158" rx="28" fill="#2a1717" stroke="url(#actStroke)" stroke-width="2.5"/>
-      <text x="30" y="34" fill="#fdba74" font-size="15" font-weight="800" letter-spacing="1.5">ACT</text>
-      <text x="30" y="76" fill="#f8fafc" font-size="24" font-weight="800">Render findings cleanly or take scoped action with audit around every write</text>
-      <text x="30" y="104" fill="#d4c0c0" font-size="16">View is the delivery edge. Remediate is the guarded write edge.</text>
+    <g transform="translate(84,564)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="160" rx="32" fill="#0a3031" stroke="url(#analyze)" stroke-width="2.5"/>
+      <text x="34" y="38" fill="#99f6e4" font-size="16" font-weight="800" letter-spacing="1.8">ANALYZE</text>
+      <text x="34" y="78" fill="#f8fafc" font-size="30" font-weight="800">Turn events into findings and controls into benchmark evidence</text>
+      <text x="34" y="108" fill="#bad9d4" font-size="17">Detect focuses on deterministic attack signals. Evaluate focuses on posture and control evidence. Same repo contract, different question.</text>
 
-      <rect x="30" y="118" width="574" height="24" rx="12" fill="#4d193d"/>
-      <rect x="638" y="118" width="604" height="24" rx="12" fill="#4d2213"/>
-      <rect x="30" y="118" width="574" height="24" rx="12" fill="#8b2cbf" opacity="0.95"/>
-      <rect x="638" y="118" width="604" height="24" rx="12" fill="#b45309" opacity="0.95"/>
-      <text x="50" y="136" fill="#f8fafc" font-size="16" font-weight="800">L5 Remediate</text>
-      <text x="658" y="136" fill="#f8fafc" font-size="16" font-weight="800">L6 View</text>
-      <text x="50" y="162" fill="#f6e9ff" font-size="14">IAM departures: HITL approval, dry-run-first, dual audit in DynamoDB + S3</text>
-      <text x="658" y="162" fill="#fff0de" font-size="14">SARIF and Mermaid delivery for downstream review, CI, and incident handoff</text>
+      <rect x="34" y="120" width="660" height="24" rx="12" fill="#14877f"/>
+      <rect x="738" y="120" width="660" height="24" rx="12" fill="#166534"/>
+      <text x="58" y="138" fill="#ffffff" font-size="16" font-weight="800">L3 Detect</text>
+      <text x="762" y="138" fill="#ffffff" font-size="16" font-weight="800">L4 Evaluate</text>
+      <text x="58" y="160" fill="#ddfff6" font-size="15">lateral movement • K8s privilege escalation • MFA fatigue • Entra • Workspace • MCP tool drift</text>
+      <text x="762" y="160" fill="#dcfce7" font-size="15">CIS AWS / GCP / Azure / K8s • container • model-serving • GPU cluster • control benchmarks</text>
     </g>
 
-    <rect x="84" y="856" width="1272" height="36" rx="18" fill="#1b2435" stroke="#55657f" stroke-width="1.5"/>
-    <text x="108" y="880" fill="#f8fafc" font-size="15" font-weight="800">Shared skill bundle contract</text>
-    <text x="354" y="880" fill="#d1d9e6" font-size="15">SKILL.md · REFERENCES.md · src/ · tests/ · native / canonical / OCSF / bridge modes</text>
+    <g transform="translate(84,752)" filter="url(#softShadow)">
+      <rect x="0" y="0" width="1432" height="160" rx="32" fill="#311814" stroke="url(#act)" stroke-width="2.5"/>
+      <text x="34" y="38" fill="#fdba74" font-size="16" font-weight="800" letter-spacing="1.8">ACT</text>
+      <text x="34" y="78" fill="#f8fafc" font-size="30" font-weight="800">Render outputs cleanly or take guarded action with audit wrapped around every write</text>
+      <text x="34" y="108" fill="#dcc2c2" font-size="17">View is the delivery edge. Remediate is the HITL write edge. Both sit on the same tested bundle model.</text>
+
+      <rect x="34" y="120" width="660" height="24" rx="12" fill="#9333ea"/>
+      <rect x="738" y="120" width="660" height="24" rx="12" fill="#c2410c"/>
+      <text x="58" y="138" fill="#ffffff" font-size="16" font-weight="800">L5 Remediate</text>
+      <text x="762" y="138" fill="#ffffff" font-size="16" font-weight="800">L6 View</text>
+      <text x="58" y="160" fill="#f3e8ff" font-size="15">IAM departures • dry-run-first • human approval • dual audit in DynamoDB + S3</text>
+      <text x="762" y="160" fill="#ffedd5" font-size="15">SARIF • Mermaid attack flow • downstream review artifacts and CI-native delivery</text>
+    </g>
+
+    <rect x="84" y="928" width="1432" height="24" rx="12" fill="#1b263a"/>
+    <rect x="84" y="928" width="420" height="24" rx="12" fill="#273449"/>
+    <rect x="548" y="928" width="368" height="24" rx="12" fill="#273449"/>
+    <rect x="956" y="928" width="560" height="24" rx="12" fill="#273449"/>
+    <text x="100" y="945" fill="#f8fafc" font-size="13" font-weight="700">Shared skill bundle contract</text>
+    <text x="260" y="945" fill="#d7e2f2" font-size="13">SKILL.md • REFERENCES.md • src/ • tests</text>
+    <text x="564" y="945" fill="#f8fafc" font-size="13" font-weight="700">Edge layers</text>
+    <text x="652" y="945" fill="#d7e2f2" font-size="13">source-* • sink-* • packs/*</text>
+    <text x="974" y="945" fill="#f8fafc" font-size="13" font-weight="700">Runtime surfaces</text>
+    <text x="1088" y="945" fill="#d7e2f2" font-size="13">CLI • CI • MCP • AWS/GCP/Azure runners • same implementation underneath</text>
   </g>
 </svg>


### PR DESCRIPTION
Follow-up visual pass after #229.

What changed
- redesigns the three top README SVGs with a stronger poster-style visual system
- keeps the flow truthful to shipped code paths and skill contracts
- uses clearer composition, spacing, workflow lanes, and inline vendor logos where they help orientation
- preserves the README-native Mermaid flow layer added on this branch

Validation
- xmllint --noout docs/images/repo-architecture.svg docs/images/end-to-end-skill-flows.svg docs/images/iam-departures-architecture.svg
- python scripts/validate_skill_contract.py
- git diff --check