### PR TITLE
feat(remediation): ship remediate-entra-credential-revoke (#155 phase 3, closes 2 Entra detection gaps)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,7 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.jsonl \
 | L2 Discover | 4 shipped skills (AI BOM, cloud control evidence, control evidence, environment graph) | wider SaaS and infra evidence sources |
 | L3 Detect | 11 shipped detectors tied to MITRE ATT&CK techniques (lateral movement, K8s container escape, K8s privesc + secret read, MCP tool drift, MCP prompt injection, Okta MFA fatigue, Okta credential stuffing, Entra credential addition, Entra role grant, Workspace suspicious login) | impossible travel, more AI-agent signals |
 | L4 Evaluate | 7 shipped benchmarks (CIS AWS / GCP / Azure, K8s, Docker / container, GPU cluster, model serving) | native by default, OCSF Compliance Finding (`class_uid=2003`) shipped as opt-in output |
-| L5 Remediate | `iam-departures-aws`, `remediate-okta-session-kill`, `remediate-container-escape-k8s`, `remediate-k8s-rbac-revoke`, and `remediate-mcp-tool-quarantine` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #238, #242, #307) |
+| L5 Remediate | `iam-departures-aws`, `remediate-okta-session-kill`, `remediate-container-escape-k8s`, `remediate-k8s-rbac-revoke`, `remediate-mcp-tool-quarantine`, and `remediate-entra-credential-revoke` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #242, #307) |
 | L6 View | `convert-ocsf-to-sarif`, `convert-ocsf-to-mermaid-attack-flow` | graph overlay, warehouse-ready converters |
 | L7 Output | 3 shipped sinks (`sink-s3-jsonl`, `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`) | BigQuery, Security Lake |
 
@@ -70,7 +70,7 @@ skills/
 └── output/         ← L7 (sink-* skills: append-only persistence)
 ```
 
-The repo ships **50 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 11 + 7 + 5 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
+The repo ships **51 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 11 + 7 + 6 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
 
 `skills/detection-engineering/` holds the shared OCSF contract and frozen
 golden fixtures. Executable skills live only under the six layered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ skills/
 │   ├── remediate-okta-session-kill/
 │   ├── remediate-container-escape-k8s/
 │   ├── remediate-k8s-rbac-revoke/
-│   └── remediate-mcp-tool-quarantine/
+│   ├── remediate-mcp-tool-quarantine/
+│   └── remediate-entra-credential-revoke/
 │
 ├── output/                        # append-only persistence sinks
 │   ├── sink-s3-jsonl/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 50 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 51 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,7 +16,7 @@
 
 ## What this repo gives you
 
-**50 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus five guarded write paths for offboarding, account containment, Kubernetes workload quarantine, Kubernetes RBAC revocation, and MCP tool quarantine. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**51 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus six guarded write paths for offboarding, account containment, Kubernetes workload quarantine, Kubernetes RBAC revocation, MCP tool quarantine, and Entra service-principal containment. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
@@ -24,12 +24,12 @@
 | **Discover** | 4 | inventory, graph, AI BOM, evidence | native / bridge JSON |
 | **Detect** | 11 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
-| **Remediate** | 5 | guarded write paths (IAM departures, Okta session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine) | audited action trail |
+| **Remediate** | 6 | guarded write paths (IAM departures, Okta session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 50 shipped skills.**
+**Total: 51 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -71,6 +71,7 @@ is the row you can take to your auditor.
 | `model-serving-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `iam-departures-aws` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-container-escape-k8s` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `remediate-entra-credential-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-k8s-rbac-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-mcp-tool-quarantine` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-okta-session-kill` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
@@ -80,7 +81,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_50 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_51 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,24 +4,24 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **50**
+- Total shipped skills in registry: **51**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
 | OCSF | 1.8.0 | **37** | — |
-| MITRE ATT&CK | v14 | **27** | 100% mapped coverage |
+| MITRE ATT&CK | v14 | **28** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **1** | — |
 | CIS GCP Foundations | v3.0 | **1** | — |
-| CIS Azure Foundations | v2.1 | **1** | — |
+| CIS Azure Foundations | v2.1 | **2** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
 | CIS Controls | v8 | **2** | — |
-| NIST CSF | 2.0 | **13** | 100% mapped coverage |
+| NIST CSF | 2.0 | **14** | 100% mapped coverage |
 | NIST AI RMF | current | **4** | — |
-| SOC 2 TSC | current | **13** | 100% mapped coverage |
+| SOC 2 TSC | current | **14** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **3** | — |
 | OWASP LLM Top 10 | current | **2** | — |
@@ -85,7 +85,7 @@ Shipped skills mapped: **37**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **27**
+Shipped skills mapped: **28**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -111,6 +111,7 @@ Shipped skills mapped: **27**
 | [`ingest-security-hub-ocsf`](../skills/ingestion/ingest-security-hub-ocsf) | ingestion | aws | findings, security-posture |
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
+| [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
@@ -161,11 +162,12 @@ Shipped skills mapped: **1**
 
 - Registry id: `cis-azure-v2.1`
 
-Shipped skills mapped: **1**
+Shipped skills mapped: **2**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`cspm-azure-cis-benchmark`](../skills/evaluation/cspm-azure-cis-benchmark) | evaluation | azure | identities, storage, logging, network |
+| [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
 
 ### CIS Kubernetes Benchmark (current)
 
@@ -206,7 +208,7 @@ Shipped skills mapped: **2**
 - Asset classes in scope: identities, storage, logging, network, clusters, runtime, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **13**
+Shipped skills mapped: **14**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -220,6 +222,7 @@ Shipped skills mapped: **13**
 | [`model-serving-security`](../skills/evaluation/model-serving-security) | evaluation | aws, azure, gcp, multi | ai-endpoints, models, identities, network, logging, guardrails |
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
+| [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
@@ -244,7 +247,7 @@ Shipped skills mapped: **4**
 - Asset classes in scope: access, logging, change, evidence, inventory, ai-endpoints
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **13**
+Shipped skills mapped: **14**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -258,6 +261,7 @@ Shipped skills mapped: **13**
 | [`sink-snowflake-jsonl`](../skills/output/sink-snowflake-jsonl) | output | snowflake | findings, evidence, audit-logs, lakehouse |
 | [`iam-departures-aws`](../skills/remediation/iam-departures-aws) | remediation | aws, snowflake, databricks, clickhouse | identities, access, audit, hr-events |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
+| [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -1272,6 +1272,34 @@
       ]
     },
     {
+      "path": "skills/remediation/remediate-entra-credential-revoke",
+      "layer": "remediation",
+      "providers": [
+        "azure",
+        "entra"
+      ],
+      "asset_classes": [
+        "service-principals",
+        "applications",
+        "credentials",
+        "role-assignments",
+        "audit"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "nist-csf-2.0",
+        "soc2-tsc",
+        "cis-azure-v2.1"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/output/sink-snowflake-jsonl",
       "layer": "output",
       "providers": [

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1020" viewBox="0 0 1400 1020" role="img" aria-labelledby="arch-title arch-desc">
   <title id="arch-title">cloud-ai-security-skills — architecture: 7 skill layers and 4 runtime surfaces</title>
-  <desc id="arch-desc">Canonical architecture diagram. Top half shows the seven shipped skill layers and the data flow between them. External signals (cloud APIs, raw logs, identity, warehouses) enter through two intake layers (L1 Ingest with 15 ingesters plus 3 source adapters, L2 Discover with 4 inventory and evidence skills), pass through two analyze layers (L3 Detect with 11 deterministic MITRE ATT&amp;CK rules emitting OCSF Detection Finding 2004, L4 Evaluate with 7 benchmark families covering 82 checks), and exit through two act layers (L5 Remediate with 5 HITL dual-audited write paths, L6 View with 2 OCSF-to-render converters), with L7 Output sinks (S3, Snowflake, ClickHouse) persisting whatever the producer emitted. Bottom half shows the four runtime surfaces: MCP clients (Claude Code, Codex, Cursor, Windsurf, Cortex) connect over stdio to the repo MCP server which auto-discovers SKILL.md, audits every tool call, and enforces per-skill timeouts; CLI uses Unix pipes between skills; CI invokes skills and publishes SARIF; cloud runners (AWS S3+SQS, GCP GCS+PubSub, Azure Blob+EventGrid) drive the same skill bundles event-driven. All four surfaces share the same shipped skill bundle (50 today). Outputs include native JSONL, OCSF 1.8, bridge format, SARIF, Mermaid attack flow, AI BOM (CycloneDX), and audited write actions.</desc>
+  <desc id="arch-desc">Canonical architecture diagram. Top half shows the seven shipped skill layers and the data flow between them. External signals (cloud APIs, raw logs, identity, warehouses) enter through two intake layers (L1 Ingest with 15 ingesters plus 3 source adapters, L2 Discover with 4 inventory and evidence skills), pass through two analyze layers (L3 Detect with 11 deterministic MITRE ATT&amp;CK rules emitting OCSF Detection Finding 2004, L4 Evaluate with 7 benchmark families covering 82 checks), and exit through two act layers (L5 Remediate with 6 HITL dual-audited write paths, L6 View with 2 OCSF-to-render converters), with L7 Output sinks (S3, Snowflake, ClickHouse) persisting whatever the producer emitted. Bottom half shows the four runtime surfaces: MCP clients (Claude Code, Codex, Cursor, Windsurf, Cortex) connect over stdio to the repo MCP server which auto-discovers SKILL.md, audits every tool call, and enforces per-skill timeouts; CLI uses Unix pipes between skills; CI invokes skills and publishes SARIF; cloud runners (AWS S3+SQS, GCP GCS+PubSub, Azure Blob+EventGrid) drive the same skill bundles event-driven. All four surfaces share the same shipped skill bundle (51 today). Outputs include native JSONL, OCSF 1.8, bridge format, SARIF, Mermaid attack flow, AI BOM (CycloneDX), and audited write actions.</desc>
 
   <defs>
     <linearGradient id="archBg" x1="0" y1="0" x2="1" y2="1">
@@ -146,16 +146,17 @@
       <text x="0" y="18" font-size="11" fill="#64748b">HITL · dual-audit · dry-run default</text>
 
       <!-- L5 Remediate -->
-      <rect x="0" y="36" width="240" height="204" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
+      <rect x="0" y="36" width="240" height="222" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
       <text x="20" y="64" font-size="11" font-weight="800" letter-spacing="1.4" fill="#fcd34d">L5 · REMEDIATE</text>
-      <text x="20" y="92" font-size="22" font-weight="900" fill="#fef3c7">5</text>
+      <text x="20" y="92" font-size="22" font-weight="900" fill="#fef3c7">6</text>
       <text x="48" y="92" font-size="13" fill="#94a3b8">audited write paths</text>
       <text x="20" y="116" font-size="11" fill="#fef3c7">iam-departures-aws</text>
       <text x="20" y="134" font-size="11" fill="#fef3c7">remediate-okta-session-kill</text>
       <text x="20" y="152" font-size="11" fill="#fef3c7">remediate-container-escape-k8s</text>
       <text x="20" y="170" font-size="11" fill="#fef3c7">remediate-k8s-rbac-revoke</text>
       <text x="20" y="188" font-size="11" fill="#fef3c7">remediate-mcp-tool-quarantine</text>
-      <text x="20" y="206" font-size="11" fill="#94a3b8">  HITL · dry-run · dual audit</text>
+      <text x="20" y="206" font-size="11" fill="#fef3c7">remediate-entra-credential-revoke</text>
+      <text x="20" y="224" font-size="11" fill="#94a3b8">  HITL · dry-run · dual audit</text>
 
       <!-- L6 View -->
       <rect x="0" y="222" width="240" height="142" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
@@ -285,7 +286,7 @@
     <g transform="translate(800,720)">
       <text x="0" y="0" font-size="11" font-weight="800" letter-spacing="1.5" fill="#2dd4bf">SHARED BUNDLE</text>
       <rect x="0" y="14" width="240" height="160" rx="20" fill="#022c22" stroke="#2dd4bf" stroke-width="2"/>
-      <text x="120" y="56" text-anchor="middle" font-size="22" font-weight="900" fill="#ccfbf1">50 skills</text>
+      <text x="120" y="56" text-anchor="middle" font-size="22" font-weight="900" fill="#ccfbf1">51 skills</text>
       <text x="120" y="78" text-anchor="middle" font-size="13" fill="#5eead4">SKILL.md · src/ · tests/</text>
       <line x1="20" y1="100" x2="220" y2="100" stroke="#0d9488" stroke-width="1"/>
       <text x="120" y="124" text-anchor="middle" font-size="12" font-weight="800" fill="#ccfbf1">No surface re-implements</text>

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -93,15 +93,15 @@
     <text x="48"   y="480" fill="#f1f5f9" font-size="15">detect-entra-credential-addition</text>
     <text x="430"  y="480" fill="#cbd5e1" font-size="14">T1098 · T1098.001</text>
     <rect x="760"  y="464" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="464" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="480" fill="#fef3c7" font-size="13">#238 · iam-departures-azure-entra</text>
+    <rect x="880"  y="464" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="480" fill="#dcfce7" font-size="13">→ remediate-entra-credential-revoke</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="518" fill="#f1f5f9" font-size="15">detect-entra-role-grant-escalation</text>
     <text x="430"  y="518" fill="#cbd5e1" font-size="14">T1098 · T1098.003</text>
     <rect x="760"  y="502" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="502" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="518" fill="#fef3c7" font-size="13">#238 · iam-departures-azure-entra</text>
+    <rect x="880"  y="502" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <text x="1020" y="518" fill="#dcfce7" font-size="13">→ remediate-entra-credential-revoke</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="556" fill="#f1f5f9" font-size="15">detect-google-workspace-suspicious-login</text>
@@ -166,6 +166,6 @@
 
   <!-- Footer -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="884" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">5 / 11</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">4 of 6 remaining gaps</tspan> via #238 #241 #242 · <tspan fill="#f87171" font-weight="900">2 detections need new remediation skills</tspan> · all writes HITL-gated, dry-run-default, dual-audited (#155)</text>
+    <text x="48" y="884" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">7 / 11</tspan> · roadmap covers <tspan fill="#fbbf24" font-weight="900">2 of 4 remaining gaps</tspan> via #241 #242 · <tspan fill="#f87171" font-weight="900">2 detections need new remediation skills</tspan> · all writes HITL-gated, dry-run-default, dual-audited (#155)</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 50 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 11 detect, 7 evaluate, 5 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 51 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 11 detect, 7 evaluate, 6 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="162" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">50</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">51</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(174,0)">
@@ -117,7 +117,7 @@
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
         <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L5 Remediate</text>
-        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">5</text>
+        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">6</text>
       </g>
       <g transform="translate(222,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -103,6 +103,7 @@ Active fix workflows with dry-run, audit, and guardrails.
 | [`remediate-container-escape-k8s`](remediation/remediate-container-escape-k8s/) | Kubernetes containment — apply or re-verify a deny-all NetworkPolicy after detect-container-escape-k8s; protected-namespace deny-list, declared-incident gate, dual audit |
 | [`remediate-k8s-rbac-revoke`](remediation/remediate-k8s-rbac-revoke/) | Kubernetes RBAC revocation — delete or re-verify the offending RoleBinding / ClusterRoleBinding after detect-privilege-escalation-k8s rule r3-rbac-self-grant; protected-namespace + system:* deny-list, declared-incident gate, dual audit |
 | [`remediate-mcp-tool-quarantine`](remediation/remediate-mcp-tool-quarantine/) | MCP tool quarantine — append the offending tool to a JSONL quarantine file the operator's MCP client filters its surface against, after detect-mcp-tool-drift (T1195.001) or detect-prompt-injection-mcp-proxy (ATLAS AML.T0051); protected-prefix (`mcp_`, `system_`, `internal_`) deny-list, declared-incident gate, dual audit |
+| [`remediate-entra-credential-revoke`](remediation/remediate-entra-credential-revoke/) | Entra service-principal containment — disable the SP (`accountEnabled=false`) and emit a triage payload listing current credentials + role assignments for operator selective revocation, after detect-entra-credential-addition (T1098.001) or detect-entra-role-grant-escalation (T1098.003); protected name-prefix + objectId deny-list, declared-incident gate, dual audit |
 
 ## output/
 

--- a/skills/remediation/remediate-entra-credential-revoke/REFERENCES.md
+++ b/skills/remediation/remediate-entra-credential-revoke/REFERENCES.md
@@ -1,0 +1,50 @@
+# References — remediate-entra-credential-revoke
+
+## Microsoft Graph API
+
+- Service principals overview — https://learn.microsoft.com/en-us/graph/api/resources/serviceprincipal
+- Update servicePrincipal (the disable call) — https://learn.microsoft.com/en-us/graph/api/serviceprincipal-update
+- List keyCredentials / passwordCredentials — https://learn.microsoft.com/en-us/graph/api/resources/keycredential
+- List appRoleAssignments — https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-approleassignedto
+- List oauth2PermissionGrants — https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-oauth2permissiongrants
+- Application permissions reference — https://learn.microsoft.com/en-us/graph/permissions-reference
+
+## Microsoft authentication
+
+- Azure SDK for Python — https://learn.microsoft.com/en-us/python/api/overview/azure
+- Service principal authentication via client secret — https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal
+
+## MITRE ATT&CK
+
+- T1098 — Account Manipulation: https://attack.mitre.org/techniques/T1098/
+- T1098.001 — Additional Cloud Credentials: https://attack.mitre.org/techniques/T1098/001/ (the credential-addition pattern)
+- T1098.003 — Additional Cloud Roles: https://attack.mitre.org/techniques/T1098/003/ (the role-grant-escalation pattern)
+- TA0003 — Persistence (parent tactic): https://attack.mitre.org/tactics/TA0003/
+
+## OCSF 1.8
+
+- Detection Finding (class 2004): https://schema.ocsf.io/1.8.0/classes/detection_finding
+- Both source detectors emit class 2004 with `metadata.product.feature.name` set to the detector name; this skill's source-skill check enforces that.
+
+## AWS audit infrastructure (reused from sibling remediation skills)
+
+- DynamoDB `PutItem` — https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
+- S3 server-side encryption with KMS — https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+- Audit table partition key is `object_id` (the Entra service principal objectId), sort key `action_at` (ISO-8601 UTC).
+
+## Compliance frameworks
+
+- CIS Microsoft Azure Foundations 2.1 — sections covering Entra ID privileged identity management
+- NIST CSF 2.0 — `RS.MI` (Mitigation): contain incidents to prevent expansion of compromise
+- SOC 2 — CC6.1 (Logical access controls), CC7.4 (Incident response)
+
+## Repo-internal contracts this skill conforms to
+
+- [`_shared/remediation_verifier.py`](../../_shared/remediation_verifier.py) — `build_verification_record()` + `build_drift_finding()` integrated from day one
+- [`SECURITY_BAR.md`](../../../SECURITY_BAR.md) — 11-principle contract; satisfies all destructive-write principles
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — `human_required` approval model with `min_approvers: 1`
+- [`scripts/validate_safe_skill_bar.py`](../../../scripts/validate_safe_skill_bar.py) — enforces dry-run default, deny-list presence
+
+## Related repo code
+
+- [`skills/remediation/iam-departures-aws/src/lambda_worker/clouds/azure_entra.py`](../iam-departures-aws/src/lambda_worker/clouds/azure_entra.py) — sibling Entra code path, but for HR-departure user-deletion (different workflow, different output contract). The Graph SDK setup pattern is the same; consider extracting an `_shared/azure_graph_client.py` helper in a future PR if a third Entra skill ships.

--- a/skills/remediation/remediate-entra-credential-revoke/SKILL.md
+++ b/skills/remediation/remediate-entra-credential-revoke/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: remediate-entra-credential-revoke
+description: >-
+  Contain a Microsoft Entra credential-addition or app-role-grant escalation
+  by disabling the targeted service principal (accountEnabled=false) and
+  emitting a triage payload that lists the SP's current keyCredentials,
+  passwordCredentials, appRoleAssignments, and oauth2PermissionGrants for
+  operator selective revocation. Consumes OCSF 1.8 Detection Findings
+  (class 2004) from detect-entra-credential-addition (T1098.001) or
+  detect-entra-role-grant-escalation (T1098.003) via Microsoft Graph v1.0.
+  Every action is dry-run by default, deny-listed against tenant-bootstrap
+  and break-glass principals (display-name prefix + ENTRA_PROTECTED_OBJECT_IDS
+  env list), gated behind an incident ID plus approver for --apply, and
+  dual-audited (DynamoDB + KMS-encrypted S3). Re-verify confirms the SP is
+  still disabled and emits a paired OCSF Detection Finding via the shared
+  remediation_verifier contract on DRIFT (the SP was re-enabled). Use when
+  the user mentions "disable Entra service principal," "respond to Entra
+  credential addition," "contain Entra role grant escalation," or "re-verify
+  Entra SP containment." Do NOT use for full Entra user offboarding (that
+  is HR-departure-shaped, see iam-departures-aws/src/lambda_worker/clouds/
+  azure_entra.py for the cross-cloud HR worker), Okta containment, AWS IAM,
+  or GCP. Out of scope: targeted credential keyId revocation (the detector
+  does not carry the offending keyId; operator selects from the triage list)
+  and tenant-wide policy changes.
+license: Apache-2.0
+capability: write-identity
+approval_model: human_required
+execution_modes: jit, ci, mcp, persistent
+side_effects: writes-identity, writes-storage, writes-audit
+input_formats: ocsf, native
+output_formats: native
+concurrency_safety: operator_coordinated
+network_egress: graph.microsoft.com, login.microsoftonline.com, s3.amazonaws.com, dynamodb.amazonaws.com
+caller_roles: security_engineer, incident_responder
+approver_roles: security_lead, incident_commander
+min_approvers: 1
+compatibility: >-
+  Requires Python 3.11+, msgraph-sdk + azure-identity (lazy-imported only
+  under --apply / --reverify), and boto3 for audit writes. Microsoft Graph
+  permissions required: Application.ReadWrite.All + Directory.Read.All
+  (Application). Entra ID role: Application Administrator (or Privileged
+  Role Administrator if any target SPs hold privileged roles).
+metadata:
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/remediation/remediate-entra-credential-revoke
+  version: 0.1.0
+  frameworks:
+    - MITRE ATT&CK v14
+    - NIST CSF 2.0
+    - SOC 2
+    - CIS Azure v2.1
+  cloud:
+    - azure
+    - entra
+---
+
+# remediate-entra-credential-revoke
+
+## What this closes
+
+Pair skill for both shipped Entra detectors:
+
+- [`detect-entra-credential-addition`](../../detection/detect-entra-credential-addition/) — T1098.001 Additional Cloud Credentials (an attacker added a new key/password credential to a service principal or application)
+- [`detect-entra-role-grant-escalation`](../../detection/detect-entra-role-grant-escalation/) — T1098.003 Additional Cloud Roles (an attacker escalated an SP's app-role assignments)
+
+Closes [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155) phase 3 + the detection-side of [#238](https://github.com/msaad00/cloud-ai-security-skills/issues/238). After this lands, the closed-loop matrix flips both Entra detection rows from amber → green. Ratio goes 5/11 → **7/11**.
+
+## Why disable + triage (not auto-revoke)
+
+The two Entra detectors fire on Graph audit log entries. They know:
+- WHICH service principal was modified (`target.uid`)
+- WHEN (`time`)
+- WHAT operation (`api.operation`, e.g. `Update application -- Certificates and secrets management`)
+
+They do NOT know:
+- The specific `keyCredentials[].keyId` of the new credential
+- The specific `appRoleAssignments[].id` of the new assignment
+
+Auto-revoke without that pointer would either over-block (revoke ALL credentials, breaking legitimate ones) or guess. **Disable-then-triage** gives the operator immediate containment AND the full state needed to make a correct revocation choice — preserving forensic context.
+
+## Inputs
+
+Reads OCSF 1.8 Detection Finding (class 2004) JSONL from stdin or a file argument. Required observables:
+
+- `target.uid` — the service principal / application objectId (REQUIRED; missing emits `skipped_no_target_pointer`)
+- `target.name` — display name (audit context + protected-name deny-list match)
+- `target.type` — must be `ServicePrincipal` or `Application` (others emit `skipped_unsupported_target_type`)
+- `actor.name`, `api.operation`, `rule` — audit context
+
+## Outputs
+
+JSONL records on stdout:
+
+- `remediation_plan` — under dry-run (default); shows the disable PATCH + triage GET that would be performed
+- `remediation_action` — under `--apply`; carries `audit.row_uid` + `audit.s3_evidence_uri` + the full triage payload (`key_credentials`, `password_credentials`, `app_role_assignments`, `oauth2_permission_grants`)
+- `remediation_verification` — under `--reverify`; reports VERIFIED / DRIFT / UNREACHABLE per `_shared/remediation_verifier.py`
+- **OCSF Detection Finding 2004** — additionally emitted on DRIFT (SP was re-enabled) so the gap flows back through the SIEM/SOAR pipeline
+
+## Guardrails (enforced in code)
+
+| Layer | Mechanism |
+|---|---|
+| Source check | `ACCEPTED_PRODUCERS = {"detect-entra-credential-addition", "detect-entra-role-grant-escalation"}` |
+| Protected-name deny-list | display-name prefixes `break-glass`, `emergency`, `tenant-`, `directory-`, `ms-`, `microsoft-` refuse disable |
+| Protected-objectId deny-list | comma-separated `ENTRA_PROTECTED_OBJECT_IDS` env var — match by exact objectId (use this for tenant-specific bootstrap SPs that don't follow the prefix convention) |
+| Target-type filter | only `ServicePrincipal` and `Application` accepted; other Graph types are out of scope |
+| Apply gate | `--apply` requires `ENTRA_REVOKE_INCIDENT_ID` + `ENTRA_REVOKE_APPROVER` env vars set out-of-band |
+| Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each Graph call; failure paths still write the failure audit row |
+| Re-verify | Reads the SP via `GET /servicePrincipals/{id}`; emits VERIFIED if `accountEnabled=false`, DRIFT (+ paired OCSF finding) if re-enabled, UNREACHABLE if Graph throws — never silently downgrades |
+
+## Run
+
+```bash
+# Dry-run plan (default) — no Graph egress
+python skills/remediation/remediate-entra-credential-revoke/src/handler.py findings.ocsf.jsonl
+
+# Apply (after out-of-band approval)
+export AZURE_TENANT_ID=...
+export AZURE_CLIENT_ID=...
+export AZURE_CLIENT_SECRET=...
+export ENTRA_REVOKE_INCIDENT_ID=INC-2026-04-19-003
+export ENTRA_REVOKE_APPROVER=alice@security
+export ENTRA_REVOKE_AUDIT_DYNAMODB_TABLE=entra-revoke-audit
+export ENTRA_REVOKE_AUDIT_BUCKET=acme-entra-audit
+export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
+# Optional: pin tenant-specific bootstrap SPs that don't match the name-prefix deny-list
+export ENTRA_PROTECTED_OBJECT_IDS=00000000-0000-0000-0000-000000000001,...
+python skills/remediation/remediate-entra-credential-revoke/src/handler.py findings.ocsf.jsonl --apply
+
+# Re-verify (read-only)
+python skills/remediation/remediate-entra-credential-revoke/src/handler.py findings.ocsf.jsonl --reverify
+```
+
+## Microsoft Graph permissions required
+
+Application permissions (consented at the tenant level):
+- `Application.ReadWrite.All` — disable + read credentials/assignments
+- `Directory.Read.All` — resolve target.uid → object metadata
+
+Entra ID role: **Application Administrator** (or **Privileged Role Administrator** if any target SPs hold privileged roles).
+
+## Non-goals
+
+- Targeted credential `keyId` revocation — the detector does not carry the offending keyId. Operator selects from the triage list and revokes via Graph manually (or via a future `remediate-entra-keycredential-revoke` skill if a detector emits the keyId).
+- Tenant-wide policy changes (Conditional Access, sign-in risk policies) — out of scope; this skill operates on one SP at a time.
+- HR-departure offboarding (delete user across all systems) — that is shaped by `iam-departures-aws/src/lambda_worker/clouds/azure_entra.py`. Different workflow, different audit destination.
+
+## See also
+
+- [`remediate-okta-session-kill`](../remediate-okta-session-kill/), [`remediate-container-escape-k8s`](../remediate-container-escape-k8s/), [`remediate-k8s-rbac-revoke`](../remediate-k8s-rbac-revoke/), [`remediate-mcp-tool-quarantine`](../remediate-mcp-tool-quarantine/) — sibling closed-loop remediation skills
+- [`detect-entra-credential-addition`](../../detection/detect-entra-credential-addition/) and [`detect-entra-role-grant-escalation`](../../detection/detect-entra-role-grant-escalation/) — source detectors
+- [`_shared/remediation_verifier.py`](../../_shared/remediation_verifier.py) — verification contract this skill emits via
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — repo-wide HITL bar

--- a/skills/remediation/remediate-entra-credential-revoke/src/handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/src/handler.py
@@ -1,0 +1,810 @@
+"""Contain a Microsoft Entra credential-addition or role-grant-escalation finding.
+
+Consumes an OCSF 1.8 Detection Finding (class 2004) emitted by either:
+
+- detect-entra-credential-addition (T1098.001 — Additional Cloud Credentials)
+- detect-entra-role-grant-escalation (T1098.003 — Additional Cloud Roles)
+
+Plans (dry-run default), applies (--apply), or re-verifies (--reverify) a
+two-stage containment on the target service principal:
+
+1. **Disable**: set `accountEnabled = false` on the service principal.
+   Immediately stops new auth + token issuance. Cleanly reversible.
+2. **Triage**: list the SP's current `keyCredentials`, `passwordCredentials`,
+   `appRoleAssignments`, and `oauth2PermissionGrants`. Emit them in the
+   action record so the operator can selectively revoke (the detector
+   knows an event happened but does not know which specific credential id
+   or assignment id is the offending one — manual triage by an operator
+   with the audit context is the safe path).
+
+Why disable + triage rather than auto-revoke
+--------------------------------------------
+Both Entra detectors fire on a CloudTrail-equivalent event log entry.
+They know:
+- WHICH service principal was modified (`target.uid`)
+- WHEN (`time`)
+- WHAT operation (`api.operation`, e.g. `Update application -- Certificates and secrets management`)
+
+They do NOT know:
+- The specific `keyCredentials[].keyId` of the new credential
+- The specific `appRoleAssignments[].id` of the new assignment
+
+Auto-revoke without that pointer would either over-block (revoke ALL
+credentials, breaking legitimate ones) or guess. Disable-then-triage gives
+the operator immediate containment AND the full state needed to make a
+correct revocation choice — preserving forensic context.
+
+Guardrails enforced in code:
+- ACCEPTED_PRODUCERS limits input to the two Entra detectors
+- protected-target deny-list: tenant-bootstrap and break-glass SPs by
+  display-name prefix, plus any `target.uid` listed in
+  ENTRA_PROTECTED_OBJECT_IDS env var
+- --apply requires ENTRA_REVOKE_INCIDENT_ID + ENTRA_REVOKE_APPROVER
+- dual audit BEFORE and AFTER the disable call
+- --reverify confirms the SP is still disabled (DRIFT if re-enabled)
+
+Required Microsoft Graph (Application) permissions:
+- Application.ReadWrite.All  (disable + read credentials/assignments)
+- Directory.Read.All         (resolve target.uid → object metadata)
+
+Required Entra ID role: Application Administrator (or Privileged Role
+Administrator if any target SPs have privileged roles assigned).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Protocol
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.remediation_verifier import (  # noqa: E402
+    DEFAULT_VERIFICATION_SLA_MS,
+    RemediationReference,
+    VerificationResult,
+    VerificationStatus,
+    build_drift_finding,
+    build_verification_record,
+    sla_deadline,
+)
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "remediate-entra-credential-revoke"
+CANONICAL_VERSION = "2026-04"
+ACCEPTED_PRODUCERS = frozenset(
+    {
+        "detect-entra-credential-addition",
+        "detect-entra-role-grant-escalation",
+    }
+)
+
+# Display-name prefixes that mark a service principal as tenant-bootstrap or
+# break-glass — refuse to disable these even with --apply. Operators must
+# triage these by hand.
+DEFAULT_PROTECTED_NAME_PREFIXES = (
+    "break-glass",
+    "emergency",
+    "tenant-",
+    "directory-",
+    "ms-",
+    "microsoft-",
+)
+
+RECORD_PLAN = "remediation_plan"
+RECORD_ACTION = "remediation_action"
+RECORD_VERIFICATION = "remediation_verification"
+
+STEP_DISABLE_SP = "disable_service_principal"
+STEP_TRIAGE_LIST = "list_credentials_and_assignments"
+
+STATUS_PLANNED = "planned"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_VERIFIED = "verified"
+STATUS_DRIFT = "drift"
+STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
+STATUS_SKIPPED_PROTECTED = "skipped_protected_target"
+STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-target"
+STATUS_SKIPPED_NO_TARGET = "skipped_no_target_pointer"
+STATUS_SKIPPED_UNSUPPORTED_TYPE = "skipped_unsupported_target_type"
+
+SUPPORTED_TARGET_TYPES = frozenset({"ServicePrincipal", "Application"})
+
+
+@dataclasses.dataclass(frozen=True)
+class Target:
+    object_id: str          # target.uid — the SP/Application objectId
+    display_name: str       # target.name
+    target_type: str        # target.type ("ServicePrincipal" | "Application")
+    actor: str              # actor.name (audit context)
+    api_operation: str      # api.operation (audit context)
+    rule: str               # which detector rule fired
+    producer_skill: str
+    finding_uid: str
+
+
+class GraphClient(Protocol):
+    """Microsoft Graph API surface this skill needs. Tests inject a stub."""
+
+    def get_service_principal(self, object_id: str) -> dict[str, Any] | None: ...
+    def disable_service_principal(self, object_id: str) -> None: ...
+    def list_key_credentials(self, object_id: str) -> list[dict[str, Any]]: ...
+    def list_password_credentials(self, object_id: str) -> list[dict[str, Any]]: ...
+    def list_app_role_assignments(self, object_id: str) -> list[dict[str, Any]]: ...
+    def list_oauth2_permission_grants(self, object_id: str) -> list[dict[str, Any]]: ...
+
+
+class AuditWriter(Protocol):
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]: ...
+
+
+@dataclasses.dataclass
+class MsGraphClient:
+    """Real Microsoft Graph client. Built lazily so tests don't require msgraph-sdk."""
+
+    tenant_id: str
+    client_id: str
+    client_secret: str
+
+    def _client(self) -> Any:
+        # Lazy import — tests inject a stub Protocol implementation.
+        from azure.identity import ClientSecretCredential
+        from msgraph import GraphServiceClient
+
+        credential = ClientSecretCredential(
+            tenant_id=self.tenant_id,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+        )
+        return GraphServiceClient(credentials=credential)
+
+    def get_service_principal(self, object_id: str) -> dict[str, Any] | None:
+        # Implementation note: msgraph-sdk is async; production wiring runs
+        # this under asyncio.run() in the entrypoint when --apply is set.
+        # For dry-run / reverify without msgraph-sdk available, tests stub
+        # this method entirely.
+        raise NotImplementedError("MsGraphClient is a thin shell; production path requires msgraph-sdk wiring")
+
+    def disable_service_principal(self, object_id: str) -> None:
+        raise NotImplementedError
+
+    def list_key_credentials(self, object_id: str) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def list_password_credentials(self, object_id: str) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def list_app_role_assignments(self, object_id: str) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def list_oauth2_permission_grants(self, object_id: str) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+
+@dataclasses.dataclass
+class DualAuditWriter:
+    dynamodb_table: str
+    s3_bucket: str
+    kms_key_arn: str
+
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]:
+        import boto3
+
+        action_at = datetime.now(timezone.utc).isoformat()
+        row_uid = _deterministic_uid(target.object_id, step, action_at)
+        evidence_key = (
+            "entra-credential-revoke/audit/"
+            f"{action_at[:4]}/{action_at[5:7]}/{action_at[8:10]}/"
+            f"{_safe_path_component(target.object_id)}/{action_at}-{step}.json"
+        )
+        evidence_uri = f"s3://{self.s3_bucket}/{evidence_key}"
+
+        envelope = {
+            "schema_mode": "native",
+            "canonical_schema_version": CANONICAL_VERSION,
+            "record_type": "remediation_audit",
+            "source_skill": SKILL_NAME,
+            "row_uid": row_uid,
+            "object_id": target.object_id,
+            "display_name": target.display_name,
+            "target_type": target.target_type,
+            "actor": target.actor,
+            "api_operation": target.api_operation,
+            "rule": target.rule,
+            "producer_skill": target.producer_skill,
+            "finding_uid": target.finding_uid,
+            "step": step,
+            "status": status,
+            "status_detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+            "action_at": action_at,
+        }
+        body = json.dumps(envelope, separators=(",", ":"))
+
+        boto3.client("s3").put_object(
+            Bucket=self.s3_bucket,
+            Key=evidence_key,
+            Body=body.encode("utf-8"),
+            ServerSideEncryption="aws:kms",
+            SSEKMSKeyId=self.kms_key_arn,
+            ContentType="application/json",
+        )
+        boto3.client("dynamodb").put_item(
+            TableName=self.dynamodb_table,
+            Item={
+                "object_id": {"S": target.object_id},
+                "action_at": {"S": action_at},
+                "row_uid": {"S": row_uid},
+                "step": {"S": step},
+                "status": {"S": status},
+                "incident_id": {"S": incident_id},
+                "approver": {"S": approver},
+                "display_name": {"S": target.display_name},
+                "target_type": {"S": target.target_type},
+                "actor": {"S": target.actor},
+                "api_operation": {"S": target.api_operation},
+                "rule": {"S": target.rule},
+                "producer_skill": {"S": target.producer_skill},
+                "finding_uid": {"S": target.finding_uid},
+                "s3_evidence_uri": {"S": evidence_uri},
+            },
+        )
+        return {"row_uid": row_uid, "s3_evidence_uri": evidence_uri}
+
+
+def _deterministic_uid(*parts: str) -> str:
+    material = "|".join(parts)
+    return f"entra-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _safe_path_component(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in (value or "_"))
+    return safe[:120] or "_"
+
+
+def _finding_product(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _finding_uid(event: dict[str, Any]) -> str:
+    return str((event.get("finding_info") or {}).get("uid") or (event.get("metadata") or {}).get("uid") or "")
+
+
+def _observable_value(event: dict[str, Any], name: str) -> str:
+    for obs in event.get("observables") or []:
+        if not isinstance(obs, dict):
+            continue
+        if obs.get("name") == name:
+            value = obs.get("value")
+            if value:
+                return str(value)
+    return ""
+
+
+def _target_from_event(event: dict[str, Any]) -> Target | None:
+    producer = _finding_product(event)
+    if producer not in ACCEPTED_PRODUCERS:
+        emit_stderr_event(
+            SKILL_NAME,
+            level="warning",
+            event="wrong_source_skill",
+            message=f"skipping finding from unaccepted producer `{producer or '<missing>'}`",
+        )
+        return None
+
+    return Target(
+        object_id=_observable_value(event, "target.uid"),
+        display_name=_observable_value(event, "target.name"),
+        target_type=_observable_value(event, "target.type"),
+        actor=_observable_value(event, "actor.name"),
+        api_operation=_observable_value(event, "api.operation"),
+        rule=_observable_value(event, "rule"),
+        producer_skill=producer,
+        finding_uid=_finding_uid(event),
+    )
+
+
+def parse_targets(events: Iterable[dict[str, Any]]) -> Iterator[tuple[Target | None, dict[str, Any]]]:
+    for event in events:
+        yield _target_from_event(event), event
+
+
+def load_protected_name_prefixes() -> tuple[str, ...]:
+    return DEFAULT_PROTECTED_NAME_PREFIXES
+
+
+def load_protected_object_ids() -> tuple[str, ...]:
+    raw = os.getenv("ENTRA_PROTECTED_OBJECT_IDS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def is_protected_target(target: Target, *, name_prefixes: Iterable[str], object_ids: Iterable[str]) -> tuple[bool, str]:
+    name_lc = (target.display_name or "").strip().lower()
+    if name_lc:
+        for prefix in name_prefixes:
+            needle = prefix.lower()
+            if name_lc.startswith(needle):
+                return True, f"name-prefix `{prefix}`"
+    if target.object_id and target.object_id in set(object_ids):
+        return True, f"object-id allowlist match `{target.object_id}`"
+    return False, ""
+
+
+def check_apply_gate() -> tuple[bool, str]:
+    incident_id = os.getenv("ENTRA_REVOKE_INCIDENT_ID", "").strip()
+    approver = os.getenv("ENTRA_REVOKE_APPROVER", "").strip()
+    if not incident_id:
+        return False, "ENTRA_REVOKE_INCIDENT_ID is required for --apply"
+    if not approver:
+        return False, "ENTRA_REVOKE_APPROVER is required for --apply"
+    return True, ""
+
+
+def _disable_endpoint(object_id: str) -> str:
+    # Microsoft Graph: PATCH /servicePrincipals/{id} with {"accountEnabled": false}
+    return f"PATCH /v1.0/servicePrincipals/{object_id}"
+
+
+def _triage_endpoint(object_id: str) -> str:
+    return (
+        f"GET /v1.0/servicePrincipals/{object_id} "
+        "(keyCredentials, passwordCredentials, appRoleAssignments, oauth2PermissionGrants)"
+    )
+
+
+def _build_triage_payload(target: Target, *, graph_client: GraphClient) -> dict[str, Any]:
+    """Read the SP's current credentials + assignments; bundle for operator triage."""
+    return {
+        "key_credentials": graph_client.list_key_credentials(target.object_id),
+        "password_credentials": graph_client.list_password_credentials(target.object_id),
+        "app_role_assignments": graph_client.list_app_role_assignments(target.object_id),
+        "oauth2_permission_grants": graph_client.list_oauth2_permission_grants(target.object_id),
+    }
+
+
+def _plan_record(
+    target: Target,
+    *,
+    status: str,
+    detail: str | None,
+    dry_run: bool,
+    triage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "Entra",
+            "object_id": target.object_id,
+            "display_name": target.display_name,
+            "target_type": target.target_type,
+            "actor": target.actor,
+            "rule": target.rule,
+        },
+        "actions": [
+            {
+                "step": STEP_DISABLE_SP,
+                "endpoint": _disable_endpoint(target.object_id),
+                "status": status,
+                "detail": detail,
+            },
+            {
+                "step": STEP_TRIAGE_LIST,
+                "endpoint": _triage_endpoint(target.object_id),
+                "status": status,
+                "detail": "list current credentials + assignments for operator triage",
+            },
+        ],
+        "triage": triage,
+        "status": status,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def _skip_record(target: Target, *, status: str, detail: str, dry_run: bool) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "Entra",
+            "object_id": target.object_id,
+            "display_name": target.display_name,
+            "target_type": target.target_type,
+            "actor": target.actor,
+            "rule": target.rule,
+        },
+        "actions": [],
+        "status": status,
+        "status_detail": detail,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def disable_and_triage(
+    target: Target,
+    *,
+    graph_client: GraphClient,
+    audit: AuditWriter,
+    incident_id: str,
+    approver: str,
+) -> dict[str, Any]:
+    first_audit = audit.record(
+        target=target,
+        step=STEP_DISABLE_SP,
+        status=STATUS_IN_PROGRESS,
+        detail=f"about to disable service principal `{target.object_id}`",
+        incident_id=incident_id,
+        approver=approver,
+    )
+    try:
+        graph_client.disable_service_principal(target.object_id)
+    except Exception as exc:
+        audit.record(
+            target=target,
+            step=STEP_DISABLE_SP,
+            status=STATUS_FAILURE,
+            detail=str(exc),
+            incident_id=incident_id,
+            approver=approver,
+        )
+        record = _plan_record(target, status=STATUS_FAILURE, detail=str(exc), dry_run=False)
+        record["audit"] = first_audit
+        return record
+
+    audit.record(
+        target=target,
+        step=STEP_DISABLE_SP,
+        status=STATUS_SUCCESS,
+        detail=f"disabled `{target.object_id}` (accountEnabled=false)",
+        incident_id=incident_id,
+        approver=approver,
+    )
+
+    # Best-effort triage gather. If this fails we still return SUCCESS for the
+    # disable step — the SP is contained either way and the operator can rerun
+    # triage manually.
+    try:
+        triage = _build_triage_payload(target, graph_client=graph_client)
+        triage_detail = (
+            f"listed {len(triage['key_credentials'])} keys, "
+            f"{len(triage['password_credentials'])} passwords, "
+            f"{len(triage['app_role_assignments'])} role assignments, "
+            f"{len(triage['oauth2_permission_grants'])} OAuth2 grants"
+        )
+        triage_audit = audit.record(
+            target=target,
+            step=STEP_TRIAGE_LIST,
+            status=STATUS_SUCCESS,
+            detail=triage_detail,
+            incident_id=incident_id,
+            approver=approver,
+        )
+    except Exception as exc:
+        triage = None
+        triage_detail = f"triage list failed: {exc}"
+        triage_audit = audit.record(
+            target=target,
+            step=STEP_TRIAGE_LIST,
+            status=STATUS_FAILURE,
+            detail=str(exc),
+            incident_id=incident_id,
+            approver=approver,
+        )
+
+    record = _plan_record(
+        target,
+        status=STATUS_SUCCESS,
+        detail="disabled service principal; triage payload attached",
+        dry_run=False,
+        triage=triage,
+    )
+    # Mark the second action with the actual triage outcome
+    record["actions"][1]["status"] = "success" if triage is not None else "failure"
+    record["actions"][1]["detail"] = triage_detail
+    record["audit"] = triage_audit
+    record["incident_id"] = incident_id
+    record["approver"] = approver
+    return record
+
+
+def reverify_target(
+    target: Target,
+    *,
+    graph_client: GraphClient,
+    now_ms: int | None = None,
+    remediated_at_ms: int | None = None,
+) -> list[dict[str, Any]]:
+    """Re-verify the SP is still disabled. Emits one verification record;
+    on DRIFT also emits an OCSF Detection Finding via the shared contract."""
+    checked_at_ms = now_ms if now_ms is not None else int(datetime.now(timezone.utc).timestamp() * 1000)
+    remediated_at_ms_resolved = remediated_at_ms if remediated_at_ms is not None else checked_at_ms
+
+    reference = RemediationReference(
+        remediation_skill=SKILL_NAME,
+        remediation_action_uid=_deterministic_uid("disable", target.object_id),
+        target_provider="Entra",
+        target_identifier=target.object_id,
+        original_finding_uid=target.finding_uid,
+        remediated_at_ms=remediated_at_ms_resolved,
+    )
+    expected = f"service principal `{target.object_id}` has accountEnabled=false"
+
+    try:
+        sp = graph_client.get_service_principal(target.object_id)
+    except Exception as exc:
+        result = VerificationResult(
+            status=VerificationStatus.UNREACHABLE,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="microsoft graph call raised; cannot determine state",
+            detail=str(exc),
+        )
+        record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
+        record["target"] = {
+            "provider": "Entra",
+            "object_id": target.object_id,
+            "display_name": target.display_name,
+        }
+        return [record]
+
+    if sp is None:
+        # SP is gone entirely. That's a STRONGER state than disabled — counts as
+        # verified containment. Operator may also want to know it was deleted.
+        result = VerificationResult(
+            status=VerificationStatus.VERIFIED,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="service principal not found (deleted or never existed) — stronger than disabled",
+            detail="containment confirmed via absence",
+        )
+    elif sp.get("accountEnabled") is False:
+        result = VerificationResult(
+            status=VerificationStatus.VERIFIED,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="accountEnabled=false",
+            detail="service principal still disabled",
+        )
+    else:
+        result = VerificationResult(
+            status=VerificationStatus.DRIFT,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state=f"accountEnabled={sp.get('accountEnabled')!r}",
+            detail="service principal was re-enabled after remediation",
+        )
+
+    record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
+    record["target"] = {
+        "provider": "Entra",
+        "object_id": target.object_id,
+        "display_name": target.display_name,
+    }
+    outputs: list[dict[str, Any]] = [record]
+    if result.status == VerificationStatus.DRIFT:
+        outputs.append(
+            build_drift_finding(reference=reference, result=result, verifier_skill=SKILL_NAME)
+        )
+    return outputs
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+        else:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="invalid_json_shape",
+                message=f"skipping line {lineno}: not a JSON object",
+                line=lineno,
+            )
+
+
+def run(
+    events: Iterable[dict[str, Any]],
+    *,
+    graph_client: GraphClient,
+    apply: bool = False,
+    reverify: bool = False,
+    audit: AuditWriter | None = None,
+    name_prefixes: Iterable[str] = DEFAULT_PROTECTED_NAME_PREFIXES,
+    object_ids: Iterable[str] = (),
+    incident_id: str = "",
+    approver: str = "",
+) -> Iterator[dict[str, Any]]:
+    name_prefixes = tuple(name_prefixes)
+    object_ids = tuple(object_ids)
+
+    for target, _ in parse_targets(events):
+        if target is None:
+            continue
+
+        dry_run = not apply and not reverify
+
+        if not target.object_id:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_NO_TARGET,
+                detail="finding did not carry a target.uid observable; cannot identify SP",
+                dry_run=dry_run,
+            )
+            continue
+
+        if target.target_type and target.target_type not in SUPPORTED_TARGET_TYPES:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_UNSUPPORTED_TYPE,
+                detail=(
+                    f"target.type=`{target.target_type}` is not in supported set "
+                    f"({sorted(SUPPORTED_TARGET_TYPES)})"
+                ),
+                dry_run=dry_run,
+            )
+            continue
+
+        protected, why = is_protected_target(
+            target, name_prefixes=name_prefixes, object_ids=object_ids
+        )
+        if protected:
+            status = STATUS_SKIPPED_PROTECTED if apply else STATUS_WOULD_VIOLATE_PROTECTED
+            yield _skip_record(
+                target,
+                status=status,
+                detail=f"target is protected: {why}",
+                dry_run=dry_run,
+            )
+            continue
+
+        if reverify:
+            yield from reverify_target(target, graph_client=graph_client)
+            continue
+
+        if not apply:
+            yield _plan_record(
+                target,
+                status=STATUS_PLANNED,
+                detail=f"dry-run: would disable `{target.object_id}` and emit triage payload",
+                dry_run=True,
+            )
+            continue
+
+        if audit is None:
+            raise ValueError("audit writer is required under --apply")
+        yield disable_and_triage(
+            target,
+            graph_client=graph_client,
+            audit=audit,
+            incident_id=incident_id,
+            approver=approver,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Plan, apply, or re-verify Entra service-principal credential containment."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Disable the offending service principal after approval gates pass.",
+    )
+    parser.add_argument(
+        "--reverify",
+        action="store_true",
+        help="Read-only verification: confirm the service principal is still disabled.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply and args.reverify:
+        print("--apply and --reverify are mutually exclusive", file=sys.stderr)
+        return 2
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        graph_client: GraphClient = MsGraphClient(
+            tenant_id=os.environ.get("AZURE_TENANT_ID", ""),
+            client_id=os.environ.get("AZURE_CLIENT_ID", ""),
+            client_secret=os.environ.get("AZURE_CLIENT_SECRET", ""),
+        )
+        audit: AuditWriter | None = None
+        incident_id = ""
+        approver = ""
+        if args.apply:
+            ok, reason = check_apply_gate()
+            if not ok:
+                print(reason, file=sys.stderr)
+                return 2
+            incident_id = os.environ["ENTRA_REVOKE_INCIDENT_ID"].strip()
+            approver = os.environ["ENTRA_REVOKE_APPROVER"].strip()
+            audit = DualAuditWriter(
+                dynamodb_table=os.environ["ENTRA_REVOKE_AUDIT_DYNAMODB_TABLE"],
+                s3_bucket=os.environ["ENTRA_REVOKE_AUDIT_BUCKET"],
+                kms_key_arn=os.environ["KMS_KEY_ARN"],
+            )
+
+        for record in run(
+            load_jsonl(in_stream),
+            graph_client=graph_client,
+            apply=args.apply,
+            reverify=args.reverify,
+            audit=audit,
+            object_ids=load_protected_object_ids(),
+            incident_id=incident_id,
+            approver=approver,
+        ):
+            out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/remediate-entra-credential-revoke/tests/conftest.py
+++ b/skills/remediation/remediate-entra-credential-revoke/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover", "handler")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
@@ -1,0 +1,420 @@
+"""Tests for remediate-entra-credential-revoke."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from handler import (  # type: ignore[import-not-found]
+    ACCEPTED_PRODUCERS,
+    DEFAULT_PROTECTED_NAME_PREFIXES,
+    STATUS_FAILURE,
+    STATUS_IN_PROGRESS,
+    STATUS_PLANNED,
+    STATUS_SKIPPED_NO_TARGET,
+    STATUS_SKIPPED_PROTECTED,
+    STATUS_SKIPPED_UNSUPPORTED_TYPE,
+    STATUS_SUCCESS,
+    STATUS_WOULD_VIOLATE_PROTECTED,
+    Target,
+    check_apply_gate,
+    is_protected_target,
+    parse_targets,
+    run,
+)
+
+
+def _finding(
+    *,
+    producer: str = "detect-entra-credential-addition",
+    object_id: str = "11111111-1111-1111-1111-111111111111",
+    display_name: str = "rogue-app",
+    target_type: str = "ServicePrincipal",
+    actor: str = "attacker@example.com",
+    api_operation: str = "Update application -- Certificates and secrets management",
+    rule: str = "entra-credential-addition",
+    finding_uid: str = "find-1",
+    omit_target_uid: bool = False,
+) -> dict:
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "Azure"},
+        {"name": "actor.name", "type": "Other", "value": actor},
+        {"name": "api.operation", "type": "Other", "value": api_operation},
+        {"name": "rule", "type": "Other", "value": rule},
+        {"name": "target.name", "type": "Other", "value": display_name},
+        {"name": "target.type", "type": "Other", "value": target_type},
+    ]
+    if not omit_target_uid:
+        observables.append({"name": "target.uid", "type": "Other", "value": object_id})
+    return {
+        "class_uid": 2004,
+        "metadata": {
+            "uid": finding_uid,
+            "product": {"feature": {"name": producer}},
+        },
+        "finding_info": {"uid": finding_uid},
+        "observables": observables,
+    }
+
+
+@dataclass
+class _FakeAudit:
+    writes: list[dict] = field(default_factory=list)
+
+    def record(self, *, target, step, status, detail, incident_id, approver):
+        entry = {
+            "object_id": target.object_id,
+            "step": step,
+            "status": status,
+            "detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+        }
+        self.writes.append(entry)
+        return {
+            "row_uid": f"row-{len(self.writes)}",
+            "s3_evidence_uri": f"s3://bucket/{target.object_id}-{len(self.writes)}.json",
+        }
+
+
+@dataclass
+class _FakeGraph:
+    sps: dict[str, dict] = field(default_factory=dict)  # object_id → {accountEnabled: bool}
+    keys: dict[str, list[dict]] = field(default_factory=dict)
+    passwords: dict[str, list[dict]] = field(default_factory=dict)
+    role_assignments: dict[str, list[dict]] = field(default_factory=dict)
+    oauth_grants: dict[str, list[dict]] = field(default_factory=dict)
+    raise_on_disable: bool = False
+    raise_on_get: bool = False
+    raise_on_triage: bool = False
+    disabled: list[str] = field(default_factory=list)
+
+    def get_service_principal(self, object_id):
+        if self.raise_on_get:
+            raise RuntimeError("simulated graph 502")
+        return self.sps.get(object_id)
+
+    def disable_service_principal(self, object_id):
+        if self.raise_on_disable:
+            raise RuntimeError("simulated graph 403 forbidden")
+        self.disabled.append(object_id)
+        existing = self.sps.setdefault(object_id, {})
+        existing["accountEnabled"] = False
+
+    def list_key_credentials(self, object_id):
+        if self.raise_on_triage:
+            raise RuntimeError("simulated graph 502 on triage")
+        return list(self.keys.get(object_id, []))
+
+    def list_password_credentials(self, object_id):
+        return list(self.passwords.get(object_id, []))
+
+    def list_app_role_assignments(self, object_id):
+        return list(self.role_assignments.get(object_id, []))
+
+    def list_oauth2_permission_grants(self, object_id):
+        return list(self.oauth_grants.get(object_id, []))
+
+
+# ----------------- helpers -----------------
+
+
+def test_accepted_producers_set_is_just_entra():
+    assert ACCEPTED_PRODUCERS == frozenset(
+        {"detect-entra-credential-addition", "detect-entra-role-grant-escalation"}
+    )
+
+
+def test_default_protected_name_prefixes_cover_critical_classes():
+    as_text = " ".join(DEFAULT_PROTECTED_NAME_PREFIXES).lower()
+    for required in ("break-glass", "emergency", "tenant-", "ms-", "microsoft-"):
+        assert required in as_text
+
+
+def _t(**overrides) -> Target:
+    base = dict(
+        object_id="oid-1", display_name="rogue", target_type="ServicePrincipal",
+        actor="x", api_operation="y", rule="z", producer_skill="detect-entra-credential-addition",
+        finding_uid="f-1",
+    )
+    base.update(overrides)
+    return Target(**base)
+
+
+def test_is_protected_matches_name_prefix():
+    protected, why = is_protected_target(
+        _t(display_name="break-glass-prod"),
+        name_prefixes=DEFAULT_PROTECTED_NAME_PREFIXES,
+        object_ids=(),
+    )
+    assert protected is True
+    assert "break-glass" in why
+
+
+def test_is_protected_matches_object_id_allowlist():
+    protected, why = is_protected_target(
+        _t(object_id="bootstrap-id"),
+        name_prefixes=(),
+        object_ids=("bootstrap-id",),
+    )
+    assert protected is True
+    assert "bootstrap-id" in why
+
+
+def test_regular_target_passes_protected_check():
+    protected, _ = is_protected_target(
+        _t(display_name="my-prod-app"),
+        name_prefixes=DEFAULT_PROTECTED_NAME_PREFIXES,
+        object_ids=(),
+    )
+    assert protected is False
+
+
+def test_check_apply_gate_requires_both_envs(monkeypatch):
+    monkeypatch.delenv("ENTRA_REVOKE_INCIDENT_ID", raising=False)
+    monkeypatch.delenv("ENTRA_REVOKE_APPROVER", raising=False)
+    ok, reason = check_apply_gate()
+    assert ok is False and "INCIDENT_ID" in reason
+    monkeypatch.setenv("ENTRA_REVOKE_INCIDENT_ID", "INC-1")
+    ok, reason = check_apply_gate()
+    assert ok is False and "APPROVER" in reason
+    monkeypatch.setenv("ENTRA_REVOKE_APPROVER", "alice")
+    ok, _ = check_apply_gate()
+    assert ok is True
+
+
+# ----------------- parse_targets -----------------
+
+
+def test_parse_targets_accepts_both_entra_producers():
+    add = next(parse_targets([_finding(producer="detect-entra-credential-addition")]))[0]
+    grant = next(parse_targets([_finding(producer="detect-entra-role-grant-escalation", rule="entra-role-grant-escalation")]))[0]
+    assert add is not None and add.producer_skill == "detect-entra-credential-addition"
+    assert grant is not None and grant.producer_skill == "detect-entra-role-grant-escalation"
+
+
+def test_parse_targets_rejects_wrong_producer(capsys):
+    target, _ = next(parse_targets([_finding(producer="detect-okta-mfa-fatigue")]))
+    assert target is None
+    assert "unaccepted producer" in capsys.readouterr().err
+
+
+def test_parse_targets_extracts_observables():
+    target, _ = next(parse_targets([_finding()]))
+    assert target.object_id == "11111111-1111-1111-1111-111111111111"
+    assert target.display_name == "rogue-app"
+    assert target.target_type == "ServicePrincipal"
+    assert target.actor == "attacker@example.com"
+
+
+# ----------------- run: dry-run -----------------
+
+
+def test_run_dry_run_emits_plan_with_two_actions():
+    records = list(run([_finding()], graph_client=_FakeGraph()))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["record_type"] == "remediation_plan"
+    assert rec["status"] == STATUS_PLANNED
+    assert rec["dry_run"] is True
+    assert len(rec["actions"]) == 2
+    assert rec["actions"][0]["step"] == "disable_service_principal"
+    assert rec["actions"][1]["step"] == "list_credentials_and_assignments"
+    # Triage payload not populated under dry-run (no Graph reads)
+    assert rec["triage"] is None
+
+
+def test_run_dry_run_does_not_touch_graph():
+    graph = _FakeGraph()
+    list(run([_finding()], graph_client=graph))
+    assert graph.disabled == []
+
+
+# ----------------- run: skip paths -----------------
+
+
+def test_run_skips_finding_without_target_uid():
+    records = list(run([_finding(omit_target_uid=True)], graph_client=_FakeGraph()))
+    assert records[0]["status"] == STATUS_SKIPPED_NO_TARGET
+    assert records[0]["actions"] == []
+
+
+def test_run_skips_unsupported_target_type():
+    records = list(run([_finding(target_type="Group")], graph_client=_FakeGraph()))
+    assert records[0]["status"] == STATUS_SKIPPED_UNSUPPORTED_TYPE
+    assert "Group" in records[0]["status_detail"]
+
+
+def test_run_skips_protected_name_prefix_in_dry_run():
+    records = list(run([_finding(display_name="break-glass-incident-app")], graph_client=_FakeGraph()))
+    assert records[0]["status"] == STATUS_WOULD_VIOLATE_PROTECTED
+    assert "break-glass" in records[0]["status_detail"]
+
+
+def test_run_skips_protected_object_id_in_apply():
+    audit = _FakeAudit()
+    graph = _FakeGraph()
+    records = list(
+        run(
+            [_finding(object_id="bootstrap-sp-id")],
+            graph_client=graph,
+            apply=True,
+            audit=audit,
+            object_ids=("bootstrap-sp-id",),
+            incident_id="INC-1",
+            approver="alice",
+        )
+    )
+    assert records[0]["status"] == STATUS_SKIPPED_PROTECTED
+    assert audit.writes == []
+    assert graph.disabled == []
+
+
+# ----------------- run: apply -----------------
+
+
+def test_run_apply_disables_and_emits_triage_with_dual_audit():
+    audit = _FakeAudit()
+    graph = _FakeGraph(
+        sps={"11111111-1111-1111-1111-111111111111": {"accountEnabled": True}},
+        keys={"11111111-1111-1111-1111-111111111111": [{"keyId": "k-1"}, {"keyId": "k-2"}]},
+        passwords={"11111111-1111-1111-1111-111111111111": [{"keyId": "p-1"}]},
+        role_assignments={"11111111-1111-1111-1111-111111111111": [{"id": "ra-1", "appRoleId": "role-x"}]},
+        oauth_grants={"11111111-1111-1111-1111-111111111111": []},
+    )
+    records = list(
+        run(
+            [_finding()],
+            graph_client=graph,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS
+    assert rec["dry_run"] is False
+    assert graph.disabled == ["11111111-1111-1111-1111-111111111111"]
+
+    # Triage payload populated
+    assert rec["triage"] is not None
+    assert len(rec["triage"]["key_credentials"]) == 2
+    assert len(rec["triage"]["password_credentials"]) == 1
+    assert len(rec["triage"]["app_role_assignments"]) == 1
+
+    # Audit: pre-disable IN_PROGRESS, post-disable SUCCESS, post-triage SUCCESS = 3 rows
+    assert len(audit.writes) == 3
+    assert audit.writes[0]["status"] == STATUS_IN_PROGRESS
+    assert audit.writes[0]["step"] == "disable_service_principal"
+    assert audit.writes[1]["status"] == STATUS_SUCCESS
+    assert audit.writes[1]["step"] == "disable_service_principal"
+    assert audit.writes[2]["status"] == STATUS_SUCCESS
+    assert audit.writes[2]["step"] == "list_credentials_and_assignments"
+
+
+def test_run_apply_writes_failure_audit_when_disable_throws():
+    audit = _FakeAudit()
+    graph = _FakeGraph(raise_on_disable=True)
+    records = list(
+        run(
+            [_finding()],
+            graph_client=graph,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_FAILURE
+    assert "forbidden" in rec["actions"][0]["detail"]
+    assert len(audit.writes) == 2
+    assert audit.writes[1]["status"] == STATUS_FAILURE
+
+
+def test_run_apply_disable_succeeds_even_if_triage_fails():
+    """Containment is the priority. If triage list fails post-disable, the
+    SP is still contained — record SUCCESS for disable but FAILURE for triage."""
+    audit = _FakeAudit()
+    graph = _FakeGraph(raise_on_triage=True)
+    records = list(
+        run(
+            [_finding()],
+            graph_client=graph,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS  # overall record reflects containment success
+    assert graph.disabled == ["11111111-1111-1111-1111-111111111111"]
+    assert rec["actions"][0]["status"] == "success"  # disable
+    assert rec["actions"][1]["status"] == "failure"  # triage
+    assert "triage list failed" in rec["actions"][1]["detail"]
+    assert rec["triage"] is None
+
+
+def test_run_apply_requires_audit_writer():
+    import pytest
+    with pytest.raises(ValueError, match="audit writer is required"):
+        list(run([_finding()], graph_client=_FakeGraph(), apply=True, audit=None))
+
+
+# ----------------- run: re-verify -----------------
+
+
+def test_run_reverify_verified_when_sp_still_disabled():
+    graph = _FakeGraph(sps={"11111111-1111-1111-1111-111111111111": {"accountEnabled": False}})
+    records = list(run([_finding()], graph_client=graph, reverify=True))
+    assert len(records) == 1
+    assert records[0]["status"] == "verified"
+
+
+def test_run_reverify_verified_when_sp_was_deleted():
+    """Absence is stronger than disabled — count as verified containment."""
+    graph = _FakeGraph(sps={})
+    records = list(run([_finding()], graph_client=graph, reverify=True))
+    assert len(records) == 1
+    assert records[0]["status"] == "verified"
+    assert "not found" in records[0]["actual_state"]
+
+
+def test_run_reverify_drift_emits_ocsf_finding_alongside_verification():
+    """DRIFT (SP was re-enabled) must yield BOTH a verification record AND
+    an OCSF Detection Finding (class_uid 2004) so the gap flows through the
+    same SIEM/SOAR pipeline."""
+    graph = _FakeGraph(sps={"11111111-1111-1111-1111-111111111111": {"accountEnabled": True}})
+    records = list(run([_finding()], graph_client=graph, reverify=True))
+    assert len(records) == 2
+    verification, finding = records
+    assert verification["status"] == "drift"
+    assert finding["class_uid"] == 2004
+    assert finding["category_uid"] == 2
+    assert finding["severity_id"] == 4
+    assert finding["finding_info"]["types"] == ["remediation-drift"]
+    assert any(
+        obs["name"] == "remediation.skill" and obs["value"] == "remediate-entra-credential-revoke"
+        for obs in finding["observables"]
+    )
+
+
+def test_run_reverify_unreachable_never_silently_downgrades():
+    graph = _FakeGraph(raise_on_get=True)
+    records = list(run([_finding()], graph_client=graph, reverify=True))
+    assert len(records) == 1
+    assert records[0]["status"] == "unreachable"
+
+
+def test_run_reverify_skips_protected_target():
+    graph = _FakeGraph()
+    records = list(
+        run([_finding(display_name="microsoft-internal-graph")], graph_client=graph, reverify=True)
+    )
+    # No graph call should fire
+    assert records[0]["status"] == STATUS_WOULD_VIOLATE_PROTECTED


### PR DESCRIPTION
## Summary

Pair skill for both shipped Entra detectors:
- [`detect-entra-credential-addition`](skills/detection/detect-entra-credential-addition/) — MITRE ATT&CK T1098.001 Additional Cloud Credentials
- [`detect-entra-role-grant-escalation`](skills/detection/detect-entra-role-grant-escalation/) — MITRE ATT&CK T1098.003 Additional Cloud Roles

This is **#155 phase 3**. Closed-loop ratio goes **5/11 → 7/11**. Both #238 amber rows in the coverage matrix flip green. Closes the detection-side of [#238](https://github.com/msaad00/cloud-ai-security-skills/issues/238).

## Scope correction vs #238's original framing

The audit's "extracts existing code" framing was off. The existing `iam-departures-aws/src/lambda_worker/clouds/azure_entra.py` is HR-departure-shaped (delete a user across Entra). The two Entra detectors emit findings about a **specific service principal credential addition or app-role grant** — different operations than "delete user". Pure extraction wouldn't close the detection gaps.

This PR ships a **finding-driven remediation skill** that uses the same msgraph-sdk auth pattern as `azure_entra.py` but operates on the credential-revoke workflow rather than user-delete.

## Why disable + triage (not auto-revoke)

The detectors know:
- WHICH service principal was modified (`target.uid`)
- WHEN, WHAT operation

They do NOT know:
- The specific `keyCredentials[].keyId` of the new credential
- The specific `appRoleAssignments[].id` of the new assignment

Auto-revoke without that pointer would either over-block (revoke ALL credentials, breaking legitimate ones) or guess. **Disable-then-triage** gives the operator immediate containment AND the full state needed to make a correct revocation choice.

## What it does

1. **Disable**: `PATCH /servicePrincipals/{id}` with `accountEnabled=false` — immediately stops new auth + token issuance, cleanly reversible
2. **Triage**: read `keyCredentials`, `passwordCredentials`, `appRoleAssignments`, `oauth2PermissionGrants` for the SP and emit them in the action record for operator selective revocation

Wires `_shared/remediation_verifier.py` from day one — DRIFT (SP was re-enabled) emits BOTH a verification record AND an OCSF Detection Finding (`class_uid: 2004`, `finding_info.types: ["remediation-drift"]`).

## Guardrails

- `ACCEPTED_PRODUCERS` limits input to the two Entra detectors
- Protected name-prefix deny-list: `break-glass`, `emergency`, `tenant-`, `directory-`, `ms-`, `microsoft-`
- Protected objectId allowlist via `ENTRA_PROTECTED_OBJECT_IDS` env var
- Target-type filter: only `ServicePrincipal` and `Application`
- `--apply` requires `ENTRA_REVOKE_INCIDENT_ID` + `ENTRA_REVOKE_APPROVER`
- Dual audit (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each Graph call
- `--reverify` confirms `accountEnabled=false`; UNREACHABLE never silently downgrades

## Doc + registry sync (50→51, remediation 5→6)

README, ARCHITECTURE.md, CLAUDE.md, skills/README.md catalog, SECURITY_BAR.md (regenerated), docs/FRAMEWORK_COVERAGE.md (regenerated), docs/framework-coverage.json, hero-banner.svg, architecture.svg (L5 count + new skill row + bundle), coverage-matrix.svg (Entra rows red/amber → green; footer ratio 5/11 → 7/11).

## Test plan

- [x] `pytest -q` — 1220 passed (1196 prior + 24 new)
- [x] All 9 contract validators pass
- [x] `ruff check skills scripts` clean
- [x] `bash scripts/run_mypy.sh` clean
- [x] count-drift scan from #309 reports zero drift

## Coverage matrix delta

| Before | After |
|---|---|
| 5 / 11 closed-loop | **7 / 11 closed-loop** |
| 4 amber gaps | 2 amber gaps (k8s-rbac discovery, CSPM auto-remediate) |
| 2 red gaps | 2 red gaps (Workspace, lateral-movement) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)