### PR TITLE
docs: OCSF is SIEM interop for ingest+detect, native elsewhere (#261)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ The remediation skills (IAM departures, vuln pipeline) write back to a dual audi
 trail (DynamoDB + S3) and ingest results into the source warehouse so the next
 reconciler run *cross-checks* the previous remediation actually landed.
 
+**OCSF 1.8 is the SIEM interop wire format, not the universal internal format.** It's the default for **ingest** and **detect** (that's where downstream SIEM/SOAR integration pays off). **Discover** emits native / CycloneDX / bridge (inventory and AI BOM don't map cleanly to OCSF). **Remediate** emits native (state changes + audit records, not findings). **Evaluate** is native today with OCSF Compliance Finding 2003 planned as opt-in. Pick the format that fits the layer's semantic; the `--output-format` flag is the runtime switch where both are supported. Full table: [`docs/ARCHITECTURE.md#31-ocsf-applicability-by-layer`](docs/ARCHITECTURE.md).
+
+The HITL bar for every skill — when human approval is required, how many approvers, where the gate sits — is codified in [`docs/HITL_POLICY.md`](docs/HITL_POLICY.md). Enforcement lives in [`scripts/validate_safe_skill_bar.py`](scripts/validate_safe_skill_bar.py) (wildcards, `sts:AssumeRole` boundaries, dry-run defaults).
+
 ## Agent guardrails — REQUIRED reading before invoking these skills
 
 If you are an AI agent (Claude, Cursor, Codex, Cortex, Windsurf, etc.) loading

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@
 
 **Total: 45 shipped skills.**
 
+### Why different layers use different formats
+
+OCSF 1.8 is the **SIEM interop wire format** — valuable exactly where events flow to a downstream analyzer. It is not the universal internal format, and this repo is honest about where it fits:
+
+| Layer | Default emit | Rationale |
+|---|---|---|
+| **Ingest** | OCSF 1.8 (native opt-in) | Raw vendor → OCSF is what OCSF was built for. SIEMs consume it natively |
+| **Detect** | OCSF 1.8 Detection Finding 2004 (native opt-in) | Findings flow to SIEM / SOAR / ticketing — OCSF spares every downstream system from writing a custom parser |
+| **Evaluate / CSPM** | native today, OCSF Compliance Finding 2003 planned opt-in (#29) | Ops dashboards prefer native; SIEM pipelines opt into OCSF |
+| **Discover** | native / CycloneDX ML-BOM / bridge | Inventory graphs and AI BOM aren't events. OCSF Inventory Info 5001 is too thin to be worth forcing |
+| **Remediate** | native | Remediation is a state change with an operator-owned audit trail, not a finding |
+| **View** | OCSF **input**, SARIF / Mermaid out | The whole point is rendering OCSF for humans |
+| **Output (sinks)** | pass-through | Sinks write whatever the producer emitted |
+
+Full discussion: [docs/ARCHITECTURE.md §3 Layer model + §6 Wire contract](docs/ARCHITECTURE.md). The pinned OCSF contract for ingest + detect lives in [skills/detection-engineering/OCSF_CONTRACT.md](skills/detection-engineering/OCSF_CONTRACT.md).
+
 ## Architecture
 
 External signals enter through two intake layers, pass through two analyze layers, and exit through two act layers. The same skill bundle contract sits underneath every layer.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ This file is the design contract. It explains how the repo is supposed to work a
 - six shipped skill layers stay at the center: ingest, discover, detect, evaluate, remediate, and view
 - three edge or runtime layers sit around them: sources and sinks, query packs, and runtime surfaces
 - one skill bundle contract is shared across CLI, CI, MCP, and runners
-- OCSF is the default interoperable stream format; native stays first for operational artifacts
+- OCSF is the SIEM interop wire format for **ingest and detect**; native / CycloneDX / bridge are correct for discover, remediate, and sinks (see §3.1 for the per-layer applicability table)
 
 <details>
 <summary><b>Related contracts and expanded design principles</b></summary>
@@ -133,12 +133,36 @@ The repo operates across four schema modes:
 - **ocsf** for shared pipelines, SIEMs, and standard interoperability
 - **bridge** when OCSF transport helps but native or canonical detail still matters
 
+### 3.1 OCSF applicability by layer
+
+OCSF 1.8 is the **SIEM interop wire format**. It is valuable exactly where
+events flow to a downstream analyzer (Splunk, Sentinel, Chronicle, Elastic).
+It is not the universal internal format, and this repo treats it as a
+per-layer choice, not a repo-wide mandate.
+
+| Layer | Default emit | OCSF role | Notes |
+|---|---|---|---|
+| **L1 Ingest** | OCSF 1.8 (native opt-in) | Default — SIEM interop | Raw vendor → OCSF is what OCSF was built for. Every ingester offers `--output-format ocsf` by default |
+| **L3 Detect** | OCSF Detection Finding 2004 (native opt-in) | Default — SIEM interop | Findings flow to SIEM / SOAR / ticketing. OCSF spares every downstream from writing a custom parser. MITRE ATT&CK lives under `finding_info.attacks[]` |
+| **L4 Evaluate / CSPM** | native today; OCSF Compliance Finding 2003 planned opt-in (#29) | Optional | Ops dashboards prefer native; SIEM pipelines opt into OCSF. The migration ships as **dual output**, not a forced replacement |
+| **L2 Discover** | native / CycloneDX ML-BOM / bridge | **Not a good fit** | Inventory graphs, AI BOM, evidence snapshots are state, not events. OCSF Inventory Info 5001 is too thin to be worth forcing |
+| **L5 Remediate** | native | **Not a good fit** | Remediation is a state change with an operator-owned audit record, not a finding. `iam-departures-aws` and `remediate-okta-session-kill` both emit native |
+| **L6 View** | OCSF input required, SARIF / Mermaid output | Consumer of OCSF | The whole point of these converters is rendering OCSF for humans |
+| **L7 Output (sinks)** | pass-through | Format-agnostic | Sinks write whatever the producer emitted |
+| **L0 Sources** | pass-through | Format-agnostic | Warehouse query adapters yield whatever the source held |
+
 Most current ingest and detect paths are **fully dual-mode** and can emit either
-repo-native JSONL or OCSF JSONL. Discovery and evidence paths may emit
-deterministic native or canonical artifacts, plus OCSF bridge events where
-that improves interoperability. Evaluation, sink, and remediation outputs remain
-primarily native because they are repo-owned operational contracts rather than
-clean OCSF fits.
+repo-native JSONL or OCSF JSONL via `--output-format`. Discovery and evidence
+paths may emit deterministic native or canonical artifacts, plus OCSF bridge
+events where that improves interoperability. Evaluation, sink, and remediation
+outputs remain primarily native because they are repo-owned operational
+contracts rather than clean OCSF fits.
+
+The principle: **pick the format that fits the semantic of the layer.** OCSF
+where events flow to analyzers; native where the signal is state,
+configuration, or an audit trail; CycloneDX where the artifact is an SBOM.
+The frontmatter `output_formats` field on each SKILL.md declares which modes
+a skill supports; `--output-format` is the runtime switch.
 
 Execution-mode note:
 - `execution_modes: persistent` means a skill is safe to embed in a persistent runner, queue consumer, scheduler, or serverless loop without changing the skill logic

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,15 +2,17 @@
 
 Skills are grouped by **layered function**, not by vendor. Start with the problem you are solving, then pick the layer and skill that match it. If you want a guided entry point instead of a catalog, read [`docs/USE_CASES.md`](../docs/USE_CASES.md) first.
 
-| Category | Question it answers | Output shape |
+| Category | Question it answers | Default output format |
 |---|---|---|
-| [`ingestion/`](ingestion/) | "How do I normalize this raw source into a stable event stream?" | native or OCSF JSONL, depending on the skill |
-| [`discovery/`](discovery/) | "What does this cloud / AI estate look like right now?" | deterministic inventory / graph JSON |
-| [`detection/`](detection/) | "What attack pattern does this event stream show?" | native or OCSF detection finding |
-| [`evaluation/`](evaluation/) | "Does this posture or event stream meet a benchmark?" | Compliance / posture result |
-| [`view/`](view/) | "How should I render or export this OCSF output?" | SARIF, Mermaid, other review formats |
-| [`remediation/`](remediation/) | "Something is wrong. How do I fix it safely?" | Audited action + re-verification |
-| [`output/`](output/) | "Where do these findings / evidence / audit rows persist?" | Append-only writes to S3, Snowflake, ClickHouse |
+| [`ingestion/`](ingestion/) | "How do I normalize this raw source into a stable event stream?" | **OCSF 1.8** (native opt-in via `--output-format native`) |
+| [`discovery/`](discovery/) | "What does this cloud / AI estate look like right now?" | **native / CycloneDX / bridge** (OCSF Inventory Info 5001 is too thin to force) |
+| [`detection/`](detection/) | "What attack pattern does this event stream show?" | **OCSF Detection Finding 2004** (native opt-in) |
+| [`evaluation/`](evaluation/) | "Does this posture or event stream meet a benchmark?" | **native** today; OCSF Compliance Finding 2003 planned opt-in ([#29](https://github.com/msaad00/cloud-ai-security-skills/issues/29)) |
+| [`view/`](view/) | "How should I render or export this OCSF output?" | **SARIF / Mermaid** — consumer of OCSF |
+| [`remediation/`](remediation/) | "Something is wrong. How do I fix it safely?" | **native** (state change + audit record, not a finding) |
+| [`output/`](output/) | "Where do these findings / evidence / audit rows persist?" | **pass-through** |
+
+**OCSF is the SIEM interop wire format for ingest + detect — not the universal internal format.** See [`../docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md#3-layer-model) §3.1 for the full applicability discussion.
 
 Every shipped skill follows the [Anthropic skills guide](https://platform.claude.com/docs/en/build-with-claude/skills-guide): `SKILL.md`, `src/`, `tests/`, `REFERENCES.md`, and explicit `Use when...` / `Do NOT use...` routing language.
 


### PR DESCRIPTION
## Summary

Closes [#261](https://github.com/msaad00/cloud-ai-security-skills/issues/261). Aligns the top-level docs to the layer-by-layer OCSF applicability stance. OCSF 1.8 is the **SIEM interop wire format** — valuable exactly where events flow to a downstream analyzer. It is not and shouldn't be the universal internal format.

**Docs-only.** The code already respects per-layer format choices via the `output_formats` frontmatter and `--output-format` runtime flag; only the top-level framing was overgeneralizing.

## Per-layer applicability (matches the code today)

| Layer | Default emit | OCSF role |
|---|---|---|
| **L1 Ingest** | OCSF 1.8 (native opt-in) | Default — SIEM interop |
| **L3 Detect** | OCSF Detection Finding 2004 (native opt-in) | Default — SIEM interop |
| **L4 Evaluate** | native today; OCSF 2003 planned opt-in (#29) | Optional, dual-output |
| **L2 Discover** | native / CycloneDX / bridge | Not a good fit (Inventory Info 5001 too thin) |
| **L5 Remediate** | native | Not a good fit (state change, not a finding) |
| **L6 View** | OCSF input, SARIF/Mermaid output | Consumer of OCSF |
| **L7 Output (sinks)** | pass-through | Format-agnostic |

## What this PR changes

- **`docs/ARCHITECTURE.md`** — quick-read bullet reworded + new §3.1 "OCSF applicability by layer" with the table and the principle ("pick the format that fits the semantic of the layer")
- **`README.md`** — new subsection "Why different layers use different formats" under the existing layer table
- **`skills/README.md`** — catalog header now has a "Default output format" column per layer + one-line summary
- **`CLAUDE.md`** — one paragraph mirroring the stance for agents loading skills, plus a pointer to the HITL policy + safe-skill lint

## What this PR does NOT change (intentional scope)

- No per-SKILL.md audit (that's ~45 files of description rewording — follow-up)
- No AGENTS.md edit (covered by CLAUDE.md for now; tracked in issue body)
- No hero SVG edit (tracked under #248 canonical visuals refresh)
- No code changes

## Test plan

- [x] 26 skill validator tests pass (`uv run pytest tests/integration/test_skill_validation_scripts.py`)
- [x] No code changes; docs-only diff is 60 lines across 4 files
- [ ] CI green (markdown lint + link check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)