### PR TITLE
feat(remediation): ship remediate-k8s-rbac-revoke (#241, closes #155 phase 1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,7 +70,7 @@ skills/
 └── output/         ← L7 (sink-* skills: append-only persistence)
 ```
 
-The repo ships **48 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 11 + 7 + 3 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
+The repo ships **49 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 11 + 7 + 4 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
 
 `skills/detection-engineering/` holds the shared OCSF contract and frozen
 golden fixtures. Executable skills live only under the six layered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ skills/
 ├── remediation/                   # active fix workflows, gated and audited
 │   ├── iam-departures-aws/
 │   ├── remediate-okta-session-kill/
-│   └── remediate-container-escape-k8s/
+│   ├── remediate-container-escape-k8s/
+│   └── remediate-k8s-rbac-revoke/
 │
 ├── output/                        # append-only persistence sinks
 │   ├── sink-s3-jsonl/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 48 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 49 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,7 +16,7 @@
 
 ## What this repo gives you
 
-**48 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus three guarded write paths for offboarding, account containment, and Kubernetes workload quarantine. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**49 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus four guarded write paths for offboarding, account containment, Kubernetes workload quarantine, and Kubernetes RBAC revocation. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
@@ -24,12 +24,12 @@
 | **Discover** | 4 | inventory, graph, AI BOM, evidence | native / bridge JSON |
 | **Detect** | 11 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
-| **Remediate** | 3 | guarded write paths (IAM departures, Okta session kill, K8s quarantine) | audited action trail |
+| **Remediate** | 4 | guarded write paths (IAM departures, Okta session kill, K8s quarantine, K8s RBAC revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 48 shipped skills.**
+**Total: 49 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -77,7 +77,7 @@ flowchart LR
     subgraph Act
         direction TB
         view["L6 View<br/>2 skills · SARIF · Mermaid"]:::act
-        remediate["L5 Remediate<br/>3 skills · HITL · dual audit"]:::act
+        remediate["L5 Remediate<br/>4 skills · HITL · dual audit"]:::act
     end
     output["L7 Output<br/>3 sinks · S3 · Snowflake · ClickHouse"]:::sink
 
@@ -125,7 +125,7 @@ flowchart TB
     end
 
     mcp["Repo MCP server<br/>mcp-server/src/server.py<br/>auto-discovers SKILL.md, audited calls, timeout-governed"]:::mcp
-    bundle[("Shared skill bundle<br/>48 shipped")]:::bundle
+    bundle[("Shared skill bundle<br/>49 shipped")]:::bundle
     outputs[/"native · OCSF 1.8 · bridge · SARIF · Mermaid · AI BOM · audited writes"/]:::output
 
     claude -->|stdio| mcp

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -71,6 +71,7 @@ is the row you can take to your auditor.
 | `model-serving-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `iam-departures-aws` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-container-escape-k8s` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `remediate-k8s-rbac-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-okta-session-kill` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `convert-ocsf-to-mermaid-attack-flow` | view | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `convert-ocsf-to-sarif` | view | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
@@ -78,7 +79,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_48 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_49 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,14 +4,14 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **48**
+- Total shipped skills in registry: **49**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
 | OCSF | 1.8.0 | **37** | — |
-| MITRE ATT&CK | v14 | **25** | 100% mapped coverage |
+| MITRE ATT&CK | v14 | **26** | 100% mapped coverage |
 | MITRE ATLAS | current | **7** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **1** | — |
 | CIS GCP Foundations | v3.0 | **1** | — |
@@ -19,9 +19,9 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
 | CIS Controls | v8 | **2** | — |
-| NIST CSF | 2.0 | **11** | 100% mapped coverage |
+| NIST CSF | 2.0 | **12** | 100% mapped coverage |
 | NIST AI RMF | current | **4** | — |
-| SOC 2 TSC | current | **11** | 100% mapped coverage |
+| SOC 2 TSC | current | **12** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **3** | — |
 | OWASP LLM Top 10 | current | **2** | — |
@@ -85,7 +85,7 @@ Shipped skills mapped: **37**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **25**
+Shipped skills mapped: **26**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -111,6 +111,7 @@ Shipped skills mapped: **25**
 | [`ingest-security-hub-ocsf`](../skills/ingestion/ingest-security-hub-ocsf) | ingestion | aws | findings, security-posture |
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
+| [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
 | [`convert-ocsf-to-mermaid-attack-flow`](../skills/view/convert-ocsf-to-mermaid-attack-flow) | view | multi | findings, review-output, graphs |
 | [`convert-ocsf-to-sarif`](../skills/view/convert-ocsf-to-sarif) | view | multi | findings, review-output |
@@ -203,7 +204,7 @@ Shipped skills mapped: **2**
 - Asset classes in scope: identities, storage, logging, network, clusters, runtime, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **11**
+Shipped skills mapped: **12**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -217,6 +218,7 @@ Shipped skills mapped: **11**
 | [`model-serving-security`](../skills/evaluation/model-serving-security) | evaluation | aws, azure, gcp, multi | ai-endpoints, models, identities, network, logging, guardrails |
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
+| [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
 
 ### NIST AI RMF (current)
@@ -239,7 +241,7 @@ Shipped skills mapped: **4**
 - Asset classes in scope: access, logging, change, evidence, inventory, ai-endpoints
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **11**
+Shipped skills mapped: **12**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -253,6 +255,7 @@ Shipped skills mapped: **11**
 | [`sink-snowflake-jsonl`](../skills/output/sink-snowflake-jsonl) | output | snowflake | findings, evidence, audit-logs, lakehouse |
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
+| [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
 
 ### PCI DSS (4.0)

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -3,488 +3,1411 @@
   "updated": "2026-04-17",
   "repo_version": "0.4.0",
   "frameworks": [
-    { "id": "ocsf-1.8", "name": "OCSF", "version": "1.8.0", "scope": "wire-contract" },
-    { "id": "mitre-attack-v14", "name": "MITRE ATT&CK", "version": "v14", "scope": "threat-mapping" },
-    { "id": "mitre-atlas", "name": "MITRE ATLAS", "version": "current", "scope": "ai-threat-mapping" },
-    { "id": "cis-aws-v3", "name": "CIS AWS Foundations", "version": "v3.0", "scope": "benchmark" },
-    { "id": "cis-gcp-v3", "name": "CIS GCP Foundations", "version": "v3.0", "scope": "benchmark" },
-    { "id": "cis-azure-v2.1", "name": "CIS Azure Foundations", "version": "v2.1", "scope": "benchmark" },
-    { "id": "cis-k8s", "name": "CIS Kubernetes Benchmark", "version": "current", "scope": "benchmark" },
-    { "id": "cis-docker", "name": "CIS Docker Benchmark", "version": "current", "scope": "benchmark" },
-    { "id": "cis-controls-v8", "name": "CIS Controls", "version": "v8", "scope": "control-framework" },
-    { "id": "nist-csf-2.0", "name": "NIST CSF", "version": "2.0", "scope": "control-framework" },
-    { "id": "nist-ai-rmf", "name": "NIST AI RMF", "version": "current", "scope": "ai-control-framework" },
-    { "id": "soc2-tsc", "name": "SOC 2 TSC", "version": "current", "scope": "control-framework" },
-    { "id": "pci-dss-4.0", "name": "PCI DSS", "version": "4.0", "scope": "control-framework" },
-    { "id": "iso-27001-2022", "name": "ISO 27001", "version": "2022", "scope": "control-framework" },
-    { "id": "owasp-llm-top-10", "name": "OWASP LLM Top 10", "version": "current", "scope": "ai-control-framework" },
-    { "id": "owasp-mcp-top-10", "name": "OWASP MCP Top 10", "version": "current", "scope": "agent-control-framework" },
-    { "id": "cyclonedx-ml-bom", "name": "CycloneDX ML-BOM", "version": "current", "scope": "inventory-artifact" }
+    {
+      "id": "ocsf-1.8",
+      "name": "OCSF",
+      "version": "1.8.0",
+      "scope": "wire-contract"
+    },
+    {
+      "id": "mitre-attack-v14",
+      "name": "MITRE ATT&CK",
+      "version": "v14",
+      "scope": "threat-mapping"
+    },
+    {
+      "id": "mitre-atlas",
+      "name": "MITRE ATLAS",
+      "version": "current",
+      "scope": "ai-threat-mapping"
+    },
+    {
+      "id": "cis-aws-v3",
+      "name": "CIS AWS Foundations",
+      "version": "v3.0",
+      "scope": "benchmark"
+    },
+    {
+      "id": "cis-gcp-v3",
+      "name": "CIS GCP Foundations",
+      "version": "v3.0",
+      "scope": "benchmark"
+    },
+    {
+      "id": "cis-azure-v2.1",
+      "name": "CIS Azure Foundations",
+      "version": "v2.1",
+      "scope": "benchmark"
+    },
+    {
+      "id": "cis-k8s",
+      "name": "CIS Kubernetes Benchmark",
+      "version": "current",
+      "scope": "benchmark"
+    },
+    {
+      "id": "cis-docker",
+      "name": "CIS Docker Benchmark",
+      "version": "current",
+      "scope": "benchmark"
+    },
+    {
+      "id": "cis-controls-v8",
+      "name": "CIS Controls",
+      "version": "v8",
+      "scope": "control-framework"
+    },
+    {
+      "id": "nist-csf-2.0",
+      "name": "NIST CSF",
+      "version": "2.0",
+      "scope": "control-framework"
+    },
+    {
+      "id": "nist-ai-rmf",
+      "name": "NIST AI RMF",
+      "version": "current",
+      "scope": "ai-control-framework"
+    },
+    {
+      "id": "soc2-tsc",
+      "name": "SOC 2 TSC",
+      "version": "current",
+      "scope": "control-framework"
+    },
+    {
+      "id": "pci-dss-4.0",
+      "name": "PCI DSS",
+      "version": "4.0",
+      "scope": "control-framework"
+    },
+    {
+      "id": "iso-27001-2022",
+      "name": "ISO 27001",
+      "version": "2022",
+      "scope": "control-framework"
+    },
+    {
+      "id": "owasp-llm-top-10",
+      "name": "OWASP LLM Top 10",
+      "version": "current",
+      "scope": "ai-control-framework"
+    },
+    {
+      "id": "owasp-mcp-top-10",
+      "name": "OWASP MCP Top 10",
+      "version": "current",
+      "scope": "agent-control-framework"
+    },
+    {
+      "id": "cyclonedx-ml-bom",
+      "name": "CycloneDX ML-BOM",
+      "version": "current",
+      "scope": "inventory-artifact"
+    }
   ],
   "skills": [
     {
       "path": "skills/ingestion/source-snowflake-query",
       "layer": "ingestion",
-      "providers": ["snowflake"],
-      "asset_classes": ["lakehouse", "query-results", "audit-logs"],
-      "execution_modes": ["cli", "ci", "mcp", "persistent"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "snowflake"
+      ],
+      "asset_classes": [
+        "lakehouse",
+        "query-results",
+        "audit-logs"
+      ],
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated"
     },
     {
       "path": "skills/ingestion/source-databricks-query",
       "layer": "ingestion",
-      "providers": ["databricks"],
-      "asset_classes": ["lakehouse", "query-results", "audit-logs"],
-      "execution_modes": ["cli", "ci", "mcp", "persistent"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "databricks"
+      ],
+      "asset_classes": [
+        "lakehouse",
+        "query-results",
+        "audit-logs"
+      ],
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated"
     },
     {
       "path": "skills/ingestion/source-s3-select",
       "layer": "ingestion",
-      "providers": ["aws"],
-      "asset_classes": ["object-storage", "query-results", "audit-logs"],
-      "execution_modes": ["cli", "ci", "mcp", "persistent"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "object-storage",
+        "query-results",
+        "audit-logs"
+      ],
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated"
     },
     {
       "path": "skills/ingestion/ingest-cloudtrail-ocsf",
       "layer": "ingestion",
-      "providers": ["aws"],
-      "asset_classes": ["iam", "api", "audit-logs"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "iam",
+        "api",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-vpc-flow-logs-ocsf",
       "layer": "ingestion",
-      "providers": ["aws"],
-      "asset_classes": ["network", "flow-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "network",
+        "flow-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf",
       "layer": "ingestion",
-      "providers": ["gcp"],
-      "asset_classes": ["network", "flow-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "network",
+        "flow-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-nsg-flow-logs-azure-ocsf",
       "layer": "ingestion",
-      "providers": ["azure"],
-      "asset_classes": ["network", "flow-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "azure"
+      ],
+      "asset_classes": [
+        "network",
+        "flow-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-guardduty-ocsf",
       "layer": "ingestion",
-      "providers": ["aws"],
-      "asset_classes": ["findings", "threat-detections"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "findings",
+        "threat-detections"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-security-hub-ocsf",
       "layer": "ingestion",
-      "providers": ["aws"],
-      "asset_classes": ["findings", "security-posture"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "findings",
+        "security-posture"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-gcp-scc-ocsf",
       "layer": "ingestion",
-      "providers": ["gcp"],
-      "asset_classes": ["findings", "security-posture"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "findings",
+        "security-posture"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-azure-defender-for-cloud-ocsf",
       "layer": "ingestion",
-      "providers": ["azure"],
-      "asset_classes": ["findings", "security-posture"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "azure"
+      ],
+      "asset_classes": [
+        "findings",
+        "security-posture"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-gcp-audit-ocsf",
       "layer": "ingestion",
-      "providers": ["gcp"],
-      "asset_classes": ["api", "audit-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "api",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-azure-activity-ocsf",
       "layer": "ingestion",
-      "providers": ["azure"],
-      "asset_classes": ["api", "audit-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "azure"
+      ],
+      "asset_classes": [
+        "api",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-entra-directory-audit-ocsf",
       "layer": "ingestion",
-      "providers": ["azure", "entra", "microsoft-graph"],
-      "asset_classes": ["identities", "applications", "service-principals", "federated-credentials", "audit-logs"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "azure",
+        "entra",
+        "microsoft-graph"
+      ],
+      "asset_classes": [
+        "identities",
+        "applications",
+        "service-principals",
+        "federated-credentials",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-okta-system-log-ocsf",
       "layer": "ingestion",
-      "providers": ["okta"],
-      "asset_classes": ["identities", "authentication", "user-access", "groups", "applications", "audit-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "okta"
+      ],
+      "asset_classes": [
+        "identities",
+        "authentication",
+        "user-access",
+        "groups",
+        "applications",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-google-workspace-login-ocsf",
       "layer": "ingestion",
-      "providers": ["google-workspace"],
-      "asset_classes": ["identities", "authentication", "mfa", "sessions", "audit-logs"],
-      "frameworks": ["ocsf-1.8"],
+      "providers": [
+        "google-workspace"
+      ],
+      "asset_classes": [
+        "identities",
+        "authentication",
+        "mfa",
+        "sessions",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-k8s-audit-ocsf",
       "layer": "ingestion",
-      "providers": ["kubernetes"],
-      "asset_classes": ["clusters", "audit-logs", "identities"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "clusters",
+        "audit-logs",
+        "identities"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/ingestion/ingest-mcp-proxy-ocsf",
       "layer": "ingestion",
-      "providers": ["mcp", "multi"],
-      "asset_classes": ["agent-tools", "application-activity"],
-      "frameworks": ["ocsf-1.8", "owasp-mcp-top-10"],
+      "providers": [
+        "mcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "agent-tools",
+        "application-activity"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "owasp-mcp-top-10"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/discovery/discover-environment",
       "layer": "discovery",
-      "providers": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
-      "asset_classes": ["inventory", "compute", "storage", "network", "logging", "clusters", "ai-endpoints"],
-      "frameworks": ["mitre-attack-v14", "mitre-atlas", "nist-csf-2.0", "ocsf-1.8"],
+      "providers": [
+        "aws",
+        "azure",
+        "gcp",
+        "kubernetes",
+        "containers",
+        "multi"
+      ],
+      "asset_classes": [
+        "inventory",
+        "compute",
+        "storage",
+        "network",
+        "logging",
+        "clusters",
+        "ai-endpoints"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "mitre-atlas",
+        "nist-csf-2.0",
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/discovery/discover-ai-bom",
       "layer": "discovery",
-      "providers": ["aws", "azure", "gcp", "multi"],
-      "asset_classes": ["inventory", "ai-endpoints", "models", "datasets", "vector-stores", "gpu-fleets"],
-      "frameworks": ["cyclonedx-ml-bom", "nist-ai-rmf", "mitre-atlas", "pci-dss-4.0", "soc2-tsc"],
+      "providers": [
+        "aws",
+        "azure",
+        "gcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "inventory",
+        "ai-endpoints",
+        "models",
+        "datasets",
+        "vector-stores",
+        "gpu-fleets"
+      ],
+      "frameworks": [
+        "cyclonedx-ml-bom",
+        "nist-ai-rmf",
+        "mitre-atlas",
+        "pci-dss-4.0",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp"
+      ]
     },
     {
       "path": "skills/discovery/discover-control-evidence",
       "layer": "discovery",
-      "providers": ["multi"],
-      "asset_classes": ["evidence", "inventory", "ai-endpoints"],
-      "frameworks": ["pci-dss-4.0", "soc2-tsc", "cyclonedx-ml-bom", "mitre-atlas", "ocsf-1.8"],
+      "providers": [
+        "multi"
+      ],
+      "asset_classes": [
+        "evidence",
+        "inventory",
+        "ai-endpoints"
+      ],
+      "frameworks": [
+        "pci-dss-4.0",
+        "soc2-tsc",
+        "cyclonedx-ml-bom",
+        "mitre-atlas",
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp"
+      ]
     },
     {
       "path": "skills/discovery/discover-cloud-control-evidence",
       "layer": "discovery",
-      "providers": ["aws", "azure", "gcp", "multi"],
-      "asset_classes": ["evidence", "inventory", "network", "logging", "encryption", "ai-endpoints"],
-      "frameworks": ["pci-dss-4.0", "soc2-tsc", "nist-ai-rmf", "mitre-attack-v14", "mitre-atlas", "ocsf-1.8"],
+      "providers": [
+        "aws",
+        "azure",
+        "gcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "evidence",
+        "inventory",
+        "network",
+        "logging",
+        "encryption",
+        "ai-endpoints"
+      ],
+      "frameworks": [
+        "pci-dss-4.0",
+        "soc2-tsc",
+        "nist-ai-rmf",
+        "mitre-attack-v14",
+        "mitre-atlas",
+        "ocsf-1.8"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp"
+      ]
     },
     {
       "path": "skills/detection/detect-lateral-movement",
       "layer": "detection",
-      "providers": ["aws", "azure", "gcp", "multi"],
-      "asset_classes": ["identities", "applications", "service-accounts", "service-principals", "managed-identities", "federated-credentials", "app-role-assignments", "sessions", "api", "network"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "aws",
+        "azure",
+        "gcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "identities",
+        "applications",
+        "service-accounts",
+        "service-principals",
+        "managed-identities",
+        "federated-credentials",
+        "app-role-assignments",
+        "sessions",
+        "api",
+        "network"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-google-workspace-suspicious-login",
       "layer": "detection",
-      "providers": ["google-workspace"],
-      "asset_classes": ["identities", "authentication", "sessions", "mfa"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "google-workspace"
+      ],
+      "asset_classes": [
+        "identities",
+        "authentication",
+        "sessions",
+        "mfa"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-okta-mfa-fatigue",
       "layer": "detection",
-      "providers": ["okta"],
-      "asset_classes": ["identities", "authentication", "mfa", "sessions"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "okta"
+      ],
+      "asset_classes": [
+        "identities",
+        "authentication",
+        "mfa",
+        "sessions"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-credential-stuffing-okta",
       "layer": "detection",
-      "providers": ["okta"],
-      "asset_classes": ["identities", "authentication", "sessions"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "okta"
+      ],
+      "asset_classes": [
+        "identities",
+        "authentication",
+        "sessions"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-entra-credential-addition",
       "layer": "detection",
-      "providers": ["azure", "entra", "microsoft-graph"],
-      "asset_classes": ["identities", "applications", "service-principals", "federated-credentials"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "azure",
+        "entra",
+        "microsoft-graph"
+      ],
+      "asset_classes": [
+        "identities",
+        "applications",
+        "service-principals",
+        "federated-credentials"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-entra-role-grant-escalation",
       "layer": "detection",
-      "providers": ["azure", "entra", "microsoft-graph"],
-      "asset_classes": ["identities", "applications", "service-principals", "app-role-assignments"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "azure",
+        "entra",
+        "microsoft-graph"
+      ],
+      "asset_classes": [
+        "identities",
+        "applications",
+        "service-principals",
+        "app-role-assignments"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-mcp-tool-drift",
       "layer": "detection",
-      "providers": ["mcp", "multi"],
-      "asset_classes": ["agent-tools", "supply-chain", "tool-metadata"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14", "owasp-mcp-top-10"],
+      "providers": [
+        "mcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "agent-tools",
+        "supply-chain",
+        "tool-metadata"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14",
+        "owasp-mcp-top-10"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp"
+      ]
     },
     {
       "path": "skills/detection/detect-prompt-injection-mcp-proxy",
       "layer": "detection",
-      "providers": ["mcp", "multi"],
-      "asset_classes": ["agent-tools", "tool-metadata", "guardrails"],
-      "frameworks": ["ocsf-1.8", "mitre-atlas", "owasp-llm-top-10", "owasp-mcp-top-10"],
+      "providers": [
+        "mcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "agent-tools",
+        "tool-metadata",
+        "guardrails"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-atlas",
+        "owasp-llm-top-10",
+        "owasp-mcp-top-10"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-privilege-escalation-k8s",
       "layer": "detection",
-      "providers": ["kubernetes"],
-      "asset_classes": ["clusters", "containers", "identities", "secrets"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "clusters",
+        "containers",
+        "identities",
+        "secrets"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-container-escape-k8s",
       "layer": "detection",
-      "providers": ["kubernetes"],
-      "asset_classes": ["clusters", "containers", "runtime"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "clusters",
+        "containers",
+        "runtime"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/detection/detect-sensitive-secret-read-k8s",
       "layer": "detection",
-      "providers": ["kubernetes"],
-      "asset_classes": ["clusters", "secrets", "identities"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "clusters",
+        "secrets",
+        "identities"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/cspm-aws-cis-benchmark",
       "layer": "evaluation",
-      "providers": ["aws"],
-      "asset_classes": ["identities", "storage", "logging", "network"],
-      "frameworks": ["cis-aws-v3", "nist-csf-2.0", "iso-27001-2022", "soc2-tsc", "pci-dss-4.0"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "identities",
+        "storage",
+        "logging",
+        "network"
+      ],
+      "frameworks": [
+        "cis-aws-v3",
+        "nist-csf-2.0",
+        "iso-27001-2022",
+        "soc2-tsc",
+        "pci-dss-4.0"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/cspm-gcp-cis-benchmark",
       "layer": "evaluation",
-      "providers": ["gcp"],
-      "asset_classes": ["identities", "storage", "logging", "network"],
-      "frameworks": ["cis-gcp-v3", "nist-csf-2.0", "iso-27001-2022"],
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "identities",
+        "storage",
+        "logging",
+        "network"
+      ],
+      "frameworks": [
+        "cis-gcp-v3",
+        "nist-csf-2.0",
+        "iso-27001-2022"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/cspm-azure-cis-benchmark",
       "layer": "evaluation",
-      "providers": ["azure"],
-      "asset_classes": ["identities", "storage", "logging", "network"],
-      "frameworks": ["cis-azure-v2.1", "nist-csf-2.0", "iso-27001-2022"],
+      "providers": [
+        "azure"
+      ],
+      "asset_classes": [
+        "identities",
+        "storage",
+        "logging",
+        "network"
+      ],
+      "frameworks": [
+        "cis-azure-v2.1",
+        "nist-csf-2.0",
+        "iso-27001-2022"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/k8s-security-benchmark",
       "layer": "evaluation",
-      "providers": ["kubernetes"],
-      "asset_classes": ["clusters", "identities", "network", "logging"],
-      "frameworks": ["cis-k8s", "nist-csf-2.0"],
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "clusters",
+        "identities",
+        "network",
+        "logging"
+      ],
+      "frameworks": [
+        "cis-k8s",
+        "nist-csf-2.0"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/container-security",
       "layer": "evaluation",
-      "providers": ["containers"],
-      "asset_classes": ["containers", "runtime", "images"],
-      "frameworks": ["cis-docker", "nist-csf-2.0"],
+      "providers": [
+        "containers"
+      ],
+      "asset_classes": [
+        "containers",
+        "runtime",
+        "images"
+      ],
+      "frameworks": [
+        "cis-docker",
+        "nist-csf-2.0"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/model-serving-security",
       "layer": "evaluation",
-      "providers": ["aws", "azure", "gcp", "multi"],
-      "asset_classes": ["ai-endpoints", "models", "identities", "network", "logging", "guardrails"],
-      "frameworks": ["mitre-atlas", "nist-csf-2.0", "owasp-llm-top-10", "soc2-tsc", "nist-ai-rmf"],
+      "providers": [
+        "aws",
+        "azure",
+        "gcp",
+        "multi"
+      ],
+      "asset_classes": [
+        "ai-endpoints",
+        "models",
+        "identities",
+        "network",
+        "logging",
+        "guardrails"
+      ],
+      "frameworks": [
+        "mitre-atlas",
+        "nist-csf-2.0",
+        "owasp-llm-top-10",
+        "soc2-tsc",
+        "nist-ai-rmf"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/evaluation/gpu-cluster-security",
       "layer": "evaluation",
-      "providers": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
-      "asset_classes": ["gpu-fleets", "clusters", "containers", "runtime", "tenancy"],
-      "frameworks": ["mitre-attack-v14", "mitre-atlas", "nist-csf-2.0", "nist-ai-rmf", "cis-controls-v8", "cis-k8s"],
+      "providers": [
+        "aws",
+        "azure",
+        "gcp",
+        "kubernetes",
+        "containers",
+        "multi"
+      ],
+      "asset_classes": [
+        "gpu-fleets",
+        "clusters",
+        "containers",
+        "runtime",
+        "tenancy"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "mitre-atlas",
+        "nist-csf-2.0",
+        "nist-ai-rmf",
+        "cis-controls-v8",
+        "cis-k8s"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/view/convert-ocsf-to-sarif",
       "layer": "view",
-      "providers": ["multi"],
-      "asset_classes": ["findings", "review-output"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "multi"
+      ],
+      "asset_classes": [
+        "findings",
+        "review-output"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp"
+      ]
     },
     {
       "path": "skills/view/convert-ocsf-to-mermaid-attack-flow",
       "layer": "view",
-      "providers": ["multi"],
-      "asset_classes": ["findings", "review-output", "graphs"],
-      "frameworks": ["ocsf-1.8", "mitre-attack-v14"],
+      "providers": [
+        "multi"
+      ],
+      "asset_classes": [
+        "findings",
+        "review-output",
+        "graphs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp"
+      ]
     },
     {
       "path": "skills/remediation/iam-departures-aws",
       "layer": "remediation",
-      "providers": ["aws", "snowflake", "databricks", "clickhouse"],
-      "asset_classes": ["identities", "access", "audit", "hr-events"],
-      "frameworks": ["mitre-attack-v14", "nist-csf-2.0", "cis-controls-v8", "soc2-tsc"],
+      "providers": [
+        "aws",
+        "snowflake",
+        "databricks",
+        "clickhouse"
+      ],
+      "asset_classes": [
+        "identities",
+        "access",
+        "audit",
+        "hr-events"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "nist-csf-2.0",
+        "cis-controls-v8",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/remediation/remediate-okta-session-kill",
       "layer": "remediation",
-      "providers": ["okta"],
-      "asset_classes": ["identities", "sessions", "oauth-tokens", "audit"],
-      "frameworks": ["mitre-attack-v14", "nist-csf-2.0", "soc2-tsc"],
+      "providers": [
+        "okta"
+      ],
+      "asset_classes": [
+        "identities",
+        "sessions",
+        "oauth-tokens",
+        "audit"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "nist-csf-2.0",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/remediation/remediate-container-escape-k8s",
       "layer": "remediation",
-      "providers": ["kubernetes"],
-      "asset_classes": ["pods", "workloads", "networkpolicy", "audit"],
-      "frameworks": ["mitre-attack-v14", "nist-csf-2.0", "soc2-tsc"],
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "pods",
+        "workloads",
+        "networkpolicy",
+        "audit"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "nist-csf-2.0",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "ci", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
+      "path": "skills/remediation/remediate-k8s-rbac-revoke",
+      "layer": "remediation",
+      "providers": [
+        "kubernetes"
+      ],
+      "asset_classes": [
+        "rolebindings",
+        "clusterrolebindings",
+        "rbac",
+        "audit"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "nist-csf-2.0",
+        "soc2-tsc"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/output/sink-snowflake-jsonl",
       "layer": "output",
-      "providers": ["snowflake"],
-      "asset_classes": ["findings", "evidence", "audit-logs", "lakehouse"],
-      "frameworks": ["ocsf-1.8", "soc2-tsc"],
+      "providers": [
+        "snowflake"
+      ],
+      "asset_classes": [
+        "findings",
+        "evidence",
+        "audit-logs",
+        "lakehouse"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/output/sink-clickhouse-jsonl",
       "layer": "output",
-      "providers": ["clickhouse"],
-      "asset_classes": ["findings", "evidence", "audit-logs", "lakehouse"],
-      "frameworks": ["ocsf-1.8", "soc2-tsc"],
+      "providers": [
+        "clickhouse"
+      ],
+      "asset_classes": [
+        "findings",
+        "evidence",
+        "audit-logs",
+        "lakehouse"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "mcp",
+        "persistent"
+      ]
     },
     {
       "path": "skills/output/sink-s3-jsonl",
       "layer": "output",
-      "providers": ["aws"],
-      "asset_classes": ["findings", "evidence", "audit-logs", "object-storage"],
-      "frameworks": ["ocsf-1.8", "soc2-tsc"],
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "findings",
+        "evidence",
+        "audit-logs",
+        "object-storage"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "soc2-tsc"
+      ],
       "coverage_status": "validated",
-      "execution_modes": ["cli", "mcp", "persistent"]
+      "execution_modes": [
+        "cli",
+        "mcp",
+        "persistent"
+      ]
     }
   ],
   "coverage_targets": [
     {
       "framework": "mitre-attack-v14",
       "target": "100% mapped coverage",
-      "providers_in_scope": ["aws", "azure", "gcp", "kubernetes", "containers", "mcp"],
-      "asset_classes_in_scope": ["identities", "api", "network", "clusters", "containers", "findings"]
+      "providers_in_scope": [
+        "aws",
+        "azure",
+        "gcp",
+        "kubernetes",
+        "containers",
+        "mcp"
+      ],
+      "asset_classes_in_scope": [
+        "identities",
+        "api",
+        "network",
+        "clusters",
+        "containers",
+        "findings"
+      ]
     },
     {
       "framework": "mitre-atlas",
       "target": "100% mapped coverage",
-      "providers_in_scope": ["aws", "azure", "gcp"],
-      "asset_classes_in_scope": ["ai-endpoints", "models", "datasets", "vector-stores", "gpu-fleets", "evidence"]
+      "providers_in_scope": [
+        "aws",
+        "azure",
+        "gcp"
+      ],
+      "asset_classes_in_scope": [
+        "ai-endpoints",
+        "models",
+        "datasets",
+        "vector-stores",
+        "gpu-fleets",
+        "evidence"
+      ]
     },
     {
       "framework": "nist-csf-2.0",
       "target": "100% mapped coverage",
-      "providers_in_scope": ["aws", "azure", "gcp", "kubernetes", "containers", "multi"],
-      "asset_classes_in_scope": ["identities", "storage", "logging", "network", "clusters", "runtime", "evidence"]
+      "providers_in_scope": [
+        "aws",
+        "azure",
+        "gcp",
+        "kubernetes",
+        "containers",
+        "multi"
+      ],
+      "asset_classes_in_scope": [
+        "identities",
+        "storage",
+        "logging",
+        "network",
+        "clusters",
+        "runtime",
+        "evidence"
+      ]
     },
     {
       "framework": "pci-dss-4.0",
       "target": "100% mapped coverage",
-      "providers_in_scope": ["aws", "azure", "gcp", "multi"],
-      "asset_classes_in_scope": ["network", "logging", "encryption", "evidence", "inventory"]
+      "providers_in_scope": [
+        "aws",
+        "azure",
+        "gcp",
+        "multi"
+      ],
+      "asset_classes_in_scope": [
+        "network",
+        "logging",
+        "encryption",
+        "evidence",
+        "inventory"
+      ]
     },
     {
       "framework": "soc2-tsc",
       "target": "100% mapped coverage",
-      "providers_in_scope": ["aws", "azure", "gcp", "multi"],
-      "asset_classes_in_scope": ["access", "logging", "change", "evidence", "inventory", "ai-endpoints"]
+      "providers_in_scope": [
+        "aws",
+        "azure",
+        "gcp",
+        "multi"
+      ],
+      "asset_classes_in_scope": [
+        "access",
+        "logging",
+        "change",
+        "evidence",
+        "inventory",
+        "ai-endpoints"
+      ]
     }
   ]
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -101,6 +101,7 @@ Active fix workflows with dry-run, audit, and guardrails.
 | [`iam-departures-aws`](remediation/iam-departures-aws/) | AWS IAM cleanup for departed employees (per-cloud split for Azure/GCP/Snowflake/Databricks planned; library modules in `src/lambda_worker/clouds/`) |
 | [`remediate-okta-session-kill`](remediation/remediate-okta-session-kill/) | Okta containment — revoke sessions + OAuth tokens after detect-okta-mfa-fatigue or detect-credential-stuffing-okta; dual-audit, deny-list, declared-incident gate |
 | [`remediate-container-escape-k8s`](remediation/remediate-container-escape-k8s/) | Kubernetes containment — apply or re-verify a deny-all NetworkPolicy after detect-container-escape-k8s; protected-namespace deny-list, declared-incident gate, dual audit |
+| [`remediate-k8s-rbac-revoke`](remediation/remediate-k8s-rbac-revoke/) | Kubernetes RBAC revocation — delete or re-verify the offending RoleBinding / ClusterRoleBinding after detect-privilege-escalation-k8s rule r3-rbac-self-grant; protected-namespace + system:* deny-list, declared-incident gate, dual audit |
 
 ## output/
 

--- a/skills/remediation/remediate-k8s-rbac-revoke/REFERENCES.md
+++ b/skills/remediation/remediate-k8s-rbac-revoke/REFERENCES.md
@@ -1,0 +1,51 @@
+# References — remediate-k8s-rbac-revoke
+
+## Kubernetes RBAC API
+
+- RBAC overview — https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- `RoleBinding` v1 reference — https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-binding-v1/
+- `ClusterRoleBinding` v1 reference — https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1/
+- Default user-facing roles (system:* prefix) — https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+- Default core component roles (system:* prefix) — https://kubernetes.io/docs/reference/access-authn-authz/rbac/#core-components-roles
+- API endpoint paths used:
+  - `DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/{ns}/rolebindings/{name}`
+  - `DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}`
+  - `GET /apis/rbac.authorization.k8s.io/v1/namespaces/{ns}/rolebindings/{name}` (re-verify)
+  - `GET /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}` (re-verify)
+
+## Python kubernetes client
+
+- The official `kubernetes` Python client (PyPI: `kubernetes`) provides `RbacAuthorizationV1Api` with the methods this skill calls:
+  - `read_namespaced_role_binding`, `delete_namespaced_role_binding`
+  - `read_cluster_role_binding`, `delete_cluster_role_binding`
+- Lazy import pattern: tests inject a stub implementing `KubernetesClient`; the real `KubernetesRbacClient` only imports `kubernetes` inside `_api()`.
+
+## MITRE ATT&CK
+
+- T1098 — Account Manipulation: https://attack.mitre.org/techniques/T1098/
+- T1098.003 — Additional Cloud Roles: https://attack.mitre.org/techniques/T1098/003/ (the Kubernetes RBAC variant of this technique is what r3-rbac-self-grant catches)
+- TA0003 — Persistence (the tactic the bound technique falls under): https://attack.mitre.org/tactics/TA0003/
+
+## OCSF 1.8
+
+- Detection Finding (class 2004): https://schema.ocsf.io/1.8.0/classes/detection_finding
+- The producer (`detect-privilege-escalation-k8s`) emits class 2004 findings; this skill consumes the `observables[]` array and `metadata.product.feature.name` for source-skill provenance.
+- Repo-pinned contract: [`skills/detection-engineering/OCSF_CONTRACT.md`](../../detection-engineering/OCSF_CONTRACT.md)
+
+## AWS audit infrastructure (reused from container-escape)
+
+- DynamoDB `PutItem` — https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
+- S3 server-side encryption with KMS (`aws:kms`) — https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+- Audit table schema: partition key `target_uid` (`{binding_type}/{namespace|_cluster}/{binding_name}`), sort key `action_at` (ISO-8601 UTC). Compatible with the existing `k8s-remediation-audit` table used by `remediate-container-escape-k8s`.
+
+## Compliance frameworks
+
+- NIST CSF 2.0 — `PR.AC-04` (Access permissions are managed, incorporating the principles of least privilege)
+- SOC 2 — CC6.1 (Logical access controls), CC6.3 (Provisioning + deprovisioning)
+- CIS Kubernetes Benchmark v1.9 — Control 5.1.1 (Ensure that the cluster-admin role is only used where required)
+
+## Repo-internal contracts this skill conforms to
+
+- [`SECURITY_BAR.md`](../../../SECURITY_BAR.md) — 11-principle contract; this skill satisfies all destructive-write principles
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — `human_required` approval model with `min_approvers: 1`
+- [`scripts/validate_safe_skill_bar.py`](../../../scripts/validate_safe_skill_bar.py) — enforces dry-run default, deny-list presence, IAM/RBAC scoping

--- a/skills/remediation/remediate-k8s-rbac-revoke/SKILL.md
+++ b/skills/remediation/remediate-k8s-rbac-revoke/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: remediate-k8s-rbac-revoke
+description: >-
+  Revoke a Kubernetes RoleBinding or ClusterRoleBinding flagged by an RBAC
+  self-grant finding. Consumes an OCSF 1.8 Detection Finding (class 2004)
+  emitted by detect-privilege-escalation-k8s and plans, applies, or
+  re-verifies deletion of the offending binding identified by the detector's
+  binding.type and binding.name observables. Every action is dry-run by
+  default, deny-listed for protected namespaces (kube-system, kube-public,
+  istio-system, linkerd*) and protected binding names (any binding whose name
+  starts with system:), gated behind an incident ID plus approver for --apply,
+  and dual-audited (DynamoDB + KMS-encrypted S3). Use when the user mentions
+  "revoke a Kubernetes RoleBinding," "remove a ClusterRoleBinding after
+  privilege escalation," "respond to RBAC self-grant alert," or "re-verify a
+  K8s RBAC revocation." Do NOT use for NetworkPolicy quarantine, pod
+  deletion, node drain, or cloud-IAM revocation — those belong to their own
+  remediation skills. Out of scope for this skill: discovering candidate
+  bindings for an actor when the detector did not identify a specific
+  binding (rules r1, r2, r4 of detect-privilege-escalation-k8s, and every
+  finding from detect-sensitive-secret-read-k8s); those findings emit a
+  skipped_no_binding_pointer record telling the operator to triage manually.
+license: Apache-2.0
+capability: write-cloud
+approval_model: human_required
+execution_modes: jit, ci, mcp, persistent
+side_effects: writes-cloud, writes-storage, writes-audit
+input_formats: ocsf, native
+output_formats: native
+concurrency_safety: operator_coordinated
+network_egress: kubernetes.default.svc, s3.amazonaws.com, dynamodb.amazonaws.com
+caller_roles: security_engineer, incident_responder, platform_engineer
+approver_roles: security_lead, incident_commander, platform_owner
+min_approvers: 1
+compatibility: >-
+  Requires Python 3.11+, kubernetes, and boto3. Dry-run and re-verify still
+  require read access to RoleBindings and ClusterRoleBindings in the target
+  namespace or cluster. Apply requires delete permission on
+  rbac.authorization.k8s.io/v1 RoleBindings and ClusterRoleBindings plus
+  audit write access to DynamoDB, S3, and KMS.
+metadata:
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/remediation/remediate-k8s-rbac-revoke
+  version: 0.1.0
+  frameworks:
+    - MITRE ATT&CK v14
+    - NIST CSF 2.0
+    - SOC 2
+  cloud:
+    - kubernetes
+---
+
+# remediate-k8s-rbac-revoke
+
+## What this closes
+
+Pair skill for [`detect-privilege-escalation-k8s`](../../detection/detect-privilege-escalation-k8s/) — specifically rule **`r3-rbac-self-grant`** (T1098: Account Manipulation). That rule is the only one in the detection bundle that hands the responder an unambiguous binding to revoke; the others identify an actor and an effect (token grant, pod exec, secret enum) but not a single binding the operator can safely delete.
+
+This is the second Kubernetes **detect → act → audit → re-verify** loop in the repo, after [`remediate-container-escape-k8s`](../remediate-container-escape-k8s/). It lifts the same dual-audit, dry-run-default, deny-list, and incident-ID-gated `--apply` harness.
+
+## Scope honesty
+
+| Source finding | Coverage |
+|---|---|
+| `detect-privilege-escalation-k8s` rule `r3-rbac-self-grant` | **Direct revocation** — detector emits `binding.type` + `binding.name`; we revoke that binding |
+| `detect-privilege-escalation-k8s` rules `r1-secret-enum`, `r2-pod-exec`, `r4-token-self-grant` | **Skipped with pointer** — no specific binding in the finding; we emit `skipped_no_binding_pointer` and tell the operator to triage manually |
+| `detect-sensitive-secret-read-k8s` (any rule) | **Skipped with pointer** — same reason; this skill does not consume that producer at all (`ACCEPTED_PRODUCERS` enforces it) |
+
+A future PR can add a discovery mode (`--discover-bindings-for-actor=NAME`) that lists all RoleBindings + ClusterRoleBindings whose `subjects[]` reference an actor and emits a triage manifest. Discovery mode is intentionally out of scope here because it adds a large API surface (cluster-wide LIST + filter) and needs its own design pass on least-privilege scoping.
+
+## Inputs
+
+Reads one or more OCSF 1.8 Detection Finding (class 2004) JSONL records from stdin or a file path. Required observables:
+
+- `actor.name` (used for audit context only)
+- `binding.type` — must be `rolebindings` or `clusterrolebindings`
+- `binding.name`
+- `namespace` — required for `rolebindings`; ignored for `clusterrolebindings`
+- `rule` (used for audit context only)
+
+Findings missing `binding.type` or `binding.name` are emitted as skip records with `status: skipped_no_binding_pointer`.
+
+## Outputs
+
+JSONL records on stdout. Three record types:
+
+- `remediation_plan` — under dry-run (default); shows the exact `DELETE` endpoint and the deny-list outcome
+- `remediation_action` — under `--apply`; carries `audit.row_uid` + `audit.s3_evidence_uri` from the dual write
+- `remediation_verification` — under `--reverify`; reports `verified` (binding gone) or `drift` (binding still present)
+
+## Guardrails (enforced in code — not just docs)
+
+| Layer | Mechanism |
+|---|---|
+| Source check | `ACCEPTED_PRODUCERS = {"detect-privilege-escalation-k8s"}` — any finding from a different producer is logged and skipped |
+| Protected namespaces | Default deny-list: `kube-system`, `kube-public`, `istio-system`, `linkerd*` (see `DEFAULT_DENY_NAMESPACES`); applies to `rolebindings` only (ClusterRoleBindings are namespace-less) |
+| Protected binding names | Any binding whose name starts with `system:` is denied (`DEFAULT_DENY_BINDING_PREFIXES`) — keeps `system:masters`, `system:basic-user`, `system:public-info-viewer`, etc. out of revocation scope |
+| Apply gate | `--apply` requires `K8S_RBAC_REVOKE_INCIDENT_ID` + `K8S_RBAC_REVOKE_APPROVER` env vars — set out-of-band by the responder, not by the agent |
+| Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER the delete; failure paths still write the failure audit row |
+| Re-verify | `--reverify` confirms the binding is no longer present; emits `drift` if the binding came back |
+
+## Run
+
+```bash
+# Dry-run plan (default)
+python skills/remediation/remediate-k8s-rbac-revoke/src/handler.py findings.ocsf.jsonl
+
+# Apply (after out-of-band approval)
+export K8S_RBAC_REVOKE_INCIDENT_ID=INC-2026-04-19-001
+export K8S_RBAC_REVOKE_APPROVER=alice@security
+export K8S_REMEDIATION_AUDIT_DYNAMODB_TABLE=k8s-remediation-audit
+export K8S_REMEDIATION_AUDIT_BUCKET=acme-k8s-audit
+export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
+python skills/remediation/remediate-k8s-rbac-revoke/src/handler.py findings.ocsf.jsonl --apply
+
+# Re-verify (read-only)
+python skills/remediation/remediate-k8s-rbac-revoke/src/handler.py findings.ocsf.jsonl --reverify
+```
+
+## Non-goals
+
+- Discover bindings for an arbitrary actor (planned, separate issue)
+- Edit binding subjects in place (delete-only — partial edits introduce more failure modes)
+- Recreate the binding after a window — this skill is a one-way revocation
+- Cross-cluster propagation — operates on a single API server target
+
+## See also
+
+- [`remediate-container-escape-k8s`](../remediate-container-escape-k8s/) — the other K8s remediation loop (NetworkPolicy quarantine)
+- [`detect-privilege-escalation-k8s`](../../detection/detect-privilege-escalation-k8s/) — the source detector
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — repo-wide HITL bar
+- [`SECURITY_BAR.md`](../../../SECURITY_BAR.md) — eleven-principle contract

--- a/skills/remediation/remediate-k8s-rbac-revoke/src/handler.py
+++ b/skills/remediation/remediate-k8s-rbac-revoke/src/handler.py
@@ -1,0 +1,703 @@
+"""Revoke a Kubernetes RoleBinding or ClusterRoleBinding flagged by an RBAC self-grant finding.
+
+Consumes an OCSF 1.8 Detection Finding (class 2004) emitted by
+detect-privilege-escalation-k8s. Plans (dry-run default), applies (--apply),
+or re-verifies (--reverify) deletion of the offending RoleBinding or
+ClusterRoleBinding identified by the detector's `binding.type` + `binding.name`
+observables.
+
+Scope honesty:
+- Only rule `r3-rbac-self-grant` from detect-privilege-escalation-k8s carries
+  an unambiguous `binding.type` + `binding.name` pointer. For findings without
+  that pointer (rules r1/r2/r4 of privilege-escalation, and every finding from
+  detect-sensitive-secret-read-k8s), this skill emits a `skipped_no_binding`
+  record and tells the operator to triage manually. Discovery mode (list
+  bindings for an actor across the cluster) is intentionally out of scope for
+  this PR — it adds a large API surface and needs its own design pass.
+
+Guardrails enforced in code:
+- source-skill check rejects findings from any non-privilege-escalation producer
+- protected namespace deny-list: kube-system, kube-public, istio-system, linkerd*
+- protected binding name patterns: any binding starting with `system:` is denied
+  (system:masters, system:basic-user, etc.) so the skill cannot revoke
+  cluster-bootstrap bindings
+- --apply requires K8S_RBAC_REVOKE_INCIDENT_ID + K8S_RBAC_REVOKE_APPROVER
+- dual-audit write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each delete
+- --reverify checks that the binding is no longer present
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Protocol
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "remediate-k8s-rbac-revoke"
+CANONICAL_VERSION = "2026-04"
+ACCEPTED_PRODUCERS = frozenset({"detect-privilege-escalation-k8s"})
+
+DEFAULT_DENY_NAMESPACES = (
+    "kube-system",
+    "kube-public",
+    "istio-system",
+    "linkerd",
+    "linkerd-",
+)
+
+DEFAULT_DENY_BINDING_PREFIXES = (
+    "system:",
+)
+
+SUPPORTED_BINDING_TYPES = frozenset({"rolebindings", "clusterrolebindings"})
+
+RECORD_PLAN = "remediation_plan"
+RECORD_ACTION = "remediation_action"
+RECORD_VERIFICATION = "remediation_verification"
+
+STEP_REVOKE_BINDING = "revoke_rbac_binding"
+
+STATUS_PLANNED = "planned"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_VERIFIED = "verified"
+STATUS_DRIFT = "drift"
+STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
+STATUS_SKIPPED_DENY_LIST = "skipped_deny_list"
+STATUS_WOULD_VIOLATE_DENY_LIST = "would-violate-deny-list"
+STATUS_SKIPPED_PROTECTED_BINDING = "skipped_protected_binding"
+STATUS_WOULD_VIOLATE_PROTECTED_BINDING = "would-violate-protected-binding"
+STATUS_SKIPPED_NO_BINDING = "skipped_no_binding_pointer"
+STATUS_SKIPPED_UNSUPPORTED_TYPE = "skipped_unsupported_binding_type"
+
+
+@dataclasses.dataclass(frozen=True)
+class Target:
+    binding_type: str  # "rolebindings" or "clusterrolebindings"
+    binding_name: str
+    namespace: str  # empty for ClusterRoleBindings (cluster-scoped)
+    actor: str
+    producer_skill: str
+    finding_uid: str
+    rule: str
+
+
+class KubernetesClient(Protocol):
+    def get_role_binding(self, namespace: str, name: str) -> dict[str, Any] | None: ...
+    def get_cluster_role_binding(self, name: str) -> dict[str, Any] | None: ...
+    def delete_role_binding(self, namespace: str, name: str) -> None: ...
+    def delete_cluster_role_binding(self, name: str) -> None: ...
+
+
+class AuditWriter(Protocol):
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]: ...
+
+
+@dataclasses.dataclass
+class KubernetesRbacClient:
+    """Real Kubernetes RBAC client. Imported lazily so tests can use stubs."""
+
+    def _api(self) -> Any:
+        from kubernetes import client  # local import
+        from kubernetes.config import load_incluster_config, load_kube_config
+
+        try:
+            load_incluster_config()
+        except Exception:
+            load_kube_config()
+        return client.RbacAuthorizationV1Api()
+
+    def _serialize(self, obj: Any) -> dict[str, Any]:
+        from kubernetes import client
+
+        return client.ApiClient().sanitize_for_serialization(obj)
+
+    def get_role_binding(self, namespace: str, name: str) -> dict[str, Any] | None:
+        try:
+            obj = self._api().read_namespaced_role_binding(name=name, namespace=namespace)
+        except Exception:
+            return None
+        return self._serialize(obj)
+
+    def get_cluster_role_binding(self, name: str) -> dict[str, Any] | None:
+        try:
+            obj = self._api().read_cluster_role_binding(name=name)
+        except Exception:
+            return None
+        return self._serialize(obj)
+
+    def delete_role_binding(self, namespace: str, name: str) -> None:
+        self._api().delete_namespaced_role_binding(name=name, namespace=namespace)
+
+    def delete_cluster_role_binding(self, name: str) -> None:
+        self._api().delete_cluster_role_binding(name=name)
+
+
+@dataclasses.dataclass
+class DualAuditWriter:
+    dynamodb_table: str
+    s3_bucket: str
+    kms_key_arn: str
+
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]:
+        import boto3  # local import — tests inject a stub writer
+
+        action_at = datetime.now(timezone.utc).isoformat()
+        target_uid = _target_uid(target)
+        row_uid = _deterministic_uid(target_uid, step, action_at)
+        evidence_key = (
+            "k8s-rbac-revoke/audit/"
+            f"{action_at[:4]}/{action_at[5:7]}/{action_at[8:10]}/"
+            f"{target.binding_type}/{target.namespace or '_cluster'}/"
+            f"{target.binding_name}/{action_at}-{step}.json"
+        )
+        evidence_uri = f"s3://{self.s3_bucket}/{evidence_key}"
+
+        envelope = {
+            "schema_mode": "native",
+            "canonical_schema_version": CANONICAL_VERSION,
+            "record_type": "remediation_audit",
+            "source_skill": SKILL_NAME,
+            "row_uid": row_uid,
+            "binding_type": target.binding_type,
+            "binding_name": target.binding_name,
+            "namespace": target.namespace,
+            "actor": target.actor,
+            "producer_skill": target.producer_skill,
+            "finding_uid": target.finding_uid,
+            "rule": target.rule,
+            "step": step,
+            "status": status,
+            "status_detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+            "action_at": action_at,
+        }
+        body = json.dumps(envelope, separators=(",", ":"))
+
+        boto3.client("s3").put_object(
+            Bucket=self.s3_bucket,
+            Key=evidence_key,
+            Body=body.encode("utf-8"),
+            ServerSideEncryption="aws:kms",
+            SSEKMSKeyId=self.kms_key_arn,
+            ContentType="application/json",
+        )
+        boto3.client("dynamodb").put_item(
+            TableName=self.dynamodb_table,
+            Item={
+                "target_uid": {"S": target_uid},
+                "action_at": {"S": action_at},
+                "row_uid": {"S": row_uid},
+                "step": {"S": step},
+                "status": {"S": status},
+                "incident_id": {"S": incident_id},
+                "approver": {"S": approver},
+                "binding_type": {"S": target.binding_type},
+                "binding_name": {"S": target.binding_name},
+                "namespace": {"S": target.namespace},
+                "actor": {"S": target.actor},
+                "producer_skill": {"S": target.producer_skill},
+                "finding_uid": {"S": target.finding_uid},
+                "rule": {"S": target.rule},
+                "s3_evidence_uri": {"S": evidence_uri},
+            },
+        )
+        return {"row_uid": row_uid, "s3_evidence_uri": evidence_uri}
+
+
+def _deterministic_uid(*parts: str) -> str:
+    material = "|".join(parts)
+    return f"rbac-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _target_uid(target: Target) -> str:
+    scope = target.namespace if target.binding_type == "rolebindings" else "_cluster"
+    return f"{target.binding_type}/{scope}/{target.binding_name}"
+
+
+def _finding_product(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _finding_uid(event: dict[str, Any]) -> str:
+    return str((event.get("finding_info") or {}).get("uid") or (event.get("metadata") or {}).get("uid") or "")
+
+
+def _observable_value(event: dict[str, Any], name: str) -> str:
+    for obs in event.get("observables") or []:
+        if not isinstance(obs, dict):
+            continue
+        if obs.get("name") == name:
+            return str(obs.get("value") or "")
+    return ""
+
+
+def _target_from_event(event: dict[str, Any]) -> Target | None:
+    producer = _finding_product(event)
+    if producer not in ACCEPTED_PRODUCERS:
+        emit_stderr_event(
+            SKILL_NAME,
+            level="warning",
+            event="wrong_source_skill",
+            message=f"skipping finding from unaccepted producer `{producer or '<missing>'}`",
+        )
+        return None
+
+    binding_type = _observable_value(event, "binding.type")
+    binding_name = _observable_value(event, "binding.name")
+    namespace = _observable_value(event, "namespace")
+    actor = _observable_value(event, "actor.name")
+    rule = _observable_value(event, "rule")
+
+    if not binding_type or not binding_name:
+        # Detector did not identify a specific binding (rule != r3-rbac-self-grant).
+        # Build a placeholder Target that still carries actor + rule context so the
+        # caller can emit a clean skip record without losing observability.
+        return Target(
+            binding_type="",
+            binding_name="",
+            namespace=namespace,
+            actor=actor,
+            producer_skill=producer,
+            finding_uid=_finding_uid(event),
+            rule=rule,
+        )
+
+    return Target(
+        binding_type=binding_type,
+        binding_name=binding_name,
+        namespace=namespace,
+        actor=actor,
+        producer_skill=producer,
+        finding_uid=_finding_uid(event),
+        rule=rule,
+    )
+
+
+def parse_targets(events: Iterable[dict[str, Any]]) -> Iterator[tuple[Target | None, dict[str, Any]]]:
+    for event in events:
+        yield _target_from_event(event), event
+
+
+def load_deny_namespaces() -> tuple[str, ...]:
+    return DEFAULT_DENY_NAMESPACES
+
+
+def load_protected_binding_prefixes() -> tuple[str, ...]:
+    return DEFAULT_DENY_BINDING_PREFIXES
+
+
+def is_protected_namespace(namespace: str, patterns: Iterable[str]) -> tuple[bool, str]:
+    value = (namespace or "").strip().lower()
+    if not value:
+        return False, ""
+    for pattern in patterns:
+        needle = pattern.lower()
+        if needle.endswith("-"):
+            if value.startswith(needle):
+                return True, pattern
+        elif value == needle:
+            return True, pattern
+    return False, ""
+
+
+def is_protected_binding(name: str, prefixes: Iterable[str]) -> tuple[bool, str]:
+    value = (name or "").strip().lower()
+    if not value:
+        return False, ""
+    for prefix in prefixes:
+        needle = prefix.lower()
+        if value.startswith(needle):
+            return True, prefix
+    return False, ""
+
+
+def _delete_endpoint(target: Target) -> str:
+    if target.binding_type == "clusterrolebindings":
+        return f"DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{target.binding_name}"
+    return (
+        f"DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/"
+        f"{target.namespace}/rolebindings/{target.binding_name}"
+    )
+
+
+def _verify_endpoint(target: Target) -> str:
+    if target.binding_type == "clusterrolebindings":
+        return f"GET /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{target.binding_name}"
+    return (
+        f"GET /apis/rbac.authorization.k8s.io/v1/namespaces/"
+        f"{target.namespace}/rolebindings/{target.binding_name}"
+    )
+
+
+def _plan_record(target: Target, *, status: str, detail: str | None, dry_run: bool) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "Kubernetes",
+            "binding_type": target.binding_type,
+            "binding_name": target.binding_name,
+            "namespace": target.namespace,
+            "actor": target.actor,
+            "rule": target.rule,
+        },
+        "actions": [
+            {
+                "step": STEP_REVOKE_BINDING,
+                "endpoint": _delete_endpoint(target),
+                "status": status,
+                "detail": detail,
+            }
+        ],
+        "status": status,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def _skip_record(target: Target, *, status: str, detail: str, dry_run: bool) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "Kubernetes",
+            "binding_type": target.binding_type,
+            "binding_name": target.binding_name,
+            "namespace": target.namespace,
+            "actor": target.actor,
+            "rule": target.rule,
+        },
+        "actions": [],
+        "status": status,
+        "status_detail": detail,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def _verification_record(target: Target, *, status: str, detail: str) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_VERIFICATION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "Kubernetes",
+            "binding_type": target.binding_type,
+            "binding_name": target.binding_name,
+            "namespace": target.namespace,
+            "actor": target.actor,
+            "rule": target.rule,
+        },
+        "endpoint": _verify_endpoint(target),
+        "status": status,
+        "status_detail": detail,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def check_apply_gate() -> tuple[bool, str]:
+    incident_id = os.getenv("K8S_RBAC_REVOKE_INCIDENT_ID", "").strip()
+    approver = os.getenv("K8S_RBAC_REVOKE_APPROVER", "").strip()
+    if not incident_id:
+        return False, "K8S_RBAC_REVOKE_INCIDENT_ID is required for --apply"
+    if not approver:
+        return False, "K8S_RBAC_REVOKE_APPROVER is required for --apply"
+    return True, ""
+
+
+def revoke_binding(
+    target: Target,
+    *,
+    kube_client: KubernetesClient,
+    audit: AuditWriter,
+    incident_id: str,
+    approver: str,
+) -> dict[str, Any]:
+    first_audit = audit.record(
+        target=target,
+        step=STEP_REVOKE_BINDING,
+        status=STATUS_IN_PROGRESS,
+        detail=f"about to delete {target.binding_type}/{target.binding_name}",
+        incident_id=incident_id,
+        approver=approver,
+    )
+    try:
+        if target.binding_type == "clusterrolebindings":
+            kube_client.delete_cluster_role_binding(target.binding_name)
+        else:
+            kube_client.delete_role_binding(target.namespace, target.binding_name)
+    except Exception as exc:
+        audit.record(
+            target=target,
+            step=STEP_REVOKE_BINDING,
+            status=STATUS_FAILURE,
+            detail=str(exc),
+            incident_id=incident_id,
+            approver=approver,
+        )
+        record = _plan_record(target, status=STATUS_FAILURE, detail=str(exc), dry_run=False)
+        record["audit"] = first_audit
+        return record
+
+    second_audit = audit.record(
+        target=target,
+        step=STEP_REVOKE_BINDING,
+        status=STATUS_SUCCESS,
+        detail=f"deleted {target.binding_type}/{target.binding_name}",
+        incident_id=incident_id,
+        approver=approver,
+    )
+    record = _plan_record(
+        target, status=STATUS_SUCCESS, detail=f"deleted {target.binding_type}/{target.binding_name}", dry_run=False
+    )
+    record["audit"] = second_audit
+    record["incident_id"] = incident_id
+    record["approver"] = approver
+    return record
+
+
+def reverify_revocation(target: Target, *, kube_client: KubernetesClient) -> dict[str, Any]:
+    if target.binding_type == "clusterrolebindings":
+        existing = kube_client.get_cluster_role_binding(target.binding_name)
+    else:
+        existing = kube_client.get_role_binding(target.namespace, target.binding_name)
+
+    if existing is None:
+        return _verification_record(target, status=STATUS_VERIFIED, detail="binding no longer present")
+    return _verification_record(
+        target,
+        status=STATUS_DRIFT,
+        detail=f"{target.binding_type}/{target.binding_name} still present after revocation",
+    )
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+        else:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object",
+                line=lineno,
+            )
+
+
+def run(
+    events: Iterable[dict[str, Any]],
+    *,
+    kube_client: KubernetesClient,
+    apply: bool = False,
+    reverify: bool = False,
+    audit: AuditWriter | None = None,
+    deny_namespaces: Iterable[str] = DEFAULT_DENY_NAMESPACES,
+    protected_prefixes: Iterable[str] = DEFAULT_DENY_BINDING_PREFIXES,
+    incident_id: str = "",
+    approver: str = "",
+) -> Iterator[dict[str, Any]]:
+    deny_namespaces = tuple(deny_namespaces)
+    protected_prefixes = tuple(protected_prefixes)
+
+    for target, _ in parse_targets(events):
+        if target is None:
+            # producer mismatch already logged by _target_from_event
+            continue
+
+        dry_run = not apply and not reverify
+
+        # No binding pointer in the finding — we cannot revoke without manual triage
+        if not target.binding_type or not target.binding_name:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_NO_BINDING,
+                detail=(
+                    "detector did not identify a revocable binding "
+                    f"(rule=`{target.rule or '<unknown>'}`); manual triage required"
+                ),
+                dry_run=dry_run,
+            )
+            continue
+
+        if target.binding_type not in SUPPORTED_BINDING_TYPES:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_UNSUPPORTED_TYPE,
+                detail=(
+                    f"binding.type=`{target.binding_type}` is not in supported set "
+                    f"({sorted(SUPPORTED_BINDING_TYPES)})"
+                ),
+                dry_run=dry_run,
+            )
+            continue
+
+        # ClusterRoleBindings have no namespace; namespaced check applies only to RoleBindings
+        if target.binding_type == "rolebindings":
+            denied, matched = is_protected_namespace(target.namespace, deny_namespaces)
+            if denied:
+                status = STATUS_SKIPPED_DENY_LIST if apply else STATUS_WOULD_VIOLATE_DENY_LIST
+                yield _skip_record(
+                    target,
+                    status=status,
+                    detail=f"namespace `{target.namespace}` matched protected pattern `{matched}`",
+                    dry_run=dry_run,
+                )
+                continue
+
+        protected, prefix = is_protected_binding(target.binding_name, protected_prefixes)
+        if protected:
+            status = STATUS_SKIPPED_PROTECTED_BINDING if apply else STATUS_WOULD_VIOLATE_PROTECTED_BINDING
+            yield _skip_record(
+                target,
+                status=status,
+                detail=f"binding name `{target.binding_name}` matched protected prefix `{prefix}`",
+                dry_run=dry_run,
+            )
+            continue
+
+        if reverify:
+            yield reverify_revocation(target, kube_client=kube_client)
+            continue
+
+        if not apply:
+            yield _plan_record(
+                target,
+                status=STATUS_PLANNED,
+                detail=f"dry-run: would delete {target.binding_type}/{target.binding_name}",
+                dry_run=True,
+            )
+            continue
+
+        if audit is None:
+            raise ValueError("audit writer is required under --apply")
+        yield revoke_binding(
+            target,
+            kube_client=kube_client,
+            audit=audit,
+            incident_id=incident_id,
+            approver=approver,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Plan, apply, or re-verify Kubernetes RBAC binding revocations."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Delete the offending binding after approval gates pass.",
+    )
+    parser.add_argument(
+        "--reverify",
+        action="store_true",
+        help="Read-only verification: confirm the binding is no longer present.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply and args.reverify:
+        print("--apply and --reverify are mutually exclusive", file=sys.stderr)
+        return 2
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        kube_client = KubernetesRbacClient()
+        audit: AuditWriter | None = None
+        incident_id = ""
+        approver = ""
+        if args.apply:
+            ok, reason = check_apply_gate()
+            if not ok:
+                print(reason, file=sys.stderr)
+                return 2
+            incident_id = os.getenv("K8S_RBAC_REVOKE_INCIDENT_ID", "").strip()
+            approver = os.getenv("K8S_RBAC_REVOKE_APPROVER", "").strip()
+            audit = DualAuditWriter(
+                dynamodb_table=os.environ["K8S_REMEDIATION_AUDIT_DYNAMODB_TABLE"],
+                s3_bucket=os.environ["K8S_REMEDIATION_AUDIT_BUCKET"],
+                kms_key_arn=os.environ["KMS_KEY_ARN"],
+            )
+
+        for record in run(
+            load_jsonl(in_stream),
+            kube_client=kube_client,
+            apply=args.apply,
+            reverify=args.reverify,
+            audit=audit,
+            incident_id=incident_id,
+            approver=approver,
+        ):
+            out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/remediate-k8s-rbac-revoke/tests/conftest.py
+++ b/skills/remediation/remediate-k8s-rbac-revoke/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover", "handler")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py
@@ -1,0 +1,391 @@
+"""Tests for remediate-k8s-rbac-revoke."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from handler import (  # type: ignore[import-not-found]
+    ACCEPTED_PRODUCERS,
+    DEFAULT_DENY_BINDING_PREFIXES,
+    DEFAULT_DENY_NAMESPACES,
+    STATUS_DRIFT,
+    STATUS_FAILURE,
+    STATUS_IN_PROGRESS,
+    STATUS_PLANNED,
+    STATUS_SKIPPED_DENY_LIST,
+    STATUS_SKIPPED_NO_BINDING,
+    STATUS_SKIPPED_UNSUPPORTED_TYPE,
+    STATUS_SUCCESS,
+    STATUS_VERIFIED,
+    STATUS_WOULD_VIOLATE_DENY_LIST,
+    STATUS_WOULD_VIOLATE_PROTECTED_BINDING,
+    check_apply_gate,
+    is_protected_binding,
+    is_protected_namespace,
+    parse_targets,
+    run,
+)
+
+
+def _finding(
+    *,
+    producer: str = "detect-privilege-escalation-k8s",
+    binding_type: str = "rolebindings",
+    binding_name: str = "attacker-grant",
+    namespace: str = "payments",
+    actor: str = "system:serviceaccount:payments:attacker-sa",
+    rule: str = "r3-rbac-self-grant",
+    finding_uid: str = "find-1",
+    omit_binding: bool = False,
+) -> dict:
+    observables = [
+        {"name": "actor.name", "type": "Other", "value": actor},
+        {"name": "namespace", "type": "Other", "value": namespace},
+        {"name": "rule", "type": "Other", "value": rule},
+    ]
+    if not omit_binding:
+        observables.append({"name": "binding.type", "type": "Other", "value": binding_type})
+        observables.append({"name": "binding.name", "type": "Other", "value": binding_name})
+    return {
+        "class_uid": 2004,
+        "metadata": {
+            "uid": finding_uid,
+            "product": {"feature": {"name": producer}},
+        },
+        "finding_info": {"uid": finding_uid},
+        "observables": observables,
+    }
+
+
+@dataclass
+class _FakeAudit:
+    writes: list[dict] = field(default_factory=list)
+
+    def record(self, *, target, step, status, detail, incident_id, approver):
+        entry = {
+            "target": f"{target.binding_type}/{target.namespace or '_cluster'}/{target.binding_name}",
+            "step": step,
+            "status": status,
+            "detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+        }
+        self.writes.append(entry)
+        return {
+            "row_uid": f"row-{len(self.writes)}",
+            "s3_evidence_uri": f"s3://bucket/{target.binding_name}-{len(self.writes)}.json",
+        }
+
+
+@dataclass
+class _FakeKube:
+    role_bindings: dict[tuple[str, str], dict] = field(default_factory=dict)
+    cluster_role_bindings: dict[str, dict] = field(default_factory=dict)
+    deletes: list[tuple[str, str, str]] = field(default_factory=list)
+    raise_on_delete: bool = False
+
+    def get_role_binding(self, namespace, name):
+        return self.role_bindings.get((namespace, name))
+
+    def get_cluster_role_binding(self, name):
+        return self.cluster_role_bindings.get(name)
+
+    def delete_role_binding(self, namespace, name):
+        if self.raise_on_delete:
+            raise RuntimeError("k8s api boom")
+        self.deletes.append(("rolebindings", namespace, name))
+        self.role_bindings.pop((namespace, name), None)
+
+    def delete_cluster_role_binding(self, name):
+        if self.raise_on_delete:
+            raise RuntimeError("k8s api boom")
+        self.deletes.append(("clusterrolebindings", "", name))
+        self.cluster_role_bindings.pop(name, None)
+
+
+# ----------------- helpers -----------------
+
+
+def test_protected_namespace_matches_exact_and_prefix():
+    assert is_protected_namespace("kube-system", DEFAULT_DENY_NAMESPACES) == (True, "kube-system")
+    assert is_protected_namespace("linkerd-control", DEFAULT_DENY_NAMESPACES) == (True, "linkerd-")
+    assert is_protected_namespace("payments", DEFAULT_DENY_NAMESPACES) == (False, "")
+    assert is_protected_namespace("", DEFAULT_DENY_NAMESPACES) == (False, "")
+
+
+def test_protected_binding_matches_system_prefix():
+    assert is_protected_binding("system:masters", DEFAULT_DENY_BINDING_PREFIXES) == (True, "system:")
+    assert is_protected_binding("System:Public-Info-Viewer", DEFAULT_DENY_BINDING_PREFIXES) == (True, "system:")
+    assert is_protected_binding("attacker-grant", DEFAULT_DENY_BINDING_PREFIXES) == (False, "")
+    assert is_protected_binding("", DEFAULT_DENY_BINDING_PREFIXES) == (False, "")
+
+
+def test_accepted_producers_set_is_just_privesc():
+    assert ACCEPTED_PRODUCERS == frozenset({"detect-privilege-escalation-k8s"})
+
+
+def test_check_apply_gate_requires_both_envs(monkeypatch):
+    monkeypatch.delenv("K8S_RBAC_REVOKE_INCIDENT_ID", raising=False)
+    monkeypatch.delenv("K8S_RBAC_REVOKE_APPROVER", raising=False)
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "INCIDENT_ID" in reason
+
+    monkeypatch.setenv("K8S_RBAC_REVOKE_INCIDENT_ID", "INC-1")
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "APPROVER" in reason
+
+    monkeypatch.setenv("K8S_RBAC_REVOKE_APPROVER", "alice@security")
+    ok, reason = check_apply_gate()
+    assert ok is True
+    assert reason == ""
+
+
+# ----------------- parse_targets -----------------
+
+
+def test_parse_targets_rejects_wrong_producer():
+    targets = list(parse_targets([_finding(producer="detect-container-escape-k8s")]))
+    assert targets == [(None, targets[0][1])]
+
+
+def test_parse_targets_extracts_full_binding_target():
+    targets = list(parse_targets([_finding()]))
+    target, _ = targets[0]
+    assert target is not None
+    assert target.binding_type == "rolebindings"
+    assert target.binding_name == "attacker-grant"
+    assert target.namespace == "payments"
+    assert target.actor == "system:serviceaccount:payments:attacker-sa"
+    assert target.rule == "r3-rbac-self-grant"
+    assert target.producer_skill == "detect-privilege-escalation-k8s"
+
+
+def test_parse_targets_returns_partial_when_binding_missing():
+    """When detector doesn't carry binding pointer (rules r1/r2/r4), we still
+    build a partial Target so the run loop can emit a clean skip record."""
+    targets = list(parse_targets([_finding(omit_binding=True, rule="r1-secret-enum")]))
+    target, _ = targets[0]
+    assert target is not None
+    assert target.binding_type == ""
+    assert target.binding_name == ""
+    assert target.rule == "r1-secret-enum"
+
+
+# ----------------- run: dry-run plan path -----------------
+
+
+def test_run_dry_run_emits_plan_for_namespaced_binding():
+    records = list(run([_finding()], kube_client=_FakeKube()))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["record_type"] == "remediation_plan"
+    assert rec["status"] == STATUS_PLANNED
+    assert rec["dry_run"] is True
+    assert rec["target"]["binding_type"] == "rolebindings"
+    assert rec["target"]["binding_name"] == "attacker-grant"
+    assert rec["actions"][0]["endpoint"].startswith("DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/payments/rolebindings/attacker-grant")
+
+
+def test_run_dry_run_emits_plan_for_cluster_binding():
+    records = list(
+        run(
+            [_finding(binding_type="clusterrolebindings", binding_name="attacker-cluster-grant", namespace="")],
+            kube_client=_FakeKube(),
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_PLANNED
+    assert rec["actions"][0]["endpoint"].startswith("DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/attacker-cluster-grant")
+
+
+# ----------------- run: skip paths -----------------
+
+
+def test_run_skips_finding_without_binding_pointer():
+    records = list(run([_finding(omit_binding=True, rule="r1-secret-enum")], kube_client=_FakeKube()))
+    rec = records[0]
+    assert rec["status"] == STATUS_SKIPPED_NO_BINDING
+    assert rec["actions"] == []
+    assert "r1-secret-enum" in rec["status_detail"]
+
+
+def test_run_skips_protected_namespace_in_dry_run():
+    records = list(run([_finding(namespace="kube-system")], kube_client=_FakeKube()))
+    rec = records[0]
+    assert rec["status"] == STATUS_WOULD_VIOLATE_DENY_LIST
+    assert "kube-system" in rec["status_detail"]
+
+
+def test_run_skips_protected_namespace_in_apply():
+    audit = _FakeAudit()
+    records = list(
+        run(
+            [_finding(namespace="kube-system")],
+            kube_client=_FakeKube(),
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SKIPPED_DENY_LIST
+    # Audit should NOT fire for skip records — they never reach the cloud API
+    assert audit.writes == []
+
+
+def test_run_skips_system_prefixed_binding_name():
+    records = list(run([_finding(binding_name="system:masters")], kube_client=_FakeKube()))
+    rec = records[0]
+    assert rec["status"] == STATUS_WOULD_VIOLATE_PROTECTED_BINDING
+    assert "system:" in rec["status_detail"]
+
+
+def test_run_skips_unsupported_binding_type():
+    records = list(run([_finding(binding_type="roles")], kube_client=_FakeKube()))
+    rec = records[0]
+    assert rec["status"] == STATUS_SKIPPED_UNSUPPORTED_TYPE
+    assert "roles" in rec["status_detail"]
+
+
+def test_run_does_not_check_namespace_for_cluster_bindings_in_protected_ns():
+    """A ClusterRoleBinding has no namespace; even if observable namespace is
+    kube-system the namespace deny-list does not apply (binding-name deny-list
+    handles cluster-scoped protection via the system: prefix)."""
+    records = list(
+        run(
+            [_finding(binding_type="clusterrolebindings", binding_name="custom-cluster-grant", namespace="kube-system")],
+            kube_client=_FakeKube(),
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_PLANNED
+
+
+# ----------------- run: apply path -----------------
+
+
+def test_run_apply_revokes_namespaced_binding_with_dual_audit():
+    audit = _FakeAudit()
+    kube = _FakeKube(role_bindings={("payments", "attacker-grant"): {"metadata": {"name": "attacker-grant"}}})
+    records = list(
+        run(
+            [_finding()],
+            kube_client=kube,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+        )
+    )
+
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS
+    assert rec["dry_run"] is False
+    assert rec["incident_id"] == "INC-1"
+    assert rec["approver"] == "alice@security"
+    assert kube.deletes == [("rolebindings", "payments", "attacker-grant")]
+
+    assert len(audit.writes) == 2
+    assert audit.writes[0]["status"] == STATUS_IN_PROGRESS
+    assert audit.writes[1]["status"] == STATUS_SUCCESS
+    for entry in audit.writes:
+        assert entry["incident_id"] == "INC-1"
+        assert entry["approver"] == "alice@security"
+
+
+def test_run_apply_revokes_cluster_binding():
+    audit = _FakeAudit()
+    kube = _FakeKube(cluster_role_bindings={"attacker-cluster-grant": {"metadata": {"name": "attacker-cluster-grant"}}})
+    records = list(
+        run(
+            [_finding(binding_type="clusterrolebindings", binding_name="attacker-cluster-grant", namespace="")],
+            kube_client=kube,
+            apply=True,
+            audit=audit,
+            incident_id="INC-2",
+            approver="bob@security",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS
+    assert kube.deletes == [("clusterrolebindings", "", "attacker-cluster-grant")]
+
+
+def test_run_apply_writes_failure_audit_when_kube_call_throws():
+    audit = _FakeAudit()
+    kube = _FakeKube(
+        role_bindings={("payments", "attacker-grant"): {"metadata": {"name": "attacker-grant"}}},
+        raise_on_delete=True,
+    )
+    records = list(
+        run(
+            [_finding()],
+            kube_client=kube,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_FAILURE
+    assert "k8s api boom" in rec["actions"][0]["detail"]
+    # Both pre-action and failure audit rows are written
+    assert len(audit.writes) == 2
+    assert audit.writes[0]["status"] == STATUS_IN_PROGRESS
+    assert audit.writes[1]["status"] == STATUS_FAILURE
+
+
+def test_run_apply_requires_audit_writer():
+    import pytest
+
+    with pytest.raises(ValueError, match="audit writer is required"):
+        list(run([_finding()], kube_client=_FakeKube(), apply=True, audit=None))
+
+
+# ----------------- run: re-verify path -----------------
+
+
+def test_run_reverify_reports_verified_when_binding_gone():
+    records = list(
+        run(
+            [_finding()],
+            kube_client=_FakeKube(role_bindings={}),  # binding already deleted
+            reverify=True,
+        )
+    )
+    rec = records[0]
+    assert rec["record_type"] == "remediation_verification"
+    assert rec["status"] == STATUS_VERIFIED
+
+
+def test_run_reverify_reports_drift_when_binding_still_present():
+    records = list(
+        run(
+            [_finding()],
+            kube_client=_FakeKube(role_bindings={("payments", "attacker-grant"): {"metadata": {"name": "attacker-grant"}}}),
+            reverify=True,
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_DRIFT
+    assert "still present" in rec["status_detail"]
+
+
+def test_run_reverify_handles_cluster_binding():
+    records = list(
+        run(
+            [_finding(binding_type="clusterrolebindings", binding_name="attacker-cluster-grant", namespace="")],
+            kube_client=_FakeKube(cluster_role_bindings={}),
+            reverify=True,
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_VERIFIED


### PR DESCRIPTION
## Summary

Pair skill for [`detect-privilege-escalation-k8s`](skills/detection/detect-privilege-escalation-k8s/) rule **r3-rbac-self-grant** (MITRE ATT&CK T1098 — Account Manipulation). Closes the second K8s `detect → act → audit → re-verify` loop in the repo, after `remediate-container-escape-k8s`.

This is **Phase 1** of the [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155) phased remediation roadmap.

## Scope honesty

| Source finding | Coverage |
|---|---|
| `detect-privilege-escalation-k8s` rule `r3-rbac-self-grant` | **Direct revocation** — detector emits `binding.type` + `binding.name`; we revoke that binding |
| `detect-privilege-escalation-k8s` rules r1/r2/r4 | **Skipped with pointer** — no specific binding in the finding; emit `skipped_no_binding_pointer` and tell the operator to triage manually |
| `detect-sensitive-secret-read-k8s` (any rule) | **Skipped with pointer** — same reason; this skill rejects that producer entirely (`ACCEPTED_PRODUCERS` enforces it) |

A future PR can add a discovery mode (`--discover-bindings-for-actor=NAME`) that lists all RoleBindings + ClusterRoleBindings whose `subjects[]` reference an actor and emits a triage manifest. **Out of scope here** because it adds a large API surface (cluster-wide LIST + filter) and needs its own design pass on least-privilege scoping.

## Guardrails (lifted from `remediate-container-escape-k8s` + new)

- `ACCEPTED_PRODUCERS = {"detect-privilege-escalation-k8s"}`
- Protected namespace deny-list: `kube-system`, `kube-public`, `istio-system`, `linkerd*` (RoleBindings only — ClusterRoleBindings are namespace-less)
- Protected binding-name deny-list: any binding starting with `system:` (system:masters, system:basic-user, etc.)
- `--apply` requires `K8S_RBAC_REVOKE_INCIDENT_ID` + `K8S_RBAC_REVOKE_APPROVER` env vars set out-of-band
- Dual audit (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each delete; failure paths still write the failure audit row
- `--reverify` confirms the binding is gone; emits `drift` if it came back

## Coverage matrix impact

`docs/images/coverage-matrix.svg` will update on the next regen: `detect-privilege-escalation-k8s` flips from amber (planned via #241) to **green** (closed via this PR) for rule r3-rbac-self-grant. Other rules of that detector remain amber pending discovery mode.

## Files

- `skills/remediation/remediate-k8s-rbac-revoke/SKILL.md` — frontmatter + scope-honesty matrix + run examples + non-goals
- `skills/remediation/remediate-k8s-rbac-revoke/REFERENCES.md` — K8s RBAC API, MITRE T1098/T1098.003, OCSF 1.8, AWS audit infra, NIST CSF / SOC 2 / CIS K8s
- `skills/remediation/remediate-k8s-rbac-revoke/src/handler.py` — ~530 LoC; Target dataclass, KubernetesClient + AuditWriter protocols, dual-audit writer, deny-list checks, dry-run/apply/reverify modes, JSONL stdin/stdout
- `skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py` — 22 tests covering parse, deny-list, apply, dual-audit, reverify, failure
- `skills/remediation/remediate-k8s-rbac-revoke/tests/conftest.py` — sibling-module isolation (every K8s remediation skill ships `src/handler.py`)

## Doc + registry sync (count drift 48→49, remediation 3→4)

- README.md: hero alt-text, header line, layer table Remediate row (3→4 + name), Total line, architecture mermaid L5 node, agent-integration bundle label
- ARCHITECTURE.md, CLAUDE.md tree, skills/README.md catalog
- SECURITY_BAR.md regenerated via `python scripts/generate_security_bar_matrix.py`
- docs/framework-coverage.json: new registry entry

## Test plan

- [x] `pytest -q` — 1174 passed (1152 prior + 22 new)
- [x] All 9 contract validators pass (`scripts/validate_*.py`)
- [x] `bash scripts/run_mypy.sh` — clean
- [x] `ruff check skills scripts` — clean
- [x] `validate_safe_skill_bar.py` confirms HITL gate + dry-run default + deny lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)