### PR TITLE
[codex] fix remediation audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,17 @@ Full discussion: [docs/ARCHITECTURE.md §3 Layer model + §6 Wire contract](docs
 
 ## Architecture
 
-External signals enter through two intake layers, pass through two analyze layers, and exit through two act layers, persisting through one output layer. Every node ships as a `SKILL.md + src/ + tests/` bundle that runs unchanged from CLI, CI, MCP, or a cloud runner.
+External signals enter through two intake layers, pass through two analyze layers, and exit through two act layers, persisting through one output layer. The README now splits the picture into two simpler visuals so the layer flow and runtime story stay readable on GitHub.
 
-![Canonical architecture — 7 skill layers (L1 Ingest 15+3 source, L2 Discover 4, L3 Detect 11, L4 Evaluate 7, L5 Remediate 4, L6 View 2, L7 Output 3 sinks) and 4 runtime surfaces (MCP clients via stdio, CLI pipes, CI GitHub Actions, cloud runners). The same shipped bundle is invoked from every surface.](docs/images/architecture.svg)
+![Clean architecture layers diagram — signals feed intake, analyze, act, and persist stages across the seven shipped skill layers.](docs/images/architecture-layers.svg)
+
+![Clean runtime surfaces diagram — MCP, CLI, CI, and cloud runners all invoke the same shared skill bundle.](docs/images/runtime-surfaces.svg)
 
 Full contract: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
 ## Agent and runtime integrations
 
-MCP clients go through the repo MCP server; CLI, CI, and cloud runners invoke the skill bundle directly. All four surfaces share the same implementation — see the runtime band of the architecture diagram above.
+MCP clients go through the repo MCP server; CLI, CI, and cloud runners invoke the skill bundle directly. All four surfaces share the same implementation — see the runtime surfaces diagram above.
 
 - **MCP** · [.mcp.json](.mcp.json) · [mcp-server/README.md](mcp-server/README.md) · [docs/MCP_AUDIT_CONTRACT.md](docs/MCP_AUDIT_CONTRACT.md)
 - **CLI / pipes** · stdin/stdout bundles compose into one-liners

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ External signals enter through two intake layers, pass through two analyze layer
 
 Full contract: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
+For UI-only audit evidence and screenshot-backed control capture, see the design note in [docs/COMPLIANCE_EVIDENCE_CAPTURE.md](docs/COMPLIANCE_EVIDENCE_CAPTURE.md). The repo direction there is export-first, screenshot-when-necessary.
+
 ## Agent and runtime integrations
 
 MCP clients go through the repo MCP server; CLI, CI, and cloud runners invoke the skill bundle directly. All four surfaces share the same implementation — see the runtime surfaces diagram above.

--- a/docs/COMPLIANCE_EVIDENCE_CAPTURE.md
+++ b/docs/COMPLIANCE_EVIDENCE_CAPTURE.md
@@ -1,0 +1,86 @@
+# UI Evidence Capture for Compliance
+
+This repo already has strong evidence paths for cloud state, logs, benchmark checks, and access-review exports. The gap is the class of controls where the system of record exposes the relevant control state only in an admin UI, or where the certification program explicitly asks for screenshots.
+
+## What the research says
+
+Screenshots are valid evidence, but they should not be the default evidence type.
+
+- Prefer machine-readable evidence first:
+  - AWS Audit Manager automatically collects configuration snapshots, user activity evidence, and compliance-check evidence from AWS services, CloudTrail, Security Hub, and Config.
+  - Microsoft Entra access reviews support downloadable review history reports and downloadable results, and the same decisions can also be retrieved programmatically through Microsoft Graph or PowerShell.
+  - Okta Access Certifications supports CSV export for completed campaign reports.
+- Use screenshots when they add evidence you cannot reliably get from an export or API:
+  - Microsoft 365 Certification explicitly requires full-screen screenshots with the URL, logged-in user, and time/date stamp visible for screenshot-based evidence submissions.
+  - UI-only control surfaces, review-state pages, and point-in-time visual attestations can still matter to auditors when no structured export exists.
+
+The implication for this repo is straightforward: an evidence-capture skill family is useful, but only as a controlled fallback and only when the output is tied back to structured metadata and audit trails.
+
+## Good fit for this repo
+
+A repo-native evidence capture capability would fit best as read-only discovery or evidence skills, not as ad hoc browser macros.
+
+Suggested family:
+
+- `evidence-entra-access-reviews`
+  - prefer CSV / Graph exports first
+  - capture screenshots only for review state, reviewer UI, or apply-state pages
+- `evidence-okta-access-certifications`
+  - prefer campaign exports first
+  - capture screenshots for reassignment history or policy-state pages when export is incomplete
+- `evidence-m365-certification-controls`
+  - screenshot-first because the certification guidance explicitly accepts and describes screenshot submissions
+- `evidence-console-control-snapshot-*`
+  - tightly scoped vendor skills for cases where a control is genuinely visible only in the UI
+
+## Required guardrails
+
+If this is built, it should follow the same design discipline as the rest of the repo:
+
+- read-only only
+- deterministic navigation
+- explicit vendor / framework scope
+- timestamp, URL, tenant/account, and operator identity captured alongside the image
+- DOM/text context stored with the screenshot so the evidence is searchable and less brittle
+- image hashing for tamper detection
+- redaction hooks for secrets, tokens, user PII, and customer data
+- append-only sink support for evidence packages
+- no marketing claims that screenshots are equivalent to continuous control monitoring
+
+## Output contract
+
+The output should not be a raw `.png` alone. It should be an evidence bundle:
+
+- screenshot
+- metadata JSON
+- capture timestamp
+- canonical control id / framework mapping
+- tenant / account / resource identifier
+- URL / page title
+- operator / agent identity
+- optional DOM extract or CSV export collected in the same run
+
+That keeps screenshot evidence auditable, reviewable, and attachable to the same evidence workflows already used elsewhere in the repo.
+
+## Recommendation
+
+This is worth building, but as a narrow evidence-capture surface, not as a general “let the agent click around” feature.
+
+Priority order:
+
+1. export-first skills for Entra and Okta access reviews / certifications
+2. screenshot-backed Microsoft 365 certification evidence capture
+3. vendor-specific UI-only control evidence skills where no better API/export path exists
+
+## Sources
+
+- AWS Audit Manager: reviewing evidence and evidence types
+  - https://docs.aws.amazon.com/audit-manager/latest/userguide/review-evidence.html
+  - https://aws.amazon.com/audit-manager/faqs/
+- Microsoft Entra access reviews: downloadable history and downloadable/programmatic results
+  - https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-downloadable-review-history
+  - https://learn.microsoft.com/en-us/entra/id-governance/complete-access-review
+- Microsoft 365 Certification evidence guidance
+  - https://learn.microsoft.com/en-us/microsoft-365-app-certification/docs/seg2_overview
+- Okta Access Certifications CSV export
+  - https://help.okta.com/en-us/content/topics/identity-governance/access-certification/iga-view-prev-campaigns.htm

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,91 +1,129 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="560" viewBox="0 0 1400 560" role="img" aria-labelledby="layers-title layers-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="760" viewBox="0 0 1400 760" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Clean architecture diagram showing the seven skill layers grouped into five readable stages: signals, intake, analyze, act, and persist. Signals feed ingest and discover. Ingest and discover feed detect and evaluate. Detect and evaluate feed remediate and view. Output persists producer-emitted JSONL sinks.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals feed intake layers ingest and discover. Intake feeds analyze layers detect and evaluate. Analyze feeds act layers remediate and view. Output persists data to append-only sinks. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#081122"/>
-      <stop offset="100%" stop-color="#0f1c34"/>
+      <stop offset="0%" stop-color="#07101f"/>
+      <stop offset="100%" stop-color="#0f1b31"/>
     </linearGradient>
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M40 0H0V40" fill="none" stroke="#1f2a44" stroke-opacity="0.35" stroke-width="1"/>
+    <radialGradient id="glow" cx="20%" cy="10%" r="80%">
+      <stop offset="0%" stop-color="#2563eb" stop-opacity="0.16"/>
+      <stop offset="60%" stop-color="#2563eb" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#2563eb" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
+      <path d="M36 0H0V36" fill="none" stroke="#1d2942" stroke-opacity="0.35" stroke-width="1"/>
     </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#020617" flood-opacity="0.45"/>
+    </filter>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
       <path d="M0 0L10 5L0 10z" fill="#7dd3fc"/>
     </marker>
   </defs>
 
-  <rect width="1400" height="560" fill="url(#bg)"/>
-  <rect width="1400" height="560" fill="url(#grid)"/>
+  <rect width="1400" height="760" fill="url(#bg)"/>
+  <rect width="1400" height="760" fill="url(#grid)"/>
+  <rect width="1400" height="760" fill="url(#glow)"/>
 
   <g font-family="Inter, Arial, sans-serif">
-    <text x="64" y="64" font-size="32" font-weight="800" fill="#f8fafc">Architecture: signal to action in seven layers</text>
-    <text x="64" y="96" font-size="16" fill="#a5b4fc">Split by role so the README stays readable: intake, analyze, act, then persist.</text>
+    <text x="72" y="76" font-size="38" font-weight="800" fill="#f8fafc">Architecture: seven skill layers, one readable flow</text>
+    <text x="72" y="112" font-size="18" fill="#cbd5e1">Signals enter on the left. The repo normalizes, analyzes, acts, then persists through producer-owned sinks.</text>
 
-    <text x="64" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#94a3b8">SIGNALS</text>
-    <text x="314" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#60a5fa">INTAKE</text>
-    <text x="594" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#34d399">ANALYZE</text>
-    <text x="874" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#fbbf24">ACT</text>
-    <text x="1154" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#2dd4bf">PERSIST</text>
+    <g transform="translate(72,156)">
+      <rect x="0" y="0" width="160" height="40" rx="20" fill="#0f172a" stroke="#475569"/>
+      <text x="80" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#cbd5e1" letter-spacing="1.5">SIGNALS</text>
 
-    <rect x="64" y="160" width="190" height="292" rx="18" fill="#0f172a" stroke="#475569" stroke-width="1.5"/>
-    <text x="159" y="204" text-anchor="middle" font-size="24" font-weight="800" fill="#f8fafc">Signals</text>
-    <text x="159" y="246" text-anchor="middle" font-size="16" fill="#cbd5e1">Cloud APIs</text>
-    <text x="159" y="272" text-anchor="middle" font-size="16" fill="#cbd5e1">Raw logs</text>
-    <text x="159" y="298" text-anchor="middle" font-size="16" fill="#cbd5e1">Identity systems</text>
-    <text x="159" y="324" text-anchor="middle" font-size="16" fill="#cbd5e1">Warehouses</text>
-    <text x="159" y="370" text-anchor="middle" font-size="14" fill="#94a3b8">AWS, GCP, Azure, K8s,</text>
-    <text x="159" y="392" text-anchor="middle" font-size="14" fill="#94a3b8">Okta, Entra, Workspace,</text>
-    <text x="159" y="414" text-anchor="middle" font-size="14" fill="#94a3b8">Snowflake, Databricks, S3</text>
+      <rect x="240" y="0" width="160" height="40" rx="20" fill="#102345" stroke="#60a5fa"/>
+      <text x="320" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#bfdbfe" letter-spacing="1.5">INTAKE</text>
 
-    <rect x="314" y="160" width="220" height="132" rx="18" fill="#112244" stroke="#60a5fa" stroke-width="1.5"/>
-    <text x="344" y="198" font-size="18" font-weight="800" fill="#dbeafe">L1 Ingest</text>
-    <text x="344" y="232" font-size="40" font-weight="800" fill="#f8fafc">15 + 3</text>
-    <text x="344" y="266" font-size="16" fill="#bfdbfe">normalize raw sources to OCSF or native JSONL</text>
+      <rect x="510" y="0" width="170" height="40" rx="20" fill="#0a3b35" stroke="#34d399"/>
+      <text x="595" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#bbf7d0" letter-spacing="1.5">ANALYZE</text>
 
-    <rect x="314" y="320" width="220" height="132" rx="18" fill="#112244" stroke="#60a5fa" stroke-width="1.5"/>
-    <text x="344" y="358" font-size="18" font-weight="800" fill="#dbeafe">L2 Discover</text>
-    <text x="344" y="392" font-size="40" font-weight="800" fill="#f8fafc">4</text>
-    <text x="344" y="426" font-size="16" fill="#bfdbfe">inventory, graphs, AI BOM, evidence collection</text>
+      <rect x="790" y="0" width="150" height="40" rx="20" fill="#4a2d09" stroke="#fbbf24"/>
+      <text x="865" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#fde68a" letter-spacing="1.5">ACT</text>
 
-    <rect x="594" y="160" width="220" height="132" rx="18" fill="#0b3b32" stroke="#34d399" stroke-width="1.5"/>
-    <text x="624" y="198" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-    <text x="624" y="232" font-size="40" font-weight="800" fill="#f8fafc">12</text>
-    <text x="624" y="266" font-size="16" fill="#a7f3d0">deterministic MITRE-tagged findings in OCSF 2004</text>
+      <rect x="1050" y="0" width="160" height="40" rx="20" fill="#083b39" stroke="#2dd4bf"/>
+      <text x="1130" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4" letter-spacing="1.5">PERSIST</text>
+    </g>
 
-    <rect x="594" y="320" width="220" height="132" rx="18" fill="#0b3b32" stroke="#34d399" stroke-width="1.5"/>
-    <text x="624" y="358" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
-    <text x="624" y="392" font-size="40" font-weight="800" fill="#f8fafc">7</text>
-    <text x="624" y="426" font-size="16" fill="#a7f3d0">82 CIS, Kubernetes, container, and AI checks</text>
+    <g filter="url(#shadow)">
+      <rect x="72" y="228" width="190" height="386" rx="28" fill="#0f172a" stroke="#334155" stroke-width="1.5"/>
+      <text x="110" y="278" font-size="30" font-weight="800" fill="#f8fafc">Signals</text>
+      <g font-size="16" fill="#dbeafe">
+        <rect x="102" y="314" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
+        <text x="166" y="338" text-anchor="middle">Cloud APIs</text>
+        <rect x="102" y="366" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
+        <text x="166" y="390" text-anchor="middle">Raw logs</text>
+        <rect x="102" y="418" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
+        <text x="166" y="442" text-anchor="middle">Identity</text>
+        <rect x="102" y="470" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
+        <text x="166" y="494" text-anchor="middle">Warehouses</text>
+      </g>
+      <text x="110" y="548" font-size="15" fill="#94a3b8">AWS, GCP, Azure, K8s, Okta,</text>
+      <text x="110" y="572" font-size="15" fill="#94a3b8">Entra, Workspace, Snowflake,</text>
+      <text x="110" y="596" font-size="15" fill="#94a3b8">Databricks, S3, ClickHouse.</text>
+    </g>
 
-    <rect x="874" y="160" width="220" height="132" rx="18" fill="#4a290d" stroke="#fbbf24" stroke-width="1.5"/>
-    <text x="904" y="198" font-size="18" font-weight="800" fill="#fde68a">L5 Remediate</text>
-    <text x="904" y="232" font-size="40" font-weight="800" fill="#f8fafc">8</text>
-    <text x="904" y="266" font-size="16" fill="#fcd34d">HITL, dry-run-first, dual-audited write paths</text>
+    <g filter="url(#shadow)">
+      <rect x="322" y="228" width="220" height="170" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
+      <text x="354" y="272" font-size="18" font-weight="800" fill="#dbeafe">L1 Ingest</text>
+      <text x="354" y="334" font-size="58" font-weight="900" fill="#ffffff">15 + 3</text>
+      <text x="354" y="370" font-size="18" fill="#bfdbfe">normalize source data to OCSF or native JSONL</text>
 
-    <rect x="874" y="320" width="220" height="132" rx="18" fill="#4a290d" stroke="#fbbf24" stroke-width="1.5"/>
-    <text x="904" y="358" font-size="18" font-weight="800" fill="#fde68a">L6 View</text>
-    <text x="904" y="392" font-size="40" font-weight="800" fill="#f8fafc">2</text>
-    <text x="904" y="426" font-size="16" fill="#fcd34d">render OCSF to SARIF or Mermaid for review</text>
+      <rect x="322" y="430" width="220" height="170" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
+      <text x="354" y="474" font-size="18" font-weight="800" fill="#dbeafe">L2 Discover</text>
+      <text x="354" y="536" font-size="58" font-weight="900" fill="#ffffff">4</text>
+      <text x="354" y="572" font-size="18" fill="#bfdbfe">inventory, AI BOM, graph, evidence collection</text>
+    </g>
 
-    <rect x="1154" y="160" width="182" height="292" rx="18" fill="#0a3d3b" stroke="#2dd4bf" stroke-width="1.5"/>
-    <text x="1184" y="198" font-size="18" font-weight="800" fill="#99f6e4">L7 Output</text>
-    <text x="1184" y="232" font-size="40" font-weight="800" fill="#f8fafc">3</text>
-    <text x="1184" y="266" font-size="16" fill="#99f6e4">append-only JSONL sinks</text>
-    <text x="1184" y="312" font-size="16" fill="#ccfbf1">S3</text>
-    <text x="1184" y="338" font-size="16" fill="#ccfbf1">Snowflake</text>
-    <text x="1184" y="364" font-size="16" fill="#ccfbf1">ClickHouse</text>
-    <text x="1184" y="406" font-size="14" fill="#99f6e4">Audit and ingest-back stay</text>
-    <text x="1184" y="428" font-size="14" fill="#99f6e4">with the producer-owned flow.</text>
+    <g filter="url(#shadow)">
+      <rect x="592" y="228" width="220" height="170" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
+      <text x="624" y="272" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
+      <text x="624" y="334" font-size="58" font-weight="900" fill="#ffffff">12</text>
+      <text x="624" y="370" font-size="18" fill="#a7f3d0">deterministic MITRE-tagged findings in OCSF 2004</text>
 
-    <path d="M254 306H298" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
-    <path d="M534 226H578" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
-    <path d="M534 386H578" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
-    <path d="M814 226H858" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
-    <path d="M814 386H858" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
-    <path d="M1094 306H1138" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+      <rect x="592" y="430" width="220" height="170" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
+      <text x="624" y="474" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
+      <text x="624" y="536" font-size="58" font-weight="900" fill="#ffffff">7</text>
+      <text x="624" y="572" font-size="18" fill="#a7f3d0">82 CIS, Kubernetes, container, and AI checks</text>
+    </g>
 
-    <rect x="64" y="484" width="1272" height="44" rx="14" fill="#111827" stroke="#334155" stroke-width="1"/>
-    <text x="92" y="512" font-size="16" fill="#cbd5e1">Wire contract by layer: OCSF 1.8 on ingest and detect, native where state and audit matter more, SARIF or Mermaid on view, pass-through on output.</text>
+    <g filter="url(#shadow)">
+      <rect x="862" y="228" width="220" height="170" rx="28" fill="#4a2d09" stroke="#fbbf24" stroke-width="1.6"/>
+      <text x="894" y="272" font-size="18" font-weight="800" fill="#fde68a">L5 Remediate</text>
+      <text x="894" y="334" font-size="58" font-weight="900" fill="#ffffff">8</text>
+      <text x="894" y="370" font-size="18" fill="#fde68a">HITL, dry-run-first, dual-audited write paths</text>
+
+      <rect x="862" y="430" width="220" height="170" rx="28" fill="#4a2d09" stroke="#fbbf24" stroke-width="1.6"/>
+      <text x="894" y="474" font-size="18" font-weight="800" fill="#fde68a">L6 View</text>
+      <text x="894" y="536" font-size="58" font-weight="900" fill="#ffffff">2</text>
+      <text x="894" y="572" font-size="18" fill="#fde68a">render OCSF to SARIF or Mermaid for review</text>
+    </g>
+
+    <g filter="url(#shadow)">
+      <rect x="1132" y="228" width="196" height="372" rx="28" fill="#083b39" stroke="#2dd4bf" stroke-width="1.6"/>
+      <text x="1164" y="272" font-size="18" font-weight="800" fill="#99f6e4">L7 Output</text>
+      <text x="1164" y="334" font-size="58" font-weight="900" fill="#ffffff">3</text>
+      <text x="1164" y="370" font-size="18" fill="#99f6e4">append-only sinks</text>
+      <g font-size="18" fill="#ecfeff">
+        <text x="1164" y="434">S3</text>
+        <text x="1164" y="470">Snowflake</text>
+        <text x="1164" y="506">ClickHouse</text>
+      </g>
+      <text x="1164" y="560" font-size="16" fill="#99f6e4">Audit trails and ingest-back</text>
+      <text x="1164" y="584" font-size="16" fill="#99f6e4">stay tied to producer-owned flows.</text>
+    </g>
+
+    <path d="M262 420H304" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M542 314H574" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M542 516H574" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M812 314H844" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M812 516H844" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M1082 420H1114" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+
+    <rect x="72" y="658" width="1256" height="48" rx="18" fill="#0b1220" stroke="#334155"/>
+    <text x="102" y="689" font-size="18" fill="#cbd5e1">Wire contract: OCSF 1.8 where interop matters, native where state and audit matter more, rendered output on view, pass-through on sinks.</text>
   </g>
 </svg>

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="560" viewBox="0 0 1400 560" role="img" aria-labelledby="layers-title layers-desc">
+  <title id="layers-title">cloud-ai-security-skills architecture layers</title>
+  <desc id="layers-desc">Clean architecture diagram showing the seven skill layers grouped into five readable stages: signals, intake, analyze, act, and persist. Signals feed ingest and discover. Ingest and discover feed detect and evaluate. Detect and evaluate feed remediate and view. Output persists producer-emitted JSONL sinks.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#081122"/>
+      <stop offset="100%" stop-color="#0f1c34"/>
+    </linearGradient>
+    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#1f2a44" stroke-opacity="0.35" stroke-width="1"/>
+    </pattern>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#7dd3fc"/>
+    </marker>
+  </defs>
+
+  <rect width="1400" height="560" fill="url(#bg)"/>
+  <rect width="1400" height="560" fill="url(#grid)"/>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <text x="64" y="64" font-size="32" font-weight="800" fill="#f8fafc">Architecture: signal to action in seven layers</text>
+    <text x="64" y="96" font-size="16" fill="#a5b4fc">Split by role so the README stays readable: intake, analyze, act, then persist.</text>
+
+    <text x="64" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#94a3b8">SIGNALS</text>
+    <text x="314" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#60a5fa">INTAKE</text>
+    <text x="594" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#34d399">ANALYZE</text>
+    <text x="874" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#fbbf24">ACT</text>
+    <text x="1154" y="138" font-size="13" font-weight="800" letter-spacing="1.8" fill="#2dd4bf">PERSIST</text>
+
+    <rect x="64" y="160" width="190" height="292" rx="18" fill="#0f172a" stroke="#475569" stroke-width="1.5"/>
+    <text x="159" y="204" text-anchor="middle" font-size="24" font-weight="800" fill="#f8fafc">Signals</text>
+    <text x="159" y="246" text-anchor="middle" font-size="16" fill="#cbd5e1">Cloud APIs</text>
+    <text x="159" y="272" text-anchor="middle" font-size="16" fill="#cbd5e1">Raw logs</text>
+    <text x="159" y="298" text-anchor="middle" font-size="16" fill="#cbd5e1">Identity systems</text>
+    <text x="159" y="324" text-anchor="middle" font-size="16" fill="#cbd5e1">Warehouses</text>
+    <text x="159" y="370" text-anchor="middle" font-size="14" fill="#94a3b8">AWS, GCP, Azure, K8s,</text>
+    <text x="159" y="392" text-anchor="middle" font-size="14" fill="#94a3b8">Okta, Entra, Workspace,</text>
+    <text x="159" y="414" text-anchor="middle" font-size="14" fill="#94a3b8">Snowflake, Databricks, S3</text>
+
+    <rect x="314" y="160" width="220" height="132" rx="18" fill="#112244" stroke="#60a5fa" stroke-width="1.5"/>
+    <text x="344" y="198" font-size="18" font-weight="800" fill="#dbeafe">L1 Ingest</text>
+    <text x="344" y="232" font-size="40" font-weight="800" fill="#f8fafc">15 + 3</text>
+    <text x="344" y="266" font-size="16" fill="#bfdbfe">normalize raw sources to OCSF or native JSONL</text>
+
+    <rect x="314" y="320" width="220" height="132" rx="18" fill="#112244" stroke="#60a5fa" stroke-width="1.5"/>
+    <text x="344" y="358" font-size="18" font-weight="800" fill="#dbeafe">L2 Discover</text>
+    <text x="344" y="392" font-size="40" font-weight="800" fill="#f8fafc">4</text>
+    <text x="344" y="426" font-size="16" fill="#bfdbfe">inventory, graphs, AI BOM, evidence collection</text>
+
+    <rect x="594" y="160" width="220" height="132" rx="18" fill="#0b3b32" stroke="#34d399" stroke-width="1.5"/>
+    <text x="624" y="198" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
+    <text x="624" y="232" font-size="40" font-weight="800" fill="#f8fafc">12</text>
+    <text x="624" y="266" font-size="16" fill="#a7f3d0">deterministic MITRE-tagged findings in OCSF 2004</text>
+
+    <rect x="594" y="320" width="220" height="132" rx="18" fill="#0b3b32" stroke="#34d399" stroke-width="1.5"/>
+    <text x="624" y="358" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
+    <text x="624" y="392" font-size="40" font-weight="800" fill="#f8fafc">7</text>
+    <text x="624" y="426" font-size="16" fill="#a7f3d0">82 CIS, Kubernetes, container, and AI checks</text>
+
+    <rect x="874" y="160" width="220" height="132" rx="18" fill="#4a290d" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="904" y="198" font-size="18" font-weight="800" fill="#fde68a">L5 Remediate</text>
+    <text x="904" y="232" font-size="40" font-weight="800" fill="#f8fafc">8</text>
+    <text x="904" y="266" font-size="16" fill="#fcd34d">HITL, dry-run-first, dual-audited write paths</text>
+
+    <rect x="874" y="320" width="220" height="132" rx="18" fill="#4a290d" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="904" y="358" font-size="18" font-weight="800" fill="#fde68a">L6 View</text>
+    <text x="904" y="392" font-size="40" font-weight="800" fill="#f8fafc">2</text>
+    <text x="904" y="426" font-size="16" fill="#fcd34d">render OCSF to SARIF or Mermaid for review</text>
+
+    <rect x="1154" y="160" width="182" height="292" rx="18" fill="#0a3d3b" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="1184" y="198" font-size="18" font-weight="800" fill="#99f6e4">L7 Output</text>
+    <text x="1184" y="232" font-size="40" font-weight="800" fill="#f8fafc">3</text>
+    <text x="1184" y="266" font-size="16" fill="#99f6e4">append-only JSONL sinks</text>
+    <text x="1184" y="312" font-size="16" fill="#ccfbf1">S3</text>
+    <text x="1184" y="338" font-size="16" fill="#ccfbf1">Snowflake</text>
+    <text x="1184" y="364" font-size="16" fill="#ccfbf1">ClickHouse</text>
+    <text x="1184" y="406" font-size="14" fill="#99f6e4">Audit and ingest-back stay</text>
+    <text x="1184" y="428" font-size="14" fill="#99f6e4">with the producer-owned flow.</text>
+
+    <path d="M254 306H298" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+    <path d="M534 226H578" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+    <path d="M534 386H578" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+    <path d="M814 226H858" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+    <path d="M814 386H858" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+    <path d="M1094 306H1138" stroke="#7dd3fc" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+
+    <rect x="64" y="484" width="1272" height="44" rx="14" fill="#111827" stroke="#334155" stroke-width="1"/>
+    <text x="92" y="512" font-size="16" fill="#cbd5e1">Wire contract by layer: OCSF 1.8 on ingest and detect, native where state and audit matter more, SARIF or Mermaid on view, pass-through on output.</text>
+  </g>
+</svg>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="420" viewBox="0 0 1400 420" role="img" aria-labelledby="runtime-title runtime-desc">
+  <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
+  <desc id="runtime-desc">Clean runtime diagram showing four invocation surfaces converging on the same shared skill bundle: MCP clients through the repo MCP server, CLI pipes, CI workflows, and cloud runners. The shared bundle emits native JSONL, OCSF, SARIF, Mermaid, and audited actions.</desc>
+
+  <defs>
+    <linearGradient id="runtimeBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#081122"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="runtimeGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#1f2a44" stroke-opacity="0.35" stroke-width="1"/>
+    </pattern>
+    <marker id="runtimeArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#c084fc"/>
+    </marker>
+  </defs>
+
+  <rect width="1400" height="420" fill="url(#runtimeBg)"/>
+  <rect width="1400" height="420" fill="url(#runtimeGrid)"/>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <text x="64" y="64" font-size="32" font-weight="800" fill="#f8fafc">Runtime surfaces: one shared skill bundle, four clean entry points</text>
+    <text x="64" y="96" font-size="16" fill="#a5b4fc">No surface re-implements the skill. Transport changes; execution core stays the same.</text>
+
+    <rect x="64" y="146" width="230" height="92" rx="18" fill="#2b1d59" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="92" y="182" font-size="18" font-weight="800" fill="#ede9fe">MCP clients</text>
+    <text x="92" y="208" font-size="16" fill="#ddd6fe">Claude, Codex, Cursor, Windsurf, Zed</text>
+
+    <rect x="64" y="258" width="230" height="92" rx="18" fill="#123b5f" stroke="#38bdf8" stroke-width="1.5"/>
+    <text x="92" y="294" font-size="18" font-weight="800" fill="#e0f2fe">Direct surfaces</text>
+    <text x="92" y="320" font-size="16" fill="#bae6fd">CLI pipes, CI workflows, cloud runners</text>
+
+    <rect x="372" y="176" width="280" height="144" rx="20" fill="#4a114f" stroke="#e879f9" stroke-width="1.5"/>
+    <text x="402" y="218" font-size="18" font-weight="800" fill="#fae8ff">Repo MCP server</text>
+    <text x="402" y="246" font-size="16" fill="#f5d0fe">auto-discovers `SKILL.md`</text>
+    <text x="402" y="270" font-size="16" fill="#f5d0fe">audits tool calls</text>
+    <text x="402" y="294" font-size="16" fill="#f5d0fe">enforces per-skill timeout and allowlist</text>
+
+    <rect x="732" y="146" width="338" height="204" rx="22" fill="#0b4a44" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="762" y="194" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
+    <text x="762" y="236" font-size="44" font-weight="800" fill="#f8fafc">54 skills</text>
+    <text x="762" y="270" font-size="18" fill="#99f6e4">`SKILL.md + src/ + tests/`</text>
+    <text x="762" y="308" font-size="16" fill="#ccfbf1">same audit, HITL, and execution logic on every surface</text>
+
+    <rect x="1146" y="146" width="190" height="204" rx="20" fill="#3f2a0b" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="1176" y="194" font-size="20" font-weight="800" fill="#fef3c7">Outputs</text>
+    <text x="1176" y="232" font-size="16" fill="#fde68a">native JSONL</text>
+    <text x="1176" y="256" font-size="16" fill="#fde68a">OCSF 1.8</text>
+    <text x="1176" y="280" font-size="16" fill="#fde68a">SARIF</text>
+    <text x="1176" y="304" font-size="16" fill="#fde68a">Mermaid</text>
+    <text x="1176" y="328" font-size="16" fill="#fde68a">audited actions</text>
+
+    <path d="M294 192H356" stroke="#c084fc" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
+    <path d="M294 304H708" stroke="#38bdf8" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
+    <path d="M652 248H708" stroke="#c084fc" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
+    <path d="M1070 248H1128" stroke="#2dd4bf" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
+
+    <text x="314" y="180" font-size="13" font-weight="700" fill="#c4b5fd">stdio</text>
+    <text x="494" y="292" font-size="13" font-weight="700" fill="#7dd3fc">invoke directly</text>
+  </g>
+</svg>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,61 +1,98 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="420" viewBox="0 0 1400 420" role="img" aria-labelledby="runtime-title runtime-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="620" viewBox="0 0 1400 620" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Clean runtime diagram showing four invocation surfaces converging on the same shared skill bundle: MCP clients through the repo MCP server, CLI pipes, CI workflows, and cloud runners. The shared bundle emits native JSONL, OCSF, SARIF, Mermaid, and audited actions.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram showing four invocation surfaces. MCP clients go through the repo MCP server. CLI, CI, and cloud runners call the same shared skill bundle directly. The shared bundle emits native JSONL, OCSF, SARIF, Mermaid, and audited actions. The diagram emphasizes that no surface reimplements the skills.</desc>
 
   <defs>
-    <linearGradient id="runtimeBg" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#081122"/>
       <stop offset="100%" stop-color="#111827"/>
     </linearGradient>
-    <pattern id="runtimeGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M40 0H0V40" fill="none" stroke="#1f2a44" stroke-opacity="0.35" stroke-width="1"/>
+    <radialGradient id="glow" cx="22%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
+      <path d="M36 0H0V36" fill="none" stroke="#1f2a44" stroke-opacity="0.35" stroke-width="1"/>
     </pattern>
-    <marker id="runtimeArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#020617" flood-opacity="0.45"/>
+    </filter>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
       <path d="M0 0L10 5L0 10z" fill="#c084fc"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#2dd4bf"/>
     </marker>
   </defs>
 
-  <rect width="1400" height="420" fill="url(#runtimeBg)"/>
-  <rect width="1400" height="420" fill="url(#runtimeGrid)"/>
+  <rect width="1400" height="620" fill="url(#bg)"/>
+  <rect width="1400" height="620" fill="url(#grid)"/>
+  <rect width="1400" height="620" fill="url(#glow)"/>
 
   <g font-family="Inter, Arial, sans-serif">
-    <text x="64" y="64" font-size="32" font-weight="800" fill="#f8fafc">Runtime surfaces: one shared skill bundle, four clean entry points</text>
-    <text x="64" y="96" font-size="16" fill="#a5b4fc">No surface re-implements the skill. Transport changes; execution core stays the same.</text>
+    <text x="72" y="76" font-size="38" font-weight="800" fill="#f8fafc">Runtime surfaces: one bundle, four real invocation paths</text>
+    <text x="72" y="112" font-size="18" fill="#cbd5e1">MCP adds transport and audit control. CLI, CI, and cloud runners call the same shipped skills directly.</text>
 
-    <rect x="64" y="146" width="230" height="92" rx="18" fill="#2b1d59" stroke="#a78bfa" stroke-width="1.5"/>
-    <text x="92" y="182" font-size="18" font-weight="800" fill="#ede9fe">MCP clients</text>
-    <text x="92" y="208" font-size="16" fill="#ddd6fe">Claude, Codex, Cursor, Windsurf, Zed</text>
+    <g filter="url(#shadow)">
+      <rect x="72" y="172" width="250" height="92" rx="24" fill="#2b1d59" stroke="#a78bfa" stroke-width="1.6"/>
+      <text x="104" y="212" font-size="22" font-weight="800" fill="#f5f3ff">MCP clients</text>
+      <text x="104" y="244" font-size="18" fill="#ddd6fe">Claude, Codex, Cursor, Windsurf, Zed</text>
 
-    <rect x="64" y="258" width="230" height="92" rx="18" fill="#123b5f" stroke="#38bdf8" stroke-width="1.5"/>
-    <text x="92" y="294" font-size="18" font-weight="800" fill="#e0f2fe">Direct surfaces</text>
-    <text x="92" y="320" font-size="16" fill="#bae6fd">CLI pipes, CI workflows, cloud runners</text>
+      <rect x="72" y="294" width="250" height="92" rx="24" fill="#123b5f" stroke="#38bdf8" stroke-width="1.6"/>
+      <text x="104" y="334" font-size="22" font-weight="800" fill="#e0f2fe">CLI</text>
+      <text x="104" y="366" font-size="18" fill="#bae6fd">stdin/stdout pipes between skill bundles</text>
 
-    <rect x="372" y="176" width="280" height="144" rx="20" fill="#4a114f" stroke="#e879f9" stroke-width="1.5"/>
-    <text x="402" y="218" font-size="18" font-weight="800" fill="#fae8ff">Repo MCP server</text>
-    <text x="402" y="246" font-size="16" fill="#f5d0fe">auto-discovers `SKILL.md`</text>
-    <text x="402" y="270" font-size="16" fill="#f5d0fe">audits tool calls</text>
-    <text x="402" y="294" font-size="16" fill="#f5d0fe">enforces per-skill timeout and allowlist</text>
+      <rect x="72" y="416" width="250" height="92" rx="24" fill="#134e4a" stroke="#2dd4bf" stroke-width="1.6"/>
+      <text x="104" y="456" font-size="22" font-weight="800" fill="#ccfbf1">CI</text>
+      <text x="104" y="488" font-size="18" fill="#99f6e4">GitHub Actions and SARIF publishing</text>
+    </g>
 
-    <rect x="732" y="146" width="338" height="204" rx="22" fill="#0b4a44" stroke="#2dd4bf" stroke-width="1.5"/>
-    <text x="762" y="194" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
-    <text x="762" y="236" font-size="44" font-weight="800" fill="#f8fafc">54 skills</text>
-    <text x="762" y="270" font-size="18" fill="#99f6e4">`SKILL.md + src/ + tests/`</text>
-    <text x="762" y="308" font-size="16" fill="#ccfbf1">same audit, HITL, and execution logic on every surface</text>
+    <g filter="url(#shadow)">
+      <rect x="400" y="172" width="300" height="182" rx="30" fill="#4a114f" stroke="#e879f9" stroke-width="1.6"/>
+      <text x="436" y="220" font-size="24" font-weight="800" fill="#fae8ff">Repo MCP server</text>
+      <text x="436" y="264" font-size="18" fill="#f5d0fe">auto-discovers `SKILL.md`</text>
+      <text x="436" y="296" font-size="18" fill="#f5d0fe">audits tool calls</text>
+      <text x="436" y="328" font-size="18" fill="#f5d0fe">enforces allowlist and timeout policy</text>
+    </g>
 
-    <rect x="1146" y="146" width="190" height="204" rx="20" fill="#3f2a0b" stroke="#fbbf24" stroke-width="1.5"/>
-    <text x="1176" y="194" font-size="20" font-weight="800" fill="#fef3c7">Outputs</text>
-    <text x="1176" y="232" font-size="16" fill="#fde68a">native JSONL</text>
-    <text x="1176" y="256" font-size="16" fill="#fde68a">OCSF 1.8</text>
-    <text x="1176" y="280" font-size="16" fill="#fde68a">SARIF</text>
-    <text x="1176" y="304" font-size="16" fill="#fde68a">Mermaid</text>
-    <text x="1176" y="328" font-size="16" fill="#fde68a">audited actions</text>
+    <g filter="url(#shadow)">
+      <rect x="780" y="150" width="360" height="380" rx="34" fill="#0b4a44" stroke="#2dd4bf" stroke-width="1.8"/>
+      <text x="824" y="212" font-size="28" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
+      <text x="824" y="298" font-size="78" font-weight="900" fill="#ffffff">54</text>
+      <text x="918" y="298" font-size="42" font-weight="800" fill="#ffffff">skills</text>
+      <text x="824" y="344" font-size="22" fill="#99f6e4">`SKILL.md + src/ + tests/`</text>
+      <text x="824" y="404" font-size="19" fill="#ccfbf1">same execution core, audit behavior, and HITL gates</text>
+      <text x="824" y="434" font-size="19" fill="#ccfbf1">regardless of whether the caller is MCP, CLI, CI, or a runner</text>
+    </g>
 
-    <path d="M294 192H356" stroke="#c084fc" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
-    <path d="M294 304H708" stroke="#38bdf8" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
-    <path d="M652 248H708" stroke="#c084fc" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
-    <path d="M1070 248H1128" stroke="#2dd4bf" stroke-width="3" fill="none" marker-end="url(#runtimeArrow)"/>
+    <g filter="url(#shadow)">
+      <rect x="1200" y="172" width="144" height="336" rx="28" fill="#4a2d09" stroke="#fbbf24" stroke-width="1.6"/>
+      <text x="1228" y="212" font-size="22" font-weight="800" fill="#fef3c7">Outputs</text>
+      <g font-size="20" fill="#fde68a">
+        <text x="1228" y="268">native JSONL</text>
+        <text x="1228" y="306">OCSF 1.8</text>
+        <text x="1228" y="344">SARIF</text>
+        <text x="1228" y="382">Mermaid</text>
+        <text x="1228" y="420">BOM / evidence</text>
+        <text x="1228" y="458">audited actions</text>
+      </g>
+    </g>
 
-    <text x="314" y="180" font-size="13" font-weight="700" fill="#c4b5fd">stdio</text>
-    <text x="494" y="292" font-size="13" font-weight="700" fill="#7dd3fc">invoke directly</text>
+    <g filter="url(#shadow)">
+      <rect x="400" y="402" width="300" height="106" rx="30" fill="#0f172a" stroke="#64748b" stroke-width="1.6"/>
+      <text x="436" y="444" font-size="22" font-weight="800" fill="#f8fafc">Cloud runners</text>
+      <text x="436" y="476" font-size="18" fill="#cbd5e1">AWS S3 + SQS, GCS + PubSub, Blob + EventGrid</text>
+    </g>
+
+    <path d="M322 218H382" stroke="#c084fc" stroke-width="4" fill="none" marker-end="url(#arrowPurple)"/>
+    <path d="M322 340H760" stroke="#38bdf8" stroke-width="4" fill="none" marker-end="url(#arrowTeal)"/>
+    <path d="M322 462H760" stroke="#2dd4bf" stroke-width="4" fill="none" marker-end="url(#arrowTeal)"/>
+    <path d="M700 262H760" stroke="#c084fc" stroke-width="4" fill="none" marker-end="url(#arrowPurple)"/>
+    <path d="M700 454H760" stroke="#94a3b8" stroke-width="4" fill="none" marker-end="url(#arrowTeal)"/>
+    <path d="M1140 340H1182" stroke="#2dd4bf" stroke-width="4" fill="none" marker-end="url(#arrowTeal)"/>
+
+    <text x="342" y="204" font-size="15" font-weight="700" fill="#c4b5fd">stdio</text>
+    <text x="520" y="330" font-size="15" font-weight="700" fill="#7dd3fc">invoke directly</text>
+    <text x="520" y="452" font-size="15" font-weight="700" fill="#99f6e4">event-driven invoke</text>
   </g>
 </svg>

--- a/skills/detection/detect-aws-open-security-group/src/detect.py
+++ b/skills/detection/detect-aws-open-security-group/src/detect.py
@@ -305,6 +305,15 @@ def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
         observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
     for cidr in native["public_cidrs_hit"]:
         observables.append({"name": "permission.cidr", "type": "Other", "value": cidr})
+    protocol = str((native["permission"] or {}).get("ipProtocol") or "")
+    if protocol:
+        observables.append({"name": "permission.protocol", "type": "Other", "value": protocol})
+    from_port = (native["permission"] or {}).get("fromPort")
+    if from_port is not None:
+        observables.append({"name": "permission.from_port", "type": "Other", "value": str(from_port)})
+    to_port = (native["permission"] or {}).get("toPort")
+    if to_port is not None:
+        observables.append({"name": "permission.to_port", "type": "Other", "value": str(to_port)})
     for port in native["risky_ports_hit"]:
         observables.append({"name": "permission.port", "type": "Other", "value": str(port)})
 

--- a/skills/detection/detect-aws-open-security-group/tests/test_detect.py
+++ b/skills/detection/detect-aws-open-security-group/tests/test_detect.py
@@ -99,6 +99,18 @@ def test_fires_on_ssh_open_to_world():
         obs["name"] == "permission.port" and obs["value"] == "22"
         for obs in f["observables"]
     )
