### PR TITLE
fix(docs): eliminate overlap in hero + IAM SVG + stack shipped-flow lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,42 +180,44 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 Three lanes. Same skill bundle contract in every lane — input, output, and control boundary are what change.
 
+Rendered as three separate diagrams so each lane gets its own full-width row — the prior single-diagram layout forced GitHub's mermaid renderer to squeeze the three lanes side-by-side into unreadable thumbnails.
+
+**Lane 1 — Raw log detection and export**
+
 ```mermaid
-flowchart TB
+flowchart LR
     classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
-    classDef lane fill:#111827,stroke:#334155,color:#e5e7eb
     classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
     classDef detect fill:#047857,stroke:#6ee7b7,color:#ecfdf5
     classDef sink fill:#6d28d9,stroke:#c4b5fd,color:#f5f3ff
+    classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
+
+    raw["raw payloads<br/>CloudTrail · K8s audit · Okta"]:::source --> ingest["ingest-*"]:::skill --> detect1["detect-*"]:::detect --> view["view/*"]:::sink --> export["SARIF · Mermaid · JSON"]:::output
+```
+
+**Lane 2 — Detection on data already in your lake**
+
+```mermaid
+flowchart LR
+    classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
+    classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
+    classDef detect fill:#047857,stroke:#6ee7b7,color:#ecfdf5
+    classDef sink fill:#6d28d9,stroke:#c4b5fd,color:#f5f3ff
+    classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
+
+    lake["warehouse rows or objects<br/>Snowflake · Databricks · S3"]:::source --> source2["source-*"]:::skill --> detect2["detect-*"]:::detect --> sink["sink-*"]:::sink --> persist["customer-owned persistence"]:::output
+```
+
+**Lane 3 — Live posture and guarded action**
+
+```mermaid
+flowchart LR
+    classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
+    classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
     classDef remediate fill:#991b1b,stroke:#fca5a5,color:#fef2f2
     classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
 
-    subgraph lane1["1. Raw log detection and export"]
-        raw["raw payloads<br/>CloudTrail · K8s audit · Okta"]:::source
-        ingest["ingest-*"]:::skill
-        detect1["detect-*"]:::detect
-        view["view/*"]:::sink
-        export["SARIF · Mermaid · JSON"]:::output
-        raw --> ingest --> detect1 --> view --> export
-    end
-
-    subgraph lane2["2. Detection on data already in your lake"]
-        lake["warehouse rows or objects<br/>Snowflake · Databricks · S3"]:::source
-        source["source-*"]:::skill
-        detect2["detect-*"]:::detect
-        sink["sink-*"]:::sink
-        persist["customer-owned persistence"]:::output
-        lake --> source --> detect2 --> sink --> persist
-    end
-
-    subgraph lane3["3. Live posture and guarded action"]
-        live["live cloud or SaaS state"]:::source
-        discover["discover-* / evaluation-*"]:::skill
-        native["native outputs"]:::output
-        remediate["remediation/*"]:::remediate
-        audit["HITL · dual audit · re-verify"]:::output
-        live --> discover --> native --> remediate --> audit
-    end
+    live["live cloud or SaaS state"]:::source --> discover["discover-* / evaluation-*"]:::skill --> native["native outputs"]:::output --> remediate["remediation/*"]:::remediate --> audit["HITL · dual audit · re-verify"]:::output
 ```
 
 **Same flow from an MCP agent:**

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="420" viewBox="0 0 1400 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
   <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 46 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 10 detect, 7 evaluate, 2 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
@@ -90,7 +90,7 @@
 
     <!-- Right panel: shipped layer map -->
     <text x="888" y="120" fill="#93c5fd" font-size="12" font-weight="800" letter-spacing="1.6">CURRENT SHIPPED SURFACE</text>
-    <text x="888" y="146" fill="#f8fafc" font-size="28" font-weight="900">Six core layers plus edges</text>
+    <text x="888" y="146" fill="#f8fafc" font-size="28" font-weight="900">Seven core layers plus edges</text>
     <text x="888" y="168" fill="#94a3b8" font-size="14">Counts below match the current repo and README routing surface.</text>
 
     <g transform="translate(888,190)">
@@ -136,12 +136,12 @@
       </g>
     </g>
 
-    <!-- Footer divider -->
-    <line x1="56" y1="350" x2="1344" y2="350" stroke="#1e293b" stroke-width="1"/>
+    <!-- Footer divider — pushed below the L7/L0 panel row (which ends at y=370) -->
+    <line x1="56" y1="408" x2="1344" y2="408" stroke="#1e293b" stroke-width="1"/>
 
     <!-- Left: vendor strip -->
