### PR TITLE
docs(visuals+readme): closed-loop matrix, IAM diagram rebuild, README collapsibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@
 
 **Total: 48 shipped skills.**
 
-### Why different layers use different formats
+<details>
+<summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
 
 OCSF 1.8 is the **SIEM interop wire format** — valuable exactly where events flow to a downstream analyzer. It is not the universal internal format, and this repo is honest about where it fits:
 
@@ -46,6 +47,8 @@ OCSF 1.8 is the **SIEM interop wire format** — valuable exactly where events f
 | **Output (sinks)** | pass-through | Sinks write whatever the producer emitted |
 
 Full discussion: [docs/ARCHITECTURE.md §3 Layer model + §6 Wire contract](docs/ARCHITECTURE.md). The pinned OCSF contract for ingest + detect lives in [skills/detection-engineering/OCSF_CONTRACT.md](skills/detection-engineering/OCSF_CONTRACT.md).
+
+</details>
 
 ## Architecture
 
@@ -160,9 +163,8 @@ Per-client setup docs under [`docs/integrations/`](docs/integrations/). Every cl
 
 Least-privilege scoping across every client via the `CLOUD_SECURITY_MCP_ALLOWED_SKILLS` env var (comma-separated skill names — unlisted skills are not registered as tools).
 
-## Start here
-
-Pick the row that matches the job.
+<details>
+<summary><b>Start here</b> — pick the row that matches the job</summary>
 
 | You have… | Start with | Typical output |
 |---|---|---|
@@ -176,6 +178,8 @@ Pick the row that matches the job.
 | a suspicious Kubernetes workload to isolate | [`remediate-container-escape-k8s`](skills/remediation/remediate-container-escape-k8s/) | audited deny-all NetworkPolicy plan / action |
 
 Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
+
+</details>
 
 ### Closed-loop coverage at a glance
 
@@ -281,7 +285,8 @@ The flagship shipped write path. Guarded, event-driven, dual-audited — and **o
 - **one cloud per worker** — the AWS worker only touches AWS IAM via cross-account `AssumeRole` inside the Org. A single worker principal never spans cloud boundaries
 - **dual audit** — DynamoDB + KMS-encrypted S3 for every write; ingest-back so the next run verifies closure
 
-### Per-cloud service mapping
+<details>
+<summary><b>Per-cloud service mapping</b> — AWS is shipped; GCP and Azure stack patterns documented (worker library code already exists under <code>src/lambda_worker/clouds/</code>)</summary>
 
 Only the AWS orchestration ships today (under [`infra/`](skills/remediation/iam-departures-aws/infra/)). For Azure and GCP, the **worker library code** lives in [`src/lambda_worker/clouds/`](skills/remediation/iam-departures-aws/src/lambda_worker/clouds/) (`azure_entra.py`, `gcp_iam.py`, `databricks_scim.py`, `snowflake_user.py`); the recommended native orchestration stack per cloud is documented below so operators pick equivalent primitives instead of forcing one stack across all clouds.
 
