### PR TITLE
feat(remediation): code-visible protected-principal guard + IaC parity validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - run: python scripts/validate_framework_coverage.py
       - run: python scripts/validate_ocsf_metadata.py
       - run: python scripts/validate_skill_count_consistency.py
+      - run: python scripts/validate_deny_list_parity.py
       - run: python scripts/generate_framework_coverage_doc.py --check
 
   type-check:

--- a/scripts/validate_deny_list_parity.py
+++ b/scripts/validate_deny_list_parity.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Assert the IaC deny list and the Python code-side deny list agree.
+
+The load-bearing guard for `iam-departures-aws` is an IAM `Deny` statement in
+`infra/iam_policies/cross_account_remediation_role.json` that refuses
+`iam:*` against `root`, `break-glass-*`, `emergency-*`, and `role/*`.
+
+A defense-in-depth Python mirror lives at
+`skills/remediation/iam-departures-aws/src/lambda_worker/protected_principals.py`
+so the worker refuses locally even if the IaC policy is ever missing.
+
+If the two lists drift, CI should fail. This script parses both and asserts
+that every ARN pattern in the `DenyProtectedUsers` IaC statement is covered
+by the Python list (and vice versa).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+IAC_POLICY = (
+    REPO_ROOT
+    / "skills"
+    / "remediation"
+    / "iam-departures-aws"
+    / "infra"
+    / "iam_policies"
+    / "cross_account_remediation_role.json"
+)
+PYTHON_MIRROR = (
+    REPO_ROOT
+    / "skills"
+    / "remediation"
+    / "iam-departures-aws"
+    / "src"
+    / "lambda_worker"
+    / "protected_principals.py"
+)
+
+# ARN template suffix patterns we treat as "user-scoped" deny entries. The
+# IaC uses `${TARGET_ACCOUNT_ID}` as a CloudFormation placeholder.
+_USER_ARN_RE = re.compile(
+    r"^arn:aws:iam::\${TARGET_ACCOUNT_ID}:user/(?P<pattern>.+)$"
+)
+_ROLE_ARN_RE = re.compile(
+    r"^arn:aws:iam::\${TARGET_ACCOUNT_ID}:role/(?P<pattern>.+)$"
+)
+
+
+def _iac_user_patterns() -> set[str]:
+    data = json.loads(IAC_POLICY.read_text(encoding="utf-8"))
+    for stmt in data.get("PermissionPolicy", {}).get("Statement", []):
+        if stmt.get("Sid") != "DenyProtectedUsers":
+            continue
+        resources = stmt.get("Resource", [])
+        if isinstance(resources, str):
+            resources = [resources]
+        users: set[str] = set()
+        for resource in resources:
+            m = _USER_ARN_RE.match(resource)
+            if m:
+                users.add(m.group("pattern"))
+        return users
+    return set()
+
+
+def _iac_role_patterns() -> set[str]:
+    data = json.loads(IAC_POLICY.read_text(encoding="utf-8"))
+    for stmt in data.get("PermissionPolicy", {}).get("Statement", []):
+        if stmt.get("Sid") != "DenyProtectedUsers":
+            continue
+        resources = stmt.get("Resource", [])
+        if isinstance(resources, str):
+            resources = [resources]
+        roles: set[str] = set()
+        for resource in resources:
+            m = _ROLE_ARN_RE.match(resource)
+            if m:
+                roles.add(m.group("pattern"))
+        return roles
+    return set()
+
+
+def _python_tuple(source: str, var_name: str) -> set[str]:
+    """Extract a tuple-of-str literal assignment by name from Python source."""
+    # Match: `PROTECTED_USER_PATTERNS: tuple[str, ...] = (...)`.
+    pattern = re.compile(
+        rf"{re.escape(var_name)}\s*:\s*tuple\[str,\s*\.\.\.\]\s*=\s*\((?P<body>[^)]*)\)",
+        re.DOTALL,
+    )
+    match = pattern.search(source)
+    if not match:
+        return set()
+    body = match.group("body")
+    return {m.group(1) for m in re.finditer(r'"([^"]+)"', body)}
+
+
+def main() -> int:
+    if not IAC_POLICY.exists():
+        print(f"error: IaC policy not found: {IAC_POLICY}", file=sys.stderr)
+        return 2
+    if not PYTHON_MIRROR.exists():
+        print(f"error: Python mirror not found: {PYTHON_MIRROR}", file=sys.stderr)
+        return 2
+
+    iac_users = _iac_user_patterns()
+    iac_roles = _iac_role_patterns()
+
+    py_source = PYTHON_MIRROR.read_text(encoding="utf-8")
+    py_users = _python_tuple(py_source, "PROTECTED_USER_PATTERNS")
+    py_roles = _python_tuple(py_source, "PROTECTED_ROLE_PATTERNS")
+
+    errors: list[str] = []
+
+    users_only_in_iac = iac_users - py_users
+    users_only_in_py = py_users - iac_users
+    if users_only_in_iac:
+        errors.append(
+            f"IaC denies user patterns {sorted(users_only_in_iac)} but they are "
+            f"missing from `PROTECTED_USER_PATTERNS` in {PYTHON_MIRROR.relative_to(REPO_ROOT)}"
+        )
+    if users_only_in_py:
+        errors.append(
+            f"Python `PROTECTED_USER_PATTERNS` lists {sorted(users_only_in_py)} but "
+            f"they are missing from the IaC `DenyProtectedUsers` statement in "
+            f"{IAC_POLICY.relative_to(REPO_ROOT)}"
+        )
+
+    roles_only_in_iac = iac_roles - py_roles
+    roles_only_in_py = py_roles - iac_roles
+    if roles_only_in_iac:
+        errors.append(
+            f"IaC denies role patterns {sorted(roles_only_in_iac)} but they are "
+            f"missing from `PROTECTED_ROLE_PATTERNS` in {PYTHON_MIRROR.relative_to(REPO_ROOT)}"
+        )
+    if roles_only_in_py:
+        errors.append(
+            f"Python `PROTECTED_ROLE_PATTERNS` lists {sorted(roles_only_in_py)} but "
+            f"they are missing from the IaC `DenyProtectedUsers` statement in "
+            f"{IAC_POLICY.relative_to(REPO_ROOT)}"
+        )
+
+    if errors:
+        print("Deny-list parity check FAILED:\n", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "\nFix: update whichever file is behind. Both locations must list "
+            "the same patterns.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Deny-list parity check passed "
+        f"(users={sorted(iac_users)}, roles={sorted(iac_roles)})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/iam-departures-aws/src/lambda_worker/handler.py
+++ b/skills/remediation/iam-departures-aws/src/lambda_worker/handler.py
@@ -50,6 +50,8 @@ from typing import Any
 
 import boto3
 
+from .protected_principals import ProtectedPrincipalError, assert_not_protected
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -96,6 +98,24 @@ def handler(event: dict, context: Any) -> dict:
         email = _require_non_empty_str(entry, "email")
         if not ACCOUNT_ID_RE.fullmatch(account_id):
             raise ValueError("recipient_account_id must be a 12-digit AWS account ID")
+        # Defense-in-depth: refuse protected principals before any IAM call.
+        # The IaC deny policy is the authoritative guard; this is a local
+        # second layer in case that policy is ever missing from a deploy.
+        assert_not_protected(iam_username)
+    except ProtectedPrincipalError as exc:
+        logger.error("Refusing protected principal: %s", exc)
+        audit_record = _build_audit_record(
+            entry, [], "refused", error=str(exc), context=context
+        )
+        _write_audit(audit_record)
+        return {
+            "email": entry.get("email", ""),
+            "iam_username": entry.get("iam_username", ""),
+            "account_id": entry.get("recipient_account_id", ""),
+            "status": "refused",
+            "actions_taken": [],
+            "error": str(exc),
+        }
     except ValueError as exc:
         logger.warning("Invalid remediation payload: %s", exc)
         audit_record = _build_audit_record(entry, [], "error", error="Invalid remediation payload", context=context)

--- a/skills/remediation/iam-departures-aws/src/lambda_worker/protected_principals.py
+++ b/skills/remediation/iam-departures-aws/src/lambda_worker/protected_principals.py
@@ -1,0 +1,73 @@
+"""Protected IAM principals — defense-in-depth deny list, mirrored from IaC.
+
+The authoritative deny list is the `DenyProtectedUsers` statement in
+`infra/iam_policies/cross_account_remediation_role.json`. That IAM policy is
+the load-bearing guard: AWS refuses `iam:*` against these ARNs at the API
+boundary, so even a compromised worker Lambda cannot delete them.
+
+This Python module is a **second-layer guard**. Before the worker calls any
+IAM API, it checks whether the target `iam_username` matches any of these
+patterns and refuses the call locally. The point is twofold:
+
+1. Defense-in-depth: if the IaC deny policy is ever missing from a deployment
+   (e.g. a region where CloudFormation StackSet has not landed yet, or a
+   hand-rolled role), the Python guard still refuses protected principals.
+2. Code visibility: operators reading `handler.py` can see the list without
+   chasing JSON policies in `infra/`.
+
+`scripts/validate_deny_list_parity.py` asserts that every pattern in the IaC
+`DenyProtectedUsers` statement has an equivalent entry here (and vice versa).
+If the lists drift, CI fails.
+
+Pattern syntax matches `fnmatch`: `*` is a wildcard, case-insensitive match.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+
+# Keep in sync with `infra/iam_policies/cross_account_remediation_role.json`
+# `DenyProtectedUsers` statement. The IaC stores fully-qualified ARNs
+# (`arn:aws:iam::...:user/<pattern>`); we store just the `<pattern>` half
+# because the handler works in terms of `iam_username`, not ARN.
+#
+# The IaC list also denies `role/*` — that's enforced at the IAM layer
+# because this worker only ever receives `iam_username` inputs, never role
+# ARNs. Still listed here to make the full protected surface visible.
+PROTECTED_USER_PATTERNS: tuple[str, ...] = (
+    "root",
+    "break-glass-*",
+    "emergency-*",
+)
+
+# Role patterns — present for documentation + parity check with IaC. The
+# handler only deletes users, so these are never reached as deletion targets.
+# The IaC `Resource` deny still covers them at the API boundary.
+PROTECTED_ROLE_PATTERNS: tuple[str, ...] = (
+    "*",
+)
+
+
+class ProtectedPrincipalError(ValueError):
+    """Raised when a remediation target matches the protected-principal deny list."""
+
+
+def is_protected_user(username: str) -> bool:
+    """True if `username` matches any protected-user pattern (case-insensitive)."""
+    lowered = username.lower()
+    return any(fnmatch.fnmatchcase(lowered, pattern.lower()) for pattern in PROTECTED_USER_PATTERNS)
+
+
+def assert_not_protected(username: str) -> None:
+    """Raise `ProtectedPrincipalError` if `username` is on the deny list.
+
+    Call this before any IAM API invocation in the worker. The IAM deny
+    policy is the load-bearing guard; this is defense-in-depth so the worker
+    refuses locally even if the deny policy is ever missing.
+    """
+    if is_protected_user(username):
+        raise ProtectedPrincipalError(
+            f"refusing to remediate protected principal `{username}` — matches one of "
+            f"{PROTECTED_USER_PATTERNS}. This list is mirrored from the IaC deny "
+            "policy in infra/iam_policies/cross_account_remediation_role.json."
+        )

--- a/skills/remediation/iam-departures-aws/tests/test_protected_principals.py
+++ b/skills/remediation/iam-departures-aws/tests/test_protected_principals.py
@@ -1,0 +1,135 @@
+"""Tests for the defense-in-depth protected-principal deny list.
+
+The IaC deny policy is the authoritative guard. These tests verify the
+Python mirror used by the worker handler as a local second layer.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from lambda_worker.handler import handler  # noqa: E402
+from lambda_worker.protected_principals import (  # noqa: E402
+    PROTECTED_USER_PATTERNS,
+    ProtectedPrincipalError,
+    assert_not_protected,
+    is_protected_user,
+)
+
+
+class TestIsProtectedUser:
+    def test_root_is_protected(self):
+        assert is_protected_user("root")
+
+    def test_root_case_insensitive(self):
+        assert is_protected_user("ROOT")
+        assert is_protected_user("Root")
+
+    def test_break_glass_wildcard(self):
+        assert is_protected_user("break-glass-1")
+        assert is_protected_user("break-glass-incident-42")
+        assert is_protected_user("break-glass-")
+
+    def test_emergency_wildcard(self):
+        assert is_protected_user("emergency-ops")
+        assert is_protected_user("emergency-sre-oncall")
+
+    def test_regular_user_not_protected(self):
+        assert not is_protected_user("alice")
+        assert not is_protected_user("jane.doe@co.com")
+
+    def test_partial_match_not_protected(self):
+        # `fnmatchcase` anchors the whole string, so substring matches don't trigger.
+        assert not is_protected_user("alice-break-glass-1")
+        assert not is_protected_user("emergencyops")  # no dash → no match
+        assert not is_protected_user("notroot")
+
+    def test_every_pattern_triggers(self):
+        # Ensure every pattern in the list actually triggers at least one match
+        # — catches a malformed pattern (e.g. typo) that would never fire.
+        for pattern in PROTECTED_USER_PATTERNS:
+            sample = pattern.replace("*", "x")
+            assert is_protected_user(sample), f"pattern `{pattern}` failed to match `{sample}`"
+
+
+class TestAssertNotProtected:
+    def test_passes_for_regular_user(self):
+        assert_not_protected("alice")  # no raise
+
+    def test_raises_for_root(self):
+        with pytest.raises(ProtectedPrincipalError) as excinfo:
+            assert_not_protected("root")
+        assert "protected principal" in str(excinfo.value)
+        # Error must reference the IaC file so operators know where to look.
+        assert "cross_account_remediation_role.json" in str(excinfo.value)
+
+    def test_raises_for_break_glass(self):
+        with pytest.raises(ProtectedPrincipalError):
+            assert_not_protected("break-glass-1")
+
+    def test_raises_for_emergency(self):
+        with pytest.raises(ProtectedPrincipalError):
+            assert_not_protected("emergency-ops")
+
+
+class TestHandlerRefusesProtectedPrincipal:
+    """End-to-end: the worker handler must return `status=refused` without
+    ever touching the IAM client when the target is protected."""
+
+    def _event(self, iam_username: str) -> dict:
+        return {
+            "entry": {
+                "email": f"{iam_username}@co.com",
+                "recipient_account_id": "123456789012",
+                "iam_username": iam_username,
+                "terminated_at": "2026-02-15T00:00:00+00:00",
+                "termination_source": "snowflake",
+                "is_rehire": False,
+            },
+            "source_bucket": "test-bucket",
+        }
+
+    @pytest.mark.parametrize("username", ["root", "break-glass-1", "emergency-ops"])
+    def test_handler_refuses_and_never_calls_iam(self, username: str):
+        with (
+            patch("lambda_worker.handler._get_iam_client") as mock_iam,
+            patch("lambda_worker.handler._write_audit") as mock_audit,
+            patch("lambda_worker.handler._load_checkpoint") as mock_checkpoint,
+        ):
+            mock_checkpoint.return_value = {
+                "status": "not_started",
+                "actions_taken": [],
+                "completed_steps": [],
+                "updated_at": None,
+            }
+            result = handler(self._event(username), context=None)
+            assert result["status"] == "refused"
+            assert "protected principal" in result["error"]
+            # Audit record written with refused status — forensic trail intact.
+            mock_audit.assert_called_once()
+            # Critical: IAM client was never instantiated.
+            mock_iam.assert_not_called()
+
+    def test_handler_still_processes_regular_user(self):
+        # Sanity check: regular usernames pass the protected-principal guard.
+        with (
+            patch("lambda_worker.handler._get_iam_client") as mock_iam,
+            patch("lambda_worker.handler._write_audit"),
+            patch("lambda_worker.handler._load_checkpoint") as mock_checkpoint,
+        ):
+            mock_checkpoint.return_value = {
+                "status": "remediated",  # short-circuit after guard so we don't need real IAM mocks
+                "actions_taken": [],
+                "completed_steps": [],
+                "updated_at": "2026-04-18T00:00:00Z",
+            }
+            result = handler(self._event("jane.doe"), context=None)
+            # Short-circuits to remediated status without calling IAM.
+            assert result["status"] == "remediated"
+            mock_iam.assert_not_called()


### PR DESCRIPTION
## Why

The \`iam-departures-aws\` deny list that protects \`root\`, \`break-glass-*\`, \`emergency-*\`, and \`:role/*\` lives only in \`infra/iam_policies/cross_account_remediation_role.json\`. AWS enforces it at the API boundary, which is the load-bearing guard — but the list is invisible in Python code, and a deploy that ever misses the IaC (new region, hand-rolled role, partial StackSet landing) would silently bypass it. Flagged by external audit as a P3 visibility issue.

## Fix

**Defense-in-depth Python mirror** — [\`src/lambda_worker/protected_principals.py\`](skills/remediation/iam-departures-aws/src/lambda_worker/protected_principals.py) declares the same patterns as Python tuples with a clear operator-facing docstring explaining this is the *second layer*, not the authoritative one.

**Handler guard** — [\`handler.py\`](skills/remediation/iam-departures-aws/src/lambda_worker/handler.py) calls \`assert_not_protected(iam_username)\` right after payload validation, before \`_get_iam_client()\`. Protected principals return \`status=refused\` with an audit record, and the IAM client is never instantiated.

**Parity validator** — [\`scripts/validate_deny_list_parity.py\`](scripts/validate_deny_list_parity.py) (new) parses the \`DenyProtectedUsers\` statement in the IaC JSON and asserts the Python tuples list the same patterns. Drift either way fails CI. Wired into the \`skill-contract\` CI job.

## Tests

15 new unit tests in [\`tests/test_protected_principals.py\`](skills/remediation/iam-departures-aws/tests/test_protected_principals.py):

- \`is_protected_user\` — root (case-insensitive), wildcards, regular users, substring-not-matched (fnmatchcase anchors), every pattern actually triggers
- \`assert_not_protected\` — passes regular, raises on each protected pattern, error references the IaC file
- Handler end-to-end (parametric across root / break-glass / emergency) — \`status=refused\`, audit written, \`_get_iam_client\` NEVER called

93/93 remediation tests pass. Ruff clean. Parity validator passes.

## Acceptance

- [x] Python mirror declared with docstring explaining the "IaC is authoritative; this is defense-in-depth" invariant
- [x] Handler refuses protected principals without touching AWS IAM
- [x] Audit record still written for refused attempts (forensic trail intact)
- [x] Parity validator fails CI if the two lists drift
- [x] All existing tests still pass
- [x] Error message points at the IaC file so operators know where to sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)