+    assert any(
+        obs["name"] == "permission.protocol" and obs["value"] == "tcp"
+        for obs in f["observables"]
+    )
+    assert any(
+        obs["name"] == "permission.from_port" and obs["value"] == "22"
+        for obs in f["observables"]
+    )
+    assert any(
+        obs["name"] == "permission.to_port" and obs["value"] == "22"
+        for obs in f["observables"]
+    )
 
 
 def test_fires_on_ipv6_world_open():
@@ -123,6 +135,10 @@ def test_fires_on_protocol_neg_one_all_ports():
     """ipProtocol=-1 means all protocols+all ports; must fire."""
     findings = list(detect([_ct_event(cidrs_v4=["0.0.0.0/0"], protocol="-1", from_port=-1, to_port=-1)]))
     assert len(findings) == 1
+    assert any(
+        obs["name"] == "permission.protocol" and obs["value"] == "-1"
+        for obs in findings[0]["observables"]
+    )
 
 
 def test_native_output_format():

--- a/skills/remediation/remediate-aws-sg-revoke/src/handler.py
+++ b/skills/remediation/remediate-aws-sg-revoke/src/handler.py
@@ -90,6 +90,9 @@ class Target:
     account_uid: str
     cidrs: tuple[str, ...]
     ports: tuple[int, ...]