-    <text x="72" y="372" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">RUNS AGAINST</text>
-    <g transform="translate(72,382)">
+    <text x="72" y="432" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">RUNS AGAINST</text>
+    <g transform="translate(72,442)">
       <g><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#aws" x="8" y="8" width="20" height="20"/></g>
       <g transform="translate(44,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#gcp" x="8" y="8" width="20" height="20"/></g>
       <g transform="translate(88,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#azure" x="8" y="8" width="20" height="20"/></g>
@@ -158,9 +158,9 @@
       </g>
     </g>
 
-    <!-- Right: access surfaces -->
-    <text x="1328" y="372" text-anchor="end" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">ACCESS SURFACES</text>
-    <g transform="translate(1012,382)" font-size="12" font-weight="700" fill="#cbd5e1">
+    <!-- Right: access surfaces — y-aligned with RUNS AGAINST at new footer position -->
+    <text x="1328" y="432" text-anchor="end" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">ACCESS SURFACES</text>
+    <g transform="translate(1012,442)" font-size="12" font-weight="700" fill="#cbd5e1">
       <rect x="0" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>
       <text x="36" y="22" text-anchor="middle">CLI</text>
       <rect x="80" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>

--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="640" viewBox="0 0 1400 640" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="700" viewBox="0 0 1400 700" role="img" aria-labelledby="title desc">
   <title id="title">IAM departures · AWS flagship write path</title>
   <desc id="desc">The AWS-only IAM departures remediation flow. Four horizontal stages: Plan reads HR sources in Snowflake or Databricks, runs the reconciler, and writes an S3 manifest containing only the actionable set. Orchestrate fires an EventBridge rule that starts a Step Function; the Step Function invokes a parser Lambda that re-checks manifest and current IAM state, then a worker Lambda that scopes writes. Write deletes AWS IAM users via cross-account role assumption inside the AWS Organization only — it never reaches into other clouds. Audit lands every action in DynamoDB and KMS-encrypted S3; a drift-check arrow runs back to the reconciler so the next run verifies closure. A footer note makes clear that per-cloud workflows for Azure Entra, GCP IAM, Databricks, and Snowflake run in their own execution environments and no single Lambda crosses cloud boundaries. Real Simple Icons (CC0) for AWS, Snowflake, Databricks, AWS Lambda, Amazon S3, and Amazon DynamoDB are used where brand marks exist; text cards are used for EventBridge, Step Functions, and IAM where Simple Icons does not yet ship a service mark.</desc>
 
@@ -42,9 +42,9 @@
   </defs>
 
   <!-- Background -->
-  <rect width="1400" height="640" fill="url(#bg)"/>
-  <rect width="1400" height="640" fill="url(#grid)"/>
-  <rect width="1400" height="640" fill="url(#glow)"/>
+  <rect width="1400" height="700" fill="url(#bg)"/>
+  <rect width="1400" height="700" fill="url(#grid)"/>
+  <rect width="1400" height="700" fill="url(#glow)"/>
 
   <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
     <!-- Title -->
@@ -105,8 +105,11 @@
     </g>
 
     <!-- Plan → Orchestrate arrow -->
+    <!-- Label sized to fit entirely within the 64px column-gutter gap (x=376 to x=440).
+         "PutObject" at font-size 11/700 is ~63px; anchored at x=408 (arrow midpoint) with
+         text-anchor middle so it never clips into the Orchestrate column content (x>=456). -->
     <path d="M376,360 L440,360" stroke="#64748b" stroke-width="2.5" fill="none" marker-end="url(#arrow)"/>
-    <text x="395" y="352" fill="#64748b" font-size="11" font-weight="700">Object Created</text>
+    <text x="408" y="352" text-anchor="middle" fill="#64748b" font-size="11" font-weight="700">PutObject</text>
 
     <!-- ============ ② ORCHESTRATE ============ -->
     <g transform="translate(456,244)">
@@ -144,8 +147,9 @@
     </g>
 
     <!-- Orchestrate → Write arrow -->
+    <!-- Label centered on arrow midpoint to stay within the 64px column-gutter gap. -->
     <path d="M716,360 L780,360" stroke="#64748b" stroke-width="2.5" fill="none" marker-end="url(#arrow)"/>
-    <text x="728" y="352" fill="#64748b" font-size="11" font-weight="700">AssumeRole</text>
+    <text x="748" y="352" text-anchor="middle" fill="#64748b" font-size="11" font-weight="700">AssumeRole</text>
 
     <!-- ============ ③ WRITE ============ -->
     <g transform="translate(796,244)">
