### PR TITLE
docs(ingest): progressive disclosure — 4 ingest skills migrate field maps to references/ (#247)

### DIFF
--- a/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/SKILL.md
@@ -39,42 +39,9 @@ By default it writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid
 
 When `--output-format native` is selected, it emits the same event in the repo's native enriched shape with stable `event_uid`, normalized provider/account/operation/status fields, and preserved actor/session/source context, but without the OCSF envelope fields.
 
-## Native output format
+## Field mapping
 
-`--output-format native` returns one JSON object per event with:
-
-- `schema_mode: "native"`
-- `canonical_schema_version`
-- `record_type: "api_activity"`
-- `event_uid`
-- `provider`, `account_uid`, `region`
-- `time_ms`
-- `activity_id`, `activity_name`
-- `status_id`, `status`, `status_detail`
-- `actor`, `api`, `src`, `cloud`, and `resources`
-
-The native shape keeps the same normalized semantics as the OCSF projection,
-but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
-
-## activity_id inference
-
-CloudTrail doesn't tell you whether an event is a Create / Read / Update / Delete — you have to infer from the verb in `eventName`. The skill uses a deterministic prefix table:
-
-| `eventName` prefix | OCSF activity | id |
-|---|---|---:|
-| `Create*`, `Run*`, `Start*`, `Issue*` | Create | 1 |
-| `Get*`, `List*`, `Describe*`, `View*`, `Lookup*`, `Search*`, `Head*`, `Read*` | Read | 2 |
-| `Update*`, `Modify*`, `Put*`, `Set*`, `Edit*`, `Attach*`, `Associate*`, `Add*`, `Enable*` | Update | 3 |
-| `Delete*`, `Remove*`, `Terminate*`, `Stop*`, `Detach*`, `Disable*`, `Disassociate*` | Delete | 4 |
-| anything else | Other | 99 |
-
-## status_id
-
-CloudTrail records a top-level `errorCode` field when an API call fails. The skill sets:
-
-- `status_id = 1` (Success) when `errorCode` is absent
-- `status_id = 2` (Failure) when `errorCode` is present
-- `status_detail` is populated with the `errorMessage` for fast triage
+The native output field list, the `eventName` → `activity_id` prefix table, the `errorCode` → `status_id` rules, and the explicit "not mapped (yet)" scope live in [`references/field-map.md`](references/field-map.md). Keeping the detail there keeps this file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)) while detectors and reviewers still get the exact mapping one click away.
 
 ## Usage
 