+    ip_protocol: str
+    from_port: int | None
+    to_port: int | None
     actor: str
     rule: str
     producer_skill: str
@@ -101,7 +104,13 @@ class EC2Client(Protocol):
 
     def describe_security_group(self, sg_id: str) -> dict[str, Any] | None: ...
     def revoke_security_group_ingress(
-        self, sg_id: str, *, cidrs: list[str], ports: list[int]
+        self,
+        sg_id: str,
+        *,
+        cidrs: list[str],
+        ip_protocol: str,
+        from_port: int | None,
+        to_port: int | None,
     ) -> None: ...
 
 
@@ -140,28 +149,30 @@ class Boto3EC2Client:
         return groups[0] if groups else None
 
     def revoke_security_group_ingress(
-        self, sg_id: str, *, cidrs: list[str], ports: list[int]
+        self,
+        sg_id: str,
+        *,
+        cidrs: list[str],
+        ip_protocol: str,
+        from_port: int | None,
+        to_port: int | None,
     ) -> None:
-        # Build IpPermissions for the revoke. We split per-port (every port
-        # in `ports` is revoked across every cidr in `cidrs`). EC2 accepts
-        # multiple IpPermissions in one call so this is one round trip.
-        ip_permissions: list[dict[str, Any]] = []
-        for port in ports:
-            perm: dict[str, Any] = {
-                "IpProtocol": "tcp",
-                "FromPort": port,
-                "ToPort": port,
-                "IpRanges": [{"CidrIp": cidr} for cidr in cidrs if "/" in cidr and ":" not in cidr],
-                "Ipv6Ranges": [{"CidrIpv6": cidr} for cidr in cidrs if ":" in cidr],
-            }
-            # Strip empty range lists so boto3 doesn't complain
-            if not perm["IpRanges"]:
-                del perm["IpRanges"]
-            if not perm["Ipv6Ranges"]:
-                del perm["Ipv6Ranges"]
-            ip_permissions.append(perm)
+        perm: dict[str, Any] = {
+            "IpProtocol": ip_protocol or "tcp",
+            "IpRanges": [{"CidrIp": cidr} for cidr in cidrs if "/" in cidr and ":" not in cidr],
+            "Ipv6Ranges": [{"CidrIpv6": cidr} for cidr in cidrs if ":" in cidr],
+        }
+        if perm["IpProtocol"] != "-1":
+            if from_port is not None:
+                perm["FromPort"] = from_port
+            if to_port is not None:
+                perm["ToPort"] = to_port
+        if not perm["IpRanges"]:
+            del perm["IpRanges"]
+        if not perm["Ipv6Ranges"]:
+            del perm["Ipv6Ranges"]
         self._client().revoke_security_group_ingress(
-            GroupId=sg_id, IpPermissions=ip_permissions
+            GroupId=sg_id, IpPermissions=[perm]
         )
 
 
