### PR TITLE
docs: align repo truth and tighten README visuals

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,9 +13,9 @@ them. One shared skill bundle contract.
 |---|---|---|
 | L1 Ingest | raw source → native, OCSF, or bridge stream | `ingest-cloudtrail-ocsf`, `ingest-k8s-audit-ocsf`, `ingest-okta-system-log-ocsf`, `ingest-entra-directory-audit-ocsf`, `ingest-google-workspace-login-ocsf`, `ingest-mcp-proxy-ocsf`, `ingest-vpc-flow-logs-*-ocsf`, `ingest-guardduty-ocsf`, `ingest-security-hub-ocsf`, `ingest-gcp-audit-ocsf`, `ingest-gcp-scc-ocsf`, `ingest-azure-activity-ocsf`, `ingest-azure-defender-for-cloud-ocsf`, `ingest-nsg-flow-logs-azure-ocsf` |
 | L2 Discover | live inventory, evidence, AI BOM, graph context | `discover-ai-bom`, `discover-cloud-control-evidence`, `discover-control-evidence`, `discover-environment` |
-| L3 Detect | deterministic attack-pattern findings | `detect-lateral-movement`, `detect-privilege-escalation-k8s`, `detect-sensitive-secret-read-k8s`, `detect-mcp-tool-drift`, `detect-okta-mfa-fatigue`, `detect-entra-credential-addition`, `detect-entra-role-grant-escalation`, `detect-google-workspace-suspicious-login` |
+| L3 Detect | deterministic attack-pattern findings | `detect-lateral-movement`, `detect-privilege-escalation-k8s`, `detect-sensitive-secret-read-k8s`, `detect-mcp-tool-drift`, `detect-prompt-injection-mcp-proxy`, `detect-okta-mfa-fatigue`, `detect-credential-stuffing-okta`, `detect-entra-credential-addition`, `detect-entra-role-grant-escalation`, `detect-google-workspace-suspicious-login` |
 | L4 Evaluate | benchmark and posture results | `cspm-aws-cis-benchmark`, `cspm-gcp-cis-benchmark`, `cspm-azure-cis-benchmark`, `k8s-security-benchmark`, `container-security`, `gpu-cluster-security`, `model-serving-security` |
-| L5 Remediate | guarded writes with HITL and dual audit | `iam-departures-aws` |
+| L5 Remediate | guarded writes with HITL and dual audit | `iam-departures-aws`, `remediate-okta-session-kill` |
 | L6 View | export into downstream formats | `convert-ocsf-to-sarif`, `convert-ocsf-to-mermaid-attack-flow` |
 
 OCSF 1.8 is the default interoperable wire format, not a layer. It is pinned
@@ -52,8 +52,8 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.jsonl \
 | L1 Ingest | 15 shipped ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources as demand justifies |
 | L2 Discover | 4 shipped skills (AI BOM, cloud control evidence, control evidence, environment graph) | wider SaaS and infra evidence sources |
 | L3 Detect | 10 shipped detectors tied to MITRE ATT&CK techniques (lateral movement, K8s privesc + secret read, MCP tool drift, MCP prompt injection, Okta MFA fatigue, Okta credential stuffing, Entra credential addition, Entra role grant, Workspace suspicious login) | impossible travel, more AI-agent signals |
-| L4 Evaluate | 7 shipped benchmarks (CIS AWS / GCP / Azure, K8s, Docker / container, GPU cluster, model serving) | migrate to OCSF Compliance Finding (`class_uid=2003`) outputs |
-| L5 Remediate | `iam-departures-aws` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #240, #241, #242) |
+| L4 Evaluate | 7 shipped benchmarks (CIS AWS / GCP / Azure, K8s, Docker / container, GPU cluster, model serving) | native by default, OCSF Compliance Finding (`class_uid=2003`) shipped as opt-in output |
+| L5 Remediate | `iam-departures-aws` and `remediate-okta-session-kill` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #240, #241, #242) |
 | L6 View | `convert-ocsf-to-sarif`, `convert-ocsf-to-mermaid-attack-flow` | graph overlay, warehouse-ready converters |
 | L7 Output | 3 shipped sinks (`sink-s3-jsonl`, `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`) | BigQuery, Security Lake |
 