@@ -297,7 +302,10 @@ Only the AWS orchestration ships today (under [`infra/`](skills/remediation/iam-
 
 Details: [skills/remediation/iam-departures-aws/](skills/remediation/iam-departures-aws/) · [SKILL.md#cross-cloud-workflow-shape](skills/remediation/iam-departures-aws/SKILL.md)
 
-## Native vs OCSF
+</details>
+
+<details>
+<summary><b>Native vs OCSF</b> — four emit modes and when each is right</summary>
 
 | Mode | When | What it is |
 |---|---|---|
@@ -307,6 +315,8 @@ Details: [skills/remediation/iam-departures-aws/](skills/remediation/iam-departu
 | `canonical` | internal only | the normalization model between ingest and detect |
 
 The `-ocsf` suffix means OCSF is the default, not the only output. Reference: [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md) · [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md) · [docs/NORMALIZATION_EXAMPLES.md](docs/NORMALIZATION_EXAMPLES.md)
+
+</details>
 
 ## Install and trust
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="820" viewBox="0 0 1400 820" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="900" viewBox="0 0 1200 900" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix with MITRE ATT&amp;CK mapping</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with the MITRE ATT&amp;CK technique IDs (or MITRE ATLAS for AI threats) that each detection emits in OCSF finding_info.attacks. Rows list every detection (11) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, MITRE technique IDs, detector or check shipped, paired remediation shipped, paired remediation planned with tracking issue, and notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Three of eleven detection rows are closed loops today (Okta MFA fatigue T1621, Okta credential stuffing T1110.003, K8s container escape T1611 and T1610). Eight detection rows lack remediation; five are amber via issues 238, 241, and 242, and three are red because no remediation skill is scoped yet for Workspace login, lateral movement, and MCP tool drift or prompt injection. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with the MITRE ATT&amp;CK technique IDs (or MITRE ATLAS for AI threats) that each detection emits in OCSF finding_info.attacks. Rows list every detection (11) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, MITRE technique IDs, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Three of eleven detection rows are closed loops today: Okta MFA fatigue T1621, Okta credential stuffing T1110.003, and K8s container escape T1611 and T1610. Eight detection rows lack remediation; five are amber via issues 238, 241, and 242, and three are red because no remediation skill is scoped yet for Workspace login, lateral movement, and MCP tool drift or prompt injection. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,188 +12,160 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="820" fill="url(#bg2)"/>
-  <rect width="1400" height="820" fill="url(#grid2)"/>
+  <rect width="1200" height="900" fill="url(#bg2)"/>
+  <rect width="1200" height="900" fill="url(#grid2)"/>
 
   <!-- Title block -->
-  <text x="48" y="56" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="26" font-weight="900">Closed-loop coverage matrix</text>
-  <text x="48" y="84" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="13">Every shipped detection (with its MITRE ATT&amp;CK / ATLAS technique IDs) and posture check, mapped to whether a paired</text>
-  <text x="48" y="102" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="13">remediation exists, is planned, or is missing. Green rows are closed loops. The red wall is tracked at issue #155.</text>
+  <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
+  <text x="48" y="94" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="16">Every shipped detection (with MITRE ATT&amp;CK / ATLAS technique IDs) and posture check, mapped to whether a paired</text>
+  <text x="48" y="116" fill="#94a3b8" font-family="Inter, system-ui, sans-serif" font-size="16">remediation exists, is planned, or is missing. Green rows are closed loops. The red wall is tracked at issue #155.</text>
 
   <!-- Legend -->
-  <g transform="translate(48,124)" font-family="Inter, system-ui, sans-serif" font-size="12">
+  <g transform="translate(48,144)" font-family="Inter, system-ui, sans-serif" font-size="14">
     <g>
-      <rect x="0" y="0" width="14" height="14" rx="3" fill="#16a34a" stroke="#22c55e"/>
-      <text x="22" y="11" fill="#dcfce7">shipped (closed loop)</text>
+      <rect x="0" y="0" width="18" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
+      <text x="28" y="14" fill="#dcfce7">shipped (closed loop)</text>
     </g>
-    <g transform="translate(190,0)">
-      <rect x="0" y="0" width="14" height="14" rx="3" fill="#b45309" stroke="#f59e0b"/>
-      <text x="22" y="11" fill="#fef3c7">planned (issue tracked)</text>
+    <g transform="translate(230,0)">
+      <rect x="0" y="0" width="18" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
+      <text x="28" y="14" fill="#fef3c7">planned (issue tracked)</text>
     </g>
-    <g transform="translate(380,0)">
-      <rect x="0" y="0" width="14" height="14" rx="3" fill="#7f1d1d" stroke="#ef4444"/>
-      <text x="22" y="11" fill="#fee2e2">missing (no remediation, no issue)</text>
+    <g transform="translate(460,0)">
+      <rect x="0" y="0" width="18" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+      <text x="28" y="14" fill="#fee2e2">missing (no issue yet)</text>
     </g>
-    <g transform="translate(660,0)">
-      <rect x="0" y="0" width="14" height="14" rx="3" fill="#1e3a8a" stroke="#3b82f6"/>
-      <text x="22" y="11" fill="#dbeafe">N/A (posture-only)</text>
+    <g transform="translate(680,0)">
+      <rect x="0" y="0" width="18" height="18" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+      <text x="28" y="14" fill="#dbeafe">posture-only</text>
     </g>
   </g>
 
-  <!-- Column headers (text baseline at y=164; divider at y=176 — no collision) -->
-  <g font-family="Inter, system-ui, sans-serif" font-size="12" font-weight="800" fill="#cbd5e1">
-    <text x="48"   y="164">Skill</text>
-    <text x="350"  y="164">MITRE ATT&amp;CK / ATLAS</text>
-    <text x="570"  y="164" text-anchor="middle">Detector</text>
-    <text x="700"  y="164" text-anchor="middle">Remediation</text>
-    <text x="830"  y="164" text-anchor="middle">Issue</text>
-    <text x="920"  y="164">Notes</text>
+  <!-- Column headers (text baseline at y=200; divider at y=212 — clean separation) -->
+  <g font-family="Inter, system-ui, sans-serif" font-size="14" font-weight="800" fill="#cbd5e1">
+    <text x="48"   y="200">Skill</text>
+    <text x="430"  y="200">MITRE ATT&amp;CK / ATLAS</text>
+    <text x="780"  y="200" text-anchor="middle">Detector</text>
+    <text x="900"  y="200" text-anchor="middle">Remediation</text>
+    <text x="1020" y="200">Status / issue</text>
   </g>
-  <line x1="48" y1="176" x2="1352" y2="176" stroke="#334155" stroke-width="1"/>
+  <line x1="48" y1="212" x2="1152" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="206" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="13" font-weight="900">DETECTION (11)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (11)</text>
 
-  <!-- Row helper: each row y-stride = 30; first row at y=232 -->
-  <!-- 1: detect-okta-mfa-fatigue -->
+  <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="246" fill="#f1f5f9" font-size="13">detect-okta-mfa-fatigue</text>
-    <text x="350" y="246" fill="#cbd5e1" font-size="12">T1621</text>
-    <rect x="550" y="234" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="234" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <text x="830" y="246" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
-    <text x="920" y="246" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
+    <text x="48"   y="290" fill="#f1f5f9" font-size="15">detect-okta-mfa-fatigue</text>
+    <text x="430"  y="290" fill="#cbd5e1" font-size="14">T1621</text>
+    <rect x="760"  y="274" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="274" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="290" fill="#dcfce7" font-size="13">→ remediate-okta-session-kill</text>
   </g>
-  <!-- 2 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="276" fill="#f1f5f9" font-size="13">detect-credential-stuffing-okta</text>
-    <text x="350" y="276" fill="#cbd5e1" font-size="12">T1110 · T1110.003</text>
-    <rect x="550" y="264" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="264" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <text x="830" y="276" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
-    <text x="920" y="276" fill="#dcfce7" font-size="12">→ remediate-okta-session-kill (closed)</text>
+    <text x="48"   y="328" fill="#f1f5f9" font-size="15">detect-credential-stuffing-okta</text>
+    <text x="430"  y="328" fill="#cbd5e1" font-size="14">T1110 · T1110.003</text>
+    <rect x="760"  y="312" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="312" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="328" fill="#dcfce7" font-size="13">→ remediate-okta-session-kill</text>
   </g>
-  <!-- 3 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="306" fill="#f1f5f9" font-size="13">detect-container-escape-k8s</text>
-    <text x="350" y="306" fill="#cbd5e1" font-size="12">T1611 · T1610</text>
-    <rect x="550" y="294" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="294" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <text x="830" y="306" text-anchor="middle" fill="#fde68a" font-size="12">#298 #299</text>
-    <text x="920" y="306" fill="#dcfce7" font-size="12">→ remediate-container-escape-k8s (closed)</text>
+    <text x="48"   y="366" fill="#f1f5f9" font-size="15">detect-container-escape-k8s</text>
+    <text x="430"  y="366" fill="#cbd5e1" font-size="14">T1611 · T1610</text>
+    <rect x="760"  y="350" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="350" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="366" fill="#dcfce7" font-size="13">→ remediate-container-escape-k8s</text>
   </g>
-  <!-- 4 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="336" fill="#f1f5f9" font-size="13">detect-privilege-escalation-k8s</text>
-    <text x="350" y="336" fill="#cbd5e1" font-size="12">T1552.007 · T1611 · T1098 · T1550.001</text>
-    <rect x="550" y="324" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="324" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="336" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
-    <text x="920" y="336" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke (planned)</text>
+    <text x="48"   y="404" fill="#f1f5f9" font-size="15">detect-privilege-escalation-k8s</text>
+    <text x="430"  y="404" fill="#cbd5e1" font-size="14">T1552.007 · T1611 · T1098 · T1550.001</text>
+    <rect x="760"  y="388" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="388" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="404" fill="#fef3c7" font-size="13">#241 · k8s-rbac-revoke (planned)</text>
   </g>
-  <!-- 5 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="366" fill="#f1f5f9" font-size="13">detect-sensitive-secret-read-k8s</text>
-    <text x="350" y="366" fill="#cbd5e1" font-size="12">T1552 · T1552.007</text>
-    <rect x="550" y="354" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="354" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="366" text-anchor="middle" fill="#fde68a" font-size="12">#241</text>
-    <text x="920" y="366" fill="#fef3c7" font-size="12">remediate-k8s-rbac-revoke covers (planned)</text>
+    <text x="48"   y="442" fill="#f1f5f9" font-size="15">detect-sensitive-secret-read-k8s</text>
+    <text x="430"  y="442" fill="#cbd5e1" font-size="14">T1552 · T1552.007</text>
+    <rect x="760"  y="426" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="426" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="442" fill="#fef3c7" font-size="13">#241 · k8s-rbac-revoke covers</text>
   </g>
-  <!-- 6 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="396" fill="#f1f5f9" font-size="13">detect-entra-credential-addition</text>
-    <text x="350" y="396" fill="#cbd5e1" font-size="12">T1098 · T1098.001</text>
-    <rect x="550" y="384" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="384" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="396" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
-    <text x="920" y="396" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
+    <text x="48"   y="480" fill="#f1f5f9" font-size="15">detect-entra-credential-addition</text>
+    <text x="430"  y="480" fill="#cbd5e1" font-size="14">T1098 · T1098.001</text>
+    <rect x="760"  y="464" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="464" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="480" fill="#fef3c7" font-size="13">#238 · iam-departures-azure-entra</text>
   </g>
-  <!-- 7 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="426" fill="#f1f5f9" font-size="13">detect-entra-role-grant-escalation</text>
-    <text x="350" y="426" fill="#cbd5e1" font-size="12">T1098 · T1098.003</text>
-    <rect x="550" y="414" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="414" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="426" text-anchor="middle" fill="#fde68a" font-size="12">#238</text>
-    <text x="920" y="426" fill="#fef3c7" font-size="12">iam-departures-azure-entra (planned)</text>
+    <text x="48"   y="518" fill="#f1f5f9" font-size="15">detect-entra-role-grant-escalation</text>
+    <text x="430"  y="518" fill="#cbd5e1" font-size="14">T1098 · T1098.003</text>
+    <rect x="760"  y="502" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="502" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="518" fill="#fef3c7" font-size="13">#238 · iam-departures-azure-entra</text>
   </g>
-  <!-- 8 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="456" fill="#f1f5f9" font-size="13">detect-google-workspace-suspicious-login</text>
-    <text x="350" y="456" fill="#cbd5e1" font-size="12">T1110 · T1078</text>
-    <rect x="550" y="444" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="444" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="830" y="456" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-    <text x="920" y="456" fill="#fee2e2" font-size="12">no Workspace session-kill skill yet</text>
+    <text x="48"   y="556" fill="#f1f5f9" font-size="15">detect-google-workspace-suspicious-login</text>
+    <text x="430"  y="556" fill="#cbd5e1" font-size="14">T1110 · T1078</text>
+    <rect x="760"  y="540" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="540" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="556" fill="#fee2e2" font-size="13">no Workspace session-kill yet</text>
   </g>
-  <!-- 9 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="486" fill="#f1f5f9" font-size="13">detect-lateral-movement</text>
-    <text x="350" y="486" fill="#cbd5e1" font-size="12">T1021 · T1078.004 (TA0008)</text>
-    <rect x="550" y="474" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="474" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="830" y="486" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-    <text x="920" y="486" fill="#fee2e2" font-size="12">cross-cloud · response is per-arm fan-out</text>
+    <text x="48"   y="594" fill="#f1f5f9" font-size="15">detect-lateral-movement</text>
+    <text x="430"  y="594" fill="#cbd5e1" font-size="14">T1021 · T1078.004 (TA0008)</text>
+    <rect x="760"  y="578" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="578" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="594" fill="#fee2e2" font-size="13">cross-cloud · per-arm fan-out</text>
   </g>
-  <!-- 10 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="516" fill="#f1f5f9" font-size="13">detect-mcp-tool-drift</text>
-    <text x="350" y="516" fill="#cbd5e1" font-size="12">T1195.001 (TA0001)</text>
-    <rect x="550" y="504" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="504" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="830" y="516" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-    <text x="920" y="516" fill="#fee2e2" font-size="12">remediate-mcp-tool-quarantine candidate</text>
+    <text x="48"   y="632" fill="#f1f5f9" font-size="15">detect-mcp-tool-drift</text>
+    <text x="430"  y="632" fill="#cbd5e1" font-size="14">T1195.001 (TA0001)</text>
+    <rect x="760"  y="616" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="616" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="632" fill="#fee2e2" font-size="13">remediate-mcp-tool-quarantine candidate</text>
   </g>
-  <!-- 11 -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="546" fill="#f1f5f9" font-size="13">detect-prompt-injection-mcp-proxy</text>
-    <text x="350" y="546" fill="#cbd5e1" font-size="12">ATLAS AML.T0051</text>
-    <rect x="550" y="534" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="534" width="40" height="18" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="830" y="546" text-anchor="middle" fill="#fca5a5" font-size="12">— file new</text>
-    <text x="920" y="546" fill="#fee2e2" font-size="12">remediate-mcp-proxy-quarantine candidate</text>
+    <text x="48"   y="670" fill="#f1f5f9" font-size="15">detect-prompt-injection-mcp-proxy</text>
+    <text x="430"  y="670" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
+    <rect x="760"  y="654" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="654" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="670" fill="#fee2e2" font-size="13">remediate-mcp-proxy-quarantine candidate</text>
   </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="600" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="13" font-weight="900">EVALUATION / CSPM (4 platforms · 82 checks)</text>
+  <text x="48" y="724" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 82 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="640" fill="#f1f5f9" font-size="13">cspm-aws-cis-benchmark</text>
-    <text x="350" y="640" fill="#cbd5e1" font-size="12">CIS AWS Foundations 1.5</text>
-    <rect x="550" y="628" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="628" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="640" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
-    <text x="920" y="640" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+    <text x="48"   y="758" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="758" fill="#cbd5e1" font-size="14">CIS AWS Foundations 1.5</text>
+    <rect x="760"  y="742" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="742" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="758" fill="#fef3c7" font-size="13">#242 #254 · --auto-remediate</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="670" fill="#f1f5f9" font-size="13">cspm-gcp-cis-benchmark</text>
-    <text x="350" y="670" fill="#cbd5e1" font-size="12">CIS GCP Foundations 2.0</text>
-    <rect x="550" y="658" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="658" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="670" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
-    <text x="920" y="670" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+    <text x="48"   y="788" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="788" fill="#cbd5e1" font-size="14">CIS GCP Foundations 2.0</text>
+    <rect x="760"  y="772" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="772" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="788" fill="#fef3c7" font-size="13">#242 #254 · --auto-remediate</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="700" fill="#f1f5f9" font-size="13">cspm-azure-cis-benchmark</text>
-    <text x="350" y="700" fill="#cbd5e1" font-size="12">CIS Azure Foundations 2.1</text>
-    <rect x="550" y="688" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="688" width="40" height="18" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="830" y="700" text-anchor="middle" fill="#fde68a" font-size="12">#242 #254</text>
-    <text x="920" y="700" fill="#fef3c7" font-size="12">--auto-remediate flag (planned, top-20)</text>
+    <text x="48"   y="818" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="818" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="802" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="802" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="818" fill="#fef3c7" font-size="13">#242 #254 · --auto-remediate</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"  y="730" fill="#f1f5f9" font-size="13">k8s + container + model + gpu benchmarks</text>
-    <text x="350" y="730" fill="#cbd5e1" font-size="12">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="550" y="718" width="40" height="18" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="680" y="718" width="40" height="18" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="830" y="730" text-anchor="middle" fill="#94a3b8" font-size="12">—</text>
-    <text x="920" y="730" fill="#dbeafe" font-size="12">posture-only · remediated via k8s-rbac-revoke</text>
+    <text x="48"   y="848" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="848" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="832" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="832" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="848" fill="#dbeafe" font-size="13">posture-only · via k8s-rbac-revoke</text>
   </g>
 
   <!-- Footer -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="780" fill="#94a3b8" font-size="12">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">3 / 11 detections</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">5 of 8 gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">3 detections (Workspace, lateral-movement, MCP) need new remediation skills</tspan></text>
-    <text x="48" y="802" fill="#64748b" font-size="11">Every "shipped" remediation cell is HITL-gated, dry-run-by-default, and dual-audited per SECURITY_BAR.md and docs/HITL_POLICY.md. Tracking: #155.</text>
+    <text x="48" y="884" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">3 / 11</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">5 of 8 gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">3 detections need new remediation skills</tspan> · all writes HITL-gated, dry-run-default, dual-audited (#155)</text>
   </g>
 </svg>

--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="700" viewBox="0 0 1400 700" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
   <title id="title">IAM departures · AWS flagship write path</title>
-  <desc id="desc">The AWS-only IAM departures remediation flow. Four horizontal stages: Plan reads HR sources in Snowflake or Databricks, runs the reconciler, and writes an S3 manifest containing only the actionable set. Orchestrate fires an EventBridge rule that starts a Step Function; the Step Function invokes a parser Lambda that re-checks manifest and current IAM state, then a worker Lambda that scopes writes. Write deletes AWS IAM users via cross-account role assumption inside the AWS Organization only — it never reaches into other clouds. Audit lands every action in DynamoDB and KMS-encrypted S3; a drift-check arrow runs back to the reconciler so the next run verifies closure. A footer note makes clear that per-cloud workflows for Azure Entra, GCP IAM, Databricks, and Snowflake run in their own execution environments and no single Lambda crosses cloud boundaries. Real Simple Icons (CC0) for AWS, Snowflake, Databricks, AWS Lambda, Amazon S3, and Amazon DynamoDB are used where brand marks exist; text cards are used for EventBridge, Step Functions, and IAM where Simple Icons does not yet ship a service mark.</desc>
+  <desc id="desc">The AWS-only IAM departures remediation flow, accurate to the shipped code in skills/remediation/iam-departures-aws/. Four horizontal stages. Plan reads HR sources in Snowflake or Databricks, runs the reconciler, and writes an S3 manifest containing only the actionable set after rehire and grace-window filtering. Orchestrate fires an EventBridge rule on the S3 PutObject; the rule starts a Step Function whose Map state fans out one execution per user; each execution invokes the parser Lambda (which re-checks manifest and current IAM state) followed by the worker Lambda (which assumes a cross-account role scoped by aws:PrincipalOrgID). Write performs the eleven-step IAM teardown sequence defined by the _remediation_steps() tuple in lambda_worker/handler.py: deactivate access keys, delete login profile, remove from groups, detach managed policies, delete inline policies, delete MFA devices, delete signing certificates, delete SSH keys, delete service credentials, tag user for audit, and finally delete the IAM user. Audit dual-writes every action to DynamoDB (fast lookup keyed by user and timestamp) and KMS-encrypted S3 (immutable evidence with seven-year retention); a closed-loop arrow runs back from the audit feed into the reconciler so the next run verifies closure or flags drift. A footer note explains that per-cloud workflows for Azure Entra, GCP IAM, Databricks, and Snowflake run in their own native execution environments and no single Lambda ever crosses cloud boundaries.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -42,198 +42,165 @@
   </defs>
 
   <!-- Background -->
-  <rect width="1400" height="700" fill="url(#bg)"/>
-  <rect width="1400" height="700" fill="url(#grid)"/>
-  <rect width="1400" height="700" fill="url(#glow)"/>
+  <rect width="1280" height="720" fill="url(#bg)"/>
+  <rect width="1280" height="720" fill="url(#grid)"/>
+  <rect width="1280" height="720" fill="url(#glow)"/>
 
   <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
     <!-- Title -->
-    <g transform="translate(56,52)">
+    <g transform="translate(56,48)">
       <rect x="0" y="0" width="148" height="28" rx="14" fill="#2a1708" stroke="#f59e0b"/>
       <use href="#aws" x="10" y="6" width="16" height="16"/>
       <text x="34" y="19" fill="#fbbf24" font-size="11" font-weight="800" letter-spacing="1.4">AWS FLAGSHIP WRITE PATH</text>
     </g>
-    <text x="56" y="120" font-size="38" font-weight="900" fill="url(#title)" letter-spacing="-0.6">IAM departures remediation</text>
-    <text x="58" y="148" fill="#94a3b8" font-size="15">Guarded · event-driven · cross-account · dual-audited · one cloud per worker</text>
+    <text x="56" y="116" font-size="36" font-weight="900" fill="url(#title)" letter-spacing="-0.6">IAM departures remediation</text>
+    <text x="58" y="142" fill="#94a3b8" font-size="14">Guarded · event-driven · cross-account · dual-audited · one cloud per worker</text>
 
-    <!-- Stage header labels -->
+    <!-- Stage header labels (4 columns at x=56, 332, 608, 884; gutter ≈ 36px each) -->
     <g font-size="11" font-weight="800" letter-spacing="1.5">
-      <text x="96" y="198" fill="#67e8f9">① PLAN</text>
-      <text x="436" y="198" fill="#93c5fd">② ORCHESTRATE</text>
-      <text x="776" y="198" fill="#fdba74">③ WRITE</text>
-      <text x="1116" y="198" fill="#5eead4">④ AUDIT</text>
+      <text x="56"  y="184" fill="#67e8f9">① PLAN</text>
+      <text x="332" y="184" fill="#93c5fd">② ORCHESTRATE</text>
+      <text x="608" y="184" fill="#fdba74">③ WRITE · 11-step IAM teardown</text>
+      <text x="956" y="184" fill="#5eead4">④ AUDIT · closed loop</text>
     </g>
-    <g font-size="12" fill="#64748b">
-      <text x="96" y="218">decide scope</text>
-      <text x="436" y="218">gate + re-check before act</text>
-      <text x="776" y="218">scoped write · AWS only</text>
-      <text x="1116" y="218">dual store · drift check</text>
-    </g>
-
-    <!-- Lane separators (subtle) -->
-    <g stroke="#1e293b" stroke-width="1" stroke-dasharray="3 6">
-      <line x1="400" y1="244" x2="400" y2="520"/>
-      <line x1="740" y1="244" x2="740" y2="520"/>
-      <line x1="1080" y1="244" x2="1080" y2="520"/>
+    <g font-size="11" fill="#64748b">
+      <text x="56"  y="202">decide scope</text>
+      <text x="332" y="202">gate + re-check before act</text>
+      <text x="608" y="202">scoped write · AWS only · matches handler.py</text>
+      <text x="956" y="202">dual store · drift verified next run</text>
     </g>
 
-    <!-- ============ ① PLAN ============ -->
-    <g transform="translate(56,244)">
-      <!-- HR sources -->
-      <rect x="0" y="0" width="320" height="56" rx="12" fill="#0b1a2e" stroke="#22d3ee" stroke-width="1.5"/>
-      <use href="#snowflake" x="16" y="16" width="24" height="24"/>
-      <use href="#databricks" x="48" y="16" width="24" height="24"/>
-      <text x="84" y="28" fill="#e0f2fe" font-size="14" font-weight="800">HR sources</text>
-      <text x="84" y="46" fill="#94a3b8" font-size="12">Snowflake · Databricks</text>
+    <!-- ============ ① PLAN ============ (x=56, width=240) -->
+    <g transform="translate(56,224)">
+      <rect x="0" y="0" width="240" height="56" rx="12" fill="#0b1a2e" stroke="#22d3ee" stroke-width="1.5"/>
+      <use href="#snowflake" x="14" y="16" width="22" height="22"/>
+      <use href="#databricks" x="42" y="16" width="22" height="22"/>
+      <text x="74" y="28" fill="#e0f2fe" font-size="14" font-weight="800">HR sources</text>
+      <text x="74" y="46" fill="#94a3b8" font-size="11">Snowflake · Databricks</text>
 
-      <!-- Arrow down to reconciler -->
-      <path d="M160,60 L160,80" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+      <path d="M120,60 L120,80" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
 
-      <!-- Reconciler -->
-      <rect x="20" y="86" width="280" height="54" rx="12" fill="#0b1a2e" stroke="#22d3ee" stroke-width="1.5"/>
-      <text x="36" y="112" fill="#e0f2fe" font-size="14" font-weight="800">Reconciler</text>
-      <text x="36" y="130" fill="#94a3b8" font-size="12">rehire + grace filter · actionable set</text>
+      <rect x="0" y="86" width="240" height="56" rx="12" fill="#0b1a2e" stroke="#22d3ee" stroke-width="1.5"/>
+      <text x="16" y="108" fill="#e0f2fe" font-size="14" font-weight="800">Reconciler</text>
+      <text x="16" y="126" fill="#94a3b8" font-size="11">rehire + grace filter · actionable set</text>
 
-      <!-- Arrow down to S3 manifest -->
-      <path d="M160,144 L160,164" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+      <path d="M120,146 L120,166" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
 
-      <!-- S3 manifest -->
-      <rect x="0" y="170" width="320" height="56" rx="12" fill="#0b2a1e" stroke="#34d399" stroke-width="1.5"/>
-      <use href="#s3" x="16" y="186" width="24" height="24"/>
-      <text x="52" y="198" fill="#d1fae5" font-size="14" font-weight="800">S3 manifest</text>
-      <text x="52" y="216" fill="#94a3b8" font-size="12">actionable set only · immutable</text>
+      <rect x="0" y="172" width="240" height="56" rx="12" fill="#0b2a1e" stroke="#34d399" stroke-width="1.5"/>
+      <use href="#s3" x="14" y="188" width="22" height="22"/>
+      <text x="46" y="200" fill="#d1fae5" font-size="14" font-weight="800">S3 manifest</text>
+      <text x="46" y="218" fill="#94a3b8" font-size="11">actionable set only · immutable</text>
     </g>
 
-    <!-- Plan → Orchestrate arrow -->
-    <!-- Label sized to fit entirely within the 64px column-gutter gap (x=376 to x=440).
-         "PutObject" at font-size 11/700 is ~63px; anchored at x=408 (arrow midpoint) with
-         text-anchor middle so it never clips into the Orchestrate column content (x>=456). -->
-    <path d="M376,360 L440,360" stroke="#64748b" stroke-width="2.5" fill="none" marker-end="url(#arrow)"/>
-    <text x="408" y="352" text-anchor="middle" fill="#64748b" font-size="11" font-weight="700">PutObject</text>
+    <!-- Plan → Orchestrate arrow (gutter x=296 to x=332) -->
+    <path d="M298,310 L330,310" stroke="#64748b" stroke-width="2.5" fill="none" marker-end="url(#arrow)"/>
+    <text x="314" y="302" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="700">PutObject</text>
 
-    <!-- ============ ② ORCHESTRATE ============ -->
-    <g transform="translate(456,244)">
-      <!-- EventBridge (text card — no SI icon) -->
+    <!-- ============ ② ORCHESTRATE ============ (x=332, width=240) -->
+    <g transform="translate(332,224)">
       <rect x="0" y="0" width="240" height="56" rx="12" fill="#0f1d36" stroke="#60a5fa" stroke-width="1.5"/>
       <rect x="12" y="14" width="30" height="28" rx="6" fill="#1e3a8a" stroke="#60a5fa"/>
       <text x="27" y="33" text-anchor="middle" fill="#93c5fd" font-size="11" font-weight="800">EB</text>
       <text x="52" y="28" fill="#dbeafe" font-size="14" font-weight="800">EventBridge rule</text>
-      <text x="52" y="46" fill="#94a3b8" font-size="12">pattern · S3 PutObject</text>
+      <text x="52" y="46" fill="#94a3b8" font-size="11">pattern · S3 ObjectCreated</text>
 
       <path d="M120,60 L120,80" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
 
-      <!-- Step Function -->
-      <rect x="0" y="86" width="240" height="54" rx="12" fill="#0f1d36" stroke="#60a5fa" stroke-width="1.5"/>
+      <rect x="0" y="86" width="240" height="56" rx="12" fill="#0f1d36" stroke="#60a5fa" stroke-width="1.5"/>
       <rect x="12" y="100" width="30" height="28" rx="6" fill="#1e3a8a" stroke="#60a5fa"/>
       <text x="27" y="119" text-anchor="middle" fill="#93c5fd" font-size="10" font-weight="800">SFN</text>
-      <text x="52" y="114" fill="#dbeafe" font-size="14" font-weight="800">Step Function</text>
-      <text x="52" y="132" fill="#94a3b8" font-size="12">Map state · fan out per user</text>
-
-      <path d="M120,144 L120,164" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
-
-      <!-- Parser Lambda -->
-      <rect x="0" y="170" width="240" height="54" rx="12" fill="#2a1708" stroke="#fbbf24" stroke-width="1.5"/>
-      <use href="#lambda" x="12" y="184" width="26" height="26"/>
-      <text x="48" y="196" fill="#fef3c7" font-size="14" font-weight="800">Parser Lambda</text>
-      <text x="48" y="214" fill="#94a3b8" font-size="12">re-check manifest + IAM state</text>
-
-      <path d="M120,228 L120,248" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
-
-      <!-- Worker Lambda -->
-      <rect x="0" y="254" width="240" height="54" rx="12" fill="#2a1708" stroke="#fbbf24" stroke-width="1.5"/>
-      <use href="#lambda" x="12" y="268" width="26" height="26"/>
-      <text x="48" y="280" fill="#fef3c7" font-size="14" font-weight="800">Worker Lambda</text>
-      <text x="48" y="298" fill="#94a3b8" font-size="12">scoped principal · cross-account STS</text>
-    </g>
-
-    <!-- Orchestrate → Write arrow -->
-    <!-- Label centered on arrow midpoint to stay within the 64px column-gutter gap. -->
-    <path d="M716,360 L780,360" stroke="#64748b" stroke-width="2.5" fill="none" marker-end="url(#arrow)"/>
-    <text x="748" y="352" text-anchor="middle" fill="#64748b" font-size="11" font-weight="700">AssumeRole</text>
-
-    <!-- ============ ③ WRITE ============ -->
-    <g transform="translate(796,244)">
-      <!-- AWS IAM (text card, AWS orange) -->
-      <rect x="0" y="0" width="240" height="86" rx="12" fill="#2a1708" stroke="#fdba74" stroke-width="1.5"/>
-      <use href="#aws" x="14" y="14" width="26" height="26"/>
-      <text x="48" y="28" fill="#fef3c7" font-size="14" font-weight="800">AWS IAM</text>
-      <text x="48" y="46" fill="#94a3b8" font-size="12">across AWS Organization</text>
-      <rect x="14" y="54" width="212" height="22" rx="6" fill="#3a2410" stroke="#f59e0b"/>
-      <text x="22" y="69" fill="#fbbf24" font-size="11" font-weight="700">cross-account role · PrincipalOrgID</text>
-
-      <!-- 13-step deletion card — two columns fit within the 176 height.
-           Matches SKILL.md and handler.py _remediation_steps(). -->
-      <rect x="0" y="100" width="240" height="176" rx="12" fill="#12112e" stroke="#a78bfa" stroke-width="1.5"/>
-      <text x="16" y="118" fill="#c4b5fd" font-size="11" font-weight="800" letter-spacing="1.2">DELETION ORDER · AWS IAM · 13</text>
-      <line x1="116" y1="126" x2="116" y2="266" stroke="#2a2446" stroke-width="1"/>
-      <g font-size="10" fill="#ddd6fe">
-        <!-- Left column: 1–7 -->
-        <text x="10" y="138">1. deactivate access keys</text>
-        <text x="10" y="154">2. delete access keys</text>
-        <text x="10" y="170">3. delete login profile</text>
-        <text x="10" y="186">4. remove from groups</text>
-        <text x="10" y="202">5. detach mgd policies</text>
-        <text x="10" y="218">6. delete inline policies</text>
-        <text x="10" y="234">7. deactivate MFA</text>
-        <!-- Right column: 8–13 -->
-        <text x="124" y="138">8. delete MFA devices</text>
-        <text x="124" y="154">9. delete signing certs</text>
-        <text x="124" y="170">10. delete SSH keys</text>
-        <text x="124" y="186">11. delete svc creds</text>
-        <text x="124" y="202">12. tag user for audit</text>
-        <text x="124" y="220" font-weight="800" fill="#f3e8ff">13. delete IAM user</text>
-      </g>
-    </g>
-
-    <!-- Write → Audit arrow -->
-    <!-- Label centered on arrow midpoint; shortened to "audit" so the text is
-         bounded by the 64px column-gutter gap and never touches the DynamoDB
-         card that sits on the right side of the arrow (x>=1136). -->
-    <path d="M1056,286 L1120,286" stroke="#fbbf24" stroke-width="2.5" fill="none" marker-end="url(#arrowAmber)"/>
-    <text x="1088" y="278" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="700">audit</text>
-
-    <!-- ============ ④ AUDIT ============ -->
-    <g transform="translate(1136,244)">
-      <!-- DynamoDB -->
-      <rect x="0" y="0" width="240" height="56" rx="12" fill="#0b1b2e" stroke="#60a5fa" stroke-width="1.5"/>
-      <use href="#dynamo" x="16" y="16" width="24" height="24"/>
-      <text x="52" y="28" fill="#dbeafe" font-size="14" font-weight="800">DynamoDB audit</text>
-      <text x="52" y="46" fill="#94a3b8" font-size="12">fast lookup · (user, ts) key</text>
-
-      <path d="M120,60 L120,80" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
-
-      <!-- S3 audit (KMS) -->
-      <rect x="0" y="86" width="240" height="56" rx="12" fill="#0b2a1e" stroke="#34d399" stroke-width="1.5"/>
-      <use href="#s3" x="16" y="102" width="24" height="24"/>
-      <text x="52" y="114" fill="#d1fae5" font-size="14" font-weight="800">S3 audit · KMS</text>
-      <text x="52" y="132" fill="#94a3b8" font-size="12">immutable evidence · 7y</text>
+      <text x="52" y="108" fill="#dbeafe" font-size="14" font-weight="800">Step Function</text>
+      <text x="52" y="126" fill="#94a3b8" font-size="11">Map state · 1 execution per user</text>
 
       <path d="M120,146 L120,166" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
 
-      <!-- Ingest-back for drift -->
-      <rect x="0" y="172" width="240" height="56" rx="12" fill="#0b3d3b" stroke="#2dd4bf" stroke-width="1.5"/>
-      <text x="16" y="196" fill="#ccfbf1" font-size="14" font-weight="800">Ingest back · drift feed</text>
-      <text x="16" y="214" fill="#94a3b8" font-size="12">next run verifies closure</text>
+      <rect x="0" y="172" width="240" height="56" rx="12" fill="#2a1708" stroke="#fbbf24" stroke-width="1.5"/>
+      <use href="#lambda" x="14" y="188" width="22" height="22"/>
+      <text x="46" y="194" fill="#fef3c7" font-size="14" font-weight="800">Parser Lambda</text>
+      <text x="46" y="214" fill="#94a3b8" font-size="11">re-check manifest + IAM state</text>
+
+      <path d="M120,234 L120,254" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+
+      <rect x="0" y="260" width="240" height="56" rx="12" fill="#2a1708" stroke="#fbbf24" stroke-width="1.5"/>
+      <use href="#lambda" x="14" y="276" width="22" height="22"/>
+      <text x="46" y="282" fill="#fef3c7" font-size="14" font-weight="800">Worker Lambda</text>
+      <text x="46" y="302" fill="#94a3b8" font-size="11">cross-account STS · per-user scope</text>
     </g>
 
-    <!-- Drift verification rail — positioned BELOW Worker Lambda (ends y=552)
-         with a 20px clearance so the three pills never touch any column card. -->
-    <g transform="translate(220,572)">
-      <rect x="0" y="0" width="220" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
-      <text x="110" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">audit export</text>
-      <rect x="292" y="0" width="260" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
-      <text x="422" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">next reconciler run</text>
-      <rect x="624" y="0" width="260" height="30" rx="15" fill="#12112e" stroke="#f472b6"/>
-      <text x="754" y="20" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">closed or flagged drift</text>
-      <path d="M220,15 L290,15" fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowDashed)"/>
-      <path d="M552,15 L622,15" fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowDashed)"/>
+    <!-- Orchestrate → Write arrow (gutter x=572 to x=608, target IAM card mid y) -->
+    <path d="M574,288 L606,288" stroke="#64748b" stroke-width="2.5" fill="none" marker-end="url(#arrow)"/>
+    <text x="590" y="280" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="700">AssumeRole</text>
+
+    <!-- ============ ③ WRITE ============ (x=608, width=320 — wider for the deletion list) -->
+    <g transform="translate(608,224)">
+      <rect x="0" y="0" width="320" height="80" rx="12" fill="#2a1708" stroke="#fdba74" stroke-width="1.5"/>
+      <use href="#aws" x="14" y="14" width="24" height="24"/>
+      <text x="46" y="28" fill="#fef3c7" font-size="14" font-weight="800">AWS IAM</text>
+      <text x="46" y="44" fill="#94a3b8" font-size="11">across AWS Organization</text>
+      <rect x="14" y="52" width="292" height="20" rx="6" fill="#3a2410" stroke="#f59e0b"/>
+      <text x="22" y="66" fill="#fbbf24" font-size="11" font-weight="700">cross-account role · aws:PrincipalOrgID</text>
+
+      <!-- 11-step deletion card — single column matching _remediation_steps() in lambda_worker/handler.py.
+           Stride = 18px, header at y=22, list y starts at 42, ends at 42 + 11*18 = 240. Box height 252. -->
+      <rect x="0" y="92" width="320" height="252" rx="12" fill="#12112e" stroke="#a78bfa" stroke-width="1.5"/>
+      <text x="16" y="114" fill="#c4b5fd" font-size="11" font-weight="800" letter-spacing="1.2">DELETION ORDER · AWS IAM · 11</text>
+      <text x="16" y="128" fill="#64748b" font-size="9">handler.py _remediation_steps()</text>
+      <g font-size="11" fill="#ddd6fe">
+        <text x="16" y="148">1.  deactivate access keys</text>
+        <text x="16" y="166">2.  delete login profile</text>
+        <text x="16" y="184">3.  remove from groups</text>
+        <text x="16" y="202">4.  detach managed policies</text>
+        <text x="16" y="220">5.  delete inline policies</text>
+        <text x="16" y="238">6.  delete MFA devices</text>
+        <text x="16" y="256">7.  delete signing certificates</text>
+        <text x="16" y="274">8.  delete SSH keys</text>
+        <text x="16" y="292">9.  delete service credentials</text>
+        <text x="16" y="310">10. tag user for audit</text>
+        <text x="16" y="330" font-weight="800" fill="#f3e8ff">11. delete IAM user</text>
+      </g>
     </g>
 
-    <!-- Footer honesty note — below drift rail (ends y=602) with 18px clearance. -->
-    <g transform="translate(56,620)">
-      <rect x="0" y="0" width="1288" height="44" rx="10" fill="#12112e" stroke="#64748b"/>
+    <!-- Write → Audit arrow (gutter x=928 to x=956) -->
+    <path d="M930,264 L954,264" stroke="#fbbf24" stroke-width="2.5" fill="none" marker-end="url(#arrowAmber)"/>
+    <text x="942" y="256" text-anchor="middle" fill="#fbbf24" font-size="10" font-weight="700">audit</text>
+
+    <!-- ============ ④ AUDIT ============ (x=956, width=268) -->
+    <g transform="translate(956,224)">
+      <rect x="0" y="0" width="268" height="56" rx="12" fill="#0b1b2e" stroke="#60a5fa" stroke-width="1.5"/>
+      <use href="#dynamo" x="14" y="16" width="22" height="22"/>
+      <text x="46" y="28" fill="#dbeafe" font-size="14" font-weight="800">DynamoDB audit</text>
+      <text x="46" y="46" fill="#94a3b8" font-size="11">fast lookup · (user, ts) key</text>
+
+      <path d="M134,60 L134,80" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+
+      <rect x="0" y="86" width="268" height="56" rx="12" fill="#0b2a1e" stroke="#34d399" stroke-width="1.5"/>
+      <use href="#s3" x="14" y="102" width="22" height="22"/>
+      <text x="46" y="114" fill="#d1fae5" font-size="14" font-weight="800">S3 audit · KMS</text>
+      <text x="46" y="132" fill="#94a3b8" font-size="11">immutable evidence · 7y retention</text>
+
+      <path d="M134,146 L134,166" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+
+      <rect x="0" y="172" width="268" height="56" rx="12" fill="#0b3d3b" stroke="#2dd4bf" stroke-width="1.5"/>
+      <text x="16" y="194" fill="#ccfbf1" font-size="14" font-weight="800">Ingest back · drift feed</text>
+      <text x="16" y="212" fill="#94a3b8" font-size="11">next reconciler run verifies closure</text>
+    </g>
+
+    <!-- Closed-loop arrow: from "Ingest back" (x=956+134=1090, y=224+228=452) curves down and
+         back to the Reconciler box (x=296, y=224+114=338) — single arc replaces the redundant
+         three-pill drift rail. Pink/dashed = audit→reconcile feedback edge. -->
+    <path d="M1090,452 C1090,560 600,610 176,610 C100,610 60,560 60,510 L60,338 L296,338"
+          fill="none" stroke="#f472b6" stroke-width="2" stroke-dasharray="6 5"
+          marker-end="url(#arrowDashed)"/>
+    <g transform="translate(560,594)">
+      <rect x="0" y="0" width="200" height="28" rx="14" fill="#12112e" stroke="#f472b6"/>
+      <text x="100" y="18" text-anchor="middle" fill="#f9a8d4" font-size="11" font-weight="800">closed-loop drift check</text>
+    </g>
+
+    <!-- Footer honesty note (full-width, ends y=712) -->
+    <g transform="translate(56,648)">
+      <rect x="0" y="0" width="1168" height="44" rx="10" fill="#12112e" stroke="#64748b"/>
       <text x="20" y="20" fill="#f1f5f9" font-size="12" font-weight="800" letter-spacing="0.4">One cloud per worker · no cross-cloud blast radius</text>
-      <text x="20" y="36" fill="#94a3b8" font-size="12">Only the AWS stack above is shipped. GCP and Azure use equivalent native stacks: Eventarc + Cloud Workflows + Cloud Run Jobs for GCP; Event Grid + Logic Apps + Azure Functions for Azure. Per-cloud workers never cross cloud boundaries. See the README mapping table.</text>
+      <text x="20" y="36" fill="#94a3b8" font-size="11">Only the AWS stack above is shipped. Azure uses Event Grid + Logic Apps + Azure Functions; GCP uses Eventarc + Cloud Workflows + Cloud Run Jobs. Per-cloud workers never cross cloud boundaries — see the README per-cloud service mapping.</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

End-to-end visuals + README polish pass. Three SVG artefacts shipped or rebuilt, four dense README sections moved into collapsibles, and architecture-diagram label drift fixed so the visuals in this PR match the data they describe.

## What's in this PR

### `docs/images/coverage-matrix.svg` — new

Closed-loop coverage matrix visualising every detection (11) and CSPM platform (4) against paired-remediation status, with the **MITRE ATT&CK / ATLAS technique IDs** each detection emits in OCSF `finding_info.attacks[]`. Becomes the single source of truth for the [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155) detect↔remediate parity gap.

- 3 closed loops shipped: Okta MFA fatigue (T1621), Okta credential stuffing (T1110.003), K8s container escape (T1611 + T1610)
- 5 amber gaps: tracked at [#241](https://github.com/msaad00/cloud-ai-security-skills/issues/241), [#238](https://github.com/msaad00/cloud-ai-security-skills/issues/238), [#242](https://github.com/msaad00/cloud-ai-security-skills/issues/242)
- 3 red gaps: Workspace login, lateral-movement, MCP (need new remediation skills)

Every MITRE TID verified against the source `skills/detection/*/SKILL.md`.

### `docs/images/iam-departures-aws.svg` — rebuilt against shipped code

| Issue | Before | After |
|---|---|---|
| Step count | 13 (artificially split atomic functions) | **11** — matches `_remediation_steps()` tuple at [`lambda_worker/handler.py:236-246`](skills/remediation/iam-departures-aws/src/lambda_worker/handler.py) |
| Layout | Two columns visually colliding ("1. deactivate access keys8. delete MFA devices") | Single column at 18px stride — no overlap |
| Drift verification | Three pills "audit export → next reconciler run → closed or flagged drift" duplicating the "Ingest back · drift feed" box | Single curved closed-loop arrow + one labelled pill |
| Canvas | 1400×700 | 1280×720; columns rebalanced (Plan 240 / Orch 240 / Write 320 / Audit 268) |
| Traceability | Implicit | Source file `handler.py _remediation_steps()` cited under the step list header |

### `docs/images/hero-banner.svg` — count drift

`<desc>` and visible labels said "46 shipped / 10 detect / 2 remediate" → now correctly "48 / 11 / 3" matching `validate_skill_count_consistency.py`.

### `docs/images/coverage-matrix.svg` — readability + overlap pass

The first version had:
- header divider drawn at y=160 with column-header text baseline at y=164 → line cut through letters; fixed by moving divider to y=176
- subtitle clipped past the right edge ("…are clos" cut off) → wrapped to two lines
- row text 13px → 15px, MITRE 12 → 14, legend 12 → 14
- canvas 1400 → 1200 (better pixel density at GitHub column width)
- redundant Notes column dropped (the green/amber/red badge plus the issue link already convey status)

### README — 4 collapsibles

Wrapped these sections in `<details>` so the architecture diagram + closed-loop matrix sit above the fold:

- Why different layers use different formats
- Start here
- Per-cloud service mapping
- Native vs OCSF

Plus the architecture-mermaid label sync (`L5 Remediate 2→3`, `bundle 46→48`).

## Why split from #300?

[#300](https://github.com/msaad00/cloud-ai-security-skills/pull/300) is the tooling+counts fix (mypy + CLAUDE.md tree). This PR is a separate stream of work focused on visual identity + README structure. Splitting them gives independent review surfaces.

## Test plan

- [x] All 9 `scripts/validate_*.py` validators pass
- [x] `pytest -q` — 1152 passed
- [x] Hero banner, coverage matrix, IAM diagram render correctly (verified in preview panel during authoring)
- [x] No `<sub>` tags in any new mermaid; dark-mode safe palette
- [x] Every MITRE TID in `coverage-matrix.svg` cross-verified against the source `SKILL.md`
- [x] Every step in `iam-departures-aws.svg` matches `_remediation_steps()` tuple

🤖 Generated with [Claude Code](https://claude.com/claude-code)