@@ -88,23 +55,6 @@ python src/ingest.py cloudtrail.json --output-format native > cloudtrail.native.
 # Piped from S3 sync
 aws s3 cp s3://my-cloudtrail-bucket/AWSLogs/.../recent.json.gz - | gunzip | python src/ingest.py
 ```
-
-## What's NOT mapped (yet)
-
-CloudTrail carries fields the OCSF 1.8 API Activity class has homes for, but the
-mapping is one-shot per skill. The first version focuses on the high-signal
-fields any detection skill needs:
-
-- `actor.user.name` (from `userIdentity.userName` or principal)
-- `actor.session.uid` (from `userIdentity.accessKeyId`)
-- `actor.session.created_time` (from `userIdentity.sessionContext.attributes.creationDate`)
-- `src_endpoint.ip` and `src_endpoint.svc_name` (from `sourceIPAddress` and `userAgent`)
-- `api.operation`, `api.service.name`, `api.request.uid` (from `eventName`, `eventSource`, `eventID`)
-- `resources[]` (from `requestParameters` — only top-level keys, no recursion)
-- `cloud.account.uid`, `cloud.region` (from `recipientAccountId`, `awsRegion`)
-- `metadata.product.feature.name = "ingest-cloudtrail-ocsf"`
-
-Fields **explicitly out of scope** for v0.1: `request.data` and `response.data` (often huge), `additionalEventData` (free-form), MFA context. Add these in a follow-up if a detector needs them.
 
 ## Tests
 

--- a/skills/ingestion/ingest-cloudtrail-ocsf/references/field-map.md
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/references/field-map.md
@@ -1,0 +1,57 @@
+# ingest-cloudtrail-ocsf OCSF field map
+
+Full CloudTrail-field → OCSF-field mapping for `ingest-cloudtrail-ocsf`. Pulled out of `SKILL.md` to keep that file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)).
+
+## Native output format
+
+`--output-format native` returns one JSON object per event with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "api_activity"`
+- `event_uid`
+- `provider`, `account_uid`, `region`
+- `time_ms`
+- `activity_id`, `activity_name`
+- `status_id`, `status`, `status_detail`
+- `actor`, `api`, `src`, `cloud`, and `resources`
+
+The native shape keeps the same normalized semantics as the OCSF projection,
+but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
+
+## activity_id inference
+
+CloudTrail doesn't tell you whether an event is a Create / Read / Update / Delete — you have to infer from the verb in `eventName`. The skill uses a deterministic prefix table:
+
+| `eventName` prefix | OCSF activity | id |
+|---|---|---:|
+| `Create*`, `Run*`, `Start*`, `Issue*` | Create | 1 |
+| `Get*`, `List*`, `Describe*`, `View*`, `Lookup*`, `Search*`, `Head*`, `Read*` | Read | 2 |
+| `Update*`, `Modify*`, `Put*`, `Set*`, `Edit*`, `Attach*`, `Associate*`, `Add*`, `Enable*` | Update | 3 |
+| `Delete*`, `Remove*`, `Terminate*`, `Stop*`, `Detach*`, `Disable*`, `Disassociate*` | Delete | 4 |
+| anything else | Other | 99 |
+
+## status_id
+
+CloudTrail records a top-level `errorCode` field when an API call fails. The skill sets:
+
+- `status_id = 1` (Success) when `errorCode` is absent
+- `status_id = 2` (Failure) when `errorCode` is present
+- `status_detail` is populated with the `errorMessage` for fast triage
+
+## What's NOT mapped (yet)
+
+CloudTrail carries fields the OCSF 1.8 API Activity class has homes for, but the
+mapping is one-shot per skill. The first version focuses on the high-signal
+fields any detection skill needs:
+
+- `actor.user.name` (from `userIdentity.userName` or principal)
+- `actor.session.uid` (from `userIdentity.accessKeyId`)
+- `actor.session.created_time` (from `userIdentity.sessionContext.attributes.creationDate`)
+- `src_endpoint.ip` and `src_endpoint.svc_name` (from `sourceIPAddress` and `userAgent`)
+- `api.operation`, `api.service.name`, `api.request.uid` (from `eventName`, `eventSource`, `eventID`)
+- `resources[]` (from `requestParameters` — only top-level keys, no recursion)
+- `cloud.account.uid`, `cloud.region` (from `recipientAccountId`, `awsRegion`)
+- `metadata.product.feature.name = "ingest-cloudtrail-ocsf"`
+
+Fields **explicitly out of scope** for v0.1: `request.data` and `response.data` (often huge), `additionalEventData` (free-form), MFA context. Add these in a follow-up if a detector needs them.

--- a/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-guardduty-ocsf/SKILL.md
@@ -39,70 +39,9 @@ Writes OCSF 1.8 **Detection Finding** (`class_uid: 2004`, `category_uid: 2`). Se
 
 When `--output-format native` is selected, it emits the same finding in the repo's native enriched shape with stable `event_uid`, normalized provider/account/severity fields, MITRE ATT&CK annotations, and preserved evidence/resource context, but without the OCSF envelope fields.
 
-## Native output format
+## Field mapping
 
