### PR TITLE
feat(docs): auto-generate SECURITY_BAR.md per-skill matrix (#246)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - run: python scripts/validate_skill_count_consistency.py
       - run: python scripts/validate_deny_list_parity.py
       - run: python scripts/generate_framework_coverage_doc.py --check
+      - run: python scripts/generate_security_bar_matrix.py --check
 
   type-check:
     runs-on: ubuntu-latest

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -26,24 +26,58 @@ is the row you can take to your auditor.
 
 ## Per-skill matrix
 
-| Skill | Read-only | Agentless | Least privilege | Closed loop | OCSF wire | No telemetry |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|
-| `cspm-aws-cis-benchmark` | ✅ | ✅ | ✅ `SecurityAudit` only | ✅ re-scan verifies | n/a | ✅ |
-| `cspm-gcp-cis-benchmark` | ✅ | ✅ | ✅ `viewer` + `iam.securityReviewer` | ✅ | n/a | ✅ |
-| `cspm-azure-cis-benchmark` | ✅ | ✅ | ✅ Reader role | ✅ | n/a | ✅ |
-| `k8s-security-benchmark` | ✅ | ✅ | ✅ kubectl viewer | ✅ | n/a | ✅ |
-| `container-security` | ✅ | ✅ | ✅ filesystem read only | ✅ | n/a | ✅ |
-| `iam-departures-aws` | ⚠️ writes via worker only | ✅ | ✅ deny on root/break-glass | ✅ DDB + S3 + ingest-back | n/a | ✅ |
-| `model-serving-security` | ✅ | ✅ | ✅ config-only | ✅ | n/a | ✅ |
-| `gpu-cluster-security` | ✅ | ✅ | ✅ config-only | ✅ | n/a | ✅ |
-| `discover-environment` | ✅ | ✅ | ✅ viewer | ✅ snapshot diff | n/a | ✅ |
-| `ingest-cloudtrail-ocsf` | ✅ | ✅ | ✅ `s3:GetObject` on one prefix | ✅ golden fixture | ✅ 1.8 | ✅ |
-| `ingest-gcp-audit-ocsf` | ✅ | ✅ | ✅ `roles/logging.viewer` | ✅ golden fixture | ✅ 1.8 | ✅ |
-| `ingest-azure-activity-ocsf` | ✅ | ✅ | ✅ Monitoring Reader | ✅ golden fixture | ✅ 1.8 | ✅ |
-| `ingest-k8s-audit-ocsf` | ✅ | ✅ | ✅ filesystem read of audit log | ✅ golden fixture | ✅ 1.8 | ✅ |
-| `ingest-mcp-proxy-ocsf` | ✅ | ✅ | ✅ stdin read | ✅ golden fixture | ✅ 1.8 | ✅ |
-| `detect-mcp-tool-drift` | ✅ | ✅ | ✅ stdin read | ✅ golden fixture | ✅ 1.8 | ✅ |
-| `detect-privilege-escalation-k8s` | ✅ | ✅ | ✅ stdin read | ✅ golden fixture | ✅ 1.8 | ✅ |
+<!-- AUTO-GENERATED MATRIX START — do not edit by hand; run scripts/generate_security_bar_matrix.py -->
+| Skill | Layer | Read-only | Agentless | Least privilege | Closed loop | OCSF wire | No telemetry |
+|---|---|:-:|:-:|---|---|---|:-:|
+| `ingest-azure-activity-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-azure-defender-for-cloud-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-cloudtrail-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-entra-directory-audit-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-gcp-audit-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-gcp-scc-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-google-workspace-login-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-guardduty-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-k8s-audit-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-mcp-proxy-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-nsg-flow-logs-azure-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-okta-system-log-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-security-hub-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-vpc-flow-logs-gcp-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-vpc-flow-logs-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `source-databricks-query` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `source-s3-select` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `source-snowflake-query` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `discover-ai-bom` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
+| `discover-cloud-control-evidence` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
+| `discover-control-evidence` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
+| `discover-environment` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
+| `detect-credential-stuffing-okta` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-entra-credential-addition` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-entra-role-grant-escalation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-mcp-tool-drift` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-okta-mfa-fatigue` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-privilege-escalation-k8s` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-prompt-injection-mcp-proxy` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-sensitive-secret-read-k8s` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `container-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `cspm-aws-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `cspm-azure-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `cspm-gcp-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `gpu-cluster-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `k8s-security-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `model-serving-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `iam-departures-aws` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `remediate-okta-session-kill` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `convert-ocsf-to-mermaid-attack-flow` | view | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
+| `convert-ocsf-to-sarif` | view | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
+| `sink-clickhouse-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+
+_46 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+<!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar
 

--- a/scripts/generate_security_bar_matrix.py
+++ b/scripts/generate_security_bar_matrix.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Regenerate the per-skill matrix block in docs/SECURITY_BAR.md.
+
+The matrix sits between two HTML comment markers:
+
+    <!-- AUTO-GENERATED MATRIX START -->
+    ...table content...
+    <!-- AUTO-GENERATED MATRIX END -->
+
+Everything outside the markers is preserved verbatim (the 11-principle
+preamble at the top and the "How to add a skill" section at the bottom
+are both hand-edited prose).
+
+Run in CI with `--check` to fail the build if the committed matrix has
+drifted from the current skill set.
+
+Closes #246.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from skill_validation_common import SkillContract, discover_skill_contracts  # noqa: E402
+
+OUTPUT = REPO_ROOT / "SECURITY_BAR.md"
+MARKER_START = "<!-- AUTO-GENERATED MATRIX START — do not edit by hand; run scripts/generate_security_bar_matrix.py -->"
+MARKER_END = "<!-- AUTO-GENERATED MATRIX END -->"
+
+# Categories where OCSF is the wire contract today (ingest + detect).
+# Everything else emits native / bridge / pass-through — `n/a` in the matrix.
+_OCSF_CATEGORIES = frozenset({"ingestion", "detection"})
+
+
+def _read_only_cell(skill: SkillContract) -> str:
+    if not skill.is_write_capable:
+        return "✅"
+    if skill.category == "remediation":
+        return "⚠️ write via HITL"
+    if skill.category == "output":
+        return "⚠️ append-only sink"
+    return "⚠️ write-capable"
+
+
+def _least_privilege_cell(skill: SkillContract) -> str:
+    # Proxy: a skill's REFERENCES.md is where the minimum IAM/RBAC is pinned.
+    # validate_safe_skill_bar.py already fails CI on wildcards without
+    # WILDCARD_OK justification, so presence of REFERENCES.md + passing
+    # the safe-skill-bar gate is a reliable "least privilege documented" signal.
+    return "✅" if skill.references_path.exists() else "⚠️ REFERENCES.md missing"
+
+
+def _closed_loop_cell(skill: SkillContract) -> str:
+    # Closed-loop evidence per layer:
+    #   - ingestion / detection: frozen golden fixture under detection-engineering/golden/
+    #   - remediation: dual-audit + re-verify enforced by the safe-skill-bar gate
+    #   - evaluation: deterministic checks re-runnable against same input
+    #   - discovery / view / output: deterministic transforms or append-only
+    if skill.category in {"remediation", "output"}:
+        return "✅ audit + re-verify"
+    if skill.category in {"ingestion", "detection"}:
+        return "✅ golden fixture"
+    return "✅ deterministic"
+
+
+def _ocsf_cell(skill: SkillContract) -> str:
+    if skill.category in _OCSF_CATEGORIES:
+        return "✅ 1.8"
+    # Evaluation opt-in (2003); Discovery/View/Remediation/Output are native.
+    if skill.category == "evaluation":
+        return "✅ 1.8 opt-in"
+    return "n/a"
+
+
+def _telemetry_cell(skill: SkillContract) -> str:
+    # Repo invariant: no skill phones home. `validate_safe_skill_bar.py`
+    # greps for undeclared HTTP libs; `bandit` + hardcoded-secret grep run
+    # in CI. If a future skill declares `network_egress: telemetry`, that
+    # becomes visible here automatically.
+    egress = skill.network_egress
+    if any("telemetry" in mode.lower() for mode in egress):
+        return "⚠️ declared"
+    return "✅"
+
+
+def _agentless_cell(_: SkillContract) -> str:
+    # Repo-wide invariant enforced by scripts/validate_skill_integrity.py:
+    # every skill is a short-lived subprocess; no daemons/sidecars/DaemonSets.
+    return "✅"
+
+
+def _render_matrix(skills: list[SkillContract]) -> str:
+    """Return the markdown table body, excluding the MARKER lines themselves."""
+    lines: list[str] = []
+    lines.append(
+        "| Skill | Layer | Read-only | Agentless | Least privilege | Closed loop | OCSF wire | No telemetry |"
+    )
+    lines.append("|---|---|:-:|:-:|---|---|---|:-:|")
+
+    def _sort_key(skill: SkillContract) -> tuple[str, str]:
+        # Group by layer, then alphabetical within layer.
+        layer_order = {
+            "ingestion": "1",
+            "discovery": "2",
+            "detection": "3",
+            "evaluation": "4",
+            "remediation": "5",
+            "view": "6",
+            "output": "7",
+            "detection-engineering": "9",
+        }
+        return (layer_order.get(skill.category, "8"), skill.name)
+
+    for skill in sorted(skills, key=_sort_key):
+        row = [
+            f"`{skill.name}`",
+            skill.category,
+            _read_only_cell(skill),
+            _agentless_cell(skill),
+            _least_privilege_cell(skill),
+            _closed_loop_cell(skill),
+            _ocsf_cell(skill),
+            _telemetry_cell(skill),
+        ]
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines.append("")
+    lines.append(
+        f"_{len(skills)} skills · generated from SKILL.md frontmatter + layer conventions. "
+        "Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; "
+        "CI enforces parity via `--check`._"
+    )
+    return "\n".join(lines)
+
+
+def _splice_into_doc(doc: str, matrix_body: str) -> str:
+    """Replace the region between MARKER_START and MARKER_END."""
+    block = f"{MARKER_START}\n{matrix_body}\n{MARKER_END}"
+    if MARKER_START not in doc or MARKER_END not in doc:
+        raise RuntimeError(
+            f"{OUTPUT.relative_to(REPO_ROOT)} is missing the AUTO-GENERATED markers. "
+            "Add them around the per-skill matrix:\n"
+            f"    {MARKER_START}\n"
+            "    ...\n"
+            f"    {MARKER_END}"
+        )
+    prefix, rest = doc.split(MARKER_START, 1)
+    _, suffix = rest.split(MARKER_END, 1)
+    return f"{prefix}{block}{suffix}"
+
+
+def main() -> int:
+    skills = discover_skill_contracts()
+    doc = OUTPUT.read_text(encoding="utf-8")
+    matrix_body = _render_matrix(skills)
+    generated = _splice_into_doc(doc, matrix_body)
+
+    if len(sys.argv) >= 2 and sys.argv[1] == "--check":
+        if doc != generated:
+            print(
+                f"ERROR: {OUTPUT.relative_to(REPO_ROOT)} per-skill matrix is out of "
+                "sync with the current skill frontmatter. Run:\n"
+                "  python scripts/generate_security_bar_matrix.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"SECURITY_BAR.md matrix in sync ({len(skills)} skills).")
+        return 0
+
+    OUTPUT.write_text(generated, encoding="utf-8")
+    print(f"wrote {OUTPUT.relative_to(REPO_ROOT)} matrix ({len(skills)} skills).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_generate_security_bar_matrix.py
+++ b/tests/integration/test_generate_security_bar_matrix.py
@@ -1,0 +1,124 @@
+"""Tests for `scripts/generate_security_bar_matrix.py` (#246).
+
+Verifies:
+  - The generated matrix is in sync with main (CI guarantee).
+  - `--check` returns exit 1 when the committed file has drifted.
+  - The generator handles missing markers cleanly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "generate_security_bar_matrix.py"
+SECURITY_BAR = REPO_ROOT / "SECURITY_BAR.md"
+
+
+def _run(args: list[str], cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    # Resolve the script path relative to cwd so tests can isolate via tmp_path.
+    script_path = cwd / "scripts" / "generate_security_bar_matrix.py"
+    return subprocess.run(
+        [sys.executable, str(script_path), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestCheckMode:
+    def test_check_passes_when_matrix_is_in_sync(self):
+        result = _run(["--check"])
+        assert result.returncode == 0, f"--check failed: stderr=\n{result.stderr}"
+        assert "in sync" in result.stdout
+
+    def test_check_fails_on_drift(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # Copy the repo structure the script needs into a tmp dir, then mutate
+        # SECURITY_BAR.md to create drift, and run `--check` against the clone.
+        tmp_repo = tmp_path / "repo"
+        tmp_repo.mkdir()
+        (tmp_repo / "scripts").mkdir()
+        (tmp_repo / "skills").mkdir()
+        # Copy the script + its dependency
+        for rel in ("scripts/generate_security_bar_matrix.py", "scripts/skill_validation_common.py"):
+            (tmp_repo / rel).write_text((REPO_ROOT / rel).read_text())
+        # Minimal fake skill so discover_skill_contracts has something to enumerate.
+        fake_skill_dir = tmp_repo / "skills" / "detection" / "detect-fake"
+        fake_skill_dir.mkdir(parents=True)
+        (fake_skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: detect-fake\n"
+            "description: fake skill for testing\n"
+            "license: Apache-2.0\n"
+            "approval_model: none\n"
+            "execution_modes: jit\n"
+            "side_effects: none\n"
+            "input_formats: ocsf\n"
+            "output_formats: ocsf\n"
+            "concurrency_safety: stateless\n"
+            "compatibility: test\n"
+            "metadata:\n"
+            "  author: test\n"
+            "  version: 0.1.0\n"
+            "  cloud: none\n"
+            "  capability: read-only\n"
+            "---\n"
+            "# detect-fake\n"
+        )
+        (fake_skill_dir / "src").mkdir()
+        (fake_skill_dir / "src" / "detect.py").write_text("# entrypoint\n")
+        (fake_skill_dir / "tests").mkdir()
+        (fake_skill_dir / "REFERENCES.md").write_text("# Refs\n")
+
+        # Write SECURITY_BAR.md with markers but NO actual matrix content.
+        (tmp_repo / "SECURITY_BAR.md").write_text(
+            "# Security Bar\n\n"
+            "## Per-skill matrix\n\n"
+            "<!-- AUTO-GENERATED MATRIX START — do not edit by hand; run scripts/generate_security_bar_matrix.py -->\n"
+            "<!-- AUTO-GENERATED MATRIX END -->\n"
+        )
+        result = _run(["--check"], cwd=tmp_repo)
+        assert result.returncode == 1
+        assert "out of sync" in result.stderr
+
+    def test_missing_markers_raises(self, tmp_path: Path):
+        tmp_repo = tmp_path / "repo"
+        tmp_repo.mkdir()
+        (tmp_repo / "scripts").mkdir()
+        (tmp_repo / "skills").mkdir()
+        for rel in ("scripts/generate_security_bar_matrix.py", "scripts/skill_validation_common.py"):
+            (tmp_repo / rel).write_text((REPO_ROOT / rel).read_text())
+        # SECURITY_BAR.md without the markers
+        (tmp_repo / "SECURITY_BAR.md").write_text("# Security Bar\n\nno markers here\n")
+        result = _run([], cwd=tmp_repo)
+        assert result.returncode != 0
+        assert "AUTO-GENERATED markers" in result.stderr
+
+
+class TestGeneratedContent:
+    def test_every_skill_present(self):
+        """Every SKILL.md on disk must have a row in the generated matrix."""
+        content = SECURITY_BAR.read_text()
+        on_disk = sorted(p.parent.name for p in REPO_ROOT.glob("skills/*/*/SKILL.md"))
+        for name in on_disk:
+            assert f"`{name}`" in content, f"{name} missing from SECURITY_BAR.md matrix"
+
+    def test_matrix_row_count_matches_skill_count(self):
+        content = SECURITY_BAR.read_text()
+        # Count rows between the markers
+        start = content.index("AUTO-GENERATED MATRIX START")
+        end = content.index("AUTO-GENERATED MATRIX END")
+        matrix = content[start:end]
+        row_count = sum(
+            1 for line in matrix.splitlines()
+            if line.startswith("| `") and "|" in line
+        )
+        on_disk_count = sum(1 for _ in REPO_ROOT.glob("skills/*/*/SKILL.md"))
+        assert row_count == on_disk_count, (
+            f"matrix has {row_count} rows; {on_disk_count} skills on disk"
+        )


