### PR TITLE
feat(remediate-k8s): add forensic collector

### DIFF
--- a/skills/remediation/remediate-container-escape-k8s/REFERENCES.md
+++ b/skills/remediation/remediate-container-escape-k8s/REFERENCES.md
@@ -15,6 +15,12 @@
 - **Kubernetes Volumes: hostPath** — https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
   - warns that `hostPath` mounts expose privileged host resources and should be
     avoided unless absolutely necessary
+- **Kubernetes Volume Snapshots** — https://kubernetes.io/docs/concepts/storage/volume-snapshots/
+  - CSI `VolumeSnapshot` objects are the portable snapshot primitive this
+    forensic collector can optionally create for PVC-backed pod volumes
+- **Kubernetes Logging Architecture** — https://kubernetes.io/docs/concepts/cluster-administration/logging/
+  - container logs under `/var/log/containers/` and `/var/log/pods/` are the
+    runtime-log sources bundled by the collector
 
 ## OCSF wire format
 
@@ -51,6 +57,9 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "create", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get"]
 ```
 
 Minimal AWS IAM for audit writes:

--- a/skills/remediation/remediate-container-escape-k8s/SKILL.md
+++ b/skills/remediation/remediate-container-escape-k8s/SKILL.md
@@ -11,9 +11,9 @@ description: >-
   dual-audited (DynamoDB + KMS-encrypted S3). Use when the user mentions
   "quarantine a suspicious Kubernetes pod," "contain container escape in
   Kubernetes," "apply deny-all NetworkPolicy after escape finding," or
-  "re-verify K8s quarantine policy." Do NOT use for node drain, pod deletion,
-  forensic collection, or identity-session containment — those belong to their
-  own remediation skills.
+  "re-verify K8s quarantine policy," or "collect K8s container-escape
+  forensics." Do NOT use for node drain, pod deletion, or identity-session
+  containment — those belong to their own remediation skills.
 license: Apache-2.0
 capability: write-cloud
 approval_model: human_required
@@ -71,7 +71,9 @@ quarantine policy is still present and still shaped as expected.
 The least-destructive first response is to isolate the affected workload from
 the network while preserving the pod for human investigation. This skill does
 that with a namespace-scoped deny-all `NetworkPolicy` matched to the target
-pod's labels or the workload selector.
+pod's labels or the workload selector. Once quarantine lands, the same skill
+can also build a deterministic forensic bundle from host-mounted `/proc`,
+runtime logs, and optional CSI `VolumeSnapshot` references.
 
 ## Inputs
 
@@ -222,6 +224,39 @@ cat finding.ocsf.jsonl | python src/handler.py --apply
 cat finding.ocsf.jsonl | python src/handler.py --reverify
 ```
 
+## Forensic evidence mode
+
+`src/forensic_collector.py` is the post-quarantine evidence path. It runs in a
+controlled follow-up worker or sidecar with read-only host mounts:
+
+- `/host/proc` for PID discovery and `/proc/<pid>` capture
+- `/host/var/log` for container runtime logs
+- optional CSI `VolumeSnapshot` creation for PVC-backed pod volumes
+
+Dry-run is still the default. Without `--upload`, the collector emits a native
+`remediation_plan` record describing the exact bundle contents it WOULD write.
+With `--upload`, it writes a deterministic `tar.gz` bundle to the same
+KMS-encrypted audit bucket under
+`container-escape/audit/<incident-id>/<timestamp>-<namespace>-<target>-forensics.tar.gz`.
+
+```bash
+# Dry-run forensic plan
+cat finding.ocsf.jsonl | python src/forensic_collector.py \
+  --proc-root /host/proc \
+  --log-root /host/var/log
+
+# Upload bundle + create VolumeSnapshot refs
+export K8S_CONTAINER_ESCAPE_INCIDENT_ID=inc-2026-04-19-001
+export K8S_CONTAINER_ESCAPE_APPROVER=alice@example.com
+export K8S_REMEDIATION_AUDIT_BUCKET=sec-k8s-remediation
+export KMS_KEY_ARN=arn:aws:kms:us-east-1:123456789012:key/...
+
+cat finding.ocsf.jsonl | python src/forensic_collector.py \
+  --upload \
+  --snapshot-volumes \
+  --snapshot-class csi-snapshots
+```
+
 ## Use when
 
 - you need a reversible first-response containment for a suspicious Kubernetes
@@ -229,10 +264,12 @@ cat finding.ocsf.jsonl | python src/handler.py --reverify
 - you want a deny-all `NetworkPolicy` matched to the live selector, not a raw
   pod name
 - you need an auditable quarantine step that can later be re-verified for drift
+- you need a reproducible forensic bundle after quarantine, without killing the
+  target pod first
 
 ## Do NOT use
 
-- to drain a node, delete a pod, or collect forensic artifacts
+- to drain a node or delete a pod
 - against protected namespaces like `kube-system` or `istio-system`
 - as a generic "pause traffic" control for planned maintenance
 - without setting `K8S_CONTAINER_ESCAPE_INCIDENT_ID` and
@@ -260,3 +297,6 @@ future PR can surface that drift as a separate finding stream if needed.
 - audit write lands before the Kubernetes mutating call
 - `--reverify` distinguishes verified from drifted policy state
 - end-to-end dry-run from the frozen container-escape findings golden
+- forensic collector builds deterministic bundles from `/proc` + runtime logs
+- forensic collector can plan or create `VolumeSnapshot` refs and upload a
+  KMS-encrypted bundle to S3

