### PR TITLE
docs(iam-departures): fix 13-step SVG + stale 'cross-cloud worker' phrase

### DIFF
--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -157,18 +157,27 @@
       <rect x="14" y="54" width="212" height="22" rx="6" fill="#3a2410" stroke="#f59e0b"/>
       <text x="22" y="69" fill="#fbbf24" font-size="11" font-weight="700">cross-account role · PrincipalOrgID</text>
 
-      <!-- 9-step deletion card -->
+      <!-- 13-step deletion card — two columns fit within the 176 height.
+           Matches SKILL.md and handler.py _remediation_steps(). -->
       <rect x="0" y="100" width="240" height="176" rx="12" fill="#12112e" stroke="#a78bfa" stroke-width="1.5"/>
-      <text x="16" y="120" fill="#c4b5fd" font-size="11" font-weight="800" letter-spacing="1.2">DELETION ORDER (AWS IAM)</text>
-      <g font-size="12" fill="#ddd6fe">
-        <text x="16" y="142">1. deactivate access keys</text>
-        <text x="16" y="160">2. delete login profile</text>
-        <text x="16" y="178">3. remove from all groups</text>
-        <text x="16" y="196">4. detach managed policies</text>
-        <text x="16" y="214">5. delete inline policies</text>
-        <text x="16" y="232">6. delete MFA devices</text>
-        <text x="16" y="250">7. delete signing certs</text>
-        <text x="16" y="268">8. tag user · 9. delete user</text>
+      <text x="16" y="118" fill="#c4b5fd" font-size="11" font-weight="800" letter-spacing="1.2">DELETION ORDER · AWS IAM · 13</text>
+      <line x1="116" y1="126" x2="116" y2="266" stroke="#2a2446" stroke-width="1"/>
+      <g font-size="10" fill="#ddd6fe">
+        <!-- Left column: 1–7 -->
+        <text x="10" y="138">1. deactivate access keys</text>
+        <text x="10" y="154">2. delete access keys</text>
+        <text x="10" y="170">3. delete login profile</text>
+        <text x="10" y="186">4. remove from groups</text>
+        <text x="10" y="202">5. detach mgd policies</text>
+        <text x="10" y="218">6. delete inline policies</text>
+        <text x="10" y="234">7. deactivate MFA</text>
+        <!-- Right column: 8–13 -->
+        <text x="124" y="138">8. delete MFA devices</text>
+        <text x="124" y="154">9. delete signing certs</text>
+        <text x="124" y="170">10. delete SSH keys</text>
+        <text x="124" y="186">11. delete svc creds</text>
+        <text x="124" y="202">12. tag user for audit</text>
+        <text x="124" y="220" font-weight="800" fill="#f3e8ff">13. delete IAM user</text>
       </g>
     </g>
 

--- a/skills/remediation/iam-departures-remediation/SKILL.md
+++ b/skills/remediation/iam-departures-remediation/SKILL.md
@@ -114,7 +114,7 @@ flowchart TD
 
 ## Security Guardrails
 
-- **Dry-run first**: use the parser and cross-cloud worker dry-run paths before any real execution. Planning, examples, and validation should never start with a destructive path.
+- **Dry-run first**: use the parser Lambda and AWS worker Lambda dry-run paths before any real execution. Planning, examples, and validation should never start with a destructive path.
 - **Deny policies**: Root, `break-glass-*`, and `emergency-*` accounts are protected by explicit IAM deny — the pipeline cannot touch them.
 - **Grace period**: 7-day default window before remediation (configurable). HR corrections within this window prevent accidental deletion.
 - **Rehire safety**: 8 scenarios handled. The reconciler/export path applies the primary rehire-aware `should_remediate()` filter before writing the S3 manifest; the parser Lambda rechecks before worker execution.


### PR DESCRIPTION
## Two accuracy fixes that got missed in recent merges

### 1. SVG showed 9 deletion steps; code runs 13

[`src/lambda_worker/handler.py`](skills/remediation/iam-departures-remediation/src/lambda_worker/handler.py) `_remediation_steps()` returns a tuple of 13 ordered operations. [`SKILL.md`](skills/remediation/iam-departures-remediation/SKILL.md#iam-deletion-order) documents the same 13. The merged SVG showed only 9 because the card was height-constrained.

**Fix:** two-column layout inside the same 176 px card — no canvas resize, no drift-lane move:

| Left column | Right column |
|---|---|
| 1. deactivate access keys | 8. delete MFA devices |
| 2. delete access keys | 9. delete signing certs |
| 3. delete login profile | 10. delete SSH keys |
| 4. remove from groups | 11. delete svc creds |
| 5. detach mgd policies | 12. tag user for audit |
| 6. delete inline policies | **13. delete IAM user** |
| 7. deactivate MFA | |

Header updated to `DELETION ORDER · AWS IAM · 13`.

### 2. Stale "cross-cloud worker" phrase

[`SKILL.md`](skills/remediation/iam-departures-remediation/SKILL.md#L117) Security Guardrails bullet said *"parser and cross-cloud worker dry-run paths."* The worker Lambda is **AWS-only** (`boto3`, AWS IAM). The `src/lambda_worker/clouds/*.py` modules are library code, not a worker that dispatches across clouds.

**Fix:** `parser Lambda and AWS worker Lambda dry-run paths.`

## Out of scope for this PR

- Folder rename → `iam-departures-aws`
- Per-cloud target skills (scaffold)
- Reconciler extraction

Those ship in the P1 structural split PR (separate branch, next up).

## Validators

Run locally:

- [x] `validate_skill_contract.py` — passed (44 skills)
- [x] `validate_skill_integrity.py` — passed

## Test plan

- [ ] CI passes (all `validate_*` jobs + integration tests)
- [ ] SVG still renders inline on GitHub with no text clipping
- [ ] All 13 deletion steps match `_remediation_steps()` order in `handler.py`