-`--output-format native` returns one JSON object per GuardDuty finding with:
-
-- `schema_mode: "native"`
-- `canonical_schema_version`
-- `record_type: "detection_finding"`
-- `event_uid` and `finding_uid`
-- `provider`, `account_uid`, `region`
-- `time_ms`
-- `severity_id`, `severity`, `status_id`, `status`
-- `title`, `description`, `finding_types`
-- `attacks`, `resources`, `cloud`, `source`, and `evidence`
-
-The native shape keeps the same normalized semantics as the OCSF projection,
-but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
-
-## GuardDuty Type → MITRE ATT&CK mapping
-
-GuardDuty finding types follow the format:
-
-```
-<ThreatPurpose>:<ResourceTypeAffected>/<ThreatFamily>.<DetectionMechanism>[!Artifact]
-```
-
-The skill extracts the `ThreatPurpose` prefix and the `ThreatFamily` segment and looks them up in two deterministic tables:
-
-| `ThreatPurpose` | MITRE tactic |
-|---|---|
-| `Backdoor` | TA0011 Command and Control |
-| `CredentialAccess` | TA0006 Credential Access |
-| `CryptoCurrency` | TA0040 Impact |
-| `DefenseEvasion` / `Stealth` | TA0005 Defense Evasion |
-| `Discovery` | TA0007 Discovery |
-| `Execution` | TA0002 Execution |
-| `Exfiltration` | TA0010 Exfiltration |
-| `Impact` | TA0040 Impact |
-| `InitialAccess` | TA0001 Initial Access |
-| `Persistence` | TA0003 Persistence |
-| `Policy` | TA0005 Defense Evasion |
-| `PrivilegeEscalation` | TA0004 Privilege Escalation |
-| `Recon` | TA0043 Reconnaissance |
-| `Trojan` | TA0002 Execution |
-| `UnauthorizedAccess` | TA0001 Initial Access |
-
-A secondary exact-match table covers ~20 high-signal GuardDuty finding types with a specific MITRE technique (e.g. `UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS` → `T1552.005` Cloud Instance Metadata API + `T1078.004` Valid Accounts: Cloud Accounts). When no specific technique is known, the skill emits the tactic-only attack so downstream pivots still work.
-
-## Severity mapping
-
-GuardDuty severity is a float on a 1.0–8.9 scale. The skill maps it to `severity_id`:
-
-| GuardDuty severity | OCSF `severity_id` | Label |
-|---:|---:|---|
-| 0.0 – 1.9 | 1 | Informational |
-| 2.0 – 3.9 | 2 | Low |
-| 4.0 – 5.9 | 3 | Medium |
-| 6.0 – 7.9 | 4 | High |
-| 8.0 – 8.9 | 5 | Critical |
-
-The raw float is also preserved as an observable (`gd.severity`) so rules don't lose precision.
-
-## Deterministic finding UID
-
-`finding_info.uid` is derived as `det-gd-<first 8 chars of sha256(GuardDuty Id)>`, so re-ingesting the same finding always yields the same OCSF uid. The original GuardDuty Id is preserved on `evidence.raw_events[].uid`.
+The native output field list, the GuardDuty Type → MITRE ATT&CK tactic/technique tables, the 1.0–8.9 severity → `severity_id` ladder, the deterministic `finding_info.uid` derivation, and the explicit "not mapped (yet)" scope live in [`references/field-map.md`](references/field-map.md). Keeping the detail there keeps this file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)) while detectors and reviewers still get the exact mapping one click away.
 
 ## Usage
 