--- a/skills/remediation/remediate-container-escape-k8s/src/forensic_collector.py
+++ b/skills/remediation/remediate-container-escape-k8s/src/forensic_collector.py
@@ -1,0 +1,844 @@
+"""Collect forensic evidence for a quarantined Kubernetes container-escape target.
+
+This module is intended to run inside a controlled sidecar or follow-up worker
+after quarantine lands. It resolves the target pod set from the same
+container-escape findings consumed by handler.py, discovers target PIDs by
+matching container IDs against host-mounted /proc cgroup entries, captures
+process and runtime-log artifacts, optionally creates CSI VolumeSnapshots, and
+can upload a deterministic tar.gz evidence bundle to KMS-encrypted S3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import gzip
+import hashlib
+import io
+import json
+import os
+import re
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Protocol
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+SRC_DIR = Path(__file__).resolve().parent
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from handler import (  # noqa: E402
+    CANONICAL_VERSION,
+    DEFAULT_DENY_NAMESPACES,
+    RECORD_ACTION,
+    RECORD_PLAN,
+    STATUS_PLANNED,
+    STATUS_SKIPPED_UNSUPPORTED_TARGET,
+    STATUS_SUCCESS,
+    STATUS_WOULD_VIOLATE_DENY_LIST,
+    ResolvedTarget,
+    Target,
+    check_apply_gate,
+    is_protected_namespace,
+    load_jsonl,
+    parse_targets,
+    resolve_target,
+)
+
+SKILL_NAME = "remediate-container-escape-k8s"
+STEP_COLLECT_FORENSICS = "collect_forensic_bundle"
+STEP_CREATE_VOLUME_SNAPSHOT = "create_volume_snapshot"
+DEFAULT_PROC_ROOT = Path("/host/proc")
+DEFAULT_LOG_ROOT = Path("/host/var/log")
+MAX_ROOT_LISTING_ENTRIES = 128
+MAX_LOG_BYTES = 1024 * 1024
+
+
+@dataclasses.dataclass(frozen=True)
+class PodContext:
+    namespace: str
+    pod_name: str
+    pod_uid: str
+    node_name: str
+    container_names: tuple[str, ...]
+    container_ids: tuple[str, ...]
+    pvc_names: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class VolumeSnapshotRef:
+    namespace: str
+    pvc_name: str
+    snapshot_name: str
+    snapshot_class_name: str
+    status: str
+
+
+class KubernetesForensicsClient(Protocol):
+    def get_pod_labels(self, namespace: str, pod_name: str) -> dict[str, str] | None: ...
+    def get_workload_selector(self, namespace: str, resource_type: str, resource_name: str) -> dict[str, str] | None: ...
+    def list_target_pods(self, namespace: str, selector: dict[str, str]) -> list[PodContext]: ...
+    def create_volume_snapshot(
+        self,
+        namespace: str,
+        pvc_name: str,
+        snapshot_name: str,
+        snapshot_class_name: str | None,
+    ) -> VolumeSnapshotRef: ...
+
+
+class BundleUploader(Protocol):
+    def upload(
+        self,
+        *,
+        bucket: str,
+        key: str,
+        body: bytes,
+        kms_key_arn: str,
+    ) -> str: ...
+
+
+@dataclasses.dataclass
+class KubernetesApiForensicsClient:
+    """Real Kubernetes client for forensic follow-up."""
+
+    def _apis(self) -> tuple[Any, Any]:
+        from kubernetes import client  # local import
+        from kubernetes.config import load_incluster_config, load_kube_config
+
+        try:
+            load_incluster_config()
+        except Exception:
+            load_kube_config()
+        return client.CoreV1Api(), client.CustomObjectsApi()
+
+    def get_pod_labels(self, namespace: str, pod_name: str) -> dict[str, str] | None:
+        core, _ = self._apis()
+        pod = core.read_namespaced_pod(name=pod_name, namespace=namespace)
+        labels = (getattr(pod.metadata, "labels", None) or {}) if getattr(pod, "metadata", None) else {}
+        return dict(labels) if labels else None
+
+    def get_workload_selector(self, namespace: str, resource_type: str, resource_name: str) -> dict[str, str] | None:
+        from kubernetes import client  # local import
+
+        core, _ = self._apis()
+        apps = client.AppsV1Api()
+        batch = client.BatchV1Api()
+
+        def _selector(obj: Any) -> dict[str, str] | None:
+            spec = getattr(obj, "spec", None)
+            if spec is None:
+                return None
+            selector = getattr(spec, "selector", None)
+            labels = getattr(selector, "match_labels", None) if selector is not None else None
+            if labels:
+                return dict(labels)
+            template = getattr(spec, "template", None)
+            metadata = getattr(template, "metadata", None) if template is not None else None
+            tmpl_labels = getattr(metadata, "labels", None) if metadata is not None else None
+            return dict(tmpl_labels) if tmpl_labels else None
+
+        if resource_type == "deployments":
+            return _selector(apps.read_namespaced_deployment(name=resource_name, namespace=namespace))
+        if resource_type == "daemonsets":
+            return _selector(apps.read_namespaced_daemon_set(name=resource_name, namespace=namespace))
+        if resource_type == "statefulsets":
+            return _selector(apps.read_namespaced_stateful_set(name=resource_name, namespace=namespace))
+        if resource_type == "replicasets":
+            return _selector(apps.read_namespaced_replica_set(name=resource_name, namespace=namespace))
+        if resource_type == "replicationcontrollers":
+            return _selector(core.read_namespaced_replication_controller(name=resource_name, namespace=namespace))
+        if resource_type == "jobs":
+            return _selector(batch.read_namespaced_job(name=resource_name, namespace=namespace))
+        if resource_type == "cronjobs":
+            return _selector(batch.read_namespaced_cron_job(name=resource_name, namespace=namespace))
+        return None
+
+    def list_target_pods(self, namespace: str, selector: dict[str, str]) -> list[PodContext]:
+        core, _ = self._apis()
+        label_selector = ",".join(f"{key}={value}" for key, value in sorted(selector.items()))
+        pods = core.list_namespaced_pod(namespace=namespace, label_selector=label_selector).items
+        results: list[PodContext] = []
+        for pod in pods:
+            metadata = getattr(pod, "metadata", None)
+            spec = getattr(pod, "spec", None)
+            status = getattr(pod, "status", None)
+            if metadata is None or spec is None:
+                continue
+
+            container_names: list[str] = []
+            container_ids: list[str] = []
+            for group in (
+                getattr(status, "container_statuses", None) or [],
+                getattr(status, "init_container_statuses", None) or [],
+                getattr(status, "ephemeral_container_statuses", None) or [],
+            ):
+                for item in group:
+                    name = str(getattr(item, "name", "") or "")
+                    if name:
+                        container_names.append(name)
+                    raw_container_id = str(getattr(item, "container_id", "") or "")
+                    container_id = _normalize_container_id(raw_container_id)
+                    if container_id:
+                        container_ids.append(container_id)
+
+            pvc_names: list[str] = []
+            for volume in getattr(spec, "volumes", None) or []:
+                pvc = getattr(volume, "persistent_volume_claim", None)
+                claim_name = str(getattr(pvc, "claim_name", "") or "")
+                if claim_name:
+                    pvc_names.append(claim_name)
+
+            results.append(
+                PodContext(
+                    namespace=namespace,
+                    pod_name=str(getattr(metadata, "name", "") or ""),
+                    pod_uid=str(getattr(metadata, "uid", "") or ""),
+                    node_name=str(getattr(spec, "node_name", "") or ""),
+                    container_names=tuple(sorted(set(name for name in container_names if name))),
+                    container_ids=tuple(sorted(set(cid for cid in container_ids if cid))),
+                    pvc_names=tuple(sorted(set(name for name in pvc_names if name))),
+                )
+            )
+        return results
+
+    def create_volume_snapshot(
+        self,
+        namespace: str,
+        pvc_name: str,
+        snapshot_name: str,
+        snapshot_class_name: str | None,
+    ) -> VolumeSnapshotRef:
+        _, custom = self._apis()
+        body: dict[str, Any] = {
+            "apiVersion": "snapshot.storage.k8s.io/v1",
+            "kind": "VolumeSnapshot",
+            "metadata": {"name": snapshot_name, "namespace": namespace},
+            "spec": {"source": {"persistentVolumeClaimName": pvc_name}},
+        }
+        if snapshot_class_name:
+            body["spec"]["volumeSnapshotClassName"] = snapshot_class_name
+        custom.create_namespaced_custom_object(
+            group="snapshot.storage.k8s.io",
+            version="v1",
+            plural="volumesnapshots",
+            namespace=namespace,
+            body=body,
+        )
+        return VolumeSnapshotRef(
+            namespace=namespace,
+            pvc_name=pvc_name,
+            snapshot_name=snapshot_name,
+            snapshot_class_name=snapshot_class_name or "",
+            status="created",
+        )
+
+
+@dataclasses.dataclass
+class KmsS3Uploader:
+    def upload(
+        self,
+        *,
+        bucket: str,
+        key: str,
+        body: bytes,
+        kms_key_arn: str,
+    ) -> str:
+        import boto3  # local import
+
+        boto3.client("s3").put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body,
+            ServerSideEncryption="aws:kms",
+            SSEKMSKeyId=kms_key_arn,
+            ContentType="application/gzip",
+        )
+        return f"s3://{bucket}/{key}"
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_container_id(value: str) -> str:
+    raw = (value or "").strip()
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    return raw.strip()
+
+
+def _sanitize_name(value: str, *, fallback: str) -> str:
+    text = (value or "").strip().lower().replace("_", "-").replace(".", "-")
+    text = re.sub(r"[^a-z0-9-]+", "-", text).strip("-")
+    return text or fallback
+
+
+def _bundle_prefix(incident_id: str) -> str:
+    return f"container-escape/audit/{_sanitize_name(incident_id, fallback='incident')}"
+
+
+def _bundle_name(target: Target, collected_at: datetime) -> str:
+    stamp = collected_at.strftime("%Y%m%dT%H%M%SZ")
+    base = _sanitize_name(target.pod_name or target.resource_name, fallback="target")
+    return f"{stamp}-{target.namespace}-{base}-forensics.tar.gz"
+
+
+def _bundle_key(target: Target, incident_id: str, collected_at: datetime) -> str:
+    return f"{_bundle_prefix(incident_id)}/{_bundle_name(target, collected_at)}"
+
+
+def _snapshot_name(namespace: str, pvc_name: str, collected_at: datetime) -> str:
+    stamp = collected_at.strftime("%Y%m%d%H%M%S")
+    base = _sanitize_name(pvc_name, fallback="pvc")
+    digest = hashlib.sha256(f"{namespace}|{pvc_name}|{stamp}".encode("utf-8")).hexdigest()[:10]
+    return f"ce-snap-{base[:39]}-{digest}"[:63].rstrip("-")
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _read_bytes(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def _discover_target_pids(proc_root: Path, container_ids: Iterable[str]) -> list[str]:
+    ids = {cid for cid in (_normalize_container_id(value) for value in container_ids) if cid}
+    if not ids or not proc_root.exists():
+        return []
+
+    matches: list[str] = []
+    for entry in sorted(proc_root.iterdir(), key=lambda item: item.name):
+        if not entry.is_dir() or not entry.name.isdigit():
+            continue
+        cgroup_path = entry / "cgroup"
+        if not cgroup_path.exists():
+            continue
+        try:
+            cgroup_text = _read_text(cgroup_path)
+        except OSError:
+            continue
+        if any(cid in cgroup_text for cid in ids):
+            matches.append(entry.name)
+    return matches
+
+
+def _root_listing(proc_root: Path, pid: str) -> bytes:
+    root_path = proc_root / pid / "root"
+    if not root_path.exists():
+        return b"<missing>\n"
+    try:
+        if root_path.is_dir():
+            items = sorted(child.name for child in root_path.iterdir())[:MAX_ROOT_LISTING_ENTRIES]
+            return ("\n".join(items) + ("\n" if items else "")).encode("utf-8")
+        return (str(root_path.resolve()) + "\n").encode("utf-8")
+    except OSError as exc:
+        return f"<error: {exc}>\n".encode("utf-8")
+
+
+def _collect_proc_artifacts(proc_root: Path, pod: PodContext) -> dict[str, bytes]:
+    artifacts: dict[str, bytes] = {}
+    pids = _discover_target_pids(proc_root, pod.container_ids)
+    for pid in pids:
+        pid_root = proc_root / pid
+        base = f"proc/{pod.pod_name}/{pid}"
+        for name in ("status", "maps", "cgroup"):
+            path = pid_root / name
+            try:
+                data = _read_bytes(path)
+            except OSError:
+                continue
+            artifacts[f"{base}/{name}.txt"] = data
+        artifacts[f"{base}/root_listing.txt"] = _root_listing(proc_root, pid)
+    if not pids:
+        artifacts[f"proc/{pod.pod_name}/no-matching-pids.txt"] = (
+            "no host PIDs matched the target container IDs\n".encode("utf-8")
+        )
+    return artifacts
+
+
+def _runtime_log_paths(log_root: Path, pod: PodContext) -> list[Path]:
+    candidates: list[Path] = []
+    container_dir = log_root / "containers"
+    if container_dir.exists():
+        for container_name in pod.container_names:
+            pattern = f"{pod.pod_name}_{pod.namespace}_{container_name}-*.log"
+            candidates.extend(sorted(container_dir.glob(pattern)))
+
+    pod_dir = log_root / "pods" / f"{pod.namespace}_{pod.pod_name}_{pod.pod_uid}"
+    if pod_dir.exists():
+        for container_name in pod.container_names:
+            container_path = pod_dir / container_name
+            if container_path.exists():
+                candidates.extend(sorted(container_path.glob("*.log")))
+
+    unique: dict[str, Path] = {}
+    for path in candidates:
+        unique[str(path)] = path
+    return [unique[key] for key in sorted(unique)]
+
+
+def _collect_runtime_log_artifacts(log_root: Path, pod: PodContext) -> dict[str, bytes]:
+    artifacts: dict[str, bytes] = {}
+    for path in _runtime_log_paths(log_root, pod):
+        try:
+            data = _read_bytes(path)[:MAX_LOG_BYTES]
+        except OSError:
+            continue
+        rel = path.relative_to(log_root)
+        artifacts[f"runtime-logs/{pod.pod_name}/{rel.as_posix()}"] = data
+    if not artifacts:
+        artifacts[f"runtime-logs/{pod.pod_name}/no-runtime-logs.txt"] = b"no runtime log files matched the target pod\n"
+    return artifacts
+
+
+def _plan_volume_snapshots(
+    *,
+    pods: Iterable[PodContext],
+    collected_at: datetime,
+    snapshot_class_name: str | None,
+) -> list[VolumeSnapshotRef]:
+    planned: list[VolumeSnapshotRef] = []
+    seen: set[tuple[str, str]] = set()
+    for pod in pods:
+        for pvc_name in pod.pvc_names:
+            key = (pod.namespace, pvc_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            planned.append(
+                VolumeSnapshotRef(
+                    namespace=pod.namespace,
+                    pvc_name=pvc_name,
+                    snapshot_name=_snapshot_name(pod.namespace, pvc_name, collected_at),
+                    snapshot_class_name=snapshot_class_name or "",
+                    status=STATUS_PLANNED,
+                )
+            )
+    return planned
+
+
+def _create_volume_snapshots(
+    kube_client: KubernetesForensicsClient,
+    *,
+    pods: Iterable[PodContext],
+    collected_at: datetime,
+    snapshot_class_name: str | None,
+) -> list[VolumeSnapshotRef]:
+    created: list[VolumeSnapshotRef] = []
+    for ref in _plan_volume_snapshots(
+        pods=pods,
+        collected_at=collected_at,
+        snapshot_class_name=snapshot_class_name,
+    ):
+        created.append(
+            kube_client.create_volume_snapshot(
+                ref.namespace,
+                ref.pvc_name,
+                ref.snapshot_name,
+                snapshot_class_name,
+            )
+        )
+    return created
+
+
+def _bundle_manifest(
+    *,
+    resolved: ResolvedTarget,
+    pods: Iterable[PodContext],
+    snapshots: Iterable[VolumeSnapshotRef],
+    collected_at: datetime,
+) -> bytes:
+    payload = {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "source_skill": SKILL_NAME,
+        "collected_at": collected_at.isoformat(),
+        "target": {
+            "namespace": resolved.target.namespace,
+            "resource_type": resolved.target.resource_type,
+            "resource_name": resolved.target.resource_name,
+            "pod_name": resolved.target.pod_name,
+            "finding_uid": resolved.target.finding_uid,
+        },
+        "selector": resolved.selector,
+        "pods": [
+            {
+                "namespace": pod.namespace,
+                "pod_name": pod.pod_name,
+                "pod_uid": pod.pod_uid,
+                "node_name": pod.node_name,
+                "container_names": list(pod.container_names),
+                "container_ids": list(pod.container_ids),
+                "pvc_names": list(pod.pvc_names),
+            }
+            for pod in pods
+        ],
+        "volume_snapshots": [
+            dataclasses.asdict(snapshot)
+            for snapshot in snapshots
+        ],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _build_bundle(artifacts: dict[str, bytes]) -> tuple[bytes, str]:
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb", mtime=0) as gz_handle:
+        with tarfile.open(fileobj=gz_handle, mode="w") as tar:
+            for name in sorted(artifacts):
+                data = artifacts[name]
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                info.mtime = 0
+                info.uid = 0
+                info.gid = 0
+                info.uname = ""
+                info.gname = ""
+                tar.addfile(info, io.BytesIO(data))
+    bundle = buffer.getvalue()
+    digest = hashlib.sha256(bundle).hexdigest()
+    return bundle, digest
+
+
+def _artifact_summary(artifacts: dict[str, bytes]) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": path,
+            "size": len(body),
+            "sha256": hashlib.sha256(body).hexdigest(),
+        }
+        for path, body in sorted(artifacts.items())
+    ]
+
+
+def _resolve_pods(
+    resolved: ResolvedTarget,
+    kube_client: KubernetesForensicsClient,
+) -> list[PodContext]:
+    pods = kube_client.list_target_pods(resolved.target.namespace, resolved.selector)
+    if resolved.target.pod_name:
+        return [pod for pod in pods if pod.pod_name == resolved.target.pod_name]
+    if resolved.target.resource_type == "pods":
+        return [pod for pod in pods if pod.pod_name == resolved.target.resource_name]
+    return pods
+
+
+def _collection_record(
+    resolved: ResolvedTarget,
+    *,
+    pods: list[PodContext],
+    artifacts: dict[str, bytes],
+    snapshots: list[VolumeSnapshotRef],
+    status: str,
+    dry_run: bool,
+    bundle_sha256: str,
+    bundle_size: int,
+    bundle_uri: str | None,
+    incident_id: str,
+    approver: str,
+    collected_at: datetime,
+) -> dict[str, Any]:
+    actions = [
+        {
+            "step": STEP_COLLECT_FORENSICS,
+            "endpoint": bundle_uri or "PUT s3://<configured bucket>/container-escape/audit/<incident-id>/<bundle>",
+            "status": status,
+            "detail": "dry-run: would collect and upload forensic bundle" if dry_run else "forensic bundle uploaded",
+        }
+    ]
+    if snapshots:
+        actions.append(
+            {
+                "step": STEP_CREATE_VOLUME_SNAPSHOT,
+                "endpoint": f"POST /apis/snapshot.storage.k8s.io/v1/namespaces/{resolved.target.namespace}/volumesnapshots",
+                "status": status,
+                "detail": (
+                    "dry-run: would create VolumeSnapshot objects"
+                    if dry_run
+                    else "VolumeSnapshot objects created"
+                ),
+            }
+        )
+    record: dict[str, Any] = {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "mode": "forensics",
+        "target": {
+            "provider": "Kubernetes",
+            "namespace": resolved.target.namespace,
+            "resource_type": resolved.target.resource_type,
+            "resource_name": resolved.target.resource_name,
+            "pod_name": resolved.target.pod_name,
+        },
+        "selector": resolved.selector,
+        "pods": [
+            {
+                "namespace": pod.namespace,
+                "pod_name": pod.pod_name,
+                "pod_uid": pod.pod_uid,
+                "node_name": pod.node_name,
+                "container_names": list(pod.container_names),
+                "pvc_names": list(pod.pvc_names),
+            }
+            for pod in pods
+        ],
+        "actions": actions,
+        "status": status,
+        "dry_run": dry_run,
+        "bundle_sha256": bundle_sha256,
+        "bundle_size_bytes": bundle_size,
+        "bundle_uri": bundle_uri,
+        "artifacts": _artifact_summary(artifacts),
+        "volume_snapshots": [dataclasses.asdict(snapshot) for snapshot in snapshots],
+        "finding_uid": resolved.target.finding_uid,
+        "collected_at": collected_at.isoformat(),
+        "time_ms": int(collected_at.timestamp() * 1000),
+    }
+    if incident_id:
+        record["incident_id"] = incident_id
+    if approver:
+        record["approver"] = approver
+    return record
+
+
+def _skip_record(target: Target, *, status: str, detail: str) -> dict[str, Any]:
+    now = _now_utc()
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN,
+        "source_skill": SKILL_NAME,
+        "mode": "forensics",
+        "target": {
+            "provider": "Kubernetes",
+            "namespace": target.namespace,
+            "resource_type": target.resource_type,
+            "resource_name": target.resource_name,
+            "pod_name": target.pod_name,
+        },
+        "actions": [],
+        "status": status,
+        "status_detail": detail,
+        "dry_run": True,
+        "finding_uid": target.finding_uid,
+        "time_ms": int(now.timestamp() * 1000),
+    }
+
+
+def collect_forensics(
+    resolved: ResolvedTarget,
+    *,
+    kube_client: KubernetesForensicsClient,
+    proc_root: Path,
+    log_root: Path,
+    upload: bool = False,
+    snapshot_volumes: bool = False,
+    snapshot_class_name: str | None = None,
+    uploader: BundleUploader | None = None,
+    s3_bucket: str = "",
+    kms_key_arn: str = "",
+    incident_id: str = "",
+    approver: str = "",
+    collected_at: datetime | None = None,
+) -> dict[str, Any]:
+    collected_at = collected_at or _now_utc()
+    pods = _resolve_pods(resolved, kube_client)
+    if not pods:
+        return _skip_record(
+            resolved.target,
+            status=STATUS_SKIPPED_UNSUPPORTED_TARGET,
+            detail="could not resolve any pods from the target selector for forensic collection",
+        )
+
+    snapshots = (
+        _plan_volume_snapshots(pods=pods, collected_at=collected_at, snapshot_class_name=snapshot_class_name)
+        if snapshot_volumes and not upload
+        else []
+    )
+
+    artifacts: dict[str, bytes] = {
+        "manifest/collection.json": _bundle_manifest(
+            resolved=resolved,
+            pods=pods,
+            snapshots=snapshots,
+            collected_at=collected_at,
+        )
+    }
+    for pod in pods:
+        artifacts.update(_collect_proc_artifacts(proc_root, pod))
+        artifacts.update(_collect_runtime_log_artifacts(log_root, pod))
+
+    if snapshot_volumes and upload:
+        snapshots = _create_volume_snapshots(
+            kube_client,
+            pods=pods,
+            collected_at=collected_at,
+            snapshot_class_name=snapshot_class_name,
+        )
+        artifacts["manifest/collection.json"] = _bundle_manifest(
+            resolved=resolved,
+            pods=pods,
+            snapshots=snapshots,
+            collected_at=collected_at,
+        )
+
+    bundle, bundle_sha256 = _build_bundle(artifacts)
+    bundle_uri: str | None = None
+    if upload:
+        if uploader is None:
+            raise ValueError("uploader is required when upload=True")
+        if not s3_bucket:
+            raise ValueError("s3_bucket is required when upload=True")
+        if not kms_key_arn:
+            raise ValueError("kms_key_arn is required when upload=True")
+        bundle_uri = uploader.upload(
+            bucket=s3_bucket,
+            key=_bundle_key(resolved.target, incident_id, collected_at),
+            body=bundle,
+            kms_key_arn=kms_key_arn,
+        )
+
+    return _collection_record(
+        resolved,
+        pods=pods,
+        artifacts=artifacts,
+        snapshots=snapshots,
+        status=STATUS_PLANNED if not upload else STATUS_SUCCESS,
+        dry_run=not upload,
+        bundle_sha256=bundle_sha256,
+        bundle_size=len(bundle),
+        bundle_uri=bundle_uri,
+        incident_id=incident_id,
+        approver=approver,
+        collected_at=collected_at,
+    )
+
+
+def run(
+    events: Iterable[dict[str, Any]],
+    *,
+    kube_client: KubernetesForensicsClient,
+    proc_root: Path,
+    log_root: Path,
+    upload: bool = False,
+    snapshot_volumes: bool = False,
+    snapshot_class_name: str | None = None,
+    uploader: BundleUploader | None = None,
+    s3_bucket: str = "",
+    kms_key_arn: str = "",
+    incident_id: str = "",
+    approver: str = "",
+    collected_at: datetime | None = None,
+) -> Iterator[dict[str, Any]]:
+    for target, _ in parse_targets(events):
+        if target is None:
+            continue
+
+        denied, matched = is_protected_namespace(target.namespace, DEFAULT_DENY_NAMESPACES)
+        if denied:
+            yield _skip_record(
+                target,
+                status=STATUS_WOULD_VIOLATE_DENY_LIST,
+                detail=f"namespace `{target.namespace}` matched protected pattern `{matched}`",
+            )
+            continue
+
+        resolved = resolve_target(target, kube_client)  # type: ignore[arg-type]
+        if resolved is None:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_UNSUPPORTED_TARGET,
+                detail="could not resolve a pod or workload selector for forensic collection",
+            )
+            continue
+
+        yield collect_forensics(
+            resolved,
+            kube_client=kube_client,
+            proc_root=proc_root,
+            log_root=log_root,
+            upload=upload,
+            snapshot_volumes=snapshot_volumes,
+            snapshot_class_name=snapshot_class_name,
+            uploader=uploader,
+            s3_bucket=s3_bucket,
+            kms_key_arn=kms_key_arn,
+            incident_id=incident_id,
+            approver=approver,
+            collected_at=collected_at,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Plan or collect forensic evidence bundles for quarantined Kubernetes container-escape targets."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument("--upload", action="store_true", help="Upload the forensic bundle to KMS-encrypted S3.")
+    parser.add_argument(
+        "--snapshot-volumes",
+        action="store_true",
+        help="Plan or create CSI VolumeSnapshot objects for PVC-backed pod volumes.",
+    )
+    parser.add_argument("--snapshot-class", help="Optional VolumeSnapshotClass name.")
+    parser.add_argument("--proc-root", default=str(DEFAULT_PROC_ROOT), help="Mounted host /proc root.")
+    parser.add_argument("--log-root", default=str(DEFAULT_LOG_ROOT), help="Mounted host /var/log root.")
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        incident_id = ""
+        approver = ""
+        uploader: BundleUploader | None = None
+        s3_bucket = ""
+        kms_key_arn = ""
+        if args.upload or args.snapshot_volumes and args.upload:
+            ok, reason = check_apply_gate()
+            if not ok:
+                print(reason, file=sys.stderr)
+                return 2
+            incident_id = os.getenv("K8S_CONTAINER_ESCAPE_INCIDENT_ID", "").strip()
+            approver = os.getenv("K8S_CONTAINER_ESCAPE_APPROVER", "").strip()
+        if args.upload:
+            uploader = KmsS3Uploader()
+            s3_bucket = os.environ["K8S_REMEDIATION_AUDIT_BUCKET"]
+            kms_key_arn = os.environ["KMS_KEY_ARN"]
+
+        kube_client = KubernetesApiForensicsClient()
+        for record in run(
+            load_jsonl(in_stream),
+            kube_client=kube_client,
+            proc_root=Path(args.proc_root),
+            log_root=Path(args.log_root),
+            upload=args.upload,
+            snapshot_volumes=args.snapshot_volumes,
+            snapshot_class_name=args.snapshot_class,
+            uploader=uploader,
+            s3_bucket=s3_bucket,
+            kms_key_arn=kms_key_arn,
+            incident_id=incident_id,
+            approver=approver,
+        ):
+            out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/remediate-container-escape-k8s/src/forensic_collector.py
+++ b/skills/remediation/remediate-container-escape-k8s/src/forensic_collector.py
@@ -23,12 +23,15 @@ import sys
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Iterator, Protocol
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Protocol
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 SRC_DIR = Path(__file__).resolve().parent
+
+if TYPE_CHECKING:
+    from handler import ResolvedTarget, Target
 
 
 def _load_handler_module() -> Any:
@@ -54,8 +57,6 @@ STATUS_PLANNED = _HANDLER.STATUS_PLANNED
 STATUS_SKIPPED_UNSUPPORTED_TARGET = _HANDLER.STATUS_SKIPPED_UNSUPPORTED_TARGET
 STATUS_SUCCESS = _HANDLER.STATUS_SUCCESS
 STATUS_WOULD_VIOLATE_DENY_LIST = _HANDLER.STATUS_WOULD_VIOLATE_DENY_LIST
-ResolvedTarget = _HANDLER.ResolvedTarget
-Target = _HANDLER.Target
 check_apply_gate = _HANDLER.check_apply_gate
 is_protected_namespace = _HANDLER.is_protected_namespace
 load_jsonl = _HANDLER.load_jsonl
@@ -764,7 +765,7 @@ def run(
             )
             continue
 
-        resolved = resolve_target(target, kube_client)  # type: ignore[arg-type]
+        resolved = resolve_target(target, kube_client)
         if resolved is None:
             yield _skip_record(
                 target,

--- a/skills/remediation/remediate-container-escape-k8s/src/forensic_collector.py
+++ b/skills/remediation/remediate-container-escape-k8s/src/forensic_collector.py
@@ -14,6 +14,7 @@ import argparse
 import dataclasses
 import gzip
 import hashlib
+import importlib.util
 import io
 import json
 import os
@@ -28,26 +29,38 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 SRC_DIR = Path(__file__).resolve().parent
-if str(SRC_DIR) not in sys.path:
-    sys.path.insert(0, str(SRC_DIR))
 
-from handler import (  # noqa: E402
-    CANONICAL_VERSION,
-    DEFAULT_DENY_NAMESPACES,
-    RECORD_ACTION,
-    RECORD_PLAN,
-    STATUS_PLANNED,
-    STATUS_SKIPPED_UNSUPPORTED_TARGET,
-    STATUS_SUCCESS,
-    STATUS_WOULD_VIOLATE_DENY_LIST,
-    ResolvedTarget,
-    Target,
-    check_apply_gate,
-    is_protected_namespace,
-    load_jsonl,
-    parse_targets,
-    resolve_target,
-)
+
+def _load_handler_module() -> Any:
+    module_name = "cloud_security_k8s_escape_handler_forensics"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+
+    spec = importlib.util.spec_from_file_location(module_name, SRC_DIR / "handler.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_HANDLER = _load_handler_module()
+CANONICAL_VERSION = _HANDLER.CANONICAL_VERSION
+DEFAULT_DENY_NAMESPACES = _HANDLER.DEFAULT_DENY_NAMESPACES
+RECORD_ACTION = _HANDLER.RECORD_ACTION
+RECORD_PLAN = _HANDLER.RECORD_PLAN
+STATUS_PLANNED = _HANDLER.STATUS_PLANNED
+STATUS_SKIPPED_UNSUPPORTED_TARGET = _HANDLER.STATUS_SKIPPED_UNSUPPORTED_TARGET
+STATUS_SUCCESS = _HANDLER.STATUS_SUCCESS
+STATUS_WOULD_VIOLATE_DENY_LIST = _HANDLER.STATUS_WOULD_VIOLATE_DENY_LIST
+ResolvedTarget = _HANDLER.ResolvedTarget
+Target = _HANDLER.Target
+check_apply_gate = _HANDLER.check_apply_gate
+is_protected_namespace = _HANDLER.is_protected_namespace
+load_jsonl = _HANDLER.load_jsonl
+parse_targets = _HANDLER.parse_targets
+resolve_target = _HANDLER.resolve_target
 
 SKILL_NAME = "remediate-container-escape-k8s"
 STEP_COLLECT_FORENSICS = "collect_forensic_bundle"

--- a/skills/remediation/remediate-container-escape-k8s/tests/test_forensic_collector.py
+++ b/skills/remediation/remediate-container-escape-k8s/tests/test_forensic_collector.py
@@ -1,0 +1,236 @@
+"""Tests for remediate-container-escape-k8s forensic collector."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tarfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SRC_DIR = ROOT / "skills" / "remediation" / "remediate-container-escape-k8s" / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+spec = importlib.util.spec_from_file_location(
+    "cloud_security_forensic_collector_test",
+    SRC_DIR / "forensic_collector.py",
+)
+assert spec and spec.loader
+collector = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = collector
+spec.loader.exec_module(collector)
+
+
+def _finding(
+    *,
+    target: str = "deployments/payments/api",
+    namespace: str = "payments",
+    resource_type: str = "deployments",
+    resource_name: str = "api",
+    pod_name: str = "",
+) -> dict:
+    observables = [
+        {"name": "namespace", "type": "Other", "value": namespace},
+        {"name": "resource.type", "type": "Other", "value": resource_type},
+        {"name": "resource.name", "type": "Other", "value": resource_name},
+    ]
+    if pod_name:
+        observables.append({"name": "pod.name", "type": "Other", "value": pod_name})
+    return {
+        "class_uid": 2004,
+        "target": target,
+        "metadata": {
+            "uid": "find-1",
+            "product": {"feature": {"name": "detect-container-escape-k8s"}},
+        },
+        "finding_info": {"uid": "find-1"},
+        "observables": observables,
+    }
+
+
+def _write_proc(proc_root: Path, pid: str, container_id: str, *, status: str = "State:\tR\n", maps: str = "00400000-00452000 r-xp\n") -> None:
+    pid_root = proc_root / pid
+    pid_root.mkdir(parents=True, exist_ok=True)
+    (pid_root / "cgroup").write_text(f"0::/kubepods/{container_id}\n")
+    (pid_root / "status").write_text(status)
+    (pid_root / "maps").write_text(maps)
+    root_fs = proc_root / "roots" / pid
+    root_fs.mkdir(parents=True, exist_ok=True)
+    (root_fs / "etc").mkdir()
+    (root_fs / "var").mkdir()
+    (pid_root / "root").symlink_to(root_fs, target_is_directory=True)
+
+
+@dataclass
+class _FakeKube:
+    pod_labels: dict[tuple[str, str], dict[str, str]] = field(default_factory=dict)
+    workload_selectors: dict[tuple[str, str, str], dict[str, str]] = field(default_factory=dict)
+    pods: list[collector.PodContext] = field(default_factory=list)
+    snapshots: list[tuple[str, str, str, str | None]] = field(default_factory=list)
+
+    def get_pod_labels(self, namespace: str, pod_name: str):
+        return self.pod_labels.get((namespace, pod_name))
+
+    def get_workload_selector(self, namespace: str, resource_type: str, resource_name: str):
+        return self.workload_selectors.get((namespace, resource_type, resource_name))
+
+    def list_target_pods(self, namespace: str, selector: dict[str, str]):
+        return [pod for pod in self.pods if pod.namespace == namespace]
+
+    def create_volume_snapshot(self, namespace: str, pvc_name: str, snapshot_name: str, snapshot_class_name: str | None):
+        self.snapshots.append((namespace, pvc_name, snapshot_name, snapshot_class_name))
+        return collector.VolumeSnapshotRef(
+            namespace=namespace,
+            pvc_name=pvc_name,
+            snapshot_name=snapshot_name,
+            snapshot_class_name=snapshot_class_name or "",
+            status="created",
+        )
+
+
+@dataclass
+class _FakeUploader:
+    uploads: list[dict] = field(default_factory=list)
+
+    def upload(self, *, bucket: str, key: str, body: bytes, kms_key_arn: str) -> str:
+        self.uploads.append(
+            {
+                "bucket": bucket,
+                "key": key,
+                "body": body,
+                "kms_key_arn": kms_key_arn,
+            }
+        )
+        return f"s3://{bucket}/{key}"
+
+
+def _pod_context() -> collector.PodContext:
+    return collector.PodContext(
+        namespace="payments",
+        pod_name="api-7d9b",
+        pod_uid="pod-uid-1",
+        node_name="worker-a",
+        container_names=("api",),
+        container_ids=("abcd1234",),
+        pvc_names=("api-data",),
+    )
+
+
+class TestHelpers:
+    def test_discover_target_pids_filters_by_container_id(self, tmp_path: Path):
+        proc_root = tmp_path / "proc"
+        proc_root.mkdir()
+        _write_proc(proc_root, "101", "abcd1234")
+        _write_proc(proc_root, "102", "other9999")
+        matches = collector._discover_target_pids(proc_root, ("abcd1234",))
+        assert matches == ["101"]
+
+    def test_bundle_is_deterministic(self):
+        artifacts = {
+            "b.txt": b"world\n",
+            "a.txt": b"hello\n",
+        }
+        first, first_sha = collector._build_bundle(artifacts)
+        second, second_sha = collector._build_bundle(artifacts)
+        assert first == second
+        assert first_sha == second_sha
+
+
+class TestRun:
+    def test_dry_run_collects_proc_and_runtime_log_artifacts(self, tmp_path: Path):
+        proc_root = tmp_path / "proc"
+        log_root = tmp_path / "var-log"
+        (log_root / "containers").mkdir(parents=True)
+        _write_proc(proc_root, "101", "abcd1234")
+        (log_root / "containers" / "api-7d9b_payments_api-abcd1234.log").write_text("runtime log line\n")
+
+        kube = _FakeKube(
+            workload_selectors={("payments", "deployments", "api"): {"app": "api"}},
+            pods=[_pod_context()],
+        )
+        record = next(
+            collector.run(
+                [_finding()],
+                kube_client=kube,
+                proc_root=proc_root,
+                log_root=log_root,
+                collected_at=datetime(2026, 4, 19, 7, 0, tzinfo=timezone.utc),
+            )
+        )
+        assert record["record_type"] == "remediation_plan"
+        assert record["mode"] == "forensics"
+        assert record["status"] == "planned"
+        assert record["dry_run"] is True
+        artifact_paths = {item["path"] for item in record["artifacts"]}
+        assert "manifest/collection.json" in artifact_paths
+        assert "proc/api-7d9b/101/status.txt" in artifact_paths
+        assert any(path.startswith("runtime-logs/api-7d9b/containers/") for path in artifact_paths)
+
+    def test_upload_writes_bundle_and_creates_volume_snapshots(self, tmp_path: Path):
+        proc_root = tmp_path / "proc"
+        log_root = tmp_path / "var-log"
+        (log_root / "containers").mkdir(parents=True)
+        _write_proc(proc_root, "101", "abcd1234")
+        (log_root / "containers" / "api-7d9b_payments_api-abcd1234.log").write_text("runtime log line\n")
+
+        kube = _FakeKube(
+            workload_selectors={("payments", "deployments", "api"): {"app": "api"}},
+            pods=[_pod_context()],
+        )
+        uploader = _FakeUploader()
+        collected_at = datetime(2026, 4, 19, 7, 5, tzinfo=timezone.utc)
+        record = next(
+            collector.run(
+                [_finding()],
+                kube_client=kube,
+                proc_root=proc_root,
+                log_root=log_root,
+                upload=True,
+                snapshot_volumes=True,
+                snapshot_class_name="csi-snapshots",
+                uploader=uploader,
+                s3_bucket="sec-k8s-remediation",
+                kms_key_arn="arn:aws:kms:us-east-1:123456789012:key/test",
+                incident_id="inc-2026-04-19-001",
+                approver="alice@example.com",
+                collected_at=collected_at,
+            )
+        )
+        assert record["record_type"] == "remediation_action"
+        assert record["status"] == "success"
+        assert record["bundle_uri"].startswith("s3://sec-k8s-remediation/container-escape/audit/")
+        assert record["incident_id"] == "inc-2026-04-19-001"
+        assert record["approver"] == "alice@example.com"
+        assert len(uploader.uploads) == 1
+        assert kube.snapshots and kube.snapshots[0][1] == "api-data"
+        with tarfile.open(fileobj=collector.io.BytesIO(uploader.uploads[0]["body"]), mode="r:gz") as tar:
+            names = sorted(tar.getnames())
+        assert "manifest/collection.json" in names
+        assert "proc/api-7d9b/101/status.txt" in names
+
+    def test_protected_namespace_yields_skip_record(self, tmp_path: Path):
+        proc_root = tmp_path / "proc"
+        log_root = tmp_path / "var-log"
+        kube = _FakeKube(pods=[_pod_context()])
+        record = next(
+            collector.run(
+                [
+                    _finding(
+                        namespace="kube-system",
+                        target="pods/kube-system/api-7d9b",
+                        resource_type="pods",
+                        resource_name="api-7d9b",
+                        pod_name="api-7d9b",
+                    )
+                ],
+                kube_client=kube,
+                proc_root=proc_root,
+                log_root=log_root,
+            )
+        )
+        assert record["status"] == "would-violate-deny-list"