@@ -272,6 +283,28 @@ def _observable_values(event: dict[str, Any], name: str) -> tuple[str, ...]:
     return tuple(values)
 
 
+def _safe_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_reference_time_ms(event: dict[str, Any]) -> int | None:
+    candidates = (
+        event.get("remediated_at_ms"),
+        event.get("time_ms"),
+        event.get("time"),
+        ((event.get("finding_info") or {}).get("last_seen_time")),
+        ((event.get("finding_info") or {}).get("first_seen_time")),
+    )
+    for value in candidates:
+        parsed = _safe_int(str(value)) if value is not None else None
+        if parsed is not None and parsed > 0:
+            return parsed
+    return None
+
+
 def _target_from_event(event: dict[str, Any]) -> Target | None:
     producer = _finding_product(event)
     if producer not in ACCEPTED_PRODUCERS:
@@ -292,14 +325,21 @@ def _target_from_event(event: dict[str, Any]) -> Target | None:
     port_strs = _observable_values(event, "permission.port")
     ports: list[int] = []
     for p in port_strs:
-        try:
-            ports.append(int(p))
-        except ValueError:
-            continue
+        parsed = _safe_int(p)
+        if parsed is not None:
+            ports.append(parsed)
+    ip_protocol = _observable_value(event, "permission.protocol") or "tcp"
+    from_port = _safe_int(_observable_value(event, "permission.from_port"))
+    to_port = _safe_int(_observable_value(event, "permission.to_port"))
+    if from_port is None and len(ports) == 1:
+        from_port = ports[0]
+    if to_port is None and len(ports) == 1:
+        to_port = ports[0]
 
     return Target(
         sg_id=sg_id, sg_name=sg_name, region=region, account_uid=account_uid,
-        cidrs=cidrs, ports=tuple(ports), actor=actor, rule=rule,
+        cidrs=cidrs, ports=tuple(ports), ip_protocol=ip_protocol, from_port=from_port, to_port=to_port,
+        actor=actor, rule=rule,
         producer_skill=producer, finding_uid=_finding_uid(event),
     )
 