@@ -119,21 +58,6 @@ aws guardduty get-findings --detector-id abc --finding-ids f1 f2 | python src/in
 # Piped downstream
 python src/ingest.py gd.json | python ../convert-ocsf-to-sarif/src/convert.py > gd.sarif
 ```
-
-## What's NOT mapped (yet)
-
-GuardDuty findings carry rich context that OCSF has field homes for; the first version focuses on fields any downstream converter or evaluator needs:
-
-- `finding_info.uid`, `title`, `desc`, `types`
-- `finding_info.attacks[]` (tactic + technique + sub_technique when known)
-- `finding_info.first_seen_time` / `last_seen_time` (from `Service.EventFirstSeen/LastSeen`)
-- `severity_id` (from the 1.0–8.9 scale)
-- `cloud.account.uid` / `cloud.region` (from `AccountId` / `Region`)
-- `resources[]` (from `Resource.ResourceType` plus the type-specific sub-object)
-- A curated `observables[]` list (resource id, resource type, GuardDuty type, severity float)
-- `evidence.raw_events[]` with the GuardDuty finding Id + ARN (pointer, not body)
-
-Fields **explicitly out of scope** for v0.1: the full `Service.Action` sub-tree (varies by finding type), `Resource` sub-objects beyond the type tag, NetworkConnectionAction bytes/ports (add when a detector needs them).
 
 ## Tests
 

--- a/skills/ingestion/ingest-guardduty-ocsf/references/field-map.md
+++ b/skills/ingestion/ingest-guardduty-ocsf/references/field-map.md
@@ -1,0 +1,83 @@
+# ingest-guardduty-ocsf OCSF field map
+
+Full GuardDuty-finding → OCSF-field mapping for `ingest-guardduty-ocsf`. Pulled out of `SKILL.md` to keep that file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)).
+
+## Native output format
+
+`--output-format native` returns one JSON object per GuardDuty finding with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "detection_finding"`
+- `event_uid` and `finding_uid`
+- `provider`, `account_uid`, `region`
+- `time_ms`
+- `severity_id`, `severity`, `status_id`, `status`
+- `title`, `description`, `finding_types`
+- `attacks`, `resources`, `cloud`, `source`, and `evidence`
+
+The native shape keeps the same normalized semantics as the OCSF projection,
+but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
+
+## GuardDuty Type → MITRE ATT&CK mapping
+
+GuardDuty finding types follow the format:
+
+```
+<ThreatPurpose>:<ResourceTypeAffected>/<ThreatFamily>.<DetectionMechanism>[!Artifact]
+```
+
+The skill extracts the `ThreatPurpose` prefix and the `ThreatFamily` segment and looks them up in two deterministic tables:
+
+| `ThreatPurpose` | MITRE tactic |
+|---|---|
+| `Backdoor` | TA0011 Command and Control |
+| `CredentialAccess` | TA0006 Credential Access |
+| `CryptoCurrency` | TA0040 Impact |
+| `DefenseEvasion` / `Stealth` | TA0005 Defense Evasion |
+| `Discovery` | TA0007 Discovery |
+| `Execution` | TA0002 Execution |
+| `Exfiltration` | TA0010 Exfiltration |
+| `Impact` | TA0040 Impact |
+| `InitialAccess` | TA0001 Initial Access |
+| `Persistence` | TA0003 Persistence |
+| `Policy` | TA0005 Defense Evasion |
+| `PrivilegeEscalation` | TA0004 Privilege Escalation |
+| `Recon` | TA0043 Reconnaissance |
+| `Trojan` | TA0002 Execution |
+| `UnauthorizedAccess` | TA0001 Initial Access |
+
+A secondary exact-match table covers ~20 high-signal GuardDuty finding types with a specific MITRE technique (e.g. `UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS` → `T1552.005` Cloud Instance Metadata API + `T1078.004` Valid Accounts: Cloud Accounts). When no specific technique is known, the skill emits the tactic-only attack so downstream pivots still work.
+
+## Severity mapping
+
+GuardDuty severity is a float on a 1.0–8.9 scale. The skill maps it to `severity_id`:
+
+| GuardDuty severity | OCSF `severity_id` | Label |
+|---:|---:|---|
+| 0.0 – 1.9 | 1 | Informational |
+| 2.0 – 3.9 | 2 | Low |
+| 4.0 – 5.9 | 3 | Medium |
+| 6.0 – 7.9 | 4 | High |
+| 8.0 – 8.9 | 5 | Critical |
+
+The raw float is also preserved as an observable (`gd.severity`) so rules don't lose precision.
+
+## Deterministic finding UID
+
+`finding_info.uid` is derived as `det-gd-<first 8 chars of sha256(GuardDuty Id)>`, so re-ingesting the same finding always yields the same OCSF uid. The original GuardDuty Id is preserved on `evidence.raw_events[].uid`.
+
+## What's NOT mapped (yet)
+
+GuardDuty findings carry rich context that OCSF has field homes for; the first version focuses on fields any downstream converter or evaluator needs:
+
+- `finding_info.uid`, `title`, `desc`, `types`
+- `finding_info.attacks[]` (tactic + technique + sub_technique when known)
+- `finding_info.first_seen_time` / `last_seen_time` (from `Service.EventFirstSeen/LastSeen`)
+- `severity_id` (from the 1.0–8.9 scale)
+- `cloud.account.uid` / `cloud.region` (from `AccountId` / `Region`)
+- `resources[]` (from `Resource.ResourceType` plus the type-specific sub-object)
+- A curated `observables[]` list (resource id, resource type, GuardDuty type, severity float)
+- `evidence.raw_events[]` with the GuardDuty finding Id + ARN (pointer, not body)
+
+Fields **explicitly out of scope** for v0.1: the full `Service.Action` sub-tree (varies by finding type), `Resource` sub-objects beyond the type tag, NetworkConnectionAction bytes/ports (add when a detector needs them).

--- a/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/SKILL.md
@@ -58,65 +58,13 @@ Writes OCSF 1.8 **API Activity** (`class_uid: 6003`, `category_uid: 6`) by defau
 With `--output-format native`, writes the repo's native enriched API activity
 shape instead of the OCSF envelope.
 
-## activity_id inference
-
-K8s verbs are standard — no guessing needed:
-
-| K8s verb | OCSF activity | id |
-|---|---|---:|
-| `create` | Create | 1 |
-| `get`, `list`, `watch`, `proxy` | Read | 2 |
-| `update`, `patch` | Update | 3 |
-| `delete`, `deletecollection` | Delete | 4 |
-| anything else (`connect`, `bind`, custom) | Other | 99 |
-
-## status_id
-
-`responseStatus.code` is an HTTP status code:
-
-- `2xx` → `status_id = 1` (Success)
-- `4xx` / `5xx` → `status_id = 2` (Failure)
-- missing (audit level below `Metadata`) → `status_id = 0` (Unknown)
-
-On failure, `status_detail` is populated with `responseStatus.message` (e.g. `"secrets \"db-password\" is forbidden: User ... cannot get resource"`) for fast triage and detection rule pivots.
-
 ## Filtering by stage
 
 K8s audit events are emitted at 4 stages: `RequestReceived`, `ResponseStarted`, `ResponseComplete`, `Panic`. The skill processes **only `ResponseComplete` and `Panic`** events — those are the ones with authoritative `responseStatus`. Earlier-stage events are skipped with a `stderr` debug line.
 
 ## Field mapping
 
