### PR TITLE
fix(tooling+docs): unbreak bare mypy and reconcile skill counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Skills are grouped into layered categories — not by cloud. The category answer
 
 ```
 skills/
-├── ingestion/                     # raw source → OCSF 1.8
+├── ingestion/                     # raw source → OCSF 1.8 (15 ingest-* + 3 source-*)
 │   ├── ingest-cloudtrail-ocsf/
 │   ├── ingest-vpc-flow-logs-ocsf/
 │   ├── ingest-vpc-flow-logs-gcp-ocsf/
@@ -27,7 +27,13 @@ skills/
 │   ├── ingest-gcp-audit-ocsf/
 │   ├── ingest-azure-activity-ocsf/
 │   ├── ingest-k8s-audit-ocsf/
-│   └── ingest-mcp-proxy-ocsf/
+│   ├── ingest-mcp-proxy-ocsf/
+│   ├── ingest-okta-system-log-ocsf/
+│   ├── ingest-entra-directory-audit-ocsf/
+│   ├── ingest-google-workspace-login-ocsf/
+│   ├── source-s3-select/                # warehouse query adapter
+│   ├── source-snowflake-query/          # warehouse query adapter
+│   └── source-databricks-query/         # warehouse query adapter
 │
 ├── discovery/                     # inventory / graph / AI BOM / evidence
 │   ├── discover-environment/
@@ -37,10 +43,16 @@ skills/
 │
 ├── detection/                     # OCSF → Detection Finding 2004 + MITRE
 │   ├── detect-mcp-tool-drift/
+│   ├── detect-prompt-injection-mcp-proxy/
 │   ├── detect-container-escape-k8s/
 │   ├── detect-privilege-escalation-k8s/
 │   ├── detect-sensitive-secret-read-k8s/
-│   └── detect-lateral-movement/
+│   ├── detect-lateral-movement/
+│   ├── detect-okta-mfa-fatigue/
+│   ├── detect-credential-stuffing-okta/
+│   ├── detect-entra-credential-addition/
+│   ├── detect-entra-role-grant-escalation/
+│   └── detect-google-workspace-suspicious-login/
 │
 ├── evaluation/                    # posture and benchmark checks
 │   ├── cspm-aws-cis-benchmark/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ flowchart LR
     subgraph Act
         direction TB
         view["L6 View<br/>2 skills · SARIF · Mermaid"]:::act
-        remediate["L5 Remediate<br/>2 skills · HITL · dual audit"]:::act
+        remediate["L5 Remediate<br/>3 skills · HITL · dual audit"]:::act
     end
     output["L7 Output<br/>3 sinks · S3 · Snowflake · ClickHouse"]:::sink
 
@@ -122,7 +122,7 @@ flowchart TB
     end
 
     mcp["Repo MCP server<br/>mcp-server/src/server.py<br/>auto-discovers SKILL.md, audited calls, timeout-governed"]:::mcp
-    bundle[("Shared skill bundle<br/>46 shipped")]:::bundle
+    bundle[("Shared skill bundle<br/>48 shipped")]:::bundle
     outputs[/"native · OCSF 1.8 · bridge · SARIF · Mermaid · AI BOM · audited writes"/]:::output
 
     claude -->|stdio| mcp

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Pick the row that matches the job.
 
 Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
+### Closed-loop coverage at a glance
+
+![Closed-loop coverage matrix — 3 of 11 detections shipped as closed loops; 5 of the remaining 8 gaps planned via tracking issues; 3 detections still need new remediation skills.](docs/images/coverage-matrix.svg)
+
+Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
+
 ## Common shipped flows
 
 Three lanes. Same skill bundle contract in every lane — input, output, and control boundary are what change.

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,0 +1,186 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="cm-title cm-desc">
+  <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation. Rows list every detection (11) plus every CSPM benchmark family (4 native CIS scopes). Columns are: detector or check shipped, paired remediation shipped, paired remediation planned. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap (linked to a tracking issue); red cells mean no remediation exists or is planned. Three out of eleven detection rows are green-green-green closed loops today (Okta MFA fatigue, Okta credential stuffing, K8s container escape). Eight detection rows are red on the remediation column, with five of those amber because issues 238, 239, 240, 241, and 242 plan the work. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#060b17"/>
+      <stop offset="100%" stop-color="#0a1325"/>
+    </linearGradient>
+    <pattern id="grid2" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-opacity="0.25" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <rect width="1400" height="780" fill="url(#bg2)"/>
+  <rect width="1400" height="780" fill="url(#grid2)"/>
+
+  <!-- Header -->
+  <text x="48" y="56" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="26" font-weight="900">Closed-loop coverage matrix</text>
+  <text x="48" y="84" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="14">Every shipped detection or posture check, mapped to whether a paired remediation exists, is planned, or is missing. Green rows are closed loops. The red wall on the remediation column is tracked at issue #155.</text>
+
+  <!-- Legend -->
+  <g transform="translate(48,108)" font-family="Inter, system-ui, sans-serif" font-size="12">
+    <g>
+      <rect x="0" y="0" width="14" height="14" rx="3" fill="#16a34a" stroke="#22c55e"/>
+      <text x="22" y="11" fill="#dcfce7">shipped (closed loop)</text>
+    </g>
+    <g transform="translate(190,0)">
+      <rect x="0" y="0" width="14" height="14" rx="3" fill="#b45309" stroke="#f59e0b"/>
+      <text x="22" y="11" fill="#fef3c7">planned (issue tracked)</text>
+    </g>
+    <g transform="translate(380,0)">
+      <rect x="0" y="0" width="14" height="14" rx="3" fill="#7f1d1d" stroke="#ef4444"/>
+      <text x="22" y="11" fill="#fee2e2">missing (no remediation, no issue)</text>
+    </g>
+    <g transform="translate(660,0)">
+      <rect x="0" y="0" width="14" height="14" rx="3" fill="#1e3a8a" stroke="#3b82f6"/>
+      <text x="22" y="11" fill="#dbeafe">N/A (no remediation needed)</text>
+    </g>
+  </g>
+
+  <!-- Column headers -->
+  <g transform="translate(48,150)" font-family="Inter, system-ui, sans-serif" font-size="12" font-weight="800" fill="#cbd5e1">
+    <text x="0" y="14">Skill</text>
+    <text x="540" y="14" text-anchor="middle">Detector / check</text>
+    <text x="740" y="14" text-anchor="middle">Paired remediation</text>
+    <text x="940" y="14" text-anchor="middle">Roadmap issue</text>
+    <text x="1140" y="14">Notes</text>
+  </g>
+  <line x1="48" y1="160" x2="1352" y2="160" stroke="#334155" stroke-width="1"/>
+
+  <!-- Section: Detection -->
+  <g transform="translate(48,178)" font-family="Inter, system-ui, sans-serif">
+    <text x="0" y="14" fill="#5eead4" font-size="13" font-weight="900">DETECTION (11)</text>
+
+    <!-- Row template (y stride 30) -->
+    <!-- 1: detect-okta-mfa-fatigue -->
+    <g transform="translate(0,30)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-okta-mfa-fatigue</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <text x="940" y="14" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
+      <text x="1140" y="14" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
+    </g>
+    <!-- 2 -->
+    <g transform="translate(0,60)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-credential-stuffing-okta</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <text x="940" y="14" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
+      <text x="1140" y="14" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
+    </g>
+    <!-- 3 -->
+    <g transform="translate(0,90)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-container-escape-k8s</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#298 #299</text>
+      <text x="1140" y="14" fill="#dcfce7" font-size="12">→ remediate-container-escape-k8s (closed)</text>
+    </g>
+    <!-- 4 -->
+    <g transform="translate(0,120)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-privilege-escalation-k8s</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke (planned)</text>
+    </g>
+    <!-- 5 -->
+    <g transform="translate(0,150)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-sensitive-secret-read-k8s</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke covers (planned)</text>
+    </g>
+    <!-- 6 -->
+    <g transform="translate(0,180)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-entra-credential-addition</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
+    </g>
+    <!-- 7 -->
+    <g transform="translate(0,210)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-entra-role-grant-escalation</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
+    </g>
+    <!-- 8 -->
+    <g transform="translate(0,240)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-google-workspace-suspicious-login</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+      <text x="1140" y="14" fill="#fee2e2" font-size="12">no Workspace session-kill skill yet</text>
+    </g>
+    <!-- 9 -->
+    <g transform="translate(0,270)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-lateral-movement</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+      <text x="1140" y="14" fill="#fee2e2" font-size="12">cross-cloud, response is per-arm</text>
+    </g>
+    <!-- 10 -->
+    <g transform="translate(0,300)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-mcp-tool-drift</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+      <text x="1140" y="14" fill="#fee2e2" font-size="12">remediate-mcp-tool-revoke candidate</text>
+    </g>
+    <!-- 11 -->
+    <g transform="translate(0,330)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-prompt-injection-mcp-proxy</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+      <text x="1140" y="14" fill="#fee2e2" font-size="12">remediate-mcp-proxy-quarantine candidate</text>
+    </g>
+  </g>
+
+  <!-- Section: Evaluation / CSPM -->
+  <g transform="translate(48,540)" font-family="Inter, system-ui, sans-serif">
+    <text x="0" y="14" fill="#5eead4" font-size="13" font-weight="900">EVALUATION / CSPM (4 platforms · 82 checks)</text>
+
+    <g transform="translate(0,30)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">cspm-aws-cis-benchmark</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+    </g>
+    <g transform="translate(0,60)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">cspm-gcp-cis-benchmark</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+    </g>
+    <g transform="translate(0,90)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">cspm-azure-cis-benchmark</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
+      <text x="1140" y="14" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+    </g>
+    <g transform="translate(0,120)">
+      <text x="0" y="14" fill="#f1f5f9" font-size="13">k8s-security-benchmark + container/model/gpu</text>
+      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <rect x="720" y="2" width="40" height="18" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+      <text x="940" y="14" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
+      <text x="1140" y="14" fill="#dbeafe" font-size="12">posture only · remediate via k8s-rbac-revoke</text>
+    </g>
+  </g>
+
+  <!-- Footer -->
+  <g transform="translate(48,720)" font-family="Inter, system-ui, sans-serif">
+    <text x="0" y="14" fill="#94a3b8" font-size="12">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">3 / 11 detections</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">5 of the 8 gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">3 detections (Workspace, lateral-movement, MCP) need new remediation skills</tspan></text>
+    <text x="0" y="34" fill="#64748b" font-size="11">Contract: every "shipped" remediation cell here is HITL-gated, dry-run-by-default, and dual-audited per SECURITY_BAR.md and docs/HITL_POLICY.md. Tracking: #155 (response parity).</text>
+  </g>
+</svg>

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="cm-title cm-desc">
-  <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation. Rows list every detection (11) plus every CSPM benchmark family (4 native CIS scopes). Columns are: detector or check shipped, paired remediation shipped, paired remediation planned. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap (linked to a tracking issue); red cells mean no remediation exists or is planned. Three out of eleven detection rows are green-green-green closed loops today (Okta MFA fatigue, Okta credential stuffing, K8s container escape). Eight detection rows are red on the remediation column, with five of those amber because issues 238, 239, 240, 241, and 242 plan the work. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="820" viewBox="0 0 1400 820" role="img" aria-labelledby="cm-title cm-desc">
+  <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix with MITRE ATT&amp;CK mapping</title>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with the MITRE ATT&amp;CK technique IDs (or MITRE ATLAS for AI threats) that each detection emits in OCSF finding_info.attacks. Rows list every detection (11) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, MITRE technique IDs, detector or check shipped, paired remediation shipped, paired remediation planned with tracking issue, and notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Three of eleven detection rows are closed loops today (Okta MFA fatigue T1621, Okta credential stuffing T1110.003, K8s container escape T1611 and T1610). Eight detection rows lack remediation; five are amber via issues 238, 241, and 242, and three are red because no remediation skill is scoped yet for Workspace login, lateral movement, and MCP tool drift or prompt injection. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,15 +12,16 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="780" fill="url(#bg2)"/>
-  <rect width="1400" height="780" fill="url(#grid2)"/>
+  <rect width="1400" height="820" fill="url(#bg2)"/>
+  <rect width="1400" height="820" fill="url(#grid2)"/>
 
-  <!-- Header -->
+  <!-- Title block -->
   <text x="48" y="56" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="26" font-weight="900">Closed-loop coverage matrix</text>
-  <text x="48" y="84" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="14">Every shipped detection or posture check, mapped to whether a paired remediation exists, is planned, or is missing. Green rows are closed loops. The red wall on the remediation column is tracked at issue #155.</text>
+  <text x="48" y="84" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="13">Every shipped detection (with its MITRE ATT&amp;CK / ATLAS technique IDs) and posture check, mapped to whether a paired</text>
+  <text x="48" y="102" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="13">remediation exists, is planned, or is missing. Green rows are closed loops. The red wall is tracked at issue #155.</text>
 
   <!-- Legend -->
-  <g transform="translate(48,108)" font-family="Inter, system-ui, sans-serif" font-size="12">
+  <g transform="translate(48,124)" font-family="Inter, system-ui, sans-serif" font-size="12">
     <g>
       <rect x="0" y="0" width="14" height="14" rx="3" fill="#16a34a" stroke="#22c55e"/>
       <text x="22" y="11" fill="#dcfce7">shipped (closed loop)</text>
@@ -35,152 +36,164 @@
     </g>
     <g transform="translate(660,0)">
       <rect x="0" y="0" width="14" height="14" rx="3" fill="#1e3a8a" stroke="#3b82f6"/>
-      <text x="22" y="11" fill="#dbeafe">N/A (no remediation needed)</text>
+      <text x="22" y="11" fill="#dbeafe">N/A (posture-only)</text>
     </g>
   </g>
 
-  <!-- Column headers -->
-  <g transform="translate(48,150)" font-family="Inter, system-ui, sans-serif" font-size="12" font-weight="800" fill="#cbd5e1">
-    <text x="0" y="14">Skill</text>
-    <text x="540" y="14" text-anchor="middle">Detector / check</text>
-    <text x="740" y="14" text-anchor="middle">Paired remediation</text>
-    <text x="940" y="14" text-anchor="middle">Roadmap issue</text>
-    <text x="1140" y="14">Notes</text>
+  <!-- Column headers (text baseline at y=164; divider at y=176 — no collision) -->
+  <g font-family="Inter, system-ui, sans-serif" font-size="12" font-weight="800" fill="#cbd5e1">
+    <text x="48"   y="164">Skill</text>
+    <text x="350"  y="164">MITRE ATT&amp;CK / ATLAS</text>
+    <text x="570"  y="164" text-anchor="middle">Detector</text>
+    <text x="700"  y="164" text-anchor="middle">Remediation</text>
+    <text x="830"  y="164" text-anchor="middle">Issue</text>
+    <text x="920"  y="164">Notes</text>
   </g>
-  <line x1="48" y1="160" x2="1352" y2="160" stroke="#334155" stroke-width="1"/>
+  <line x1="48" y1="176" x2="1352" y2="176" stroke="#334155" stroke-width="1"/>
 
-  <!-- Section: Detection -->
-  <g transform="translate(48,178)" font-family="Inter, system-ui, sans-serif">
-    <text x="0" y="14" fill="#5eead4" font-size="13" font-weight="900">DETECTION (11)</text>
+  <!-- DETECTION SECTION -->
+  <text x="48" y="206" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="13" font-weight="900">DETECTION (11)</text>
 
-    <!-- Row template (y stride 30) -->
-    <!-- 1: detect-okta-mfa-fatigue -->
-    <g transform="translate(0,30)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-okta-mfa-fatigue</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <text x="940" y="14" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
-      <text x="1140" y="14" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
-    </g>
-    <!-- 2 -->
-    <g transform="translate(0,60)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-credential-stuffing-okta</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <text x="940" y="14" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
-      <text x="1140" y="14" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
-    </g>
-    <!-- 3 -->
-    <g transform="translate(0,90)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-container-escape-k8s</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#298 #299</text>
-      <text x="1140" y="14" fill="#dcfce7" font-size="12">→ remediate-container-escape-k8s (closed)</text>
-    </g>
-    <!-- 4 -->
-    <g transform="translate(0,120)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-privilege-escalation-k8s</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke (planned)</text>
-    </g>
-    <!-- 5 -->
-    <g transform="translate(0,150)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-sensitive-secret-read-k8s</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke covers (planned)</text>
-    </g>
-    <!-- 6 -->
-    <g transform="translate(0,180)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-entra-credential-addition</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
-    </g>
-    <!-- 7 -->
-    <g transform="translate(0,210)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-entra-role-grant-escalation</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
-    </g>
-    <!-- 8 -->
-    <g transform="translate(0,240)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-google-workspace-suspicious-login</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-      <text x="1140" y="14" fill="#fee2e2" font-size="12">no Workspace session-kill skill yet</text>
-    </g>
-    <!-- 9 -->
-    <g transform="translate(0,270)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-lateral-movement</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-      <text x="1140" y="14" fill="#fee2e2" font-size="12">cross-cloud, response is per-arm</text>
-    </g>
-    <!-- 10 -->
-    <g transform="translate(0,300)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-mcp-tool-drift</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-      <text x="1140" y="14" fill="#fee2e2" font-size="12">remediate-mcp-tool-revoke candidate</text>
-    </g>
-    <!-- 11 -->
-    <g transform="translate(0,330)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">detect-prompt-injection-mcp-proxy</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-      <text x="1140" y="14" fill="#fee2e2" font-size="12">remediate-mcp-proxy-quarantine candidate</text>
-    </g>
+  <!-- Row helper: each row y-stride = 30; first row at y=232 -->
+  <!-- 1: detect-okta-mfa-fatigue -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="246" fill="#f1f5f9" font-size="13">detect-okta-mfa-fatigue</text>
+    <text x="350" y="246" fill="#cbd5e1" font-size="12">T1621</text>
+    <rect x="550" y="234" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="234" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="830" y="246" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
+    <text x="920" y="246" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
+  </g>
+  <!-- 2 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="276" fill="#f1f5f9" font-size="13">detect-credential-stuffing-okta</text>
+    <text x="350" y="276" fill="#cbd5e1" font-size="12">T1110 · T1110.003</text>
+    <rect x="550" y="264" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="264" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="830" y="276" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
+    <text x="920" y="276" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
+  </g>
+  <!-- 3 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="306" fill="#f1f5f9" font-size="13">detect-container-escape-k8s</text>
+    <text x="350" y="306" fill="#cbd5e1" font-size="12">T1611 · T1610</text>
+    <rect x="550" y="294" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="294" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="830" y="306" text-anchor="middle" fill="#fde68a" font-size="12">#298 #299</text>
+    <text x="920" y="306" fill="#dcfce7" font-size="12">→ remediate-container-escape-k8s (closed)</text>
+  </g>
+  <!-- 4 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="336" fill="#f1f5f9" font-size="13">detect-privilege-escalation-k8s</text>
+    <text x="350" y="336" fill="#cbd5e1" font-size="12">T1552.007 · T1611 · T1098 · T1550.001</text>
+    <rect x="550" y="324" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="324" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="336" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
+    <text x="920" y="336" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke (planned)</text>
+  </g>
+  <!-- 5 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="366" fill="#f1f5f9" font-size="13">detect-sensitive-secret-read-k8s</text>
+    <text x="350" y="366" fill="#cbd5e1" font-size="12">T1552 · T1552.007</text>
+    <rect x="550" y="354" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="354" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="366" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
+    <text x="920" y="366" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke covers (planned)</text>
+  </g>
+  <!-- 6 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="396" fill="#f1f5f9" font-size="13">detect-entra-credential-addition</text>
+    <text x="350" y="396" fill="#cbd5e1" font-size="12">T1098 · T1098.001</text>
+    <rect x="550" y="384" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="384" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="396" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
+    <text x="920" y="396" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
+  </g>
+  <!-- 7 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="426" fill="#f1f5f9" font-size="13">detect-entra-role-grant-escalation</text>
+    <text x="350" y="426" fill="#cbd5e1" font-size="12">T1098 · T1098.003</text>
+    <rect x="550" y="414" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="414" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="426" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
+    <text x="920" y="426" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
+  </g>
+  <!-- 8 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="456" fill="#f1f5f9" font-size="13">detect-google-workspace-suspicious-login</text>
+    <text x="350" y="456" fill="#cbd5e1" font-size="12">T1110 · T1078</text>
+    <rect x="550" y="444" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="444" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="830" y="456" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+    <text x="920" y="456" fill="#fee2e2" font-size="12">no Workspace session-kill skill yet</text>
+  </g>
+  <!-- 9 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="486" fill="#f1f5f9" font-size="13">detect-lateral-movement</text>
+    <text x="350" y="486" fill="#cbd5e1" font-size="12">T1021 · T1078.004 (TA0008)</text>
+    <rect x="550" y="474" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="474" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="830" y="486" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+    <text x="920" y="486" fill="#fee2e2" font-size="12">cross-cloud · response is per-arm fan-out</text>
+  </g>
+  <!-- 10 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="516" fill="#f1f5f9" font-size="13">detect-mcp-tool-drift</text>
+    <text x="350" y="516" fill="#cbd5e1" font-size="12">T1195.001 (TA0001)</text>
+    <rect x="550" y="504" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="504" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="830" y="516" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+    <text x="920" y="516" fill="#fee2e2" font-size="12">remediate-mcp-tool-quarantine candidate</text>
+  </g>
+  <!-- 11 -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="546" fill="#f1f5f9" font-size="13">detect-prompt-injection-mcp-proxy</text>
+    <text x="350" y="546" fill="#cbd5e1" font-size="12">ATLAS AML.T0051</text>
+    <rect x="550" y="534" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="534" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="830" y="546" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
+    <text x="920" y="546" fill="#fee2e2" font-size="12">remediate-mcp-proxy-quarantine candidate</text>
   </g>
 
-  <!-- Section: Evaluation / CSPM -->
-  <g transform="translate(48,540)" font-family="Inter, system-ui, sans-serif">
-    <text x="0" y="14" fill="#5eead4" font-size="13" font-weight="900">EVALUATION / CSPM (4 platforms · 82 checks)</text>
+  <!-- EVALUATION SECTION -->
+  <text x="48" y="600" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="13" font-weight="900">EVALUATION / CSPM (4 platforms · 82 checks)</text>
 
-    <g transform="translate(0,30)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">cspm-aws-cis-benchmark</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
-    </g>
-    <g transform="translate(0,60)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">cspm-gcp-cis-benchmark</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
-    </g>
-    <g transform="translate(0,90)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">cspm-azure-cis-benchmark</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-      <text x="940" y="14" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
-      <text x="1140" y="14" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
-    </g>
-    <g transform="translate(0,120)">
-      <text x="0" y="14" fill="#f1f5f9" font-size="13">k8s-security-benchmark + container/model/gpu</text>
-      <rect x="520" y="2" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-      <rect x="720" y="2" width="40" height="18" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-      <text x="940" y="14" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
-      <text x="1140" y="14" fill="#dbeafe" font-size="12">posture only · remediate via k8s-rbac-revoke</text>
-    </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="640" fill="#f1f5f9" font-size="13">cspm-aws-cis-benchmark</text>
+    <text x="350" y="640" fill="#cbd5e1" font-size="12">CIS AWS Foundations 1.5</text>
+    <rect x="550" y="628" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="628" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="640" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
+    <text x="920" y="640" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+  </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="670" fill="#f1f5f9" font-size="13">cspm-gcp-cis-benchmark</text>
+    <text x="350" y="670" fill="#cbd5e1" font-size="12">CIS GCP Foundations 2.0</text>
+    <rect x="550" y="658" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="658" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="670" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
+    <text x="920" y="670" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+  </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="700" fill="#f1f5f9" font-size="13">cspm-azure-cis-benchmark</text>
+    <text x="350" y="700" fill="#cbd5e1" font-size="12">CIS Azure Foundations 2.1</text>
+    <rect x="550" y="688" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="688" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="830" y="700" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
+    <text x="920" y="700" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+  </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"  y="730" fill="#f1f5f9" font-size="13">k8s + container + model + gpu benchmarks</text>
+    <text x="350" y="730" fill="#cbd5e1" font-size="12">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="550" y="718" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="680" y="718" width="40" height="18" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="830" y="730" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
+    <text x="920" y="730" fill="#dbeafe" font-size="12">posture-only · remediated via k8s-rbac-revoke</text>
   </g>
 
   <!-- Footer -->
-  <g transform="translate(48,720)" font-family="Inter, system-ui, sans-serif">
-    <text x="0" y="14" fill="#94a3b8" font-size="12">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">3 / 11 detections</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">5 of the 8 gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">3 detections (Workspace, lateral-movement, MCP) need new remediation skills</tspan></text>
-    <text x="0" y="34" fill="#64748b" font-size="11">Contract: every "shipped" remediation cell here is HITL-gated, dry-run-by-default, and dual-audited per SECURITY_BAR.md and docs/HITL_POLICY.md. Tracking: #155 (response parity).</text>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48" y="780" fill="#94a3b8" font-size="12">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">3 / 11 detections</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">5 of 8 gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">3 detections (Workspace, lateral-movement, MCP) need new remediation skills</tspan></text>
+    <text x="48" y="802" fill="#64748b" font-size="11">Every "shipped" remediation cell is HITL-gated, dry-run-by-default, and dual-audited per SECURITY_BAR.md and docs/HITL_POLICY.md. Tracking: #155.</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 46 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 10 detect, 7 evaluate, 2 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 48 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 11 detect, 7 evaluate, 3 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="162" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">46</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">48</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(174,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">10</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">11</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
@@ -117,7 +117,7 @@
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
         <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L5 Remediate</text>
-        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">2</text>
+        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">3</text>
       </g>
       <g transform="translate(222,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,15 @@ python_classes = "Test*"
 python_functions = "test_*"
 
 [tool.mypy]
+# Skills use a flat src/<entrypoint>.py layout (e.g. src/detect.py, src/ingest.py)
+# repeated across dozens of skill directories. Running `mypy skills/` discovers
+# many same-named modules and aborts with "Duplicate module named 'detect'".
+# The canonical entrypoint is `scripts/run_mypy.sh`, which invokes mypy once
+# per skill src/ directory. `explicit_package_bases` + `namespace_packages`
+# keep ad-hoc per-directory invocations working from the IDE.
 python_version = "3.11"
-files = ["skills"]
+explicit_package_bases = true
+namespace_packages = true
 ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
## Summary

- **Tooling**: `mypy` invoked from pyproject defaults aborted with `Duplicate module named "detect"` because every detection skill ships `src/detect.py`. Drops the unconditional `files = ["skills"]` and adds `explicit_package_bases` + `namespace_packages` so per-directory invocations (IDE, contributor) resolve cleanly. The canonical entrypoint remains `scripts/run_mypy.sh`.
- **Docs**: agent-integration Mermaid label "46 shipped" → "48 shipped"; L5 Remediate node "2 skills" → "3 skills" (matches the shipped layer table at README L22-30 and `validate_skill_count_consistency.py`).
- **CLAUDE.md**: `skills/` tree was a stale snapshot (12 ingestion, 5 detection). Refreshed to the actual 18 ingestion (15 `ingest-*` + 3 `source-*`) and 11 detection skills.

## Why

End-to-end audit on 2026-04-19 surfaced these as P1 doc/tooling drift. Caught by:

1. `mypy --config-file pyproject.toml` (without explicit args): hard error.
2. `grep "46 shipped" README.md` vs `validate_skill_count_consistency.py` reporting `total=48`.
3. `wc -l` on the CLAUDE.md skills tree vs `ls skills/ingestion/`.

## Test plan

- [x] `bash scripts/run_mypy.sh` — clean
- [x] `mypy --config-file pyproject.toml skills/_shared` — clean (no duplicate-module crash)
- [x] All 9 `scripts/validate_*.py` validators pass
- [x] `pytest -q` — 1152 passed
- [x] `ruff check skills scripts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)