@@ -182,8 +186,11 @@
     </g>
 
     <!-- Write → Audit arrow -->
+    <!-- Label centered on arrow midpoint; shortened to "audit" so the text is
+         bounded by the 64px column-gutter gap and never touches the DynamoDB
+         card that sits on the right side of the arrow (x>=1136). -->
     <path d="M1056,286 L1120,286" stroke="#fbbf24" stroke-width="2.5" fill="none" marker-end="url(#arrowAmber)"/>
-    <text x="1066" y="278" fill="#fbbf24" font-size="11" font-weight="700">audit write</text>
+    <text x="1088" y="278" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="700">audit</text>
 
     <!-- ============ ④ AUDIT ============ -->
     <g transform="translate(1136,244)">
@@ -209,8 +216,9 @@
       <text x="16" y="214" fill="#94a3b8" font-size="12">next run verifies closure</text>
     </g>
 
-    <!-- Drift verification rail -->
-    <g transform="translate(220,520)">
+    <!-- Drift verification rail — positioned BELOW Worker Lambda (ends y=552)
+         with a 20px clearance so the three pills never touch any column card. -->
+    <g transform="translate(220,572)">
       <rect x="0" y="0" width="220" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
       <text x="110" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">audit export</text>
       <rect x="292" y="0" width="260" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
@@ -221,8 +229,8 @@
       <path d="M552,15 L622,15" fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowDashed)"/>
     </g>
 
-    <!-- Footer honesty note -->
-    <g transform="translate(56,580)">
+    <!-- Footer honesty note — below drift rail (ends y=602) with 18px clearance. -->
+    <g transform="translate(56,620)">
       <rect x="0" y="0" width="1288" height="44" rx="10" fill="#12112e" stroke="#64748b"/>
       <text x="20" y="20" fill="#f1f5f9" font-size="12" font-weight="800" letter-spacing="0.4">One cloud per worker · no cross-cloud blast radius</text>
       <text x="20" y="36" fill="#94a3b8" font-size="12">Only the AWS stack above is shipped. GCP and Azure use equivalent native stacks: Eventarc + Cloud Workflows + Cloud Run Jobs for GCP; Event Grid + Logic Apps + Azure Functions for Azure. Per-cloud workers never cross cloud boundaries. See the README mapping table.</text>


### PR DESCRIPTION
Closes the visual-overlap issues user flagged with screenshots.

## Summary

Three distinct bugs, all "text / container / line overlap" — the style of defect ruff won't catch because it's pixel-layout, not syntax. Fixed by measuring the actual coordinate collisions and respacing.

## 1. Hero banner — L0 pill / ACCESS SURFACES clash

- Canvas: 420h → 500h
- Heading: "Six core layers plus edges" → "Seven core layers plus edges"
- Divider moved y=350 → y=408 (was crossing through the L7/L0 pill row at y=334–370)
- "RUNS AGAINST" + "ACCESS SURFACES" labels and pill rows pushed below the divider with 24px clearance

## 2. IAM departures SVG — four overlap sites

- **\`Object Created\`** label (~85px wide) extended past x=456 into the Orchestrate column → centered on arrow midpoint + shortened to \`PutObject\` (~63px), fits in 64px gutter
- **\`AssumeRole\`** → \`text-anchor="middle"\` at x=748 so it stays in the gutter
- **\`audit write\`** → shortened to \`audit\` at x=1088 so it stays bounded
- **Drift rail pills** ("audit export" / "next reconciler run" / "closed or flagged drift") at y=520–550 sat under Worker Lambda (y=498–552) → moved to y=572–602 with 20px clearance
- Canvas 640h → 700h; footer moved to y=620 with 18px clearance

## 3. README "Common shipped flows" lanes

Three lanes were one \`flowchart TB\` with three unconnected subgraphs. GitHub's mermaid renderer laid them side-by-side at ~1/3 width each — tiny and unreadable.

Split into three separate \`\`\`mermaid fences, each \`flowchart LR\`, so each lane renders full-width on its own row.

## Verification

Every fix was verified by computing the actual coordinate ranges (label start/end, card left/right/top/bottom, gutter widths) and checking no ranges intersect.

All validators green:
- \`validate_skill_count_consistency.py\` — pass
- \`validate_skill_contract.py\` — 46 skills
- \`validate_skill_integrity.py\` — pass

No behavior change. SVGs are pure layout; README mermaid is pure rendering. Kept alt text content-faithful (hero desc enumerates all 8 lane pills unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)