-| K8s field | OCSF field |
-|---|---|
-| `user.username` | `actor.user.name` |
-| `user.uid` | `actor.user.uid` |
-| `user.groups` | `actor.user.groups[]` (each as `{name: ...}`) |
-| `sourceIPs[0]` | `src_endpoint.ip` |
-| `userAgent` | `src_endpoint.svc_name` |
-| `verb` | `api.operation` |
-| `"kubernetes"` | `api.service.name` (hard-coded) |
-| `auditID` | `api.request.uid` |
-| `objectRef.resource` / `namespace` / `name` / `apiGroup` | `resources[0]` |
-| `requestReceivedTimestamp` | `time` (ms epoch) |
-| `annotations["authorization.k8s.io/decision"]` | `metadata.labels` (`authz-allow` / `authz-deny`) |
-
-`cloud.provider` is hard-coded to `"Kubernetes"` (even though K8s is not a cloud, OCSF uses the `cloud` object as the deployment-context holder).
-
-### `unmapped.k8s.*` preservation
-
-Fields without a clean first-class OCSF slot round-trip verbatim under
-`unmapped.k8s.*` in both native and OCSF output:
-
-- `requestObject` → `unmapped.k8s.request_object`
-- `responseObject` → `unmapped.k8s.response_object`
-- raw `objectRef` → `unmapped.k8s.object_ref`
-
-This preserves spec-patch and response-body detail for downstream detectors
-without overloading the normalized `resources[]` shape.
-
-## Service-account marker
-
-When `user.username` starts with `system:serviceaccount:<namespace>:<name>`, the skill sets `actor.user.type = "ServiceAccount"` and records `mcp.sa_namespace` under a non-standard k8s custom profile so detection skills can key off it without parsing the username string.
+The K8s verb → `activity_id` table, the `responseStatus.code` → `status_id` rules, the full K8s-field → OCSF-field map, the `unmapped.k8s.*` preservation rules, the service-account marker, and the native output field list live in [`references/field-map.md`](references/field-map.md). Keeping the detail there keeps this file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)) while detectors and reviewers still get the exact mapping one click away.
 
 ## Usage
 
