### PR TITLE
feat(remediation): ship remediate-mcp-tool-quarantine (#155 phase 2, closes 2 MCP detection gaps)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,7 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.jsonl \
 | L2 Discover | 4 shipped skills (AI BOM, cloud control evidence, control evidence, environment graph) | wider SaaS and infra evidence sources |
 | L3 Detect | 11 shipped detectors tied to MITRE ATT&CK techniques (lateral movement, K8s container escape, K8s privesc + secret read, MCP tool drift, MCP prompt injection, Okta MFA fatigue, Okta credential stuffing, Entra credential addition, Entra role grant, Workspace suspicious login) | impossible travel, more AI-agent signals |
 | L4 Evaluate | 7 shipped benchmarks (CIS AWS / GCP / Azure, K8s, Docker / container, GPU cluster, model serving) | native by default, OCSF Compliance Finding (`class_uid=2003`) shipped as opt-in output |
-| L5 Remediate | `iam-departures-aws`, `remediate-okta-session-kill`, and `remediate-container-escape-k8s` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #240, #241, #242) |
+| L5 Remediate | `iam-departures-aws`, `remediate-okta-session-kill`, `remediate-container-escape-k8s`, `remediate-k8s-rbac-revoke`, and `remediate-mcp-tool-quarantine` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #238, #242, #307) |
 | L6 View | `convert-ocsf-to-sarif`, `convert-ocsf-to-mermaid-attack-flow` | graph overlay, warehouse-ready converters |
 | L7 Output | 3 shipped sinks (`sink-s3-jsonl`, `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`) | BigQuery, Security Lake |
 
@@ -70,7 +70,7 @@ skills/
 └── output/         ← L7 (sink-* skills: append-only persistence)
 ```
 
-The repo ships **49 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 11 + 7 + 4 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
+The repo ships **50 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 11 + 7 + 5 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
 
 `skills/detection-engineering/` holds the shared OCSF contract and frozen
 golden fixtures. Executable skills live only under the six layered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ skills/
 │   ├── iam-departures-aws/
 │   ├── remediate-okta-session-kill/
 │   ├── remediate-container-escape-k8s/
-│   └── remediate-k8s-rbac-revoke/
+│   ├── remediate-k8s-rbac-revoke/
+│   └── remediate-mcp-tool-quarantine/
 │
 ├── output/                        # append-only persistence sinks
 │   ├── sink-s3-jsonl/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 49 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 50 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,7 +16,7 @@
 
 ## What this repo gives you
 
-**49 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus four guarded write paths for offboarding, account containment, Kubernetes workload quarantine, and Kubernetes RBAC revocation. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**50 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus five guarded write paths for offboarding, account containment, Kubernetes workload quarantine, Kubernetes RBAC revocation, and MCP tool quarantine. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
@@ -24,12 +24,12 @@
 | **Discover** | 4 | inventory, graph, AI BOM, evidence | native / bridge JSON |
 | **Detect** | 11 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
-| **Remediate** | 4 | guarded write paths (IAM departures, Okta session kill, K8s quarantine, K8s RBAC revoke) | audited action trail |
+| **Remediate** | 5 | guarded write paths (IAM departures, Okta session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 49 shipped skills.**
+**Total: 50 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -72,6 +72,7 @@ is the row you can take to your auditor.
 | `iam-departures-aws` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-container-escape-k8s` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-k8s-rbac-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `remediate-mcp-tool-quarantine` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-okta-session-kill` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `convert-ocsf-to-mermaid-attack-flow` | view | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `convert-ocsf-to-sarif` | view | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
@@ -79,7 +80,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_49 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_50 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,28 +4,28 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **49**
+- Total shipped skills in registry: **50**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
 | OCSF | 1.8.0 | **37** | — |
-| MITRE ATT&CK | v14 | **26** | 100% mapped coverage |
-| MITRE ATLAS | current | **7** | 100% mapped coverage |
+| MITRE ATT&CK | v14 | **27** | 100% mapped coverage |
+| MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **1** | — |
 | CIS GCP Foundations | v3.0 | **1** | — |
 | CIS Azure Foundations | v2.1 | **1** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
 | CIS Controls | v8 | **2** | — |
-| NIST CSF | 2.0 | **12** | 100% mapped coverage |
+| NIST CSF | 2.0 | **13** | 100% mapped coverage |
 | NIST AI RMF | current | **4** | — |
-| SOC 2 TSC | current | **12** | 100% mapped coverage |
+| SOC 2 TSC | current | **13** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **3** | — |
 | OWASP LLM Top 10 | current | **2** | — |
-| OWASP MCP Top 10 | current | **3** | — |
+| OWASP MCP Top 10 | current | **4** | — |
 | CycloneDX ML-BOM | current | **2** | — |
 
 Shipped skills mapped counts the number of skills in the registry that declare this framework under `frameworks`. It does not claim per-control depth; see each skill's `SKILL.md` and `REFERENCES.md` for the concrete controls, techniques, or benchmarks covered.
@@ -85,7 +85,7 @@ Shipped skills mapped: **37**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **26**
+Shipped skills mapped: **27**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -112,6 +112,7 @@ Shipped skills mapped: **26**
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
+| [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
 | [`convert-ocsf-to-mermaid-attack-flow`](../skills/view/convert-ocsf-to-mermaid-attack-flow) | view | multi | findings, review-output, graphs |
 | [`convert-ocsf-to-sarif`](../skills/view/convert-ocsf-to-sarif) | view | multi | findings, review-output |
@@ -123,7 +124,7 @@ Shipped skills mapped: **26**
 - Asset classes in scope: ai-endpoints, models, datasets, vector-stores, gpu-fleets, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **7**
+Shipped skills mapped: **8**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -134,6 +135,7 @@ Shipped skills mapped: **7**
 | [`discover-environment`](../skills/discovery/discover-environment) | discovery | aws, azure, gcp, kubernetes, containers, multi | inventory, compute, storage, network, logging, clusters, ai-endpoints |
 | [`gpu-cluster-security`](../skills/evaluation/gpu-cluster-security) | evaluation | aws, azure, gcp, kubernetes, containers, multi | gpu-fleets, clusters, containers, runtime, tenancy |
 | [`model-serving-security`](../skills/evaluation/model-serving-security) | evaluation | aws, azure, gcp, multi | ai-endpoints, models, identities, network, logging, guardrails |
+| [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 
 ### CIS AWS Foundations (v3.0)
 
@@ -204,7 +206,7 @@ Shipped skills mapped: **2**
 - Asset classes in scope: identities, storage, logging, network, clusters, runtime, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **12**
+Shipped skills mapped: **13**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -219,6 +221,7 @@ Shipped skills mapped: **12**
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
+| [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
 
 ### NIST AI RMF (current)
@@ -241,7 +244,7 @@ Shipped skills mapped: **4**
 - Asset classes in scope: access, logging, change, evidence, inventory, ai-endpoints
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **12**
+Shipped skills mapped: **13**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -256,6 +259,7 @@ Shipped skills mapped: **12**
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
+| [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
 
 ### PCI DSS (4.0)
@@ -301,13 +305,14 @@ Shipped skills mapped: **2**
 
 - Registry id: `owasp-mcp-top-10`
 
-Shipped skills mapped: **3**
+Shipped skills mapped: **4**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
 | [`detect-prompt-injection-mcp-proxy`](../skills/detection/detect-prompt-injection-mcp-proxy) | detection | mcp, multi | agent-tools, tool-metadata, guardrails |
 | [`ingest-mcp-proxy-ocsf`](../skills/ingestion/ingest-mcp-proxy-ocsf) | ingestion | mcp, multi | agent-tools, application-activity |
+| [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 
 ### CycloneDX ML-BOM (current)
 

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -1246,6 +1246,32 @@
       ]
     },
     {
+      "path": "skills/remediation/remediate-mcp-tool-quarantine",
+      "layer": "remediation",
+      "providers": [
+        "mcp"
+      ],
+      "asset_classes": [
+        "mcp-tools",
+        "quarantine-list",
+        "audit"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "mitre-atlas",
+        "owasp-mcp-top-10",
+        "nist-csf-2.0",
+        "soc2-tsc"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/output/sink-snowflake-jsonl",
       "layer": "output",
       "providers": [

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1020" viewBox="0 0 1400 1020" role="img" aria-labelledby="arch-title arch-desc">
   <title id="arch-title">cloud-ai-security-skills — architecture: 7 skill layers and 4 runtime surfaces</title>
-  <desc id="arch-desc">Canonical architecture diagram. Top half shows the seven shipped skill layers and the data flow between them. External signals (cloud APIs, raw logs, identity, warehouses) enter through two intake layers (L1 Ingest with 15 ingesters plus 3 source adapters, L2 Discover with 4 inventory and evidence skills), pass through two analyze layers (L3 Detect with 11 deterministic MITRE ATT&amp;CK rules emitting OCSF Detection Finding 2004, L4 Evaluate with 7 benchmark families covering 82 checks), and exit through two act layers (L5 Remediate with 4 HITL dual-audited write paths, L6 View with 2 OCSF-to-render converters), with L7 Output sinks (S3, Snowflake, ClickHouse) persisting whatever the producer emitted. Bottom half shows the four runtime surfaces: MCP clients (Claude Code, Codex, Cursor, Windsurf, Cortex) connect over stdio to the repo MCP server which auto-discovers SKILL.md, audits every tool call, and enforces per-skill timeouts; CLI uses Unix pipes between skills; CI invokes skills and publishes SARIF; cloud runners (AWS S3+SQS, GCP GCS+PubSub, Azure Blob+EventGrid) drive the same skill bundles event-driven. All four surfaces share the same shipped skill bundle (49 today). Outputs include native JSONL, OCSF 1.8, bridge format, SARIF, Mermaid attack flow, AI BOM (CycloneDX), and audited write actions.</desc>
+  <desc id="arch-desc">Canonical architecture diagram. Top half shows the seven shipped skill layers and the data flow between them. External signals (cloud APIs, raw logs, identity, warehouses) enter through two intake layers (L1 Ingest with 15 ingesters plus 3 source adapters, L2 Discover with 4 inventory and evidence skills), pass through two analyze layers (L3 Detect with 11 deterministic MITRE ATT&amp;CK rules emitting OCSF Detection Finding 2004, L4 Evaluate with 7 benchmark families covering 82 checks), and exit through two act layers (L5 Remediate with 5 HITL dual-audited write paths, L6 View with 2 OCSF-to-render converters), with L7 Output sinks (S3, Snowflake, ClickHouse) persisting whatever the producer emitted. Bottom half shows the four runtime surfaces: MCP clients (Claude Code, Codex, Cursor, Windsurf, Cortex) connect over stdio to the repo MCP server which auto-discovers SKILL.md, audits every tool call, and enforces per-skill timeouts; CLI uses Unix pipes between skills; CI invokes skills and publishes SARIF; cloud runners (AWS S3+SQS, GCP GCS+PubSub, Azure Blob+EventGrid) drive the same skill bundles event-driven. All four surfaces share the same shipped skill bundle (50 today). Outputs include native JSONL, OCSF 1.8, bridge format, SARIF, Mermaid attack flow, AI BOM (CycloneDX), and audited write actions.</desc>
 
   <defs>
     <linearGradient id="archBg" x1="0" y1="0" x2="1" y2="1">
@@ -146,16 +146,16 @@
       <text x="0" y="18" font-size="11" fill="#64748b">HITL · dual-audit · dry-run default</text>
 
       <!-- L5 Remediate -->
-      <rect x="0" y="36" width="240" height="186" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
+      <rect x="0" y="36" width="240" height="204" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
       <text x="20" y="64" font-size="11" font-weight="800" letter-spacing="1.4" fill="#fcd34d">L5 · REMEDIATE</text>
-      <text x="20" y="92" font-size="22" font-weight="900" fill="#fef3c7">4</text>
+      <text x="20" y="92" font-size="22" font-weight="900" fill="#fef3c7">5</text>
       <text x="48" y="92" font-size="13" fill="#94a3b8">audited write paths</text>
       <text x="20" y="116" font-size="11" fill="#fef3c7">iam-departures-aws</text>
-      <text x="20" y="132" font-size="11" fill="#94a3b8">  Step Function · cross-account STS</text>
-      <text x="20" y="150" font-size="11" fill="#fef3c7">remediate-okta-session-kill</text>
-      <text x="20" y="166" font-size="11" fill="#94a3b8">  revoke sessions + OAuth tokens</text>
-      <text x="20" y="184" font-size="11" fill="#fef3c7">remediate-container-escape-k8s</text>
-      <text x="20" y="202" font-size="11" fill="#fef3c7">remediate-k8s-rbac-revoke</text>
+      <text x="20" y="134" font-size="11" fill="#fef3c7">remediate-okta-session-kill</text>
+      <text x="20" y="152" font-size="11" fill="#fef3c7">remediate-container-escape-k8s</text>
+      <text x="20" y="170" font-size="11" fill="#fef3c7">remediate-k8s-rbac-revoke</text>
+      <text x="20" y="188" font-size="11" fill="#fef3c7">remediate-mcp-tool-quarantine</text>
+      <text x="20" y="206" font-size="11" fill="#94a3b8">  HITL · dry-run · dual audit</text>
 
       <!-- L6 View -->
       <rect x="0" y="222" width="240" height="142" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
@@ -285,7 +285,7 @@
     <g transform="translate(800,720)">
       <text x="0" y="0" font-size="11" font-weight="800" letter-spacing="1.5" fill="#2dd4bf">SHARED BUNDLE</text>
       <rect x="0" y="14" width="240" height="160" rx="20" fill="#022c22" stroke="#2dd4bf" stroke-width="2"/>
-      <text x="120" y="56" text-anchor="middle" font-size="22" font-weight="900" fill="#ccfbf1">49 skills</text>
+      <text x="120" y="56" text-anchor="middle" font-size="22" font-weight="900" fill="#ccfbf1">50 skills</text>
       <text x="120" y="78" text-anchor="middle" font-size="13" fill="#5eead4">SKILL.md · src/ · tests/</text>
       <line x1="20" y1="100" x2="220" y2="100" stroke="#0d9488" stroke-width="1"/>
       <text x="120" y="124" text-anchor="middle" font-size="12" font-weight="800" fill="#ccfbf1">No surface re-implements</text>

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -121,15 +121,15 @@
     <text x="48"   y="632" fill="#f1f5f9" font-size="15">detect-mcp-tool-drift</text>
     <text x="430"  y="632" fill="#cbd5e1" font-size="14">T1195.001 (TA0001)</text>
     <rect x="760"  y="616" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="616" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="632" fill="#fee2e2" font-size="13">remediate-mcp-tool-quarantine candidate</text>
+    <rect x="880"  y="616" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="632" fill="#dcfce7" font-size="13">→ remediate-mcp-tool-quarantine</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="670" fill="#f1f5f9" font-size="15">detect-prompt-injection-mcp-proxy</text>
     <text x="430"  y="670" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
     <rect x="760"  y="654" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="654" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="670" fill="#fee2e2" font-size="13">remediate-mcp-proxy-quarantine candidate</text>
+    <rect x="880"  y="654" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="670" fill="#dcfce7" font-size="13">→ remediate-mcp-tool-quarantine</text>
   </g>
 
   <!-- EVALUATION SECTION -->
@@ -166,6 +166,6 @@
 
   <!-- Footer -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="884" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">3 / 11</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">5 of 8 gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">3 detections need new remediation skills</tspan> · all writes HITL-gated, dry-run-default, dual-audited (#155)</text>
+    <text x="48" y="884" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">5 / 11</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">4 of 6 remaining gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">2 detections need new remediation skills</tspan> · all writes HITL-gated, dry-run-default, dual-audited (#155)</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 48 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 11 detect, 7 evaluate, 3 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 50 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 11 detect, 7 evaluate, 5 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="162" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">48</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">50</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(174,0)">
@@ -117,7 +117,7 @@
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
         <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L5 Remediate</text>
-        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">3</text>
+        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">5</text>
       </g>
       <g transform="translate(222,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -102,6 +102,7 @@ Active fix workflows with dry-run, audit, and guardrails.
 | [`remediate-okta-session-kill`](remediation/remediate-okta-session-kill/) | Okta containment — revoke sessions + OAuth tokens after detect-okta-mfa-fatigue or detect-credential-stuffing-okta; dual-audit, deny-list, declared-incident gate |
 | [`remediate-container-escape-k8s`](remediation/remediate-container-escape-k8s/) | Kubernetes containment — apply or re-verify a deny-all NetworkPolicy after detect-container-escape-k8s; protected-namespace deny-list, declared-incident gate, dual audit |
 | [`remediate-k8s-rbac-revoke`](remediation/remediate-k8s-rbac-revoke/) | Kubernetes RBAC revocation — delete or re-verify the offending RoleBinding / ClusterRoleBinding after detect-privilege-escalation-k8s rule r3-rbac-self-grant; protected-namespace + system:* deny-list, declared-incident gate, dual audit |
+| [`remediate-mcp-tool-quarantine`](remediation/remediate-mcp-tool-quarantine/) | MCP tool quarantine — append the offending tool to a JSONL quarantine file the operator's MCP client filters its surface against, after detect-mcp-tool-drift (T1195.001) or detect-prompt-injection-mcp-proxy (ATLAS AML.T0051); protected-prefix (`mcp_`, `system_`, `internal_`) deny-list, declared-incident gate, dual audit |
 
 ## output/
 

--- a/skills/remediation/remediate-mcp-tool-quarantine/REFERENCES.md
+++ b/skills/remediation/remediate-mcp-tool-quarantine/REFERENCES.md
@@ -1,0 +1,42 @@
+# References — remediate-mcp-tool-quarantine
+
+## Model Context Protocol
+
+- Spec — https://modelcontextprotocol.io/specification
+- Tools concept — https://modelcontextprotocol.io/docs/concepts/tools
+- The MCP spec defines tool discovery via `tools/list`; clients are free to filter that list before exposing tools to the agent. This skill produces the structured artifact (the JSONL quarantine file) that operators wire into their client's filter logic.
+
+## MITRE ATT&CK + ATLAS
+
+- T1195.001 — Compromise Software Supply Chain: https://attack.mitre.org/techniques/T1195/001/ (the rug-pull / tool-poisoning pattern caught by `detect-mcp-tool-drift`)
+- TA0001 — Initial Access (parent tactic): https://attack.mitre.org/tactics/TA0001/
+- MITRE ATLAS AML.T0051 — Prompt Injection: https://atlas.mitre.org/techniques/AML.T0051/ (the suspicious-description pattern caught by `detect-prompt-injection-mcp-proxy`)
+
+## OWASP
+
+- OWASP Top 10 for MCP (community draft) — referenced in [`docs/FRAMEWORK_MAPPINGS.md`](../../../docs/FRAMEWORK_MAPPINGS.md)
+- OWASP LLM02 Insecure Output Handling and LLM05 Improper Output Handling are adjacent — quarantining a tool that emits manipulated output is a direct mitigation.
+
+## OCSF 1.8
+
+- Detection Finding (class 2004): https://schema.ocsf.io/1.8.0/classes/detection_finding
+- The two source detectors (`detect-mcp-tool-drift`, `detect-prompt-injection-mcp-proxy`) emit class 2004 findings; this skill consumes the `observables[]` array and `metadata.product.feature.name` for source-skill provenance.
+
+## AWS audit infrastructure (reused from sister remediation skills)
+
+- DynamoDB `PutItem` — https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
+- S3 server-side encryption with KMS (`aws:kms`) — https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+- Audit table partition key is `tool_name`, sort key `action_at` (ISO-8601 UTC). Compatible with the existing audit table schema used by `remediate-okta-session-kill` and `remediate-container-escape-k8s` — operators can reuse one table or split per-skill at deployment time.
+
+## Repo-internal contracts this skill conforms to
+
+- [`_shared/remediation_verifier.py`](../../_shared/remediation_verifier.py) — `build_verification_record()` + `build_drift_finding()` integration (per workflow convention, integrated from day one — see PR #305)
+- [`SECURITY_BAR.md`](../../../SECURITY_BAR.md) — 11-principle contract; this skill satisfies all destructive-write principles
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — `human_required` approval model with `min_approvers: 1`
+- [`scripts/validate_safe_skill_bar.py`](../../../scripts/validate_safe_skill_bar.py) — enforces dry-run default, deny-list presence
+
+## Compliance frameworks
+
+- NIST CSF 2.0 — `RS.MI` (Mitigation): contain incidents to prevent expansion of compromise
+- SOC 2 — CC7.4 (System operations: incident response)
+- OWASP MCP Top 10 — supply-chain compromise + prompt-injection mitigation classes

--- a/skills/remediation/remediate-mcp-tool-quarantine/SKILL.md
+++ b/skills/remediation/remediate-mcp-tool-quarantine/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: remediate-mcp-tool-quarantine
+description: >-
+  Quarantine an MCP tool flagged by detect-mcp-tool-drift (T1195.001 supply
+  chain compromise) or detect-prompt-injection-mcp-proxy (MITRE ATLAS
+  AML.T0051) by appending a structured entry to a JSONL quarantine file
+  the operator's MCP client reads at startup or via hot-reload to exclude
+  the tool from its discoverable surface. Every action is dry-run by
+  default, deny-listed against MCP infrastructure prefixes (mcp_, system_,
+  internal_), gated behind an incident ID plus approver for --apply, and
+  dual-audited (DynamoDB + KMS-encrypted S3). Re-verify reads the
+  quarantine file and emits VERIFIED, DRIFT, or UNREACHABLE via the shared
+  remediation_verifier contract — DRIFT also emits a paired OCSF Detection
+  Finding so the gap flows back through the SIEM/SOAR pipeline. Use when
+  the user mentions "quarantine an MCP tool," "block a poisoned MCP tool,"
+  "respond to MCP tool drift," "remediate prompt injection in MCP proxy,"
+  or "re-verify MCP tool quarantine." Do NOT use for cloud IAM revocation,
+  Kubernetes containment, Okta session-kill, or any cloud-API write —
+  those belong to their own remediation skills. Out of scope: revoking the
+  MCP server itself, mutating remote tool definitions, or contacting the
+  third-party MCP server author.
+license: Apache-2.0
+capability: write-storage
+approval_model: human_required
+execution_modes: jit, ci, mcp, persistent
+side_effects: writes-storage, writes-audit
+input_formats: ocsf, native
+output_formats: native
+concurrency_safety: operator_coordinated
+network_egress: s3.amazonaws.com, dynamodb.amazonaws.com
+caller_roles: security_engineer, incident_responder, platform_engineer
+approver_roles: security_lead, incident_commander, platform_owner
+min_approvers: 1
+compatibility: >-
+  Requires Python 3.11+. Dry-run and re-verify need only filesystem read
+  access to the quarantine file. Apply additionally requires write access
+  to the quarantine file plus audit write access to DynamoDB, S3, and KMS.
+  No third-party MCP SDK required — this skill writes a structured JSONL
+  file that the operator's MCP client filters its tool list against.
+metadata:
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/remediation/remediate-mcp-tool-quarantine
+  version: 0.1.0
+  frameworks:
+    - MITRE ATT&CK v14
+    - MITRE ATLAS
+    - OWASP MCP Top 10
+    - NIST CSF 2.0
+    - SOC 2
+  cloud:
+    - mcp
+---
+
+# remediate-mcp-tool-quarantine
+
+## What this closes
+
+Pair skill for both shipped MCP detectors:
+
+- [`detect-mcp-tool-drift`](../../detection/detect-mcp-tool-drift/) — T1195.001 Compromise Software Supply Chain (the rug-pull / tool-poisoning pattern where an MCP tool's behavior or schema mutates between calls)
+- [`detect-prompt-injection-mcp-proxy`](../../detection/detect-prompt-injection-mcp-proxy/) — MITRE ATLAS AML.T0051 Prompt Injection (suspicious natural-language patterns in tool descriptions designed to override agent instructions)
+
+Closes [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155) phase 2: 2 of 8 detection gaps in one skill, the AI-native loop. After this PR ships, **5 of 11 detections are closed-loop**.
+
+## Why file-based quarantine
+
+The MCP attack surface is in-process from the agent's POV — there's no cloud API to call to "block a tool." The cleanest, surface-neutral remediation is a **structured JSONL quarantine file** that the operator's MCP client reads at startup (or via hot-reload) to filter its tool surface:
+
+- **MCP servers in this repo** can read it via `CLOUD_SECURITY_MCP_QUARANTINED_TOOLS_FILE` (operators wire this in their `.mcp.json`).
+- **Third-party MCP clients** (Claude Code / Desktop, Codex, Cursor, Windsurf, etc.) can wire it via their per-client allow/deny config — the file is the protocol.
+
+Each line of the file is one quarantine entry with `tool_name`, `session_uid`, `fingerprint`, `producer_skill`, `finding_uid`, `incident_id`, `approver`, `quarantined_at`. The MCP client filters its discoverable tool list against this on startup.
+
+The dual-audit (DynamoDB + KMS-encrypted S3) is preserved for organizational traceability — same shape as the other 4 remediation skills.
+
+## Inputs
+
+Reads OCSF 1.8 Detection Finding (class 2004) JSONL from stdin or a file argument. Required observables:
+
+- `tool.name` — the MCP tool to quarantine (REQUIRED; missing emits `skipped_no_tool_pointer`)
+- `session.uid` — the MCP session that surfaced the finding (audit context only)
+- `tool.after_fingerprint`, `tool.before_fingerprint`, or `tool.description_sha256` — recorded for forensic context
+
+Findings whose `metadata.product.feature.name` is not in `ACCEPTED_PRODUCERS` are logged and skipped.
+
+## Outputs
+
+JSONL records on stdout:
+
+- `remediation_plan` — under dry-run (default); shows the exact quarantine entry that would be written
+- `remediation_action` — under `--apply`; carries `audit.row_uid` + `audit.s3_evidence_uri`
+- `remediation_verification` — under `--reverify`; reports VERIFIED / DRIFT / UNREACHABLE per the shared `_shared/remediation_verifier.py` contract
+- **OCSF Detection Finding 2004** — additionally emitted on DRIFT so the gap flows back through the same SIEM/SOAR pipeline as every other finding
+
+## Guardrails (enforced in code)
+
+| Layer | Mechanism |
+|---|---|
+| Source check | `ACCEPTED_PRODUCERS = {"detect-mcp-tool-drift", "detect-prompt-injection-mcp-proxy"}` |
+| Protected-tool deny-list | `mcp_*`, `system_*`, `internal_*` prefixes refuse quarantine — operators should revoke / patch infrastructure tools, not silently block them |
+| Apply gate | `--apply` requires `MCP_QUARANTINE_INCIDENT_ID` + `MCP_QUARANTINE_APPROVER` env vars set out-of-band |
+| Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each quarantine append; failure paths still write the failure audit row |
+| Re-verify | Reads the quarantine file; emits VERIFIED if tool is present, DRIFT (+ paired OCSF finding) if removed, UNREACHABLE if file unreadable — never silently downgrades |
+
+## Run
+
+```bash
+# Dry-run plan (default)
+python skills/remediation/remediate-mcp-tool-quarantine/src/handler.py findings.ocsf.jsonl
+
+# Apply (after out-of-band approval)
+export MCP_QUARANTINE_INCIDENT_ID=INC-2026-04-19-002
+export MCP_QUARANTINE_APPROVER=alice@security
+export MCP_QUARANTINE_FILE=$HOME/.mcp-quarantine.jsonl
+export MCP_QUARANTINE_AUDIT_DYNAMODB_TABLE=mcp-quarantine-audit
+export MCP_QUARANTINE_AUDIT_BUCKET=acme-mcp-audit
+export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
+python skills/remediation/remediate-mcp-tool-quarantine/src/handler.py findings.ocsf.jsonl --apply
+
+# Re-verify (read-only)
+python skills/remediation/remediate-mcp-tool-quarantine/src/handler.py findings.ocsf.jsonl --reverify
+```
+
+## Non-goals
+
+- Mutating remote tool definitions on the third-party MCP server (out of scope; this is operator-side only)
+- Contacting the MCP server author or filing a vendor disclosure (manual workflow)
+- Revoking the MCP server itself — use the operator's MCP client config for that
+- Killing in-flight tool calls — the quarantine takes effect on next MCP client load / hot-reload
+
+## See also
+
+- [`remediate-container-escape-k8s`](../remediate-container-escape-k8s/) and [`remediate-k8s-rbac-revoke`](../remediate-k8s-rbac-revoke/) — sibling closed-loop remediation skills
+- [`detect-mcp-tool-drift`](../../detection/detect-mcp-tool-drift/) and [`detect-prompt-injection-mcp-proxy`](../../detection/detect-prompt-injection-mcp-proxy/) — source detectors
+- [`_shared/remediation_verifier.py`](../../_shared/remediation_verifier.py) — verification contract this skill emits via
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — repo-wide HITL bar
+- [`SECURITY_BAR.md`](../../../SECURITY_BAR.md) — eleven-principle contract

--- a/skills/remediation/remediate-mcp-tool-quarantine/src/handler.py
+++ b/skills/remediation/remediate-mcp-tool-quarantine/src/handler.py
@@ -1,0 +1,690 @@
+"""Quarantine an MCP tool flagged by tool-drift or prompt-injection findings.
+
+Consumes an OCSF 1.8 Detection Finding (class 2004) emitted by either
+`detect-mcp-tool-drift` (T1195.001 — Compromise Software Supply Chain) or
+`detect-prompt-injection-mcp-proxy` (MITRE ATLAS AML.T0051). Plans (dry-run
+default), applies (--apply), or re-verifies (--reverify) an entry in a local
+JSONL quarantine file that the operator's MCP client reads at startup or via
+hot-reload to exclude the tool from its discoverable surface.
+
+Why file-based + dual audit:
+- The MCP attack surface is in-process from the agent's POV — no cloud API
+  to call. The quarantine artifact is a small structured JSONL file the
+  operator's MCP client filters its tool list against.
+- The dual-audit pattern (DynamoDB + KMS-encrypted S3) is preserved for
+  organizational traceability — same shape as the other 4 remediation
+  skills, even though the cloud API surface here is just storage.
+- Wiring `_shared/remediation_verifier.py` from day one means a re-verify
+  that finds the tool removed from the quarantine file (drift) emits an
+  OCSF Detection Finding through the same SIEM/SOAR pipeline as every
+  other finding.
+
+Guardrails enforced in code:
+- ACCEPTED_PRODUCERS limits input to the two MCP detectors
+- protected-tool deny-list: `mcp_*`, `system_*`, `internal_*` patterns
+  refuse quarantine (operators should revoke, not auto-block, infrastructure
+  tools)
+- --apply requires MCP_QUARANTINE_INCIDENT_ID + MCP_QUARANTINE_APPROVER
+- audit row written BEFORE and AFTER each quarantine append
+- --reverify reads the quarantine file and reports VERIFIED / DRIFT /
+  UNREACHABLE via the shared verifier contract
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Protocol
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.remediation_verifier import (  # noqa: E402
+    DEFAULT_VERIFICATION_SLA_MS,
+    RemediationReference,
+    VerificationResult,
+    VerificationStatus,
+    build_drift_finding,
+    build_verification_record,
+    sla_deadline,
+)
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "remediate-mcp-tool-quarantine"
+CANONICAL_VERSION = "2026-04"
+ACCEPTED_PRODUCERS = frozenset(
+    {
+        "detect-mcp-tool-drift",
+        "detect-prompt-injection-mcp-proxy",
+    }
+)
+
+# Tools matching these prefixes are considered protected MCP infrastructure
+# (the repo's own MCP server, system probes, etc.) and refuse quarantine.
+# Operators should revoke / patch — not silently block — infrastructure tools.
+DEFAULT_PROTECTED_TOOL_PREFIXES = (
+    "mcp_",
+    "system_",
+    "internal_",
+)
+
+RECORD_PLAN = "remediation_plan"
+RECORD_ACTION = "remediation_action"
+RECORD_VERIFICATION = "remediation_verification"
+
+STEP_QUARANTINE_TOOL = "append_to_quarantine_file"
+
+STATUS_PLANNED = "planned"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_VERIFIED = "verified"
+STATUS_DRIFT = "drift"
+STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
+STATUS_SKIPPED_PROTECTED = "skipped_protected_tool"
+STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-tool"
+STATUS_SKIPPED_NO_TOOL = "skipped_no_tool_pointer"
+
+
+@dataclasses.dataclass(frozen=True)
+class Target:
+    tool_name: str
+    session_uid: str
+    fingerprint: str  # tool.after_fingerprint or tool.description_sha256
+    producer_skill: str
+    finding_uid: str
+
+
+class QuarantineStore(Protocol):
+    """Read + append the quarantine list. File-based default; tests inject stub."""
+
+    def list_tools(self) -> list[str]: ...
+    def append(self, entry: dict[str, Any]) -> None: ...
+
+
+class AuditWriter(Protocol):
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]: ...
+
+
+@dataclasses.dataclass
+class JSONLQuarantineFile:
+    """Default quarantine store: append-only JSONL on disk.
+
+    The MCP client reads this file at startup (or via hot-reload) to filter
+    its tool surface. Each line is one quarantined tool entry.
+    """
+
+    path: Path
+
+    def list_tools(self) -> list[str]:
+        if not self.path.exists():
+            return []
+        names: list[str] = []
+        with self.path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict) and obj.get("tool_name"):
+                    names.append(str(obj["tool_name"]))
+        return names
+
+    def append(self, entry: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
+@dataclasses.dataclass
+class DualAuditWriter:
+    dynamodb_table: str
+    s3_bucket: str
+    kms_key_arn: str
+
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]:
+        import boto3
+
+        action_at = datetime.now(timezone.utc).isoformat()
+        row_uid = _deterministic_uid(target.tool_name, target.session_uid, step, action_at)
+        evidence_key = (
+            "mcp-tool-quarantine/audit/"
+            f"{action_at[:4]}/{action_at[5:7]}/{action_at[8:10]}/"
+            f"{_safe_path_component(target.tool_name)}/{action_at}-{step}.json"
+        )
+        evidence_uri = f"s3://{self.s3_bucket}/{evidence_key}"
+
+        envelope = {
+            "schema_mode": "native",
+            "canonical_schema_version": CANONICAL_VERSION,
+            "record_type": "remediation_audit",
+            "source_skill": SKILL_NAME,
+            "row_uid": row_uid,
+            "tool_name": target.tool_name,
+            "session_uid": target.session_uid,
+            "fingerprint": target.fingerprint,
+            "producer_skill": target.producer_skill,
+            "finding_uid": target.finding_uid,
+            "step": step,
+            "status": status,
+            "status_detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+            "action_at": action_at,
+        }
+        body = json.dumps(envelope, separators=(",", ":"))
+
+        boto3.client("s3").put_object(
+            Bucket=self.s3_bucket,
+            Key=evidence_key,
+            Body=body.encode("utf-8"),
+            ServerSideEncryption="aws:kms",
+            SSEKMSKeyId=self.kms_key_arn,
+            ContentType="application/json",
+        )
+        boto3.client("dynamodb").put_item(
+            TableName=self.dynamodb_table,
+            Item={
+                "tool_name": {"S": target.tool_name},
+                "action_at": {"S": action_at},
+                "row_uid": {"S": row_uid},
+                "step": {"S": step},
+                "status": {"S": status},
+                "incident_id": {"S": incident_id},
+                "approver": {"S": approver},
+                "session_uid": {"S": target.session_uid},
+                "fingerprint": {"S": target.fingerprint},
+                "producer_skill": {"S": target.producer_skill},
+                "finding_uid": {"S": target.finding_uid},
+                "s3_evidence_uri": {"S": evidence_uri},
+            },
+        )
+        return {"row_uid": row_uid, "s3_evidence_uri": evidence_uri}
+
+
+def _deterministic_uid(*parts: str) -> str:
+    material = "|".join(parts)
+    return f"mcpq-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _safe_path_component(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in (value or "_"))
+    return safe[:120] or "_"
+
+
+def _finding_product(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _finding_uid(event: dict[str, Any]) -> str:
+    return str((event.get("finding_info") or {}).get("uid") or (event.get("metadata") or {}).get("uid") or "")
+
+
+def _observable_value(event: dict[str, Any], *names: str) -> str:
+    """Return the first matching observable value across `names` (in order)."""
+    for obs in event.get("observables") or []:
+        if not isinstance(obs, dict):
+            continue
+        if obs.get("name") in names:
+            value = obs.get("value")
+            if value:
+                return str(value)
+    return ""
+
+
+def _target_from_event(event: dict[str, Any]) -> Target | None:
+    producer = _finding_product(event)
+    if producer not in ACCEPTED_PRODUCERS:
+        emit_stderr_event(
+            SKILL_NAME,
+            level="warning",
+            event="wrong_source_skill",
+            message=f"skipping finding from unaccepted producer `{producer or '<missing>'}`",
+        )
+        return None
+
+    tool_name = _observable_value(event, "tool.name")
+    session_uid = _observable_value(event, "session.uid")
+    fingerprint = _observable_value(
+        event,
+        "tool.after_fingerprint",
+        "tool.description_sha256",
+        "tool.before_fingerprint",
+    )
+    return Target(
+        tool_name=tool_name,
+        session_uid=session_uid,
+        fingerprint=fingerprint,
+        producer_skill=producer,
+        finding_uid=_finding_uid(event),
+    )
+
+
+def parse_targets(events: Iterable[dict[str, Any]]) -> Iterator[tuple[Target | None, dict[str, Any]]]:
+    for event in events:
+        yield _target_from_event(event), event
+
+
+def load_protected_tool_prefixes() -> tuple[str, ...]:
+    return DEFAULT_PROTECTED_TOOL_PREFIXES
+
+
+def is_protected_tool(name: str, prefixes: Iterable[str]) -> tuple[bool, str]:
+    value = (name or "").strip().lower()
+    if not value:
+        return False, ""
+    for prefix in prefixes:
+        needle = prefix.lower()
+        if value.startswith(needle):
+            return True, prefix
+    return False, ""
+
+
+def check_apply_gate() -> tuple[bool, str]:
+    incident_id = os.getenv("MCP_QUARANTINE_INCIDENT_ID", "").strip()
+    approver = os.getenv("MCP_QUARANTINE_APPROVER", "").strip()
+    if not incident_id:
+        return False, "MCP_QUARANTINE_INCIDENT_ID is required for --apply"
+    if not approver:
+        return False, "MCP_QUARANTINE_APPROVER is required for --apply"
+    return True, ""
+
+
+def _quarantine_entry(target: Target, *, incident_id: str, approver: str) -> dict[str, Any]:
+    """Structured quarantine record the MCP client reads to filter its tool list."""
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "mcp_tool_quarantine_entry",
+        "source_skill": SKILL_NAME,
+        "tool_name": target.tool_name,
+        "session_uid": target.session_uid,
+        "fingerprint": target.fingerprint,
+        "producer_skill": target.producer_skill,
+        "finding_uid": target.finding_uid,
+        "incident_id": incident_id,
+        "approver": approver,
+        "quarantined_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _plan_record(
+    target: Target, *, status: str, detail: str | None, dry_run: bool, entry: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "MCP",
+            "tool_name": target.tool_name,
+            "session_uid": target.session_uid,
+            "fingerprint": target.fingerprint,
+        },
+        "actions": [
+            {
+                "step": STEP_QUARANTINE_TOOL,
+                "endpoint": "APPEND quarantine_file",
+                "status": status,
+                "detail": detail,
+            }
+        ],
+        "quarantine_entry": entry,
+        "status": status,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def _skip_record(target: Target, *, status: str, detail: str, dry_run: bool) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "MCP",
+            "tool_name": target.tool_name,
+            "session_uid": target.session_uid,
+            "fingerprint": target.fingerprint,
+        },
+        "actions": [],
+        "status": status,
+        "status_detail": detail,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def quarantine_tool(
+    target: Target,
+    *,
+    store: QuarantineStore,
+    audit: AuditWriter,
+    incident_id: str,
+    approver: str,
+) -> dict[str, Any]:
+    entry = _quarantine_entry(target, incident_id=incident_id, approver=approver)
+    first_audit = audit.record(
+        target=target,
+        step=STEP_QUARANTINE_TOOL,
+        status=STATUS_IN_PROGRESS,
+        detail=f"about to quarantine `{target.tool_name}`",
+        incident_id=incident_id,
+        approver=approver,
+    )
+    try:
+        store.append(entry)
+    except Exception as exc:
+        audit.record(
+            target=target,
+            step=STEP_QUARANTINE_TOOL,
+            status=STATUS_FAILURE,
+            detail=str(exc),
+            incident_id=incident_id,
+            approver=approver,
+        )
+        record = _plan_record(target, status=STATUS_FAILURE, detail=str(exc), dry_run=False, entry=entry)
+        record["audit"] = first_audit
+        return record
+
+    second_audit = audit.record(
+        target=target,
+        step=STEP_QUARANTINE_TOOL,
+        status=STATUS_SUCCESS,
+        detail=f"quarantined `{target.tool_name}`",
+        incident_id=incident_id,
+        approver=approver,
+    )
+    record = _plan_record(
+        target,
+        status=STATUS_SUCCESS,
+        detail=f"appended `{target.tool_name}` to quarantine file",
+        dry_run=False,
+        entry=entry,
+    )
+    record["audit"] = second_audit
+    record["incident_id"] = incident_id
+    record["approver"] = approver
+    return record
+
+
+def reverify_target(
+    target: Target,
+    *,
+    store: QuarantineStore,
+    now_ms: int | None = None,
+    remediated_at_ms: int | None = None,
+) -> list[dict[str, Any]]:
+    """Re-verify the tool is still on the quarantine list. Emits one
+    `remediation_verification` record always; on DRIFT also emits an OCSF
+    Detection Finding via the shared `_shared/remediation_verifier.py` contract."""
+    checked_at_ms = now_ms if now_ms is not None else int(datetime.now(timezone.utc).timestamp() * 1000)
+    remediated_at_ms_resolved = remediated_at_ms if remediated_at_ms is not None else checked_at_ms
+
+    reference = RemediationReference(
+        remediation_skill=SKILL_NAME,
+        remediation_action_uid=_deterministic_uid("quarantine", target.tool_name, target.session_uid),
+        target_provider="MCP",
+        target_identifier=target.tool_name,
+        original_finding_uid=target.finding_uid,
+        remediated_at_ms=remediated_at_ms_resolved,
+    )
+    expected = f"`{target.tool_name}` present in MCP quarantine file"
+
+    try:
+        tools = store.list_tools()
+    except Exception as exc:
+        result = VerificationResult(
+            status=VerificationStatus.UNREACHABLE,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="quarantine store unreadable; cannot determine state",
+            detail=str(exc),
+        )
+        record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
+        record["target"] = {
+            "provider": "MCP",
+            "tool_name": target.tool_name,
+            "session_uid": target.session_uid,
+        }
+        return [record]
+
+    if target.tool_name in tools:
+        result = VerificationResult(
+            status=VerificationStatus.VERIFIED,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state=f"present in quarantine file (file lists {len(tools)} tools)",
+            detail="quarantine entry confirmed",
+        )
+    else:
+        result = VerificationResult(
+            status=VerificationStatus.DRIFT,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="not present in quarantine file — entry was removed or never landed",
+            detail=f"tool `{target.tool_name}` is no longer quarantined",
+        )
+
+    record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
+    record["target"] = {
+        "provider": "MCP",
+        "tool_name": target.tool_name,
+        "session_uid": target.session_uid,
+    }
+    outputs: list[dict[str, Any]] = [record]
+    if result.status == VerificationStatus.DRIFT:
+        outputs.append(
+            build_drift_finding(reference=reference, result=result, verifier_skill=SKILL_NAME)
+        )
+    return outputs
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+        else:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object",
+                line=lineno,
+            )
+
+
+def run(
+    events: Iterable[dict[str, Any]],
+    *,
+    store: QuarantineStore,
+    apply: bool = False,
+    reverify: bool = False,
+    audit: AuditWriter | None = None,
+    protected_prefixes: Iterable[str] = DEFAULT_PROTECTED_TOOL_PREFIXES,
+    incident_id: str = "",
+    approver: str = "",
+) -> Iterator[dict[str, Any]]:
+    protected_prefixes = tuple(protected_prefixes)
+
+    for target, _ in parse_targets(events):
+        if target is None:
+            continue
+
+        dry_run = not apply and not reverify
+
+        if not target.tool_name:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_NO_TOOL,
+                detail="finding did not carry a tool.name observable; cannot quarantine",
+                dry_run=dry_run,
+            )
+            continue
+
+        protected, prefix = is_protected_tool(target.tool_name, protected_prefixes)
+        if protected:
+            status = STATUS_SKIPPED_PROTECTED if apply else STATUS_WOULD_VIOLATE_PROTECTED
+            yield _skip_record(
+                target,
+                status=status,
+                detail=f"tool `{target.tool_name}` matched protected prefix `{prefix}`",
+                dry_run=dry_run,
+            )
+            continue
+
+        if reverify:
+            yield from reverify_target(target, store=store)
+            continue
+
+        if not apply:
+            entry = _quarantine_entry(target, incident_id=incident_id, approver=approver)
+            yield _plan_record(
+                target,
+                status=STATUS_PLANNED,
+                detail=f"dry-run: would quarantine `{target.tool_name}`",
+                dry_run=True,
+                entry=entry,
+            )
+            continue
+
+        if audit is None:
+            raise ValueError("audit writer is required under --apply")
+        yield quarantine_tool(
+            target,
+            store=store,
+            audit=audit,
+            incident_id=incident_id,
+            approver=approver,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Plan, apply, or re-verify MCP tool quarantine entries."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Append the offending tool to the quarantine file after approval gates pass.",
+    )
+    parser.add_argument(
+        "--reverify",
+        action="store_true",
+        help="Read-only verification: confirm the tool is still on the quarantine list.",
+    )
+    parser.add_argument(
+        "--quarantine-file",
+        help=(
+            "Path to the JSONL quarantine file the MCP client filters against. "
+            "Defaults to $MCP_QUARANTINE_FILE or ~/.mcp-quarantine.jsonl"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply and args.reverify:
+        print("--apply and --reverify are mutually exclusive", file=sys.stderr)
+        return 2
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    quarantine_path = Path(
+        args.quarantine_file
+        or os.environ.get("MCP_QUARANTINE_FILE")
+        or (Path.home() / ".mcp-quarantine.jsonl")
+    )
+    store = JSONLQuarantineFile(path=quarantine_path)
+
+    try:
+        audit: AuditWriter | None = None
+        incident_id = ""
+        approver = ""
+        if args.apply:
+            ok, reason = check_apply_gate()
+            if not ok:
+                print(reason, file=sys.stderr)
+                return 2
+            incident_id = os.environ["MCP_QUARANTINE_INCIDENT_ID"].strip()
+            approver = os.environ["MCP_QUARANTINE_APPROVER"].strip()
+            audit = DualAuditWriter(
+                dynamodb_table=os.environ["MCP_QUARANTINE_AUDIT_DYNAMODB_TABLE"],
+                s3_bucket=os.environ["MCP_QUARANTINE_AUDIT_BUCKET"],
+                kms_key_arn=os.environ["KMS_KEY_ARN"],
+            )
+
+        for record in run(
+            load_jsonl(in_stream),
+            store=store,
+            apply=args.apply,
+            reverify=args.reverify,
+            audit=audit,
+            incident_id=incident_id,
+            approver=approver,
+        ):
+            out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/remediate-mcp-tool-quarantine/tests/conftest.py
+++ b/skills/remediation/remediate-mcp-tool-quarantine/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover", "handler")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/remediation/remediate-mcp-tool-quarantine/tests/test_handler.py
+++ b/skills/remediation/remediate-mcp-tool-quarantine/tests/test_handler.py
@@ -1,0 +1,358 @@
+"""Tests for remediate-mcp-tool-quarantine."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from handler import (  # type: ignore[import-not-found]
+    ACCEPTED_PRODUCERS,
+    DEFAULT_PROTECTED_TOOL_PREFIXES,
+    STATUS_FAILURE,
+    STATUS_IN_PROGRESS,
+    STATUS_PLANNED,
+    STATUS_SKIPPED_NO_TOOL,
+    STATUS_SKIPPED_PROTECTED,
+    STATUS_SUCCESS,
+    STATUS_WOULD_VIOLATE_PROTECTED,
+    JSONLQuarantineFile,
+    check_apply_gate,
+    is_protected_tool,
+    parse_targets,
+    run,
+)
+
+
+def _finding(
+    *,
+    producer: str = "detect-mcp-tool-drift",
+    tool_name: str = "rogue-search",
+    session_uid: str = "sess-1",
+    fingerprint: str = "sha256:abcd",
+    finding_uid: str = "find-1",
+    omit_tool: bool = False,
+    fp_observable: str = "tool.after_fingerprint",
+) -> dict:
+    observables = [
+        {"name": "session.uid", "type": "Other", "value": session_uid},
+    ]
+    if not omit_tool:
+        observables.append({"name": "tool.name", "type": "Other", "value": tool_name})
+    observables.append({"name": fp_observable, "type": "Fingerprint", "value": fingerprint})
+    return {
+        "class_uid": 2004,
+        "metadata": {
+            "uid": finding_uid,
+            "product": {"feature": {"name": producer}},
+        },
+        "finding_info": {"uid": finding_uid},
+        "observables": observables,
+    }
+
+
+@dataclass
+class _FakeAudit:
+    writes: list[dict] = field(default_factory=list)
+
+    def record(self, *, target, step, status, detail, incident_id, approver):
+        entry = {
+            "tool_name": target.tool_name,
+            "step": step,
+            "status": status,
+            "detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+        }
+        self.writes.append(entry)
+        return {
+            "row_uid": f"row-{len(self.writes)}",
+            "s3_evidence_uri": f"s3://bucket/{target.tool_name}-{len(self.writes)}.json",
+        }
+
+
+@dataclass
+class _FakeStore:
+    tools: list[str] = field(default_factory=list)
+    appended: list[dict] = field(default_factory=list)
+    raise_on_append: bool = False
+    raise_on_list: bool = False
+
+    def list_tools(self):
+        if self.raise_on_list:
+            raise IOError("simulated unreadable quarantine file")
+        return list(self.tools)
+
+    def append(self, entry):
+        if self.raise_on_append:
+            raise IOError("simulated disk full")
+        self.appended.append(entry)
+        if entry.get("tool_name"):
+            self.tools.append(entry["tool_name"])
+
+
+# ----------------- helpers -----------------
+
+
+def test_accepted_producers_set():
+    assert ACCEPTED_PRODUCERS == frozenset(
+        {"detect-mcp-tool-drift", "detect-prompt-injection-mcp-proxy"}
+    )
+
+
+def test_default_protected_prefixes_cover_infra_tools():
+    assert "mcp_" in DEFAULT_PROTECTED_TOOL_PREFIXES
+    assert "system_" in DEFAULT_PROTECTED_TOOL_PREFIXES
+    assert "internal_" in DEFAULT_PROTECTED_TOOL_PREFIXES
+
+
+def test_is_protected_tool_matches_prefix():
+    assert is_protected_tool("mcp_audit", DEFAULT_PROTECTED_TOOL_PREFIXES) == (True, "mcp_")
+    assert is_protected_tool("System_Probe", DEFAULT_PROTECTED_TOOL_PREFIXES) == (True, "system_")
+    assert is_protected_tool("rogue-search", DEFAULT_PROTECTED_TOOL_PREFIXES) == (False, "")
+    assert is_protected_tool("", DEFAULT_PROTECTED_TOOL_PREFIXES) == (False, "")
+
+
+def test_check_apply_gate_requires_both_envs(monkeypatch):
+    monkeypatch.delenv("MCP_QUARANTINE_INCIDENT_ID", raising=False)
+    monkeypatch.delenv("MCP_QUARANTINE_APPROVER", raising=False)
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "INCIDENT_ID" in reason
+
+    monkeypatch.setenv("MCP_QUARANTINE_INCIDENT_ID", "INC-1")
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "APPROVER" in reason
+
+    monkeypatch.setenv("MCP_QUARANTINE_APPROVER", "alice@security")
+    ok, reason = check_apply_gate()
+    assert ok is True
+
+
+# ----------------- parse_targets -----------------
+
+
+def test_parse_targets_accepts_both_producers():
+    drift = next(parse_targets([_finding(producer="detect-mcp-tool-drift")]))[0]
+    inj = next(parse_targets([_finding(
+        producer="detect-prompt-injection-mcp-proxy",
+        fp_observable="tool.description_sha256",
+    )]))[0]
+    assert drift is not None and drift.producer_skill == "detect-mcp-tool-drift"
+    assert inj is not None and inj.producer_skill == "detect-prompt-injection-mcp-proxy"
+
+
+def test_parse_targets_rejects_wrong_producer(capsys):
+    target, _ = next(parse_targets([_finding(producer="detect-okta-mfa-fatigue")]))
+    assert target is None
+    assert "unaccepted producer" in capsys.readouterr().err
+
+
+def test_parse_targets_extracts_observables():
+    target, _ = next(parse_targets([_finding()]))
+    assert target.tool_name == "rogue-search"
+    assert target.session_uid == "sess-1"
+    assert target.fingerprint == "sha256:abcd"
+
+
+# ----------------- run: dry-run path -----------------
+
+
+def test_run_dry_run_emits_plan_with_quarantine_entry():
+    records = list(run([_finding()], store=_FakeStore()))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["record_type"] == "remediation_plan"
+    assert rec["status"] == STATUS_PLANNED
+    assert rec["dry_run"] is True
+    assert rec["quarantine_entry"]["tool_name"] == "rogue-search"
+    assert rec["quarantine_entry"]["record_type"] == "mcp_tool_quarantine_entry"
+
+
+def test_run_dry_run_does_not_touch_store():
+    store = _FakeStore()
+    list(run([_finding()], store=store))
+    assert store.appended == []
+    assert store.tools == []
+
+
+# ----------------- run: skip paths -----------------
+
+
+def test_run_skips_finding_without_tool_name():
+    records = list(run([_finding(omit_tool=True)], store=_FakeStore()))
+    rec = records[0]
+    assert rec["status"] == STATUS_SKIPPED_NO_TOOL
+    assert rec["actions"] == []
+
+
+def test_run_skips_protected_tool_in_dry_run():
+    records = list(run([_finding(tool_name="mcp_audit_proxy")], store=_FakeStore()))
+    rec = records[0]
+    assert rec["status"] == STATUS_WOULD_VIOLATE_PROTECTED
+    assert "mcp_" in rec["status_detail"]
+
+
+def test_run_skips_protected_tool_in_apply():
+    audit = _FakeAudit()
+    store = _FakeStore()
+    records = list(
+        run(
+            [_finding(tool_name="system_probe")],
+            store=store,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SKIPPED_PROTECTED
+    assert audit.writes == []
+    assert store.appended == []
+
+
+# ----------------- run: apply path -----------------
+
+
+def test_run_apply_quarantines_tool_with_dual_audit():
+    audit = _FakeAudit()
+    store = _FakeStore()
+    records = list(
+        run(
+            [_finding()],
+            store=store,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS
+    assert rec["dry_run"] is False
+    assert rec["incident_id"] == "INC-1"
+    assert store.appended[0]["tool_name"] == "rogue-search"
+    assert "rogue-search" in store.tools
+
+    # Dual audit: pre-action + post-action
+    assert len(audit.writes) == 2
+    assert audit.writes[0]["status"] == STATUS_IN_PROGRESS
+    assert audit.writes[1]["status"] == STATUS_SUCCESS
+
+
+def test_run_apply_writes_failure_audit_when_store_throws():
+    audit = _FakeAudit()
+    store = _FakeStore(raise_on_append=True)
+    records = list(
+        run(
+            [_finding()],
+            store=store,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_FAILURE
+    assert "disk full" in rec["actions"][0]["detail"]
+    assert len(audit.writes) == 2
+    assert audit.writes[1]["status"] == STATUS_FAILURE
+    assert store.appended == []  # the throwing append did not persist
+
+
+def test_run_apply_requires_audit_writer():
+    import pytest
+    with pytest.raises(ValueError, match="audit writer is required"):
+        list(run([_finding()], store=_FakeStore(), apply=True, audit=None))
+
+
+# ----------------- run: re-verify path -----------------
+
+
+def test_run_reverify_verified_when_tool_present():
+    store = _FakeStore(tools=["rogue-search"])
+    records = list(run([_finding()], store=store, reverify=True))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["record_type"] == "remediation_verification"
+    assert rec["status"] == "verified"
+    assert rec["reference"]["target_provider"] == "MCP"
+
+
+def test_run_reverify_drift_emits_ocsf_finding_alongside_verification():
+    """DRIFT outcome must yield BOTH a remediation_verification record AND
+    an OCSF Detection Finding (class_uid 2004) so the drift flows through
+    the same SIEM/SOAR pipeline as every other finding."""
+    store = _FakeStore(tools=[])  # tool was removed from quarantine
+    records = list(run([_finding()], store=store, reverify=True))
+    assert len(records) == 2
+    verification, finding = records
+    assert verification["status"] == "drift"
+    assert finding["class_uid"] == 2004
+    assert finding["category_uid"] == 2
+    assert finding["severity_id"] == 4  # SEVERITY_HIGH
+    assert finding["finding_info"]["types"] == ["remediation-drift"]
+    assert any(
+        obs["name"] == "remediation.skill" and obs["value"] == "remediate-mcp-tool-quarantine"
+        for obs in finding["observables"]
+    )
+
+
+def test_run_reverify_unreachable_never_silently_downgrades():
+    store = _FakeStore(raise_on_list=True)
+    records = list(run([_finding()], store=store, reverify=True))
+    assert len(records) == 1  # no drift finding on UNREACHABLE
+    assert records[0]["status"] == "unreachable"
+
+
+def test_run_reverify_skips_protected_tool():
+    store = _FakeStore()
+    records = list(run([_finding(tool_name="mcp_internal")], store=store, reverify=True))
+    assert records[0]["status"] == STATUS_WOULD_VIOLATE_PROTECTED
+
+
+# ----------------- JSONLQuarantineFile -----------------
+
+
+def test_quarantine_file_round_trips_tool_names(tmp_path):
+    path = tmp_path / "q.jsonl"
+    store = JSONLQuarantineFile(path=path)
+    assert store.list_tools() == []  # missing file → empty list
+
+    store.append({"tool_name": "alpha", "incident_id": "INC-1"})
+    store.append({"tool_name": "beta", "incident_id": "INC-2"})
+    assert store.list_tools() == ["alpha", "beta"]
+
+
+def test_quarantine_file_skips_malformed_lines(tmp_path):
+    path = tmp_path / "q.jsonl"
+    path.write_text(
+        '\n'.join(
+            [
+                '{"tool_name": "good"}',
+                'this-is-not-json',
+                '',
+                '{"missing_tool_name": true}',
+                '{"tool_name": "also-good"}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    store = JSONLQuarantineFile(path=path)
+    assert store.list_tools() == ["good", "also-good"]
+
+
+def test_quarantine_file_creates_parent_dirs(tmp_path):
+    path = tmp_path / "nested" / "deeper" / "q.jsonl"
+    store = JSONLQuarantineFile(path=path)
+    store.append({"tool_name": "alpha"})
+    assert path.exists()
+    # Re-read to confirm appended payload
+    line = path.read_text(encoding="utf-8").strip()
+    assert json.loads(line)["tool_name"] == "alpha"


### PR DESCRIPTION
## Summary

Pair skill for **both** shipped MCP detectors:
- [`detect-mcp-tool-drift`](skills/detection/detect-mcp-tool-drift/) — MITRE ATT&CK T1195.001 (Compromise Software Supply Chain)
- [`detect-prompt-injection-mcp-proxy`](skills/detection/detect-prompt-injection-mcp-proxy/) — MITRE ATLAS AML.T0051 (Prompt Injection)

This is **#155 phase 2** of the phased remediation roadmap. After this lands, the closed-loop coverage matrix flips MCP from red→green on both rows. **Ratio goes 4/11 → 5/11.**

## Why file-based quarantine

The MCP attack surface is in-process — there's no cloud API to call to "block a tool." The cleanest, surface-neutral remediation is a **structured JSONL quarantine file** the operator's MCP client filters its discoverable tool surface against (read at startup or via hot-reload). Each line is one quarantine entry with `tool_name`, `session_uid`, `fingerprint`, `producer_skill`, `finding_uid`, `incident_id`, `approver`, `quarantined_at`.

The dual-audit pattern (DynamoDB + KMS-encrypted S3) is preserved for organizational traceability — same shape as the other 4 remediation skills.

## Wires the verifier contract from day one

Per the convention captured after #305: drift outcomes emit BOTH a verification record AND an OCSF Detection Finding (`class_uid: 2004`, `finding_info.types: ["remediation-drift"]`) so re-detection of an unblocked tool flows back through the same SIEM/SOAR pipeline as every other finding.

## Guardrails

- `ACCEPTED_PRODUCERS` limits input to the two MCP detectors
- Protected-tool deny-list: any tool name starting with `mcp_`, `system_`, or `internal_` refuses quarantine — operators should revoke / patch infrastructure tools, not silently block them
- `--apply` requires `MCP_QUARANTINE_INCIDENT_ID` + `MCP_QUARANTINE_APPROVER` env vars set out-of-band
- Dual audit (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each append; failure paths still write the failure audit row
- `--reverify` emits VERIFIED / DRIFT / UNREACHABLE; never silently downgrades

## Doc + registry sync (count drift 49→50, remediation 4→5)

Touched alongside the new skill:
- README.md hero alt-text + header + layer table + Total + write-path naming
- ARCHITECTURE.md skill count + L5 enumeration
- CLAUDE.md remediation tree
- skills/README.md catalog
- SECURITY_BAR.md (regenerated via `python scripts/generate_security_bar_matrix.py`)
- docs/FRAMEWORK_COVERAGE.md (regenerated)
- docs/framework-coverage.json registry entry
- docs/images/hero-banner.svg — was stale on main at 48/3, brought to 50/5
- docs/images/architecture.svg — L5 count 4→5 + new skill row + bundle 49→50 + `<desc>` sync
- docs/images/coverage-matrix.svg — both MCP rows flip red→green; footer ratio 3/11→5/11 (4 of 6 remaining gaps amber, 2 red)

## Test plan

- [x] `pytest -q` — 1196 passed (1171 prior + 22 new + 3 dependent)
- [x] All 9 `scripts/validate_*.py` validators pass
- [x] `bash scripts/run_mypy.sh` clean
- [x] `ruff check skills scripts` clean
- [x] `validate_skill_count_consistency.py` confirms `total=50, detection=11, remediation=5, evaluation=7`
- [x] New count-drift CI guard from #309 reports zero drift across all docs + SVGs

## Coverage matrix delta

| Before | After |
|---|---|
| 4 / 11 closed-loop | **5 / 11 closed-loop** |
| 5 amber gaps | 4 amber gaps |
| 3 red gaps | **2 red gaps** (Workspace session-kill, lateral-movement orchestrator) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)