@@ -348,7 +388,11 @@ def check_apply_gate() -> tuple[bool, str]:
 
 
 def _revoke_endpoint(target: Target) -> str:
-    return f"POST ec2:RevokeSecurityGroupIngress GroupId={target.sg_id}"
+    return (
+        "POST ec2:RevokeSecurityGroupIngress "
+        f"GroupId={target.sg_id} IpProtocol={target.ip_protocol or 'tcp'} "
+        f"FromPort={target.from_port!r} ToPort={target.to_port!r}"
+    )
 
 
 def _verify_endpoint(target: Target) -> str:
@@ -369,6 +413,9 @@ def _plan_record(target: Target, *, status: str, detail: str | None, dry_run: bo
             "account_uid": target.account_uid,
             "cidrs": list(target.cidrs),
             "ports": list(target.ports),
+            "ip_protocol": target.ip_protocol,
+            "from_port": target.from_port,
+            "to_port": target.to_port,
             "actor": target.actor,
             "rule": target.rule,
         },
@@ -395,6 +442,7 @@ def _skip_record(target: Target, *, status: str, detail: str, dry_run: bool) -> 
             "provider": "AWS", "sg_id": target.sg_id, "sg_name": target.sg_name,
             "region": target.region, "account_uid": target.account_uid,
             "cidrs": list(target.cidrs), "ports": list(target.ports),
+            "ip_protocol": target.ip_protocol, "from_port": target.from_port, "to_port": target.to_port,
             "actor": target.actor, "rule": target.rule,
         },
         "actions": [],
