### PR TITLE
docs(iam-departures): narrow description to AWS-only, add negative triggers for Azure/GCP/Snowflake/Databricks

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -93,7 +93,7 @@ Active fix workflows with dry-run, audit, and guardrails.
 
 | Skill | Scope |
 |---|---|
-| [`iam-departures-remediation`](remediation/iam-departures-remediation/) | Multi-cloud IAM cleanup for departed employees |
+| [`iam-departures-remediation`](remediation/iam-departures-remediation/) | AWS IAM cleanup for departed employees (per-cloud split for Azure/GCP/Snowflake/Databricks planned; library modules in `src/lambda_worker/clouds/`) |
 
 ## How to add a new skill
 

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: iam-departures-remediation
 description: >-
-  Auto-remediate IAM users belonging to departed employees across AWS, Azure Entra,
-  GCP, Snowflake, and Databricks. Reconciles HR termination data (Workday via
-  Snowflake, Databricks, ClickHouse, or direct API) against IAM, exports
-  change-detected manifests to S3, and triggers a Step Function pipeline that
-  safely deletes IAM principals with all dependencies through a 13-step cleanup.
-  Every action is grace-period-gated (7 days default), rehire-aware, deny-listed
-  for root/break-glass/emergency users, and dual-audited (DynamoDB + S3). Use when
-  the user mentions departed employees, IAM cleanup, termination remediation,
-  offboarding automation, or stale credential removal. Do NOT use this skill to
-  bypass the grace period, call the Step Function directly (always go through
-  EventBridge), disable deny policies, or write to the audit table by hand — those
-  are closed-loop guarantees that must not be broken. Do NOT use for access
+  Auto-remediate AWS IAM users belonging to departed employees. Reconciles HR
+  termination data (Workday via Snowflake, Databricks, ClickHouse, or direct API)
+  against AWS IAM inside an AWS Organization, exports change-detected manifests
+  to S3, and triggers a Step Function pipeline that safely deletes IAM users with
+  all dependencies through a 13-step cleanup. Every action is grace-period-gated
+  (7 days default), rehire-aware, deny-listed for root / break-glass / emergency
+  users, and dual-audited (S3 with KMS, plus DynamoDB hot lookup and warehouse
+  ingest-back). Use when the user mentions AWS offboarding, AWS IAM cleanup for
+  departed employees, AWS termination remediation, or stale AWS credential
+  removal. Do NOT use for Azure Entra, GCP IAM, Snowflake user, or Databricks
+  user remediation — the library modules under src/lambda_worker/clouds/ exist
+  but per-cloud orchestration (Event Grid + Logic Apps for Azure; Eventarc +
+  Cloud Workflows for GCP; SaaS admin-API workers for Snowflake and Databricks)
+  is not yet shipped in this skill. Do NOT use this skill to bypass the grace
+  period, call the Step Function directly (always go through EventBridge),
+  disable deny policies, or write to the audit table by hand — those are
+  closed-loop guarantees that must not be broken. Do NOT use for access
   provisioning; this skill only deactivates and deletes.
 license: Apache-2.0
 approval_model: human_required


### PR DESCRIPTION
## Why

The current `iam-departures-remediation` SKILL.md description claims scope across **AWS, Azure Entra, GCP, Snowflake, and Databricks.** The shipped code (in `infra/terraform/main.tf`, `infra/cloudformation.yaml`, Step Function ASL, and `src/lambda_worker/handler.py`) only remediates **AWS IAM**. Per-cloud library modules at `src/lambda_worker/clouds/{azure_entra,gcp_iam,snowflake_user,databricks_scim}.py` exist but are not wired into any shipped handler.

Claude's skill auto-loader uses the `description` field as the primary trigger signal. From [Anthropic's *Complete Guide to Building Skills for Claude*](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf):

> "This metadata provides just enough information for Claude to know when each skill should be used without loading all of it into context."

An over-broad description triggers on phrases the skill can't actually deliver on ("offboard a Snowflake user", "remove from Entra") — producing a support/expectation mismatch. The skills guide's fix for over-triggering is explicit:

> Solutions: Add negative triggers, be more specific.
>
> ```
> description: Advanced data analysis for CSV files. Use for statistical modeling, regression, clustering. Do NOT use for simple data exploration (use data-viz skill instead).
> ```

This PR applies that pattern.

## What changed

**`skills/remediation/iam-departures-remediation/SKILL.md`:**
- Description narrowed from multi-cloud to **AWS IAM only**
- Concrete AWS trigger phrases added: "AWS offboarding", "AWS IAM cleanup for departed employees", "AWS termination remediation", "stale AWS credential removal"
- Explicit **negative triggers** for Azure Entra, GCP IAM, Snowflake user, and Databricks user remediation, with a pointer to where the library code lives and why per-cloud orchestration is not yet shipped
- Audit path wording aligned with the recently-merged SVG: S3 with KMS as primary, DynamoDB as hot-lookup secondary, warehouse ingest-back as the operational loop

**`skills/README.md`:**
- Catalog entry updated from *"Multi-cloud IAM cleanup for departed employees"* to *"AWS IAM cleanup for departed employees (per-cloud split for Azure/GCP/Snowflake/Databricks planned; library modules in `src/lambda_worker/clouds/`)"*

## What is NOT changed in this PR

- Folder name stays `iam-departures-remediation` (rename belongs to the follow-up split)
- No code changes
- No infra changes
- No test changes

## Follow-up PRs (sized but not in this change)

Per the skills-guide recommendation (narrow scope + sharp triggers per system with different SDK, auth, blast radius), the next change will:

1. Extract `iam-departures-reconciler` as a read-only planner skill (rehire/grace filter, manifest production).
2. Split per-cloud target skills: `iam-departures-aws`, `iam-departures-azure-entra`, `iam-departures-gcp`, `iam-departures-snowflake`, `iam-departures-databricks`. Each gets its own `SKILL.md + src/ + tests/ + REFERENCES.md` and imports the existing `src/lambda_worker/clouds/*.py` module.
3. Add reference orchestration infra for GCP (Eventarc + Cloud Workflows + Cloud Run Jobs) and Azure (Event Grid + Logic Apps + Azure Functions).

## Validators

Run locally on this branch:

- [x] `validate_skill_contract.py` — passed (44 skills)
- [x] `validate_skill_integrity.py` — passed
- [x] `validate_safe_skill_bar.py` — passed
- [x] `validate_ocsf_metadata.py` — passed

## Test plan

- [ ] CI passes (all `validate_*` jobs + integration tests)
- [ ] Description still under 1024 chars (per the skills guide's field requirement)
- [ ] `Use when…` and `Do NOT use…` blocks render cleanly in GitHub markdown preview