@@ -131,32 +79,6 @@ kubectl logs -n kube-system audit-webhook-receiver \
 # Native enriched output (same source truth, no OCSF envelope)
 python src/ingest.py --output-format native /var/log/k8s-audit.log > k8s-audit.native.jsonl
 ```
-
-## Native output format
-
-`--output-format native` emits one enriched event per accepted audit entry with:
-
-- `schema_mode`
-- `canonical_schema_version`
-- `record_type`
-- `event_uid`
-- `provider`
-- `account_uid`
-- `region`
-- `time_ms`
-- `activity_id`
-- `activity_name`
-- `status_id`
-- `status`
-- `status_detail` when present
-- `operation`
-- `service_name`
-- `actor`
-- `src`
-- `resources`
-- `source`
-- `k8s.service_account_namespace` when the actor is a service account
-- `unmapped.k8s.*` when raw request / response / objectRef detail is present
 
 ## Tests
 

--- a/skills/ingestion/ingest-k8s-audit-ocsf/references/field-map.md
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/references/field-map.md
@@ -1,0 +1,85 @@
+# ingest-k8s-audit-ocsf OCSF field map
+
+Full Kubernetes-audit-field → OCSF-field mapping for `ingest-k8s-audit-ocsf`. Pulled out of `SKILL.md` to keep that file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)).
+
+## activity_id inference
+
+K8s verbs are standard — no guessing needed:
+
+| K8s verb | OCSF activity | id |
+|---|---|---:|
+| `create` | Create | 1 |
+| `get`, `list`, `watch`, `proxy` | Read | 2 |
+| `update`, `patch` | Update | 3 |
+| `delete`, `deletecollection` | Delete | 4 |
+| anything else (`connect`, `bind`, custom) | Other | 99 |
+
+## status_id
+
+`responseStatus.code` is an HTTP status code:
+
+- `2xx` → `status_id = 1` (Success)
+- `4xx` / `5xx` → `status_id = 2` (Failure)
+- missing (audit level below `Metadata`) → `status_id = 0` (Unknown)
+
+On failure, `status_detail` is populated with `responseStatus.message` (e.g. `"secrets \"db-password\" is forbidden: User ... cannot get resource"`) for fast triage and detection rule pivots.
+
+## Field mapping
+
+| K8s field | OCSF field |
+|---|---|
+| `user.username` | `actor.user.name` |
+| `user.uid` | `actor.user.uid` |
+| `user.groups` | `actor.user.groups[]` (each as `{name: ...}`) |
+| `sourceIPs[0]` | `src_endpoint.ip` |
+| `userAgent` | `src_endpoint.svc_name` |
+| `verb` | `api.operation` |
+| `"kubernetes"` | `api.service.name` (hard-coded) |
+| `auditID` | `api.request.uid` |
+| `objectRef.resource` / `namespace` / `name` / `apiGroup` | `resources[0]` |
+| `requestReceivedTimestamp` | `time` (ms epoch) |
+| `annotations["authorization.k8s.io/decision"]` | `metadata.labels` (`authz-allow` / `authz-deny`) |
+
+`cloud.provider` is hard-coded to `"Kubernetes"` (even though K8s is not a cloud, OCSF uses the `cloud` object as the deployment-context holder).
+
+### `unmapped.k8s.*` preservation
+
+Fields without a clean first-class OCSF slot round-trip verbatim under
+`unmapped.k8s.*` in both native and OCSF output:
+
+- `requestObject` → `unmapped.k8s.request_object`
+- `responseObject` → `unmapped.k8s.response_object`
+- raw `objectRef` → `unmapped.k8s.object_ref`
+
+This preserves spec-patch and response-body detail for downstream detectors
+without overloading the normalized `resources[]` shape.
+
+## Service-account marker
+
+When `user.username` starts with `system:serviceaccount:<namespace>:<name>`, the skill sets `actor.user.type = "ServiceAccount"` and records `mcp.sa_namespace` under a non-standard k8s custom profile so detection skills can key off it without parsing the username string.
+
+## Native output format
+
+`--output-format native` emits one enriched event per accepted audit entry with:
+
+- `schema_mode`
+- `canonical_schema_version`
+- `record_type`
+- `event_uid`
+- `provider`
+- `account_uid`
+- `region`
+- `time_ms`
+- `activity_id`
+- `activity_name`
+- `status_id`
+- `status`
+- `status_detail` when present
+- `operation`
+- `service_name`
+- `actor`
+- `src`
+- `resources`
+- `source`
+- `k8s.service_account_namespace` when the actor is a service account
+- `unmapped.k8s.*` when raw request / response / objectRef detail is present

--- a/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-security-hub-ocsf/SKILL.md
@@ -35,72 +35,9 @@ Writes OCSF 1.8 **Detection Finding** (`class_uid: 2004`, `category_uid: 2`). Se
 
 When `--output-format native` is selected, it emits the same finding in the repo's native enriched shape with stable `event_uid`, normalized provider/account/severity fields, MITRE ATT&CK annotations, preserved compliance/resource context, and no OCSF envelope fields.
 
-## Native output format
+## Field mapping
 
-`--output-format native` returns one JSON object per Security Hub finding with:
-
-- `schema_mode: "native"`
-- `canonical_schema_version`
-- `record_type: "detection_finding"`
-- `event_uid` and `finding_uid`
-- `provider`, `account_uid`, `region`
-- `time_ms`
-- `severity_id`, `severity_label`, `severity_normalized`, `status_id`, `status`
-- `title`, `description`, `finding_types`
-- `attacks`, `resources`, `cloud`, `source`, `compliance`, and `evidence`
-
-The native shape keeps the same normalized semantics as the OCSF projection,
-but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
-
-## ASFF validation
-
-The skill enforces the ASFF required fields defined in the AWS Security Hub user guide. A finding is **dropped with a stderr warning** (never fatal) if any of these are missing or empty:
-
-- `SchemaVersion`
-- `Id`
-- `ProductArn`
-- `GeneratorId`
-- `AwsAccountId`
-- `Types` (must be a non-empty list)
-- `CreatedAt`
-- `UpdatedAt`
-- `Severity` (must be a dict with `Label` or `Normalized`)
-- `Title`
-- `Description`
-- `Resources` (must be a non-empty list)
-
-This keeps the downstream OCSF stream trustable: every record that makes it past the ingester is ASFF-valid *and* OCSF-valid.
-
-## Severity mapping
-
-ASFF carries both a `Label` enum and a 0–100 `Normalized` score. The skill prefers `Label` (more stable), falling back to `Normalized`:
-
-| ASFF `Severity.Label` | Normalized fallback | OCSF `severity_id` |
-|---|---:|---:|
-| `INFORMATIONAL` | 0 | 1 (Informational) |
-| `LOW` | 1–39 | 2 (Low) |
-| `MEDIUM` | 40–69 | 3 (Medium) |
-| `HIGH` | 70–89 | 4 (High) |
-| `CRITICAL` | 90–100 | 5 (Critical) |
-
-The raw label and score are both preserved as observables so rules can pivot either way.
-
-## MITRE ATT&CK extraction
-
-ASFF doesn't have a first-class MITRE field, but several AWS products (GuardDuty, Inspector, Config Conformance Packs) now populate `ProductFields` with `aws/securityhub/annotations/mitre-*` keys or include MITRE hints in the `Types[]` taxonomy. The skill extracts both sources:
-
-1. **Types[] taxonomy walk.** ASFF Types use the format `<namespace>/<category>/<classifier>`. When the namespace is `TTPs` and the category matches a MITRE tactic name, the skill emits a tactic-only attack entry.
-2. **ProductFields lookup.** When a key matches `aws/securityhub/annotations/mitre-technique`, the value is parsed for a `T####` technique ID and promoted into `attacks[].technique.uid`.
-
-Findings without any MITRE hints still get a valid OCSF event — `finding_info.attacks[]` is simply empty. Downstream pivots that filter by technique will just skip these, which is the intended behaviour.
-
-## Deterministic finding UID
-
-`finding_info.uid` is derived as `det-shub-<first 8 chars of sha256(ASFF Id)>`. The original ASFF Id (a long ARN) is preserved on `evidence.raw_events[].uid`.
-
-## Compliance passthrough
-
-When the ASFF finding carries a `Compliance` block (typical for Config rules, CIS benchmarks, PCI packs), the skill lifts `Compliance.Status`, `Compliance.StatusReasons[]`, and `Compliance.SecurityControlId` into observables. This lets downstream compliance evaluators (cspm-aws-cis-benchmark, etc.) consume Security Hub findings through the same OCSF pipeline without needing to re-read the raw ASFF.
+The native output field list, the ASFF required-field validation list, the `Severity.Label` / `Normalized` → `severity_id` ladder, the MITRE ATT&CK extraction rules (Types[] taxonomy + ProductFields lookup), the deterministic `finding_info.uid` derivation, and the `Compliance` block passthrough live in [`references/field-map.md`](references/field-map.md). Keeping the detail there keeps this file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)) while detectors and reviewers still get the exact mapping one click away.
 
 ## Usage
 