--- a/tests/integration/test_k8s_container_escape_forensics_pipeline.py
+++ b/tests/integration/test_k8s_container_escape_forensics_pipeline.py
@@ -1,0 +1,98 @@
+"""Integration-style test for K8s container-escape forensic bundle planning."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SKILLS_ROOT = REPO_ROOT / "skills"
+GOLDEN_DIR = SKILLS_ROOT / "detection-engineering" / "golden"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"could not spec {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+@dataclass
+class _FakeKube:
+    handler: object
+    pods: list[object] = field(default_factory=list)
+
+    def get_pod_labels(self, namespace: str, pod_name: str):
+        return {("payments", "api-7d9b"): {"app": "api", "pod-template-hash": "7d9b"}}.get((namespace, pod_name))
+
+    def get_workload_selector(self, namespace: str, resource_type: str, resource_name: str):
+        return {("payments", "deployments", "api"): {"app": "api"}}.get((namespace, resource_type, resource_name))
+
+    def list_target_pods(self, namespace: str, selector: dict[str, str]):
+        return [pod for pod in self.pods if pod.namespace == namespace]
+
+    def create_volume_snapshot(self, namespace: str, pvc_name: str, snapshot_name: str, snapshot_class_name: str | None):
+        raise AssertionError("dry-run integration test must not create snapshots")
+
+
+class TestK8sContainerEscapeForensicsPipeline:
+    def setup_method(self):
+        self.collector = _load_module(
+            "_int_collect_container_escape_k8s",
+            SKILLS_ROOT / "remediation" / "remediate-container-escape-k8s" / "src" / "forensic_collector.py",
+        )
+
+    def test_frozen_findings_produce_dry_run_forensic_plans(self, tmp_path: Path):
+        proc_root = tmp_path / "proc"
+        log_root = tmp_path / "var-log"
+        (log_root / "containers").mkdir(parents=True)
+
+        for pid, cid in (("101", "abcd1234"), ("102", "efgh5678")):
+            pid_root = proc_root / pid
+            pid_root.mkdir(parents=True)
+            (pid_root / "cgroup").write_text(f"0::/kubepods/{cid}\n")
+            (pid_root / "status").write_text("State:\tR\n")
+            (pid_root / "maps").write_text("00400000-00452000 r-xp\n")
+            root_fs = proc_root / "roots" / pid
+            root_fs.mkdir(parents=True)
+            (root_fs / "etc").mkdir()
+            (pid_root / "root").symlink_to(root_fs, target_is_directory=True)
+
+        (log_root / "containers" / "api-7d9b_payments_api-abcd1234.log").write_text("runtime log line\n")
+
+        pods = [
+            self.collector.PodContext(
+                namespace="payments",
+                pod_name="api-7d9b",
+                pod_uid="pod-uid-1",
+                node_name="worker-a",
+                container_names=("api",),
+                container_ids=("abcd1234",),
+                pvc_names=("api-data",),
+            )
+        ]
+        findings = _load_jsonl(GOLDEN_DIR / "k8s_container_escape_findings.ocsf.jsonl")
+        records = list(
+            self.collector.run(
+                findings,
+                kube_client=_FakeKube(handler=self.collector, pods=pods),
+                proc_root=proc_root,
+                log_root=log_root,
+                collected_at=datetime(2026, 4, 19, 7, 10, tzinfo=timezone.utc),
+            )
+        )
+        assert len(records) == 3
+        assert {record["record_type"] for record in records} == {"remediation_plan"}
+        assert {record["mode"] for record in records} == {"forensics"}
+        assert all(record["bundle_size_bytes"] > 0 for record in records)
+        assert all(record["artifacts"] for record in records)


### PR DESCRIPTION
## What changed

- added `src/forensic_collector.py` under `remediate-container-escape-k8s` for post-quarantine evidence collection from host-mounted `/proc`, runtime logs, and optional CSI `VolumeSnapshot` refs
- kept the scope narrow: forensic bundle planning/upload only, with no node drain or pod-kill logic mixed into the PR
- added unit coverage for deterministic bundle creation, PID discovery, snapshot planning, and S3 upload behavior
- added an integration-style dry-run pipeline test from the frozen container-escape findings golden
- updated the remediation skill contract and official references for the new forensic mode

## Why

This is the remaining forensic slice from issue `#274` after the ingest preservation, detector, and quarantine remediation PRs merged. It preserves the reviewable sequencing: quarantine first, evidence collection second, destructive response later if still needed.

## Validation

- `ruff check skills/ tests/ mcp-server/ scripts/ --config pyproject.toml`
- `uv run pytest skills/remediation/remediate-container-escape-k8s/tests/test_handler.py -q`
- `uv run pytest skills/remediation/remediate-container-escape-k8s/tests/test_forensic_collector.py -q`
- `uv run pytest tests/integration/test_k8s_container_escape_remediation_pipeline.py -q`
- `uv run pytest tests/integration/test_k8s_container_escape_forensics_pipeline.py -q`
- `uv run python scripts/validate_skill_contract.py`
- `uv run python scripts/validate_skill_integrity.py`
- `uv run python scripts/validate_safe_skill_bar.py`