@@ -416,12 +464,19 @@ def revoke_ingress(
 ) -> dict[str, Any]:
     first = audit.record(
         target=target, step=STEP_REVOKE_INGRESS, status=STATUS_IN_PROGRESS,
-        detail=f"about to revoke {target.cidrs}:{target.ports} on {target.sg_id}",
+        detail=(
+            f"about to revoke {target.cidrs} protocol={target.ip_protocol or 'tcp'} "
+            f"ports={target.from_port!r}-{target.to_port!r} on {target.sg_id}"
+        ),
         incident_id=incident_id, approver=approver,
     )
     try:
         ec2_client.revoke_security_group_ingress(
-            target.sg_id, cidrs=list(target.cidrs), ports=list(target.ports),
+            target.sg_id,
+            cidrs=list(target.cidrs),
+            ip_protocol=target.ip_protocol,
+            from_port=target.from_port,
+            to_port=target.to_port,
         )
     except Exception as exc:
         audit.record(
@@ -434,7 +489,10 @@ def revoke_ingress(
 
     last = audit.record(
         target=target, step=STEP_REVOKE_INGRESS, status=STATUS_SUCCESS,
-        detail=f"revoked ingress {target.cidrs}:{target.ports} on {target.sg_id}",
+        detail=(
+            f"revoked ingress {target.cidrs} protocol={target.ip_protocol or 'tcp'} "
+            f"ports={target.from_port!r}-{target.to_port!r} on {target.sg_id}"
+        ),
         incident_id=incident_id, approver=approver,
     )
     rec = _plan_record(target, status=STATUS_SUCCESS, detail=None, dry_run=False)
@@ -458,15 +516,25 @@ def reverify_target(
 
     reference = RemediationReference(
         remediation_skill=SKILL_NAME,
-        remediation_action_uid=_deterministic_uid("revoke", target.sg_id, ",".join(target.cidrs)),
+        remediation_action_uid=_deterministic_uid(
+            "revoke",
+            target.sg_id,
+            ",".join(target.cidrs),
+            target.ip_protocol or "tcp",
+            str(target.from_port),
+            str(target.to_port),
+        ),
         target_provider="AWS",
-        target_identifier=f"{target.sg_id}/{','.join(target.cidrs)}:{','.join(str(p) for p in target.ports)}",
+        target_identifier=(
+            f"{target.sg_id}/{','.join(target.cidrs)}:"
+            f"{target.ip_protocol or 'tcp'}:{target.from_port!r}-{target.to_port!r}"
+        ),
         original_finding_uid=target.finding_uid,
         remediated_at_ms=remediated_at_ms_resolved,
     )
     expected = (
-        f"no IpPermissions on `{target.sg_id}` granting `{list(target.cidrs)}` to ports "
-        f"{list(target.ports)}"
+        f"no IpPermissions on `{target.sg_id}` granting `{list(target.cidrs)}` for protocol "
+        f"`{target.ip_protocol or 'tcp'}` ports `{target.from_port!r}`-`{target.to_port!r}`"
     )
 
     try:
@@ -495,31 +563,35 @@ def reverify_target(
             detail="containment confirmed via absence",
         )
     else:
-        # Look for any IpPermission still granting any cidr in target.cidrs to any
-        # port in target.ports
+        # Look for any IpPermission still granting the original protocol/range
+        # shape to any cidr in target.cidrs.
         offending: list[dict[str, Any]] = []
         target_cidrs = set(target.cidrs)
-        target_ports = set(target.ports)
+        target_protocol = (target.ip_protocol or "tcp").lower()
         for perm in sg.get("IpPermissions") or []:
-            from_p = perm.get("FromPort")
-            to_p = perm.get("ToPort")
-            try:
-                lo = int(from_p) if from_p is not None else None
-                hi = int(to_p) if to_p is not None else None
-            except (TypeError, ValueError):
-                lo = hi = None
-            if lo is not None and hi is not None:
-                covered = {p for p in target_ports if lo <= p <= hi}
+            perm_protocol = str(perm.get("IpProtocol") or "").lower()
+            protocol_matches = perm_protocol == target_protocol
+            if target_protocol == "-1":
+                ports_match = True
             else:
-                covered = set()
+                perm_from = _safe_int(str(perm.get("FromPort"))) if perm.get("FromPort") is not None else None
+                perm_to = _safe_int(str(perm.get("ToPort"))) if perm.get("ToPort") is not None else None
+                ports_match = perm_from == target.from_port and perm_to == target.to_port
             cidrs_in_perm = {
                 str((r or {}).get("CidrIp", "")) for r in perm.get("IpRanges") or []
             } | {
                 str((r or {}).get("CidrIpv6", "")) for r in perm.get("Ipv6Ranges") or []
             }
             cidr_overlap = target_cidrs & cidrs_in_perm
-            if covered and cidr_overlap:
-                offending.append({"cidrs": sorted(cidr_overlap), "ports": sorted(covered)})
+            if protocol_matches and ports_match and cidr_overlap:
+                offending.append(
+                    {
+                        "cidrs": sorted(cidr_overlap),
+                        "ip_protocol": perm_protocol,
+                        "from_port": perm.get("FromPort"),
+                        "to_port": perm.get("ToPort"),
+                    }
+                )
 
         if offending:
             result = VerificationResult(
@@ -581,7 +653,7 @@ def run(
     name_prefixes = tuple(name_prefixes)
     sg_ids = tuple(sg_ids)
 
-    for target, _ in parse_targets(events):
+    for target, event in parse_targets(events):
         if target is None:
             continue
 
@@ -614,13 +686,20 @@ def run(
             continue
 
         if reverify:
-            yield from reverify_target(target, ec2_client=ec2_client)
+            yield from reverify_target(
+                target,
+                ec2_client=ec2_client,
+                remediated_at_ms=_event_reference_time_ms(event),
+            )
             continue
 
         if not apply:
             yield _plan_record(
                 target, status=STATUS_PLANNED,
-                detail=f"dry-run: would revoke {list(target.cidrs)}:{list(target.ports)} on {target.sg_id}",
+                detail=(
+                    f"dry-run: would revoke {list(target.cidrs)} protocol={target.ip_protocol or 'tcp'} "
+                    f"ports={target.from_port!r}-{target.to_port!r} on {target.sg_id}"
+                ),
                 dry_run=True,
             )
             continue

--- a/skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py
@@ -33,10 +33,17 @@ def _finding(
     sg_name: str = "web-tier",
     cidrs: list[str] | None = None,
     ports: list[int] | None = None,
+    ip_protocol: str = "tcp",
+    from_port: int | None = None,
+    to_port: int | None = None,
     omit_sg_id: bool = False,
 ) -> dict:
     cidrs = cidrs if cidrs is not None else ["0.0.0.0/0"]
     ports = ports if ports is not None else [22]
+    if from_port is None and ports:
+        from_port = ports[0]
+    if to_port is None and ports:
+        to_port = ports[-1]
     obs: list[dict] = [
         {"name": "cloud.provider", "type": "Other", "value": "AWS"},
         {"name": "actor.name", "type": "Other", "value": "alice"},
@@ -46,9 +53,14 @@ def _finding(
         {"name": "target.type", "type": "Other", "value": "SecurityGroup"},
         {"name": "account.uid", "type": "Other", "value": "111122223333"},
         {"name": "region", "type": "Other", "value": "us-east-1"},
+        {"name": "permission.protocol", "type": "Other", "value": ip_protocol},
     ]
     if not omit_sg_id:
         obs.append({"name": "target.uid", "type": "Other", "value": sg_id})
+    if from_port is not None:
+        obs.append({"name": "permission.from_port", "type": "Other", "value": str(from_port)})
+    if to_port is not None:
+        obs.append({"name": "permission.to_port", "type": "Other", "value": str(to_port)})
     for c in cidrs:
         obs.append({"name": "permission.cidr", "type": "Other", "value": c})
     for p in ports:
@@ -78,27 +90,25 @@ class _FakeEC2:
     sgs: dict[str, dict] = field(default_factory=dict)
     raise_on_describe: bool = False
     raise_on_revoke: bool = False
-    revokes: list[tuple[str, list[str], list[int]]] = field(default_factory=list)
+    revokes: list[tuple[str, list[str], str, int | None, int | None]] = field(default_factory=list)
 
     def describe_security_group(self, sg_id):
         if self.raise_on_describe:
             raise RuntimeError("simulated ec2 502")
         return self.sgs.get(sg_id)
 
-    def revoke_security_group_ingress(self, sg_id, *, cidrs, ports):
+    def revoke_security_group_ingress(self, sg_id, *, cidrs, ip_protocol, from_port, to_port):
         if self.raise_on_revoke:
             raise RuntimeError("simulated ec2 403")
-        self.revokes.append((sg_id, list(cidrs), list(ports)))
+        self.revokes.append((sg_id, list(cidrs), ip_protocol, from_port, to_port))
         # Update the in-memory SG to reflect the revoke
         sg = self.sgs.setdefault(sg_id, {"GroupId": sg_id, "GroupName": "x", "IpPermissions": [], "Tags": []})
         keep = []
         for perm in sg.get("IpPermissions") or []:
-            from_p, to_p = perm.get("FromPort"), perm.get("ToPort")
-            try:
-                lo, hi = int(from_p), int(to_p)
-            except (TypeError, ValueError):
-                lo = hi = None
-            if lo is not None and hi is not None and any(lo <= p <= hi for p in ports):
+            perm_protocol = str(perm.get("IpProtocol") or "")
+            if perm_protocol == ip_protocol and (
+                ip_protocol == "-1" or (perm.get("FromPort") == from_port and perm.get("ToPort") == to_port)
+            ):
                 # Drop cidrs that match
                 new_v4 = [r for r in perm.get("IpRanges") or []
                           if (r or {}).get("CidrIp") not in cidrs]
@@ -146,10 +156,17 @@ def test_check_apply_gate_requires_both_envs(monkeypatch):
 
 
 def test_parse_targets_extracts_full_target():
-    target, _ = next(parse_targets([_finding(cidrs=["0.0.0.0/0", "::/0"], ports=[22, 3306])]))
+    target, _ = next(
+        parse_targets(
+            [_finding(cidrs=["0.0.0.0/0", "::/0"], ports=[22, 3306], from_port=22, to_port=3306)]
+        )
+    )
     assert target.sg_id == "sg-rogue"
     assert target.cidrs == ("0.0.0.0/0", "::/0")
     assert target.ports == (22, 3306)
+    assert target.ip_protocol == "tcp"
+    assert target.from_port == 22
+    assert target.to_port == 3306
     assert target.account_uid == "111122223333"
 
 
@@ -166,7 +183,7 @@ def test_parse_targets_rejects_wrong_producer(capsys):
 
 def _t(**overrides) -> Target:
     base = dict(sg_id="sg-x", sg_name="x", region="us-east-1", account_uid="1",
-                cidrs=("0.0.0.0/0",), ports=(22,), actor="a", rule="r",
+                cidrs=("0.0.0.0/0",), ports=(22,), ip_protocol="tcp", from_port=22, to_port=22, actor="a", rule="r",
                 producer_skill="detect-aws-open-security-group", finding_uid="f")
     base.update(overrides)
     return Target(**base)
@@ -264,10 +281,37 @@ def test_run_apply_revokes_with_dual_audit():
     rec = records[0]
     assert rec["status"] == STATUS_SUCCESS
     assert rec["dry_run"] is False
-    assert ec2.revokes == [("sg-rogue", ["0.0.0.0/0"], [22])]
+    assert ec2.revokes == [("sg-rogue", ["0.0.0.0/0"], "tcp", 22, 22)]
     assert len(audit.writes) == 2
     assert audit.writes[0]["status"] == STATUS_IN_PROGRESS
     assert audit.writes[1]["status"] == STATUS_SUCCESS
+
+
+def test_run_apply_revokes_all_protocol_permission_with_exact_shape():
+    audit = _FakeAudit()
+    ec2 = _FakeEC2(
+        sgs={
+            "sg-rogue": {
+                "GroupId": "sg-rogue",
+                "Tags": [],
+                "IpPermissions": [
+                    {"IpProtocol": "-1", "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},
+                ],
+            }
+        }
+    )
+    records = list(
+        run(
+            [_finding(ports=[22, 3389], ip_protocol="-1", from_port=-1, to_port=-1)],
+            ec2_client=ec2,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+        )
+    )
+    assert records[0]["status"] == STATUS_SUCCESS
+    assert ec2.revokes == [("sg-rogue", ["0.0.0.0/0"], "-1", -1, -1)]
 
 
 def test_run_apply_writes_failure_audit_when_revoke_throws():
@@ -321,6 +365,14 @@ def test_run_reverify_drift_emits_ocsf_finding_alongside_verification():
         obs["name"] == "remediation.skill" and obs["value"] == "remediate-aws-sg-revoke"
         for obs in finding["observables"]
     )
+
+
+def test_run_reverify_uses_finding_time_as_remediation_reference():
+    ec2 = _FakeEC2(sgs={"sg-rogue": {"GroupId": "sg-rogue", "Tags": [], "IpPermissions": []}})
+    event = _finding()
+    event["time"] = 1700000000123
+    records = list(run([event], ec2_client=ec2, reverify=True))
+    assert records[0]["reference"]["remediated_at_ms"] == 1700000000123
 
 
 def test_run_reverify_unreachable_never_silently_downgrades():

--- a/skills/remediation/remediate-entra-credential-revoke/src/handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/src/handler.py
@@ -56,15 +56,14 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import hashlib
+import http.client
 import json
 import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Protocol
-from urllib import error as urllib_error
 from urllib import parse as urllib_parse
-from urllib import request as urllib_request
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
@@ -198,20 +197,33 @@ class MsGraphClient:
         body: dict[str, Any] | None = None,
         allow_not_found: bool = False,
     ) -> Any | None:
-        data = None
+        parsed = urllib_parse.urlsplit(url)
+        if parsed.scheme != "https" or parsed.netloc != "graph.microsoft.com":
+            raise RuntimeError(f"refusing non-Microsoft Graph URL `{url}`")
+        body_bytes = None
         headers = {"Authorization": f"Bearer {self._token()}"}
         if body is not None:
-            data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            body_bytes = json.dumps(body, separators=(",", ":")).encode("utf-8")
             headers["Content-Type"] = "application/json"
-        request = urllib_request.Request(url=url, data=data, method=method.upper(), headers=headers)
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        connection = http.client.HTTPSConnection(parsed.netloc)
         try:
-            with urllib_request.urlopen(request) as response:
-                payload = response.read()
-        except urllib_error.HTTPError as exc:
-            if exc.code == 404 and allow_not_found:
+            connection.request(method.upper(), path, body=body_bytes, headers=headers)
+            response = connection.getresponse()
+            payload = response.read()
+        except OSError as exc:
+            raise RuntimeError(f"Microsoft Graph connection failed: {exc}") from exc
+        finally:
+            connection.close()
+        if response.status >= 400:
+            if response.status == 404 and allow_not_found:
                 return None
-            detail = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"Microsoft Graph {exc.code}: {detail or exc.reason}") from exc
+            detail = payload.decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Microsoft Graph {response.status}: {detail or response.reason}"
+            )
         if not payload:
             return None
         return json.loads(payload)

--- a/skills/remediation/remediate-entra-credential-revoke/src/handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/src/handler.py
@@ -62,6 +62,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Protocol
+from urllib import error as urllib_error
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
@@ -133,9 +136,19 @@ class Target:
     finding_uid: str
 
 
+@dataclasses.dataclass(frozen=True)
+class ResolvedServicePrincipal:
+    object_id: str
+    display_name: str
+    app_id: str
+    source_target_type: str
+    source_object_id: str
+
+
 class GraphClient(Protocol):
     """Microsoft Graph API surface this skill needs. Tests inject a stub."""
 
+    def resolve_service_principal(self, target: Target) -> ResolvedServicePrincipal | None: ...
     def get_service_principal(self, object_id: str) -> dict[str, Any] | None: ...
     def disable_service_principal(self, object_id: str) -> None: ...
     def list_key_credentials(self, object_id: str) -> list[dict[str, Any]]: ...
@@ -159,45 +172,172 @@ class AuditWriter(Protocol):
 
 @dataclasses.dataclass
 class MsGraphClient:
-    """Real Microsoft Graph client. Built lazily so tests don't require msgraph-sdk."""
+    """Real Microsoft Graph REST client. Built lazily so tests don't require Azure SDKs."""
 
     tenant_id: str
     client_id: str
     client_secret: str
 
-    def _client(self) -> Any:
-        # Lazy import — tests inject a stub Protocol implementation.
+    def _credential(self) -> Any:
         from azure.identity import ClientSecretCredential
-        from msgraph import GraphServiceClient
 
-        credential = ClientSecretCredential(
+        return ClientSecretCredential(
             tenant_id=self.tenant_id,
             client_id=self.client_id,
             client_secret=self.client_secret,
         )
-        return GraphServiceClient(credentials=credential)
+
+    def _token(self) -> str:
+        return self._credential().get_token("https://graph.microsoft.com/.default").token
+
+    def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        body: dict[str, Any] | None = None,
+        allow_not_found: bool = False,
+    ) -> Any | None:
+        data = None
+        headers = {"Authorization": f"Bearer {self._token()}"}
+        if body is not None:
+            data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib_request.Request(url=url, data=data, method=method.upper(), headers=headers)
+        try:
+            with urllib_request.urlopen(request) as response:
+                payload = response.read()
+        except urllib_error.HTTPError as exc:
+            if exc.code == 404 and allow_not_found:
+                return None
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Microsoft Graph {exc.code}: {detail or exc.reason}") from exc
+        if not payload:
+            return None
+        return json.loads(payload)
+
+    def _collection(self, url: str) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        next_url: str | None = url
+        while next_url:
+            payload = self._request_json("GET", next_url)
+            if not isinstance(payload, dict):
+                break
+            value = payload.get("value")
+            if isinstance(value, list):
+                items.extend(item for item in value if isinstance(item, dict))
+            raw_next = payload.get("@odata.nextLink")
+            next_url = str(raw_next) if raw_next else None
+        return items
+
+    def _service_principal_base_url(self, object_id: str) -> str:
+        object_id_q = urllib_parse.quote(object_id, safe="")
+        return f"https://graph.microsoft.com/v1.0/servicePrincipals/{object_id_q}"
+
+    def _service_principal_url(self, object_id: str, *, select: str) -> str:
+        return f"{self._service_principal_base_url(object_id)}?$select={select}"
+
+    def _application_url(self, object_id: str, *, select: str) -> str:
+        object_id_q = urllib_parse.quote(object_id, safe="")
+        return f"https://graph.microsoft.com/v1.0/applications/{object_id_q}?$select={select}"
+
+    def _service_principals_by_app_id_url(self, app_id: str, *, select: str) -> str:
+        escaped = app_id.replace("'", "''")
+        filter_expr = urllib_parse.quote(f"appId eq '{escaped}'", safe="'")
+        return (
+            "https://graph.microsoft.com/v1.0/servicePrincipals"
+            f"?$filter={filter_expr}&$select={select}"
+        )
+
+    def resolve_service_principal(self, target: Target) -> ResolvedServicePrincipal | None:
+        if target.target_type == "Application":
+            app = self._request_json(
+                "GET",
+                self._application_url(target.object_id, select="id,appId,displayName"),
+                allow_not_found=True,
+            )
+            if app is None:
+                return None
+            if not isinstance(app, dict):
+                raise RuntimeError("Microsoft Graph returned a non-object application response")
+            app_id = str(app.get("appId") or "")
+            if not app_id:
+                raise RuntimeError(f"application `{target.object_id}` is missing appId")
+            matches = self._collection(
+                self._service_principals_by_app_id_url(
+                    app_id,
+                    select="id,appId,displayName,accountEnabled",
+                )
+            )
+            if not matches:
+                return None
+            if len(matches) > 1:
+                raise RuntimeError(
+                    f"application `{target.object_id}` resolved to multiple service principals for appId `{app_id}`"
+                )
+            match = matches[0]
+            return ResolvedServicePrincipal(
+                object_id=str(match.get("id") or ""),
+                display_name=str(match.get("displayName") or target.display_name or target.object_id),
+                app_id=str(match.get("appId") or app_id),
+                source_target_type=target.target_type,
+                source_object_id=target.object_id,
+            )
+        sp = self.get_service_principal(target.object_id)
+        if sp is None:
+            return None
+        return ResolvedServicePrincipal(
+            object_id=str(sp.get("id") or target.object_id),
+            display_name=str(sp.get("displayName") or target.display_name or target.object_id),
+            app_id=str(sp.get("appId") or ""),
+            source_target_type=target.target_type or "ServicePrincipal",
+            source_object_id=target.object_id,
+        )
 
     def get_service_principal(self, object_id: str) -> dict[str, Any] | None:
-        # Implementation note: msgraph-sdk is async; production wiring runs
-        # this under asyncio.run() in the entrypoint when --apply is set.
-        # For dry-run / reverify without msgraph-sdk available, tests stub
-        # this method entirely.
-        raise NotImplementedError("MsGraphClient is a thin shell; production path requires msgraph-sdk wiring")
+        payload = self._request_json(
+            "GET",
+            self._service_principal_url(
+                object_id,
+                select="id,appId,displayName,accountEnabled,keyCredentials,passwordCredentials",
+            ),
+            allow_not_found=True,
+        )
+        if payload is None:
+            return None
+        if not isinstance(payload, dict):
+            raise RuntimeError("Microsoft Graph returned a non-object servicePrincipal response")
+        return payload
 
     def disable_service_principal(self, object_id: str) -> None:
-        raise NotImplementedError
+        self._request_json(
+            "PATCH",
+            self._service_principal_base_url(object_id),
+            body={"accountEnabled": False},
+        )
 
     def list_key_credentials(self, object_id: str) -> list[dict[str, Any]]:
-        raise NotImplementedError
+        sp = self.get_service_principal(object_id) or {}
+        values = sp.get("keyCredentials") or []
+        return [item for item in values if isinstance(item, dict)]
 
     def list_password_credentials(self, object_id: str) -> list[dict[str, Any]]:
-        raise NotImplementedError
+        sp = self.get_service_principal(object_id) or {}
+        values = sp.get("passwordCredentials") or []
+        return [item for item in values if isinstance(item, dict)]
 
     def list_app_role_assignments(self, object_id: str) -> list[dict[str, Any]]:
-        raise NotImplementedError
+        return self._collection(
+            f"{self._service_principal_base_url(object_id)}/appRoleAssignments"
+        )
 
     def list_oauth2_permission_grants(self, object_id: str) -> list[dict[str, Any]]:
-        raise NotImplementedError
+        escaped = object_id.replace("'", "''")
+        filter_expr = urllib_parse.quote(f"clientId eq '{escaped}'", safe="'")
+        return self._collection(
+            "https://graph.microsoft.com/v1.0/oauth2PermissionGrants"
+            f"?$filter={filter_expr}&$select=id,clientId,resourceId,scope,consentType"
+        )
 
 
 @dataclasses.dataclass
@@ -313,6 +453,28 @@ def _observable_value(event: dict[str, Any], name: str) -> str:
     return ""
 
 
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_reference_time_ms(event: dict[str, Any]) -> int | None:
+    candidates = (
+        event.get("remediated_at_ms"),
+        event.get("time_ms"),
+        event.get("time"),
+        ((event.get("finding_info") or {}).get("last_seen_time")),
+        ((event.get("finding_info") or {}).get("first_seen_time")),
+    )
+    for value in candidates:
+        parsed = _safe_int(value)
+        if parsed is not None and parsed > 0:
+            return parsed
+    return None
+
+
 def _target_from_event(event: dict[str, Any]) -> Target | None:
     producer = _finding_product(event)
     if producer not in ACCEPTED_PRODUCERS:
@@ -372,25 +534,38 @@ def check_apply_gate() -> tuple[bool, str]:
     return True, ""
 
 
-def _disable_endpoint(object_id: str) -> str:
+def _disable_endpoint(resolved: ResolvedServicePrincipal) -> str:
     # Microsoft Graph: PATCH /servicePrincipals/{id} with {"accountEnabled": false}
-    return f"PATCH /v1.0/servicePrincipals/{object_id}"
+    return f"PATCH /v1.0/servicePrincipals/{resolved.object_id}"
 
 
-def _triage_endpoint(object_id: str) -> str:
+def _triage_endpoint(resolved: ResolvedServicePrincipal) -> str:
     return (
-        f"GET /v1.0/servicePrincipals/{object_id} "
+        f"GET /v1.0/servicePrincipals/{resolved.object_id} "
         "(keyCredentials, passwordCredentials, appRoleAssignments, oauth2PermissionGrants)"
     )
 
 
-def _build_triage_payload(target: Target, *, graph_client: GraphClient) -> dict[str, Any]:
+def _resolved_target(target: Target, resolved: ResolvedServicePrincipal) -> Target:
+    return Target(
+        object_id=resolved.object_id,
+        display_name=resolved.display_name or target.display_name,
+        target_type="ServicePrincipal",
+        actor=target.actor,
+        api_operation=target.api_operation,
+        rule=target.rule,
+        producer_skill=target.producer_skill,
+        finding_uid=target.finding_uid,
+    )
+
+
+def _build_triage_payload(resolved: ResolvedServicePrincipal, *, graph_client: GraphClient) -> dict[str, Any]:
     """Read the SP's current credentials + assignments; bundle for operator triage."""
     return {
-        "key_credentials": graph_client.list_key_credentials(target.object_id),
-        "password_credentials": graph_client.list_password_credentials(target.object_id),
-        "app_role_assignments": graph_client.list_app_role_assignments(target.object_id),
-        "oauth2_permission_grants": graph_client.list_oauth2_permission_grants(target.object_id),
+        "key_credentials": graph_client.list_key_credentials(resolved.object_id),
+        "password_credentials": graph_client.list_password_credentials(resolved.object_id),
+        "app_role_assignments": graph_client.list_app_role_assignments(resolved.object_id),
+        "oauth2_permission_grants": graph_client.list_oauth2_permission_grants(resolved.object_id),
     }
 
 
@@ -401,7 +576,17 @@ def _plan_record(
     detail: str | None,
     dry_run: bool,
     triage: dict[str, Any] | None = None,
+    resolved: ResolvedServicePrincipal | None = None,
 ) -> dict[str, Any]:
+    resolved_section = None
+    if resolved is not None:
+        resolved_section = {
+            "object_id": resolved.object_id,
+            "display_name": resolved.display_name,
+            "app_id": resolved.app_id,
+            "source_target_type": resolved.source_target_type,
+            "source_object_id": resolved.source_object_id,
+        }
     return {
         "schema_mode": "native",
         "canonical_schema_version": CANONICAL_VERSION,
@@ -418,17 +603,18 @@ def _plan_record(
         "actions": [
             {
                 "step": STEP_DISABLE_SP,
-                "endpoint": _disable_endpoint(target.object_id),
+                "endpoint": _disable_endpoint(resolved) if resolved is not None else "PATCH /v1.0/servicePrincipals/<resolved-target>",
                 "status": status,
                 "detail": detail,
             },
             {
                 "step": STEP_TRIAGE_LIST,
-                "endpoint": _triage_endpoint(target.object_id),
+                "endpoint": _triage_endpoint(resolved) if resolved is not None else "GET /v1.0/servicePrincipals/<resolved-target> (...)",
                 "status": status,
                 "detail": "list current credentials + assignments for operator triage",
             },
         ],
+        "resolved_service_principal": resolved_section,
         "triage": triage,
         "status": status,
         "dry_run": dry_run,
@@ -468,34 +654,52 @@ def disable_and_triage(
     incident_id: str,
     approver: str,
 ) -> dict[str, Any]:
+    resolved = graph_client.resolve_service_principal(target)
+    if resolved is None:
+        return _plan_record(
+            target,
+            status=STATUS_FAILURE,
+            detail=(
+                "could not resolve a backing service principal for "
+                f"{target.target_type or 'target'} `{target.object_id}`"
+            ),
+            dry_run=False,
+        )
+    audit_target = _resolved_target(target, resolved)
     first_audit = audit.record(
-        target=target,
+        target=audit_target,
         step=STEP_DISABLE_SP,
         status=STATUS_IN_PROGRESS,
-        detail=f"about to disable service principal `{target.object_id}`",
+        detail=f"about to disable service principal `{resolved.object_id}`",
         incident_id=incident_id,
         approver=approver,
     )
     try:
-        graph_client.disable_service_principal(target.object_id)
+        graph_client.disable_service_principal(resolved.object_id)
     except Exception as exc:
         audit.record(
-            target=target,
+            target=audit_target,
             step=STEP_DISABLE_SP,
             status=STATUS_FAILURE,
             detail=str(exc),
             incident_id=incident_id,
             approver=approver,
         )
-        record = _plan_record(target, status=STATUS_FAILURE, detail=str(exc), dry_run=False)
+        record = _plan_record(
+            target,
+            status=STATUS_FAILURE,
+            detail=str(exc),
+            dry_run=False,
+            resolved=resolved,
+        )
         record["audit"] = first_audit
         return record
 
     audit.record(
-        target=target,
+        target=audit_target,
         step=STEP_DISABLE_SP,
         status=STATUS_SUCCESS,
-        detail=f"disabled `{target.object_id}` (accountEnabled=false)",
+        detail=f"disabled `{resolved.object_id}` (accountEnabled=false)",
         incident_id=incident_id,
         approver=approver,
     )
@@ -504,7 +708,7 @@ def disable_and_triage(
     # disable step — the SP is contained either way and the operator can rerun
     # triage manually.
     try:
-        triage = _build_triage_payload(target, graph_client=graph_client)
+        triage = _build_triage_payload(resolved, graph_client=graph_client)
         triage_detail = (
             f"listed {len(triage['key_credentials'])} keys, "
             f"{len(triage['password_credentials'])} passwords, "
@@ -512,7 +716,7 @@ def disable_and_triage(
             f"{len(triage['oauth2_permission_grants'])} OAuth2 grants"
         )
         triage_audit = audit.record(
-            target=target,
+            target=audit_target,
             step=STEP_TRIAGE_LIST,
             status=STATUS_SUCCESS,
             detail=triage_detail,
@@ -523,7 +727,7 @@ def disable_and_triage(
         triage = None
         triage_detail = f"triage list failed: {exc}"
         triage_audit = audit.record(
-            target=target,
+            target=audit_target,
             step=STEP_TRIAGE_LIST,
             status=STATUS_FAILURE,
             detail=str(exc),
@@ -537,6 +741,7 @@ def disable_and_triage(
         detail="disabled service principal; triage payload attached",
         dry_run=False,
         triage=triage,
+        resolved=resolved,
     )
     # Mark the second action with the actual triage outcome
     record["actions"][1]["status"] = "success" if triage is not None else "failure"
@@ -570,14 +775,14 @@ def reverify_target(
     expected = f"service principal `{target.object_id}` has accountEnabled=false"
 
     try:
-        sp = graph_client.get_service_principal(target.object_id)
+        resolved = graph_client.resolve_service_principal(target)
     except Exception as exc:
         result = VerificationResult(
             status=VerificationStatus.UNREACHABLE,
             checked_at_ms=checked_at_ms,
             sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
             expected_state=expected,
-            actual_state="microsoft graph call raised; cannot determine state",
+            actual_state="microsoft graph resolution raised; cannot determine state",
             detail=str(exc),
         )
         record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
@@ -588,7 +793,7 @@ def reverify_target(
         }
         return [record]
 
-    if sp is None:
+    if resolved is None:
         # SP is gone entirely. That's a STRONGER state than disabled — counts as
         # verified containment. Operator may also want to know it was deleted.
         result = VerificationResult(
@@ -596,27 +801,49 @@ def reverify_target(
             checked_at_ms=checked_at_ms,
             sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
             expected_state=expected,
-            actual_state="service principal not found (deleted or never existed) — stronger than disabled",
+            actual_state="backing service principal not found (deleted or never existed) — stronger than disabled",
             detail="containment confirmed via absence",
         )
-    elif sp.get("accountEnabled") is False:
-        result = VerificationResult(
-            status=VerificationStatus.VERIFIED,
-            checked_at_ms=checked_at_ms,
-            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
-            expected_state=expected,
-            actual_state="accountEnabled=false",
-            detail="service principal still disabled",
-        )
     else:
-        result = VerificationResult(
-            status=VerificationStatus.DRIFT,
-            checked_at_ms=checked_at_ms,
-            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
-            expected_state=expected,
-            actual_state=f"accountEnabled={sp.get('accountEnabled')!r}",
-            detail="service principal was re-enabled after remediation",
-        )
+        try:
+            sp = graph_client.get_service_principal(resolved.object_id)
+        except Exception as exc:
+            result = VerificationResult(
+                status=VerificationStatus.UNREACHABLE,
+                checked_at_ms=checked_at_ms,
+                sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+                expected_state=expected,
+                actual_state="microsoft graph call raised; cannot determine state",
+                detail=str(exc),
+            )
+        else:
+            if sp is None:
+                result = VerificationResult(
+                    status=VerificationStatus.VERIFIED,
+                    checked_at_ms=checked_at_ms,
+                    sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+                    expected_state=expected,
+                    actual_state="service principal not found (deleted) — stronger than disabled",
+                    detail="containment confirmed via absence",
+                )
+            elif sp.get("accountEnabled") is False:
+                result = VerificationResult(
+                    status=VerificationStatus.VERIFIED,
+                    checked_at_ms=checked_at_ms,
+                    sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+                    expected_state=expected,
+                    actual_state="accountEnabled=false",
+                    detail="service principal still disabled",
+                )
+            else:
+                result = VerificationResult(
+                    status=VerificationStatus.DRIFT,
+                    checked_at_ms=checked_at_ms,
+                    sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+                    expected_state=expected,
+                    actual_state=f"accountEnabled={sp.get('accountEnabled')!r}",
+                    detail="service principal was re-enabled after remediation",
+                )
 
     record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
     record["target"] = {
@@ -675,7 +902,7 @@ def run(
     name_prefixes = tuple(name_prefixes)
     object_ids = tuple(object_ids)
 
-    for target, _ in parse_targets(events):
+    for target, event in parse_targets(events):
         if target is None:
             continue
 
@@ -716,7 +943,11 @@ def run(
             continue
 
         if reverify:
-            yield from reverify_target(target, graph_client=graph_client)
+            yield from reverify_target(
+                target,
+                graph_client=graph_client,
+                remediated_at_ms=_event_reference_time_ms(event),
+            )
             continue
 
         if not apply:

--- a/skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
@@ -19,6 +19,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_SKIPPED_UNSUPPORTED_TYPE,
     STATUS_SUCCESS,
     STATUS_WOULD_VIOLATE_PROTECTED,
+    ResolvedServicePrincipal,
     Target,
     check_apply_gate,
     is_protected_target,
@@ -83,6 +84,8 @@ class _FakeAudit:
 @dataclass
 class _FakeGraph:
     sps: dict[str, dict] = field(default_factory=dict)  # object_id → {accountEnabled: bool}
+    applications: dict[str, dict] = field(default_factory=dict)  # object_id → {appId: str, displayName: str}
+    service_principals_by_app_id: dict[str, list[dict]] = field(default_factory=dict)
     keys: dict[str, list[dict]] = field(default_factory=dict)
     passwords: dict[str, list[dict]] = field(default_factory=dict)
     role_assignments: dict[str, list[dict]] = field(default_factory=dict)
@@ -91,6 +94,34 @@ class _FakeGraph:
     raise_on_get: bool = False
     raise_on_triage: bool = False
     disabled: list[str] = field(default_factory=list)
+
+    def resolve_service_principal(self, target):
+        if target.target_type == "Application":
+            app = self.applications.get(target.object_id)
+            if app is None:
+                return None
+            app_id = str(app.get("appId") or "")
+            matches = list(self.service_principals_by_app_id.get(app_id, []))
+            if not matches:
+                return None
+            if len(matches) > 1:
+                raise RuntimeError("application resolved to multiple service principals")
+            match = matches[0]
+            return ResolvedServicePrincipal(
+                object_id=str(match.get("id") or ""),
+                display_name=str(match.get("displayName") or target.display_name),
+                app_id=str(match.get("appId") or app_id),
+                source_target_type=target.target_type,
+                source_object_id=target.object_id,
+            )
+        sp = self.sps.get(target.object_id, {})
+        return ResolvedServicePrincipal(
+            object_id=target.object_id,
+            display_name=str(sp.get("displayName") or target.display_name),
+            app_id=str(sp.get("appId") or ""),
+            source_target_type=target.target_type,
+            source_object_id=target.object_id,
+        )
 
     def get_service_principal(self, object_id):
         if self.raise_on_get:
@@ -360,6 +391,32 @@ def test_run_apply_disable_succeeds_even_if_triage_fails():
     assert rec["triage"] is None
 
 
+def test_run_apply_application_target_resolves_backing_service_principal():
+    audit = _FakeAudit()
+    graph = _FakeGraph(
+        applications={"app-1": {"appId": "client-1", "displayName": "rogue-app"}},
+        service_principals_by_app_id={
+            "client-1": [{"id": "sp-1", "appId": "client-1", "displayName": "rogue-sp"}]
+        },
+        sps={"sp-1": {"accountEnabled": True, "displayName": "rogue-sp", "appId": "client-1"}},
+    )
+    records = list(
+        run(
+            [_finding(object_id="app-1", target_type="Application")],
+            graph_client=graph,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS
+    assert graph.disabled == ["sp-1"]
+    assert rec["resolved_service_principal"]["object_id"] == "sp-1"
+    assert audit.writes[0]["object_id"] == "sp-1"
+
+
 def test_run_apply_requires_audit_writer():
     import pytest
     with pytest.raises(ValueError, match="audit writer is required"):
@@ -409,6 +466,33 @@ def test_run_reverify_unreachable_never_silently_downgrades():
     records = list(run([_finding()], graph_client=graph, reverify=True))
     assert len(records) == 1
     assert records[0]["status"] == "unreachable"
+
+
+def test_run_reverify_uses_finding_time_as_remediation_reference():
+    graph = _FakeGraph(sps={"11111111-1111-1111-1111-111111111111": {"accountEnabled": False}})
+    event = _finding()
+    event["time"] = 1700000000789
+    records = list(run([event], graph_client=graph, reverify=True))
+    assert records[0]["reference"]["remediated_at_ms"] == 1700000000789
+
+
+def test_run_reverify_application_target_uses_backing_service_principal():
+    graph = _FakeGraph(
+        applications={"app-1": {"appId": "client-1", "displayName": "rogue-app"}},
+        service_principals_by_app_id={
+            "client-1": [{"id": "sp-1", "appId": "client-1", "displayName": "rogue-sp"}]
+        },
+        sps={"sp-1": {"accountEnabled": False, "displayName": "rogue-sp", "appId": "client-1"}},
+    )
+    records = list(
+        run(
+            [_finding(object_id="app-1", target_type="Application")],
+            graph_client=graph,
+            reverify=True,
+        )
+    )
+    assert len(records) == 1
+    assert records[0]["status"] == "verified"
 
 
 def test_run_reverify_skips_protected_target():

--- a/skills/remediation/remediate-workspace-session-kill/src/handler.py
+++ b/skills/remediation/remediate-workspace-session-kill/src/handler.py
@@ -295,6 +295,28 @@ def _observable_values(event: dict[str, Any], name: str) -> tuple[str, ...]:
     return tuple(values)
 
 
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_reference_time_ms(event: dict[str, Any]) -> int | None:
+    candidates = (
+        event.get("remediated_at_ms"),
+        event.get("time_ms"),
+        event.get("time"),
+        ((event.get("finding_info") or {}).get("last_seen_time")),
+        ((event.get("finding_info") or {}).get("first_seen_time")),
+    )
+    for value in candidates:
+        parsed = _safe_int(value)
+        if parsed is not None and parsed > 0:
+            return parsed
+    return None
+
+
 def _target_from_event(event: dict[str, Any]) -> Target | None:
     producer = _finding_product(event)
     if producer not in ACCEPTED_PRODUCERS:
@@ -577,7 +599,7 @@ def run(
     now_ms: int | None = None,
 ) -> Iterator[dict[str, Any]]:
     deny_patterns = deny_patterns if deny_patterns is not None else load_deny_patterns()
-    for target, _ in parse_targets(events):
+    for target, event in parse_targets(events):
         if target is None:
             continue
 
@@ -610,7 +632,12 @@ def run(
         if reverify:
             if workspace_client is None:
                 raise RuntimeError("reverify=True requires workspace_client to be provided")
-            yield from reverify_target(target, workspace_client=workspace_client, now_ms=now_ms)
+            yield from reverify_target(
+                target,
+                workspace_client=workspace_client,
+                now_ms=now_ms,
+                remediated_at_ms=_event_reference_time_ms(event),
+            )
             continue
 
         if not apply:

--- a/skills/remediation/remediate-workspace-session-kill/tests/test_handler.py
+++ b/skills/remediation/remediate-workspace-session-kill/tests/test_handler.py
@@ -74,21 +74,21 @@ class _FakeAudit:
 @dataclass
 class _FakeWorkspace:
     fail_on: str | None = None
-    calls: list[tuple[str, str]] = field(default_factory=list)
+    calls: list[tuple[str, str, int | None]] = field(default_factory=list)
     recent_logins_by_user: dict[str, list[dict]] = field(default_factory=dict)
 
     def sign_out(self, user_key):
-        self.calls.append(("sign_out", user_key))
+        self.calls.append(("sign_out", user_key, None))
         if self.fail_on == "sign_out":
             raise RuntimeError("simulated workspace 500")
 
     def force_password_change(self, user_key):
-        self.calls.append(("force_password_change", user_key))
+        self.calls.append(("force_password_change", user_key, None))
         if self.fail_on == "force_password_change":
             raise RuntimeError("simulated workspace 403")
 
     def list_recent_successful_logins(self, user_key, *, since_ms):
-        self.calls.append(("list_recent_successful_logins", user_key))
+        self.calls.append(("list_recent_successful_logins", user_key, since_ms))
         if self.fail_on == "list_recent_successful_logins":
             raise RuntimeError("simulated workspace 502")
         return list(self.recent_logins_by_user.get(user_key, []))
@@ -325,6 +325,15 @@ def test_run_reverify_unreachable_never_silently_downgrades():
     records = list(run([_finding()], workspace_client=ws, reverify=True))
     assert len(records) == 1  # no drift finding on UNREACHABLE
     assert records[0]["status"] == "unreachable"
+
+
+def test_run_reverify_uses_finding_time_as_remediation_reference():
+    ws = _FakeWorkspace()
+    event = _finding()
+    event["time"] = 1700000000456
+    records = list(run([event], workspace_client=ws, reverify=True))
+    assert records[0]["reference"]["remediated_at_ms"] == 1700000000456
+    assert ws.calls[-1] == ("list_recent_successful_logins", "alice@example.com", 1700000000456)
 
 
 def test_run_reverify_requires_workspace_client():


### PR DESCRIPTION
## What changed

- implemented a real Microsoft Graph REST client for `remediate-entra-credential-revoke` so `--apply` and `--reverify` no longer die on `NotImplementedError`
- resolved Entra `Application` findings to their backing service principal before disable/triage/reverify instead of hard-coding `servicePrincipals/{applicationObjectId}` semantics
- fixed `--reverify` in the Entra, Workspace, and AWS SG remediators to use the input event/finding remediation timestamp instead of defaulting to "now"
- preserved exact AWS SG permission shape across detect -> remediate by emitting and consuming `permission.protocol`, `permission.from_port`, and `permission.to_port`
- updated unit tests to cover the new resolution, reverify, and exact-rule revoke paths

## Why

The recent remediation additions shipped four real behavioral bugs:

1. Entra production apply/reverify paths were stubbed.
2. Reverify flows could report false `verified` results by checking an empty forward-looking window.
3. AWS SG revoke could not reliably remove ranged or `ipProtocol=-1` permissions because the detector flattened the permission shape to per-port observables.
4. Entra remediation advertised `Application` support but actually targeted the wrong Graph resource type.

## Impact

- Entra remediation is now runnable against real Graph credentials.
- Reverify records now carry a defensible remediation reference time instead of an artifact of when the verifier happened to run.
- AWS SG revocation now issues the exact `RevokeSecurityGroupIngress` permission shape that the detector observed, including all-protocol and ranged rules.

## Validation

- `ruff check skills/remediation/remediate-entra-credential-revoke/src/handler.py skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py skills/remediation/remediate-aws-sg-revoke/src/handler.py skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py skills/remediation/remediate-workspace-session-kill/src/handler.py skills/remediation/remediate-workspace-session-kill/tests/test_handler.py skills/detection/detect-aws-open-security-group/src/detect.py skills/detection/detect-aws-open-security-group/tests/test_detect.py --config pyproject.toml`
- `bash scripts/run_mypy.sh`
- `uv run pytest skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py -q`
- `uv run pytest skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py -q`
- `uv run pytest skills/remediation/remediate-workspace-session-kill/tests/test_handler.py -q`
- `uv run pytest skills/detection/detect-aws-open-security-group/tests/test_detect.py -q`