--- a/skills/ingestion/ingest-security-hub-ocsf/references/field-map.md
+++ b/skills/ingestion/ingest-security-hub-ocsf/references/field-map.md
@@ -1,0 +1,70 @@
+# ingest-security-hub-ocsf OCSF field map
+
+Full ASFF-field → OCSF-field mapping for `ingest-security-hub-ocsf`. Pulled out of `SKILL.md` to keep that file under the progressive-disclosure target ([#247](https://github.com/msaad00/cloud-ai-security-skills/issues/247)).
+
+## Native output format
+
+`--output-format native` returns one JSON object per Security Hub finding with:
+
+- `schema_mode: "native"`
+- `canonical_schema_version`
+- `record_type: "detection_finding"`
+- `event_uid` and `finding_uid`
+- `provider`, `account_uid`, `region`
+- `time_ms`
+- `severity_id`, `severity_label`, `severity_normalized`, `status_id`, `status`
+- `title`, `description`, `finding_types`
+- `attacks`, `resources`, `cloud`, `source`, `compliance`, and `evidence`
+
+The native shape keeps the same normalized semantics as the OCSF projection,
+but omits `class_uid`, `category_uid`, `type_uid`, and `metadata.product`.
+
+## ASFF validation
+
+The skill enforces the ASFF required fields defined in the AWS Security Hub user guide. A finding is **dropped with a stderr warning** (never fatal) if any of these are missing or empty:
+
+- `SchemaVersion`
+- `Id`
+- `ProductArn`
+- `GeneratorId`
+- `AwsAccountId`
+- `Types` (must be a non-empty list)
+- `CreatedAt`
+- `UpdatedAt`
+- `Severity` (must be a dict with `Label` or `Normalized`)
+- `Title`
+- `Description`
+- `Resources` (must be a non-empty list)
+
+This keeps the downstream OCSF stream trustable: every record that makes it past the ingester is ASFF-valid *and* OCSF-valid.
+
+## Severity mapping
+
+ASFF carries both a `Label` enum and a 0–100 `Normalized` score. The skill prefers `Label` (more stable), falling back to `Normalized`:
+
+| ASFF `Severity.Label` | Normalized fallback | OCSF `severity_id` |
+|---|---:|---:|
+| `INFORMATIONAL` | 0 | 1 (Informational) |
+| `LOW` | 1–39 | 2 (Low) |
+| `MEDIUM` | 40–69 | 3 (Medium) |
+| `HIGH` | 70–89 | 4 (High) |
+| `CRITICAL` | 90–100 | 5 (Critical) |
+
+The raw label and score are both preserved as observables so rules can pivot either way.
+
+## MITRE ATT&CK extraction
+
+ASFF doesn't have a first-class MITRE field, but several AWS products (GuardDuty, Inspector, Config Conformance Packs) now populate `ProductFields` with `aws/securityhub/annotations/mitre-*` keys or include MITRE hints in the `Types[]` taxonomy. The skill extracts both sources:
+
+1. **Types[] taxonomy walk.** ASFF Types use the format `<namespace>/<category>/<classifier>`. When the namespace is `TTPs` and the category matches a MITRE tactic name, the skill emits a tactic-only attack entry.
+2. **ProductFields lookup.** When a key matches `aws/securityhub/annotations/mitre-technique`, the value is parsed for a `T####` technique ID and promoted into `attacks[].technique.uid`.
+
+Findings without any MITRE hints still get a valid OCSF event — `finding_info.attacks[]` is simply empty. Downstream pivots that filter by technique will just skip these, which is the intended behaviour.
+
+## Deterministic finding UID
+
+`finding_info.uid` is derived as `det-shub-<first 8 chars of sha256(ASFF Id)>`. The original ASFF Id (a long ARN) is preserved on `evidence.raw_events[].uid`.
+
+## Compliance passthrough
+
+When the ASFF finding carries a `Compliance` block (typical for Config rules, CIS benchmarks, PCI packs), the skill lifts `Compliance.Status`, `Compliance.StatusReasons[]`, and `Compliance.SecurityControlId` into observables. This lets downstream compliance evaluators (cspm-aws-cis-benchmark, etc.) consume Security Hub findings through the same OCSF pipeline without needing to re-read the raw ASFF.


### PR DESCRIPTION
## Summary

Applies the progressive-disclosure pattern (already shipped for okta-system-log + google-workspace-login in #308) to four more ingest skills. SKILL.md keeps the routing / discovery surface; deep OCSF mapping detail moves to \`references/field-map.md\`.

| Skill | SKILL.md | references/field-map.md |
|---|---|---|
| ingest-cloudtrail-ocsf | 112 → 61 lines | 57 lines (new) |
| ingest-guardduty-ocsf | 141 → 64 lines | 83 lines (new) |
| ingest-k8s-audit-ocsf | 164 → 85 lines | 85 lines (new) |
| ingest-security-hub-ocsf | 124 → 60 lines | 70 lines (new) |

**Moved out of SKILL.md** (now in references/field-map.md per skill): activity_id inference tables, status_id rules, expanded native field lists, GuardDuty Type → MITRE mapping, severity mapping, deterministic finding UID derivation, ASFF validation, MITRE extraction, compliance passthrough, "What's NOT mapped" out-of-scope lists, \`unmapped.k8s.*\` preservation rules, service-account marker semantics.

**Kept in SKILL.md** (routing / discovery surface): \`Use when\`, \`Do NOT use\`, Wire contract overview (1 paragraph), Usage examples, Tests pointer, and a one-line pointer to references/field-map.md.

## Test plan
- [x] \`python scripts/validate_skill_contract.py\` — 54 skills passed
- [x] \`python scripts/validate_safe_skill_bar.py\` — passed
- [x] \`pytest skills/ingestion/ingest-cloudtrail-ocsf/tests -q\` — 36/36
- [x] \`pytest skills/ingestion/ingest-guardduty-ocsf/tests -q\` — 45/45
- [x] \`pytest skills/ingestion/ingest-k8s-audit-ocsf/tests -q\` — 42/42
- [x] \`pytest skills/ingestion/ingest-security-hub-ocsf/tests -q\` — 49/49

Closes #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)