### PR DESCRIPTION
Closes #246.

## Summary

The hand-maintained per-skill matrix was 29 skills behind reality — only 17 rows for a 46-skill repo. Now auto-generated from SKILL.md frontmatter, with a CI \`--check\` gate so the class of drift cannot recur.

## What shipped

- **Generator:** \`scripts/generate_security_bar_matrix.py\` reads every \`SKILL.md\` via the existing \`discover_skill_contracts()\` helper, derives each column, splices the table between two AUTO-GENERATED markers in \`SECURITY_BAR.md\`.
- **CI gate:** \`--check\` mode wired into the \`skill-contract\` job next to the existing \`generate_framework_coverage_doc.py --check\`.
- **5 tests:** all pass.

## Column derivations

| Column | Source |
|---|---|
| Read-only | \`is_write_capable\` |
| Agentless | Repo invariant (enforced by \`validate_skill_integrity.py\`) |
| Least privilege | \`REFERENCES.md\` presence (already CI-enforced) |
| Closed loop | Layer convention (ingest/detect = golden fixture; remediate/output = audit+re-verify) |
| OCSF wire | Layer convention (1.8 for ingest/detect; 1.8 opt-in for evaluate; n/a elsewhere) |
| No telemetry | \`network_egress\` frontmatter (repo invariant = ✅ unless declared otherwise) |

## Semantics shifted

The old hand-written matrix had per-skill prose in each cell (\"SecurityAudit only\", \"\`roles/viewer\` + \`iam.securityReviewer\`\", etc). The generated matrix is more uniform — same badges across skills that share a layer/capability class. That's deliberate: the point of the matrix is the **at-a-glance invariants hold**, not to replace REFERENCES.md's per-skill IAM detail. Operators who want the exact IAM still click through to the skill's REFERENCES.md (linked from the SKILL.md).

## Test plan

- [x] \`python scripts/generate_security_bar_matrix.py --check\` — exit 0 on main
- [x] 5 tests in \`tests/integration/test_generate_security_bar_matrix.py\`
- [x] All 46 skills present in rendered matrix
- [x] CI wired in \`skill-contract\` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)