### PR TITLE
fix(scripts): clean error messages when Python <3.11 or dev deps missing

### DIFF
--- a/scripts/validate_dependency_consistency.py
+++ b/scripts/validate_dependency_consistency.py
@@ -2,8 +2,18 @@ from __future__ import annotations
 
 import ast
 import sys
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised only on Python <3.11
+    sys.stderr.write(
+        "error: validate_dependency_consistency.py requires Python 3.11+ "
+        "(stdlib `tomllib`). Detected Python "
+        f"{sys.version_info.major}.{sys.version_info.minor}. "
+        "See pyproject.toml `requires-python = \">=3.11\"`.\n"
+    )
+    sys.exit(2)
 
 from skill_validation_common import ROOT
 

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -4,7 +4,15 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from defusedxml import ElementTree as ET
+try:
+    from defusedxml import ElementTree as ET
+except ModuleNotFoundError:  # pragma: no cover - exercised when dev deps not installed
+    sys.stderr.write(
+        "error: validate_test_coverage.py requires `defusedxml` "
+        "(listed in pyproject.toml `[dependency-groups].dev`). "
+        "Install dev dependencies: `uv sync --group dev` or `pip install defusedxml`.\n"
+    )
+    sys.exit(2)
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_XML = ROOT / "coverage.xml"


### PR DESCRIPTION
## Summary

Two validator scripts fail with an opaque \`ModuleNotFoundError\` when run outside the supported environment (3.11 + dev deps installed). Flagged by external audit. CI is green because it runs 3.11 with dev deps, but contributors on macOS system Python (3.9) or without dev deps see a stack trace with no actionable hint.

## Changes

- \`validate_dependency_consistency.py\` — wrap \`import tomllib\` in a try/except that prints a 3.11-required error + exit 2
- \`validate_test_coverage.py\` — wrap \`from defusedxml import ElementTree\` in a try/except that points to \`uv sync --group dev\` + exit 2

## Verification

```
$ /usr/bin/python3 scripts/validate_dependency_consistency.py  # Python 3.9
error: validate_dependency_consistency.py requires Python 3.11+ (stdlib tomllib). …
exit=2

$ /usr/bin/python3 scripts/validate_test_coverage.py  # defusedxml missing
error: validate_test_coverage.py requires defusedxml (listed in pyproject.toml …)
exit=2
```

No behavior change on Python 3.11 + dev deps (CI path). Skipped unit test — mocking \`ImportError\` wouldn't exercise the real path, and manual verification on system 3.9 is decisive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)