### PR TITLE
feat(ci): catch-all scan for stale mermaid skill counts in any *.md (closes-class #302)

### DIFF
--- a/scripts/validate_skill_count_consistency.py
+++ b/scripts/validate_skill_count_consistency.py
@@ -37,6 +37,51 @@ CLAIMS: list[Claim] = [
     (REPO_ROOT / "docs" / "ARCHITECTURE.md", r"(\d+) shipped detectors", "detection"),
 ]
 
+# Catch-all scan: any mermaid label of the form `<br/>N skills` or `<br/>N shipped`
+# inside a `*.md` file MUST equal an on-disk count for the layer it names. This
+# is what catches drift like the issue #302 case where README mermaid said
+# "46 shipped" while the actual total was 48 — a stale label that escaped CLAIMS.
+#
+# The scan parses the layer name from the same mermaid node text. Recognized
+# layer hints map to the truth dict keys; unknown hints fall back to the
+# repo-wide total. Lines inside ALLOWED_DRIFT_LINES are skipped (e.g. example
+# snippets in skill-authoring docs).
+
+# Ordered: more specific terms first. The README/diagrams treat "L1 Ingest" as
+# the count of `ingest-*` skills only, with `source-*` adapters listed
+# separately in the layer table. Hence the `ingest_only` (= 15 today) vs
+# `ingestion` (= 18 today, includes source-*) split.
+LAYER_HINT_TO_METRIC = (
+    ("source", "sources"),
+    ("ingestion", "ingestion"),
+    ("ingest", "ingest_only"),
+    ("discover", "discovery"),
+    ("detect", "detection"),
+    ("evaluate", "evaluation"),
+    ("evaluation", "evaluation"),
+    ("remediate", "remediation"),
+    ("remediation", "remediation"),
+    ("view", "view"),
+    ("output", "output"),
+    ("sink", "output"),
+    ("shipped", "total"),
+    ("bundle", "total"),
+)
+
+# Substrings (matched on the line) that mark a count-claim as intentionally
+# decorative or example-only and exclude it from the scan. Add sparingly.
+ALLOWED_DRIFT_LINES: tuple[str, ...] = (
+    "<!-- skill-count-scan: ignore -->",
+)
+
+# Pattern: `<br/>N <something> skills|shipped|sinks` inside a mermaid node.
+# The `<br/>` prefix anchors us to flowchart node labels (single-line text in
+# rect labels) and avoids matching every `\d+` in prose.
+SCAN_PATTERN = re.compile(
+    r"<br/>(\d+)\s+(?:[A-Za-z·\-/+]+\s+)?(skills?|shipped|sinks?)\b",
+    re.IGNORECASE,
+)
+
 
 def _count_skills(layer: str | None = None) -> int:
     """Count SKILL.md files under skills/<layer>/*/ (or all layers when None)."""
@@ -45,10 +90,82 @@ def _count_skills(layer: str | None = None) -> int:
     return sum(1 for _ in (REPO_ROOT / "skills" / layer).glob("*/SKILL.md"))
 
 
+def _count_ingest_only() -> int:
+    """Count `ingest-*` skills under ingestion/, excluding `source-*` adapters.
+    Mirrors the layer-table convention used in README and the architecture
+    diagram (Ingest = 15 + Sources = 3 listed separately)."""
+    return sum(
+        1 for _ in (REPO_ROOT / "skills" / "ingestion").glob("ingest-*/SKILL.md")
+    )
+
+
+def _count_sources() -> int:
+    """Count `source-*` warehouse query adapters under ingestion/."""
+    return sum(
+        1 for _ in (REPO_ROOT / "skills" / "ingestion").glob("source-*/SKILL.md")
+    )
+
+
+def _resolve_metric_for_line(line: str) -> str:
+    """Inspect the mermaid node text and pick the truth-dict key it should equal.
+
+    Heuristic: if the line names a specific layer (e.g. `L1 Ingest`, `Remediate`),
+    use that layer's count; otherwise default to total. Keeps the scan honest
+    about what each label is claiming. Order in LAYER_HINT_TO_METRIC matters:
+    the first matching hint wins, so more specific terms (e.g. `source`,
+    `ingestion`) come before broader ones (`ingest`, `shipped`).
+    """
+    lowered = line.lower()
+    for hint, metric in LAYER_HINT_TO_METRIC:
+        if hint in lowered:
+            return metric
+    return "total"
+
+
+def _scan_drift(truth: dict[str, int]) -> list[str]:
+    """Walk every tracked `*.md` file and flag any `<br/>N (skills|shipped|sinks)`
+    label whose number does not equal the on-disk count for the layer it names.
+
+    Catches the failure mode from issue #302: a stale mermaid count in README
+    or any other doc that wasn't on the explicit CLAIMS allow-list.
+    """
+    errors: list[str] = []
+    md_paths = sorted(
+        p
+        for p in REPO_ROOT.rglob("*.md")
+        if ".venv" not in p.parts and "node_modules" not in p.parts
+    )
+    for path in md_paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for match in SCAN_PATTERN.finditer(text):
+            claimed = int(match.group(1))
+            line_start = text.rfind("\n", 0, match.start()) + 1
+            line_end = text.find("\n", match.end())
+            line = text[line_start : line_end if line_end != -1 else None]
+            if any(skip in line for skip in ALLOWED_DRIFT_LINES):
+                continue
+            metric = _resolve_metric_for_line(line)
+            expected = truth.get(metric)
+            if expected is None or claimed == expected:
+                continue
+            line_no = text[: match.start()].count("\n") + 1
+            errors.append(
+                f"{path.relative_to(REPO_ROOT)}:{line_no}: mermaid label claims "
+                f"{claimed} for `{metric}`, on-disk count is {expected} — "
+                f"line: `{line.strip()}`"
+            )
+    return errors
+
+
 def main() -> int:
     truth: dict[str, int] = {
         "total": _count_skills(),
         "ingestion": _count_skills("ingestion"),
+        "ingest_only": _count_ingest_only(),
+        "sources": _count_sources(),
         "discovery": _count_skills("discovery"),
         "detection": _count_skills("detection"),
         "evaluation": _count_skills("evaluation"),
@@ -79,6 +196,9 @@ def main() -> int:
                     f"{path.relative_to(REPO_ROOT)}:{line_no}: claims {claimed} for `{metric}`, "
                     f"but on-disk count is {expected} (pattern `{pattern}`)"
                 )
+
+    # Catch-all scan for any unauthorized mermaid count drift (issue #302 class)
+    errors.extend(_scan_drift(truth))
 
     if errors:
         print("Skill-count consistency check FAILED:\n")

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -592,3 +592,51 @@ class TestAssumeRoleBoundaryGuardrail:
         skill_like_dirs = COMMON.iter_skill_like_dirs()
         missing = [path for path in skill_like_dirs if not (path / "SKILL.md").exists()]
         assert missing == []
+
+
+COUNT_CONSISTENCY = _load_module(
+    "cloud_security_validate_skill_count_consistency_test",
+    SCRIPTS / "validate_skill_count_consistency.py",
+)
+
+
+class TestCountDriftScan:
+    """Catch the issue #302 class of bug: a stale mermaid count slipped into
+    a doc that wasn't on the explicit CLAIMS allow-list."""
+
+    def test_scan_passes_against_current_repo_state(self):
+        # The script's main() runs both CLAIMS and the catch-all scan.
+        assert COUNT_CONSISTENCY.main() == 0
+
+    def test_scan_resolves_layer_hint_to_specific_metric(self):
+        resolve = COUNT_CONSISTENCY._resolve_metric_for_line
+        assert resolve("L1 Ingest<br/>15 skills") == "ingest_only"
+        assert resolve("L2 Discover<br/>4 skills") == "discovery"
+        assert resolve("L3 Detect<br/>11 skills · ATT&CK") == "detection"
+        assert resolve("L4 Evaluate<br/>7 skills · 82 checks") == "evaluation"
+        assert resolve("L5 Remediate<br/>4 skills · HITL") == "remediation"
+        assert resolve("L6 View<br/>2 skills · SARIF") == "view"
+        assert resolve("L7 Output<br/>3 sinks · S3") == "output"
+        assert resolve("Sources<br/>3 adapters") == "sources"
+
+    def test_ingestion_vs_ingest_only_split(self):
+        """README treats `Ingest = 15` and `Sources = 3` as separate counts,
+        even though both live under skills/ingestion/. The validator must
+        split `ingest_only` from full `ingestion` so it can tell them apart."""
+        ingest_only = COUNT_CONSISTENCY._count_ingest_only()
+        sources = COUNT_CONSISTENCY._count_sources()
+        full = COUNT_CONSISTENCY._count_skills("ingestion")
+        assert full == ingest_only + sources
+
+    def test_scan_falls_back_to_total_when_no_layer_hint(self):
+        resolve = COUNT_CONSISTENCY._resolve_metric_for_line
+        assert resolve("Shared skill bundle<br/>49 shipped") == "total"
+        assert resolve("<br/>49 something-unknown") == "total"
+
+    def test_scan_pattern_matches_mermaid_node_labels(self):
+        pat = COUNT_CONSISTENCY.SCAN_PATTERN
+        assert pat.search('ingest["L1 Ingest<br/>15 skills"]') is not None
+        assert pat.search('node["Shared skill bundle<br/>48 shipped"]') is not None
+        assert pat.search('out["L7 Output<br/>3 sinks · S3"]') is not None
+        # Should NOT match prose (no <br/> prefix)
+        assert pat.search("The repo ships 49 skills today.") is None


### PR DESCRIPTION
## Summary

Closes the failure mode behind [#302](https://github.com/msaad00/cloud-ai-security-skills/issues/302): a stale mermaid count in README or any other doc that wasn't on the explicit CLAIMS allow-list of `validate_skill_count_consistency.py`. The CLAIMS approach catches known-good locations but silently misses any new mermaid block that ships with a hardcoded number.

## What this adds

`scripts/validate_skill_count_consistency.py`:

- New `_scan_drift(truth)` walks every `*.md` in the repo (skipping `.venv` and `node_modules`) and matches `<br/>(\d+) (skills|shipped|sinks)` inside mermaid node labels.
- New `LAYER_HINT_TO_METRIC` ordered tuple maps layer hints in the surrounding line to the truth-dict key. More-specific terms first (`source`, `ingestion`) so they win over broader matches (`ingest`, `shipped`).
- New `_count_ingest_only()` and `_count_sources()` so the validator can tell the README's `L1 Ingest = 15` apart from the directory's `skills/ingestion/ = 18` — the layer table treats Sources as a separate row even though both live under `ingestion/`.
- New `ALLOWED_DRIFT_LINES` escape (`<!-- skill-count-scan: ignore -->`) for intentionally decorative labels. Used sparingly.
- `main()` runs CLAIMS + scan, reports both classes of drift in one pass.

## What this catches that CLAIMS missed

- The original [#302](https://github.com/msaad00/cloud-ai-security-skills/issues/302) case: README mermaid label `46 shipped` while total was 48. CLAIMS didn't list it; scan would have fired.
- Any future PR that adds a mermaid like `<br/>2 skills · HITL` without bumping the count when a new remediation skill lands.
- Equivalent patterns in `ARCHITECTURE.md`, `skills/README.md`, or any doc someone might add a counted-mermaid to.

## Tests

`tests/integration/test_skill_validation_scripts.py::TestCountDriftScan` adds 5 tests:
- scan passes against current repo state
- layer-hint resolution maps each L1-L7 + Sources correctly
- `ingest_only + sources` sums to full ingestion count
- fallback to `total` when no layer hint
- pattern matches mermaid labels but not prose

## Test plan

- [x] `pytest -q` — 1171 passed (1166 prior + 5 new)
- [x] All 9 contract validators pass (including the new scan as part of `validate_skill_count_consistency.py`)
- [x] `ruff check skills scripts` clean
- [x] `bash scripts/run_mypy.sh` clean
- [x] CI already runs this script in the `skill-contract` job ([.github/workflows/ci.yml:55](.github/workflows/ci.yml)) — no workflow change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)