### PR TITLE
fix(docs): reconcile post-0.6.0 truth drift (codex audit at 21150a3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Native wire format is the same content in a repo-owned envelope — see [docs/NA
 
 The flagship shipped write path. Guarded, event-driven, dual-audited — and **one cloud per worker**, never cross-cloud.
 
-![AWS-only IAM departures flow. Plan reads HR sources in Snowflake or Databricks, runs the reconciler, writes an S3 manifest of the actionable set. Orchestrate fires an EventBridge rule that starts a Step Function; the Step Function invokes a parser Lambda that re-checks manifest and IAM state, then a worker Lambda with a scoped principal that assumes a cross-account role inside the AWS Organization. Write deletes the AWS IAM user through the nine-step deletion order. Audit lands in DynamoDB plus KMS-encrypted S3, then ingest-back feeds drift checks into the next reconciler run. The footer makes clear that Azure and GCP use their own native orchestration stacks. No single worker ever crosses cloud boundaries.](docs/images/iam-departures-aws.svg)
+![AWS-only IAM departures flow. Plan reads HR sources in Snowflake or Databricks, runs the reconciler, writes an S3 manifest of the actionable set. Orchestrate fires an EventBridge rule that starts a Step Function; the Step Function invokes a parser Lambda that re-checks manifest and IAM state, then a worker Lambda with a scoped principal that assumes a cross-account role inside the AWS Organization. Write deletes the AWS IAM user through the 13-step deletion order (11 worker functions spanning 13 distinct IAM API operations). Audit lands in DynamoDB plus KMS-encrypted S3, then ingest-back feeds drift checks into the next reconciler run. The footer makes clear that Azure and GCP use their own native orchestration stacks. No single worker ever crosses cloud boundaries.](docs/images/iam-departures-aws.svg)
 
 - **scope first** — rehire and grace-window logic run in the reconciler before the manifest is written
 - **separate principals** — EventBridge, Step Function, parser Lambda, worker Lambda each have their own execution role
@@ -331,9 +331,9 @@ Per-skill framework mapping: [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPING
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 4 skills (AI BOM, cloud control evidence, control evidence, environment graph) | wider SaaS and infra evidence |
-| **Detect** | 9 detectors tied to MITRE ATT&CK | credential stuffing, impossible travel, more MCP patterns |
-| **Evaluate** | 7 benchmarks (82 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, model serving | OCSF Compliance Finding class `2003` outputs |
-| **Remediate** | IAM departures with HITL, dry-run, dual audit | broader remediation families as detection matures |
+| **Detect** | 10 detectors tied to MITRE ATT&CK (inc. credential stuffing, Okta MFA fatigue, K8s priv-esc, MCP tool drift, prompt injection) | impossible travel, container escape (#274), more MCP patterns |
+| **Evaluate** | 7 benchmarks (82 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), `--auto-remediate` flag |
+| **Remediate** | `iam-departures-aws` + `remediate-okta-session-kill` — both HITL-gated, dry-run default, dual audit | broader remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |
 | **Sinks** | Snowflake, ClickHouse, S3 | Security Lake, BigQuery |
 | **Packs** | `lateral-movement`, `privilege-escalation-k8s` | broader warehouse dialect coverage |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ This file is the design contract. It explains how the repo is supposed to work a
 ## Quick read
 
 - seven shipped skill layers stay at the center: ingest, discover, detect, evaluate, remediate, view, and output
-- three edge or runtime layers sit around them: sources and sinks, query packs, and runtime surfaces
+- two edge or runtime layers sit around them: query packs (L8) and runtime surfaces (L9) — source adapters and sinks are now first-class skill layers under `skills/ingestion/source-*` and `skills/output/`
 - one skill bundle contract is shared across CLI, CI, MCP, and runners
 - OCSF is the SIEM interop wire format for **ingest and detect**; native / CycloneDX / bridge are correct for discover, remediate, and sinks (see §3.1 for the per-layer applicability table)
 

--- a/skills/remediation/iam-departures-aws/src/lambda_worker/handler.py
+++ b/skills/remediation/iam-departures-aws/src/lambda_worker/handler.py
@@ -219,6 +219,19 @@ def handler(event: dict, context: Any) -> dict:
 
 
 def _remediation_steps() -> tuple[tuple[str, Any], ...]:
+    """11 worker functions that collectively perform 13 distinct IAM API operations.
+
+    Why the two numbers differ: `_deactivate_access_keys` below issues BOTH
+    `iam:UpdateAccessKey(Inactive)` and `iam:DeleteAccessKey` per key, and
+    `_delete_mfa_devices` issues BOTH `iam:DeactivateMFADevice` and
+    `iam:DeleteVirtualMFADevice` per device. The SVG + SKILL.md "13-step
+    deletion order" counts distinct IAM API calls (what shows up in
+    CloudTrail); this tuple counts function-level steps for the checkpoint
+    loop. Both views are truthful; the numbers describe different things.
+
+    Keep in sync with `SKILL.md § Deletion order` and
+    `docs/images/iam-departures-aws.svg` DELETION ORDER card.
+    """
     return (
         ("deactivate_access_keys", lambda iam, username, _entry, actions: _deactivate_access_keys(iam, username, actions)),
         ("delete_login_profile", lambda iam, username, _entry, actions: _delete_login_profile(iam, username, actions)),


### PR DESCRIPTION
Fresh audit of origin/main at 21150a3 found four drifts. Each gets the narrowest fix.

## 1. README \"Where things stand\" stale

| Claim | Before | After |
|---|---|---|
| Detect count | 9 detectors | 10 (detect-credential-stuffing-okta shipped in 0.6.0) |
| OCSF 2003 | listed as \"Planned\" | removed (shipped in 0.6.0, #261/#266); Planned now = 50% CIS coverage + \`--auto-remediate\` |
| Remediate row | only mentioned IAM departures | both shipped skills: \`iam-departures-aws\` + \`remediate-okta-session-kill\` |

## 2. IAM departures step-count drift (biggest finding)

Four surfaces disagreed: README alt text \"nine-step\", SKILL.md \"13-step\", SVG \"13-step\", handler.py \`_remediation_steps()\` had 11 entries.

All four now consistent with an honest explanation:

- **13** is the distinct IAM API operation count (what shows up in CloudTrail) — SVG + SKILL.md already correct
- **11** is the function-level count in \`_remediation_steps()\` — two functions (\`_deactivate_access_keys\`, \`_delete_mfa_devices\`) each issue two IAM calls
- **README alt text** updated to \"13-step deletion order (11 worker functions spanning 13 distinct IAM API operations)\"
- **handler.py** gets a docstring on \`_remediation_steps()\` explaining the 11-vs-13 split and pointing at SKILL.md + SVG as cross-references

Both numbers are truthful — they describe different things. Prior state had no reconciliation.

## 3. ARCHITECTURE.md layer count

Line 10 said \"three edge or runtime layers\" (counting source adapters + sinks); line 80 said \"two edge/runtime layers\". Line 80 is correct post-0.6.0 (sources are under \`skills/ingestion/source-*\`, sinks under \`skills/output/\`, both first-class skill layers). Line 10 updated to match.

## Explicit non-goals

- **Visual polish** — Codex also noted \"Mermaids still wider than ideal for GitHub reading\". Valid readability observation but a polish task, not a correctness task. Separate PR if desired.

## Validators

- [x] validate_skill_count_consistency.py
- [x] validate_skill_contract.py — 46 skills
- [x] validate_skill_integrity.py
- [x] validate_safe_skill_bar.py
- [x] iam-departures-aws tests — 93/93

🤖 Generated with [Claude Code](https://claude.com/claude-code)