@@ -70,7 +70,7 @@ skills/
 └── output/         ← L7 (sink-* skills: append-only persistence)
 ```
 
-The repo ships **45 skills** across these seven layers (15 + 4 + 10 + 7 + 1 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
+The repo ships **46 skills** across these seven layers (15 + 4 + 10 + 7 + 2 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
 
 `skills/detection-engineering/` holds the shared OCSF contract and frozen
 golden fixtures. Executable skills live only under the six layered

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 44 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 46 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,7 +16,7 @@
 
 ## What this repo gives you
 
-**45 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus one guarded write path for offboarding. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**46 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus two guarded write paths for offboarding and account containment. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
@@ -24,12 +24,12 @@
 | **Discover** | 4 | inventory, graph, AI BOM, evidence | native / bridge JSON |
 | **Detect** | 10 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
-| **Remediate** | 1 | IAM departures (HITL + dual audit) | audited action trail |
+| **Remediate** | 2 | guarded write paths (IAM departures, Okta session kill) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 45 shipped skills.**
+**Total: 46 shipped skills.**
 
 ### Why different layers use different formats
 
@@ -39,7 +39,7 @@ OCSF 1.8 is the **SIEM interop wire format** — valuable exactly where events f
 |---|---|---|
 | **Ingest** | OCSF 1.8 (native opt-in) | Raw vendor → OCSF is what OCSF was built for. SIEMs consume it natively |
 | **Detect** | OCSF 1.8 Detection Finding 2004 (native opt-in) | Findings flow to SIEM / SOAR / ticketing — OCSF spares every downstream system from writing a custom parser |
-| **Evaluate / CSPM** | native today, OCSF Compliance Finding 2003 planned opt-in (#29) | Ops dashboards prefer native; SIEM pipelines opt into OCSF |
+| **Evaluate / CSPM** | native by default, OCSF Compliance Finding 2003 opt-in | Ops dashboards prefer native; SIEM pipelines can opt into OCSF without losing the native path |
 | **Discover** | native / CycloneDX ML-BOM / bridge | Inventory graphs and AI BOM aren't events. OCSF Inventory Info 5001 is too thin to be worth forcing |
 | **Remediate** | native | Remediation is a state change with an operator-owned audit trail, not a finding |
 | **View** | OCSF **input**, SARIF / Mermaid out | The whole point is rendering OCSF for humans |
@@ -69,7 +69,7 @@ flowchart LR
         discover["L2 Discover<br/>4 skills"]:::intake
     end
     subgraph Analyze
-        detect["L3 Detect<br/>9 skills · ATT&amp;CK"]:::analyze
+        detect["L3 Detect<br/>10 skills · ATT&amp;CK"]:::analyze
         evaluate["L4 Evaluate<br/>7 skills · 82 checks"]:::analyze
     end
     subgraph Act
@@ -131,7 +131,7 @@ flowchart TB
     end
 
     mcp["Repo MCP server<br/>mcp-server/src/server.py<br/>auto-discovers SKILL.md, audited calls, timeout-governed"]:::mcp
-    bundle[("Shared skill bundle<br/>44 shipped")]:::bundle
+    bundle[("Shared skill bundle<br/>46 shipped")]:::bundle
     outputs[/"native · OCSF 1.8 · bridge · SARIF · Mermaid · AI BOM · audited writes"/]:::output
 
     claude -->|stdio| mcp
@@ -159,7 +159,7 @@ Pick the row that matches the job.
 |---|---|---|
 | a raw log file or stream | [`ingest-*`](skills/ingestion/) → [`detect-*`](skills/detection/) | OCSF Detection Finding |
 | live cloud API access | [`discover-*`](skills/discovery/) or [`evaluation/*`](skills/evaluation/) | graph / benchmark JSON |
-| logs already in your lake (CloudTrail in S3, Okta in Snowflake, Databricks tables) | [`source-*`](skills/ingestion/) → `detect-*` → [`sink-*`](skills/remediation/) | customer-owned persistence |
+| logs already in your lake (CloudTrail in S3, Okta in Snowflake, Databricks tables) | [`source-*`](skills/ingestion/) → `detect-*` → [`sink-*`](skills/output/) | customer-owned persistence |
 | an AI estate to inventory | [`discover-ai-bom`](skills/discovery/discover-ai-bom/) | CycloneDX-aligned AI BOM |
 | audit evidence to produce | [`discover-control-evidence`](skills/discovery/discover-control-evidence/) | PCI / SOC 2 evidence JSON |
 | OCSF findings to publish | [`view/*`](skills/view/) | SARIF · Mermaid |
@@ -186,7 +186,16 @@ Three lanes. Same skill bundle contract in every lane — input, output, and con
                        evaluation-* ─┼─▶ remediation/* ─▶ HITL + dual audit
 ```
 
-**Example — Kubernetes privilege escalation, end-to-end:**
+**Same flow from an MCP agent:**
+
+```text
+tools/call name="ingest-k8s-audit-ocsf" args={"args":["skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl"]}
+tools/call name="detect-privilege-escalation-k8s" args={"input":"<stdout>"}
+tools/call name="convert-ocsf-to-sarif"          args={"input":"<stdout>"}
+```
+
+<details>
+<summary><b>Low-level execution core: the same flow as raw Python entrypoints</b></summary>
 
 ```bash
 python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
@@ -196,13 +205,7 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
   > findings.sarif
 ```
 
-**Same flow from an MCP agent:**
-
-```text
-tools/call name="ingest-k8s-audit-ocsf" args={"args":["skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl"]}
-tools/call name="detect-privilege-escalation-k8s" args={"input":"<stdout>"}
-tools/call name="convert-ocsf-to-sarif"          args={"input":"<stdout>"}
-```
+</details>
 
 <details>
 <summary><b>What you get back</b></summary>
@@ -228,7 +231,7 @@ Native wire format is the same content in a repo-owned envelope — see [docs/NA
 
 ## Flagship · IAM departures remediation
 
-The one shipped write path. Guarded, event-driven, dual-audited — and **one cloud per worker**, never cross-cloud.
+The flagship shipped write path. Guarded, event-driven, dual-audited — and **one cloud per worker**, never cross-cloud.
 
 ![AWS-only IAM departures flow. Plan reads HR sources in Snowflake or Databricks, runs the reconciler, writes an S3 manifest of the actionable set. Orchestrate fires an EventBridge rule that starts a Step Function; the Step Function invokes a parser Lambda that re-checks manifest and IAM state, then a worker Lambda with a scoped principal that assumes a cross-account role inside the AWS Organization. Write deletes the AWS IAM user through the nine-step deletion order. Audit lands in DynamoDB plus KMS-encrypted S3, then ingest-back feeds drift checks into the next reconciler run. The footer makes clear that Azure and GCP use their own native orchestration stacks. No single worker ever crosses cloud boundaries.](docs/images/iam-departures-aws.svg)
 

--- a/README.md
+++ b/README.md
@@ -171,19 +171,42 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 Three lanes. Same skill bundle contract in every lane — input, output, and control boundary are what change.
 
-```
-① Raw log detection
-   raw payload ─▶ ingest-* ─▶ detect-* ─▶ view/*
-                                        └─▶ SARIF · Mermaid attack flow
+```mermaid
+flowchart TB
+    classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
+    classDef lane fill:#111827,stroke:#334155,color:#e5e7eb
+    classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
+    classDef detect fill:#047857,stroke:#6ee7b7,color:#ecfdf5
+    classDef sink fill:#6d28d9,stroke:#c4b5fd,color:#f5f3ff
+    classDef remediate fill:#991b1b,stroke:#fca5a5,color:#fef2f2
+    classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
 
-② Detection on data already in your lake
-   CloudTrail in S3 ─┐
-   Okta in Snowflake ─┼─▶ source-* ─▶ detect-* ─▶ sink-*
-   Databricks tables ─┘                        └─▶ customer-owned persistence
+    subgraph lane1["1. Raw log detection and export"]
+        raw["raw payloads<br/>CloudTrail · K8s audit · Okta"]:::source
+        ingest["ingest-*"]:::skill
+        detect1["detect-*"]:::detect
+        view["view/*"]:::sink
+        export["SARIF · Mermaid · JSON"]:::output
+        raw --> ingest --> detect1 --> view --> export
+    end
 
-③ Live posture and guarded action
-   live cloud / SaaS ─▶ discover-* ─┐
-                       evaluation-* ─┼─▶ remediation/* ─▶ HITL + dual audit
+    subgraph lane2["2. Detection on data already in your lake"]
+        lake["warehouse rows or objects<br/>Snowflake · Databricks · S3"]:::source
+        source["source-*"]:::skill
+        detect2["detect-*"]:::detect
+        sink["sink-*"]:::sink
+        persist["customer-owned persistence"]:::output
+        lake --> source --> detect2 --> sink --> persist
+    end
+
+    subgraph lane3["3. Live posture and guarded action"]
+        live["live cloud or SaaS state"]:::source
+        discover["discover-* / evaluation-*"]:::skill
+        native["native outputs"]:::output
+        remediate["remediation/*"]:::remediate
+        audit["HITL · dual audit · re-verify"]:::output
+        live --> discover --> native --> remediate --> audit
+    end
 ```
 
 **Same flow from an MCP agent:**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,7 +144,7 @@ per-layer choice, not a repo-wide mandate.
 |---|---|---|---|
 | **L1 Ingest** | OCSF 1.8 (native opt-in) | Default — SIEM interop | Raw vendor → OCSF is what OCSF was built for. Every ingester offers `--output-format ocsf` by default |
 | **L3 Detect** | OCSF Detection Finding 2004 (native opt-in) | Default — SIEM interop | Findings flow to SIEM / SOAR / ticketing. OCSF spares every downstream from writing a custom parser. MITRE ATT&CK lives under `finding_info.attacks[]` |
-| **L4 Evaluate / CSPM** | native today; OCSF Compliance Finding 2003 planned opt-in (#29) | Optional | Ops dashboards prefer native; SIEM pipelines opt into OCSF. The migration ships as **dual output**, not a forced replacement |
+| **L4 Evaluate / CSPM** | native by default; OCSF Compliance Finding 2003 opt-in | Optional | Ops dashboards prefer native; SIEM pipelines can opt into OCSF. Evaluation ships as **dual output**, not a forced replacement |
 | **L2 Discover** | native / CycloneDX ML-BOM / bridge | **Not a good fit** | Inventory graphs, AI BOM, evidence snapshots are state, not events. OCSF Inventory Info 5001 is too thin to be worth forcing |
 | **L5 Remediate** | native | **Not a good fit** | Remediation is a state change with an operator-owned audit record, not a finding. `iam-departures-aws` and `remediate-okta-session-kill` both emit native |
 | **L6 View** | OCSF input required, SARIF / Mermaid output | Consumer of OCSF | The whole point of these converters is rendering OCSF for humans |
@@ -192,11 +192,11 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 9 shipped detectors across cloud, identity, Kubernetes, and MCP drift |
-| L4 evaluate | shipping | 8 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths |
-| L5 remediate | shipping | IAM departures is the current flagship write path |
+| L3 detect | shipping | 10 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
+| L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |
-| L7 sinks | shipping | `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`, and `sink-s3-jsonl` ship today under `skills/remediation/` |
+| L7 sinks | shipping | `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`, and `sink-s3-jsonl` ship today under `skills/output/` |
 | L8 query packs | partial shipping | `packs/lateral-movement/` and `packs/privilege-escalation-k8s/` are shipped; broader pack coverage remains future work |
 | L9 agent/runtime surfaces | shipping | `mcp-server`, CLI, CI, and runners call the same skill contract |
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="340" viewBox="0 0 1400 340" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="420" viewBox="0 0 1400 420" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Compact hero banner for the cloud-ai-security-skills repository. Wordmark plus one-line tagline, five metric pills (46 skills, OCSF 1.8, 82 CIS and Kubernetes checks, MITRE ATT&amp;CK, MCP audited), and one horizontal strip of real Simple Icons brand marks for AWS, Google Cloud, Microsoft Azure, Kubernetes, Okta, Microsoft (as Entra stand-in), Google (as Workspace stand-in), Snowflake, Databricks, and ClickHouse, plus a text pill for MCP.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 46 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 10 detect, 7 evaluate, 2 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -32,63 +32,116 @@
     <symbol id="clickhouse" viewBox="0 0 24 24"><path fill="#fbbf24" d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z"/></symbol>
   </defs>
 
-  <rect width="1400" height="340" fill="url(#bg)"/>
-  <rect width="1400" height="340" fill="url(#grid)"/>
-  <rect width="1400" height="340" fill="url(#glow)"/>
+  <rect width="1400" height="420" fill="url(#bg)"/>
+  <rect width="1400" height="420" fill="url(#grid)"/>
+  <rect width="1400" height="420" fill="url(#glow)"/>
 
   <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
     <!-- Eyebrow -->
-    <g transform="translate(72,44)">
-      <rect x="0" y="0" width="172" height="28" rx="14" fill="#0b1628" stroke="#334155"/>
+    <g transform="translate(72,40)">
+      <rect x="0" y="0" width="206" height="28" rx="14" fill="#0b1628" stroke="#334155"/>
       <circle cx="18" cy="14" r="3.5" fill="#22d3ee"/>
-      <text x="32" y="19" fill="#c7d2fe" font-size="11" font-weight="800" letter-spacing="1.6">OSS · APACHE 2.0</text>
+      <text x="32" y="19" fill="#c7d2fe" font-size="11" font-weight="800" letter-spacing="1.6">OSS · APACHE 2.0 · OCSF 1.8</text>
     </g>
 
-    <!-- Wordmark (fits within 1400) -->
-    <text x="72" y="138" font-size="62" font-weight="900" fill="url(#wordmark)" letter-spacing="-1.2">cloud-ai-security-skills</text>
+    <!-- Main panels -->
+    <rect x="56" y="84" width="772" height="248" rx="22" fill="#0b1628" stroke="#22314d"/>
+    <rect x="856" y="84" width="488" height="248" rx="22" fill="#0b1628" stroke="#22314d"/>
 
-    <!-- Tagline -->
-    <text x="74" y="172" fill="#e5eefb" font-size="18" font-weight="600">Production-grade security skills for cloud and AI systems — one skill bundle, any surface.</text>
+    <!-- Left panel -->
+    <text x="88" y="142" font-size="58" font-weight="900" fill="url(#wordmark)" letter-spacing="-1.2">cloud-ai-security-skills</text>
+    <text x="90" y="176" fill="#e5eefb" font-size="18" font-weight="600">Production-grade security skills for cloud and AI systems.</text>
+    <text x="90" y="202" fill="#94a3b8" font-size="16">Same skill bundle contract across CLI, CI, MCP, and persistent runners.</text>
+    <text x="90" y="228" fill="#94a3b8" font-size="16">OCSF where interop matters. Native where state, evidence, and audit matter more.</text>
 
-    <!-- Metric pills, single row -->
-    <g transform="translate(72,200)">
+    <g transform="translate(88,252)">
       <g>
-        <rect x="0" y="0" width="102" height="32" rx="10" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="14" y="21" fill="#93c5fd" font-size="15" font-weight="800">46</text>
-        <text x="38" y="21" fill="#dbe4f0" font-size="12" font-weight="700">skills</text>
+        <rect x="0" y="0" width="162" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">46</text>
+        <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
-      <g transform="translate(114,0)">
-        <rect x="0" y="0" width="116" height="32" rx="10" fill="#0f2235" stroke="#22d3ee"/>
-        <text x="14" y="21" fill="#67e8f9" font-size="14" font-weight="800">OCSF 1.8</text>
+      <g transform="translate(174,0)">
+        <rect x="0" y="0" width="134" height="36" rx="12" fill="#0f2235" stroke="#22d3ee"/>
+        <text x="16" y="23" fill="#67e8f9" font-size="14" font-weight="900">OCSF 1.8</text>
       </g>
-      <g transform="translate(240,0)">
-        <rect x="0" y="0" width="160" height="32" rx="10" fill="#0f2a28" stroke="#2dd4bf"/>
-        <text x="14" y="21" fill="#5eead4" font-size="15" font-weight="800">82</text>
-        <text x="38" y="21" fill="#dbe4f0" font-size="12" font-weight="700">CIS / K8s checks</text>
+      <g transform="translate(320,0)">
+        <rect x="0" y="0" width="186" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
+        <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">82</text>
+        <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">benchmark checks</text>
       </g>
-      <g transform="translate(410,0)">
-        <rect x="0" y="0" width="182" height="32" rx="10" fill="#2a0b1e" stroke="#ef4444"/>
-        <text x="14" y="21" fill="#fca5a5" font-size="13" font-weight="800">MITRE</text>
-        <text x="68" y="21" fill="#dbe4f0" font-size="12" font-weight="700">ATT&amp;CK tagged</text>
+    </g>
+    <g transform="translate(88,298)">
+      <g>
+        <rect x="0" y="0" width="204" height="36" rx="12" fill="#2a0b1e" stroke="#ef4444"/>
+        <text x="16" y="23" fill="#fca5a5" font-size="13" font-weight="900">MITRE ATT&amp;CK</text>
+        <text x="126" y="23" fill="#dbe4f0" font-size="13" font-weight="700">tagged</text>
       </g>
-      <g transform="translate(602,0)">
-        <rect x="0" y="0" width="188" height="32" rx="10" fill="#1f142e" stroke="#a78bfa"/>
-        <text x="14" y="21" fill="#c4b5fd" font-size="13" font-weight="800">MCP</text>
-        <text x="60" y="21" fill="#dbe4f0" font-size="12" font-weight="700">audited tool calls</text>
+      <g transform="translate(216,0)">
+        <rect x="0" y="0" width="212" height="36" rx="12" fill="#1f142e" stroke="#a78bfa"/>
+        <text x="16" y="23" fill="#c4b5fd" font-size="13" font-weight="900">MCP</text>
+        <text x="56" y="23" fill="#dbe4f0" font-size="13" font-weight="700">audited tool calls</text>
       </g>
-      <g transform="translate(800,0)">
-        <rect x="0" y="0" width="144" height="32" rx="10" fill="#2a1708" stroke="#f59e0b"/>
-        <text x="14" y="21" fill="#fbbf24" font-size="13" font-weight="800">HITL</text>
-        <text x="62" y="21" fill="#dbe4f0" font-size="12" font-weight="700">dual audit</text>
+      <g transform="translate(440,0)">
+        <rect x="0" y="0" width="180" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
+        <text x="16" y="23" fill="#fbbf24" font-size="13" font-weight="900">HITL</text>
+        <text x="54" y="23" fill="#dbe4f0" font-size="13" font-weight="700">dual-audited writes</text>
       </g>
     </g>
 
-    <!-- Divider -->
-    <line x1="72" y1="258" x2="1328" y2="258" stroke="#1e293b" stroke-width="1"/>
+    <!-- Right panel: shipped layer map -->
+    <text x="888" y="120" fill="#93c5fd" font-size="12" font-weight="800" letter-spacing="1.6">CURRENT SHIPPED SURFACE</text>
+    <text x="888" y="146" fill="#f8fafc" font-size="28" font-weight="900">Six core layers plus edges</text>
+    <text x="888" y="168" fill="#94a3b8" font-size="14">Counts below match the current repo and README routing surface.</text>
+
+    <g transform="translate(888,190)">
+      <g>
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
+        <text x="14" y="23" fill="#dbeafe" font-size="13" font-weight="800">L1 Ingest</text>
+        <text x="182" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">15</text>
+      </g>
+      <g transform="translate(222,0)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
+        <text x="14" y="23" fill="#dbeafe" font-size="13" font-weight="800">L2 Discover</text>
+        <text x="182" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">4</text>
+      </g>
+      <g transform="translate(0,48)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
+        <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">10</text>
+      </g>
+      <g transform="translate(222,48)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
+        <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L4 Evaluate</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">7</text>
+      </g>
+      <g transform="translate(0,96)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
+        <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L5 Remediate</text>
+        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">2</text>
+      </g>
+      <g transform="translate(222,96)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
+        <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L6 View</text>
+        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">2</text>
+      </g>
+      <g transform="translate(0,144)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#12112e" stroke="#a78bfa"/>
+        <text x="14" y="23" fill="#ede9fe" font-size="13" font-weight="800">L7 Output</text>
+        <text x="182" y="23" text-anchor="end" fill="#c4b5fd" font-size="13" font-weight="900">3</text>
+      </g>
+      <g transform="translate(222,144)">
+        <rect x="0" y="0" width="210" height="36" rx="12" fill="#12112e" stroke="#a78bfa"/>
+        <text x="14" y="23" fill="#ede9fe" font-size="13" font-weight="800">L0 Source adapters</text>
+        <text x="182" y="23" text-anchor="end" fill="#c4b5fd" font-size="13" font-weight="900">3</text>
+      </g>
+    </g>
+
+    <!-- Footer divider -->
+    <line x1="56" y1="350" x2="1344" y2="350" stroke="#1e293b" stroke-width="1"/>
 
     <!-- Left: vendor strip -->
-    <text x="72" y="280" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">RUNS AGAINST</text>
-    <g transform="translate(72,290)">
+    <text x="72" y="372" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">RUNS AGAINST</text>
+    <g transform="translate(72,382)">
       <g><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#aws" x="8" y="8" width="20" height="20"/></g>
       <g transform="translate(44,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#gcp" x="8" y="8" width="20" height="20"/></g>
       <g transform="translate(88,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#azure" x="8" y="8" width="20" height="20"/></g>
@@ -106,8 +159,8 @@
     </g>
 
     <!-- Right: access surfaces -->
-    <text x="1328" y="280" text-anchor="end" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">ACCESS SURFACES</text>
-    <g transform="translate(1012,290)" font-size="12" font-weight="700" fill="#cbd5e1">
+    <text x="1328" y="372" text-anchor="end" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">ACCESS SURFACES</text>
+    <g transform="translate(1012,382)" font-size="12" font-weight="700" fill="#cbd5e1">
       <rect x="0" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>
       <text x="36" y="22" text-anchor="middle">CLI</text>
       <rect x="80" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="340" viewBox="0 0 1400 340" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Compact hero banner for the cloud-ai-security-skills repository. Wordmark plus one-line tagline, five metric pills (44 skills, OCSF 1.8, 82 CIS and Kubernetes checks, MITRE ATT&amp;CK, MCP audited), and one horizontal strip of real Simple Icons brand marks for AWS, Google Cloud, Microsoft Azure, Kubernetes, Okta, Microsoft (as Entra stand-in), Google (as Workspace stand-in), Snowflake, Databricks, and ClickHouse, plus a text pill for MCP.</desc>
+  <desc id="desc">Compact hero banner for the cloud-ai-security-skills repository. Wordmark plus one-line tagline, five metric pills (46 skills, OCSF 1.8, 82 CIS and Kubernetes checks, MITRE ATT&amp;CK, MCP audited), and one horizontal strip of real Simple Icons brand marks for AWS, Google Cloud, Microsoft Azure, Kubernetes, Okta, Microsoft (as Entra stand-in), Google (as Workspace stand-in), Snowflake, Databricks, and ClickHouse, plus a text pill for MCP.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -54,7 +54,7 @@
     <g transform="translate(72,200)">
       <g>
         <rect x="0" y="0" width="102" height="32" rx="10" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="14" y="21" fill="#93c5fd" font-size="15" font-weight="800">44</text>
+        <text x="14" y="21" fill="#93c5fd" font-size="15" font-weight="800">46</text>
         <text x="38" y="21" fill="#dbe4f0" font-size="12" font-weight="700">skills</text>
       </g>
       <g transform="translate(114,0)">

--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -209,11 +209,16 @@
       <text x="16" y="214" fill="#94a3b8" font-size="12">next run verifies closure</text>
     </g>
 
-    <!-- Drift-check dashed return path (bottom of diagram, audit → plan) -->
-    <path d="M1256,472 C 1256,540 600,540 216,540 L 216,540 L 216,470" fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowDashed)"/>
-    <g transform="translate(620,524)">
-      <rect x="0" y="0" width="160" height="22" rx="11" fill="#2a0b1e" stroke="#f472b6"/>
-      <text x="80" y="16" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">drift check loop</text>
+    <!-- Drift verification rail -->
+    <g transform="translate(220,520)">
+      <rect x="0" y="0" width="220" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
+      <text x="110" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">audit export</text>
+      <rect x="292" y="0" width="260" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
+      <text x="422" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">next reconciler run</text>
+      <rect x="624" y="0" width="260" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
+      <text x="754" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">closed or flagged drift</text>
+      <path d="M220,15 L290,15" fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowDashed)"/>
+      <path d="M552,15 L622,15" fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowDashed)"/>
     </g>
 
     <!-- Footer honesty note -->

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,7 +7,7 @@ Skills are grouped by **layered function**, not by vendor. Start with the proble
 | [`ingestion/`](ingestion/) | "How do I normalize this raw source into a stable event stream?" | **OCSF 1.8** (native opt-in via `--output-format native`) |
 | [`discovery/`](discovery/) | "What does this cloud / AI estate look like right now?" | **native / CycloneDX / bridge** (OCSF Inventory Info 5001 is too thin to force) |
 | [`detection/`](detection/) | "What attack pattern does this event stream show?" | **OCSF Detection Finding 2004** (native opt-in) |
-| [`evaluation/`](evaluation/) | "Does this posture or event stream meet a benchmark?" | **native** today; OCSF Compliance Finding 2003 planned opt-in ([#29](https://github.com/msaad00/cloud-ai-security-skills/issues/29)) |
+| [`evaluation/`](evaluation/) | "Does this posture or event stream meet a benchmark?" | **native** by default; OCSF Compliance Finding 2003 opt-in |
 | [`view/`](view/) | "How should I render or export this OCSF output?" | **SARIF / Mermaid** — consumer of OCSF |
 | [`remediation/`](remediation/) | "Something is wrong. How do I fix it safely?" | **native** (state change + audit record, not a finding) |
 | [`output/`](output/) | "Where do these findings / evidence / audit rows persist?" | **pass-through** |


### PR DESCRIPTION
Closes the current repo-truth drift on main and tightens the top README visual surface.

What changed
- aligns shipped counts and layer framing with the current repo state
- updates evaluation framing to reflect shipped opt-in OCSF 2003 output
- fixes the broken sink routing link in the README
- moves MCP / skill-name usage ahead of raw Python examples
- replaces the ASCII common-flows block with a Mermaid lane diagram
- rebuilds the hero banner around current shipped counts and surfaces
- simplifies the IAM departures feedback loop into a clean drift-verification rail

Validation
- python scripts/validate_skill_contract.py
- xmllint --noout docs/images/hero-banner.svg docs/images/iam-departures-aws.svg
- git diff --check