### PR TITLE
feat(detect+remediate): ship detect-gcp-open-firewall + remediate-gcp-firewall-revoke (#307 phase B-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 54 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 56 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**54 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus eight guarded write paths spanning AWS IAM, AWS security-group revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**56 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus eight guarded write paths spanning AWS IAM, AWS security-group revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 4 | inventory, graph, AI BOM, evidence | native / bridge JSON |
-| **Detect** | 12 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 13 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
-| **Remediate** | 8 | guarded write paths (IAM departures, AWS SG revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
+| **Remediate** | 9 | guarded write paths (IAM departures, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 54 shipped skills.**
+**Total: 56 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -56,6 +56,7 @@ is the row you can take to your auditor.
 | `detect-credential-stuffing-okta` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-entra-credential-addition` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-entra-role-grant-escalation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-gcp-open-firewall` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-mcp-tool-drift` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -74,6 +75,7 @@ is the row you can take to your auditor.
 | `remediate-aws-sg-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-container-escape-k8s` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-entra-credential-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
+| `remediate-gcp-firewall-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-k8s-rbac-revoke` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-mcp-tool-quarantine` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `remediate-okta-session-kill` | remediation | ⚠️ write via HITL | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
@@ -84,7 +86,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_54 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_56 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 12 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 13 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,24 +4,24 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **54**
+- Total shipped skills in registry: **56**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **38** | — |
-| MITRE ATT&CK | v14 | **31** | 100% mapped coverage |
+| OCSF | 1.8.0 | **39** | — |
+| MITRE ATT&CK | v14 | **33** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **3** | — |
-| CIS GCP Foundations | v3.0 | **1** | — |
+| CIS GCP Foundations | v3.0 | **3** | — |
 | CIS Azure Foundations | v2.1 | **2** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
 | CIS Controls | v8 | **2** | — |
-| NIST CSF | 2.0 | **16** | 100% mapped coverage |
+| NIST CSF | 2.0 | **17** | 100% mapped coverage |
 | NIST AI RMF | current | **4** | — |
-| SOC 2 TSC | current | **16** | 100% mapped coverage |
+| SOC 2 TSC | current | **17** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **3** | — |
 | OWASP LLM Top 10 | current | **2** | — |
@@ -36,7 +36,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **38**
+Shipped skills mapped: **39**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -45,6 +45,7 @@ Shipped skills mapped: **38**
 | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta) | detection | okta | identities, authentication, sessions |
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
+| [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
@@ -86,7 +87,7 @@ Shipped skills mapped: **38**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **31**
+Shipped skills mapped: **33**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -95,6 +96,7 @@ Shipped skills mapped: **31**
 | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta) | detection | okta | identities, authentication, sessions |
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
+| [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
@@ -115,6 +117,7 @@ Shipped skills mapped: **31**
 | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke) | remediation | aws | security-groups, ingress-rules, audit |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
 | [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
+| [`remediate-gcp-firewall-revoke`](../skills/remediation/remediate-gcp-firewall-revoke) | remediation | gcp | vpc-firewall-rules, ingress-rules, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
@@ -158,11 +161,13 @@ Shipped skills mapped: **3**
 
 - Registry id: `cis-gcp-v3`
 
-Shipped skills mapped: **1**
+Shipped skills mapped: **3**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
+| [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`cspm-gcp-cis-benchmark`](../skills/evaluation/cspm-gcp-cis-benchmark) | evaluation | gcp | identities, storage, logging, network |
+| [`remediate-gcp-firewall-revoke`](../skills/remediation/remediate-gcp-firewall-revoke) | remediation | gcp | vpc-firewall-rules, ingress-rules, audit |
 
 ### CIS Azure Foundations (v2.1)
 
@@ -214,7 +219,7 @@ Shipped skills mapped: **2**
 - Asset classes in scope: identities, storage, logging, network, clusters, runtime, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **16**
+Shipped skills mapped: **17**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -230,6 +235,7 @@ Shipped skills mapped: **16**
 | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke) | remediation | aws | security-groups, ingress-rules, audit |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
 | [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
+| [`remediate-gcp-firewall-revoke`](../skills/remediation/remediate-gcp-firewall-revoke) | remediation | gcp | vpc-firewall-rules, ingress-rules, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |
@@ -255,7 +261,7 @@ Shipped skills mapped: **4**
 - Asset classes in scope: access, logging, change, evidence, inventory, ai-endpoints
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **16**
+Shipped skills mapped: **17**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -271,6 +277,7 @@ Shipped skills mapped: **16**
 | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke) | remediation | aws | security-groups, ingress-rules, audit |
 | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s) | remediation | kubernetes | pods, workloads, networkpolicy, audit |
 | [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke) | remediation | azure, entra | service-principals, applications, credentials, role-assignments, audit |
+| [`remediate-gcp-firewall-revoke`](../skills/remediation/remediate-gcp-firewall-revoke) | remediation | gcp | vpc-firewall-rules, ingress-rules, audit |
 | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke) | remediation | kubernetes | rolebindings, clusterrolebindings, rbac, audit |
 | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine) | remediation | mcp | mcp-tools, quarantine-list, audit |
 | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill) | remediation | okta | identities, sessions, oauth-tokens, audit |

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -715,6 +715,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-gcp-open-firewall",
+      "layer": "detection",
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "vpc-firewall-rules",
+        "ingress-rules",
+        "cloud-audit-logs"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "ocsf-1.8",
+        "cis-gcp-v3"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-okta-mfa-fatigue",
       "layer": "detection",
       "providers": [
@@ -1363,6 +1387,31 @@
         "nist-csf-2.0",
         "soc2-tsc",
         "cis-aws-v3"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
+      "path": "skills/remediation/remediate-gcp-firewall-revoke",
+      "layer": "remediation",
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "vpc-firewall-rules",
+        "ingress-rules",
+        "audit"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "nist-csf-2.0",
+        "soc2-tsc",
+        "cis-gcp-v3"
       ],
       "coverage_status": "validated",
       "execution_modes": [

--- a/skills/README.md
+++ b/skills/README.md
@@ -51,6 +51,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-entra-role-grant-escalation`](detection/detect-entra-role-grant-escalation/) | successful Entra app-role grants to service principals |
 | [`detect-google-workspace-suspicious-login`](detection/detect-google-workspace-suspicious-login/) | provider-marked suspicious Workspace login or repeated failures followed by success |
 | [`detect-aws-open-security-group`](detection/detect-aws-open-security-group/) | AWS Security Group ingress opened to 0.0.0.0/0 or ::/0 on risky admin / database / cache ports (T1190 Exploit Public-Facing Application) |
+| [`detect-gcp-open-firewall`](detection/detect-gcp-open-firewall/) | GCP VPC firewall rule (`compute.firewalls.insert` / `patch`) opened to 0.0.0.0/0 or ::/0 on risky admin / database / cache ports, INGRESS, non-disabled (T1190 Exploit Public-Facing Application) |
 | [`detect-prompt-injection-mcp-proxy`](detection/detect-prompt-injection-mcp-proxy/) | suspicious prompt-injection language in MCP tool descriptions |
 | [`detect-mcp-tool-drift`](detection/detect-mcp-tool-drift/) | T1195.001 |
 | [`detect-container-escape-k8s`](detection/detect-container-escape-k8s/) | T1611, T1610 |
@@ -107,6 +108,7 @@ Active fix workflows with dry-run, audit, and guardrails.
 | [`remediate-entra-credential-revoke`](remediation/remediate-entra-credential-revoke/) | Entra service-principal containment — disable the SP (`accountEnabled=false`) and emit a triage payload listing current credentials + role assignments for operator selective revocation, after detect-entra-credential-addition (T1098.001) or detect-entra-role-grant-escalation (T1098.003); protected name-prefix + objectId deny-list, declared-incident gate, dual audit |
 | [`remediate-workspace-session-kill`](remediation/remediate-workspace-session-kill/) | Google Workspace containment — sign out the user (`Users.signOut`) + force password change (`Users.patch changePasswordAtNextLogin`) after detect-google-workspace-suspicious-login (T1110, T1078); dual-audit, deny-list (admin/break-glass/@google.com + extensible), declared-incident gate; reverify reads Admin SDK Reports for any login_success since remediation |
 | [`remediate-aws-sg-revoke`](remediation/remediate-aws-sg-revoke/) | AWS Security Group surgical revoke — `RevokeSecurityGroupIngress` for the specific cidr+port flagged by detect-aws-open-security-group (T1190); deny-list (`default*` SG names + `intentionally-open` tag + env-pinned sg ids), declared-incident gate, dual audit; reverify re-reads via `DescribeSecurityGroups` and emits OCSF Detection Finding on DRIFT |
+| [`remediate-gcp-firewall-revoke`](remediation/remediate-gcp-firewall-revoke/) | GCP VPC firewall rule containment — `compute.firewalls.patch` with `disabled: true` (default safe) or `compute.firewalls.delete` (opt-in via `--mode delete`) for the specific rule flagged by detect-gcp-open-firewall (T1190); deny-list (`default-*` rule names + `intentionally-open` description + env-pinned rule names), declared-incident gate, dual audit; reverify re-reads via `compute.firewalls.get` and emits OCSF Detection Finding on DRIFT |
 
 ## output/
 

--- a/skills/detection/detect-gcp-open-firewall/REFERENCES.md
+++ b/skills/detection/detect-gcp-open-firewall/REFERENCES.md
@@ -1,0 +1,32 @@
+# References — detect-gcp-open-firewall
+
+## GCP
+
+- VPC firewall rules overview — https://cloud.google.com/firewall/docs/firewalls
+- Firewall rule components (direction, sourceRanges, allowed) — https://cloud.google.com/firewall/docs/firewalls#firewall_rule_components
+- Compute Engine API: `firewalls.insert` — https://cloud.google.com/compute/docs/reference/rest/v1/firewalls/insert
+- Compute Engine API: `firewalls.patch` — https://cloud.google.com/compute/docs/reference/rest/v1/firewalls/patch
+- Cloud Audit Logs: AuditLog message — https://cloud.google.com/logging/docs/reference/audit/auditlog/rest/Shared.Types/AuditLog
+- Cloud Audit Logs: types of audit logs — https://cloud.google.com/logging/docs/audit
+
+## MITRE ATT&CK
+
+- T1190 — Exploit Public-Facing Application: https://attack.mitre.org/techniques/T1190/
+- TA0001 — Initial Access: https://attack.mitre.org/tactics/TA0001/
+
+## OCSF
+
+- API Activity (class 6003): https://schema.ocsf.io/1.8.0/classes/api_activity (input shape)
+- Detection Finding (class 2004): https://schema.ocsf.io/1.8.0/classes/detection_finding (output shape)
+- Repo-pinned contract: [`skills/detection-engineering/OCSF_CONTRACT.md`](../../detection-engineering/OCSF_CONTRACT.md)
+
+## Compliance
+
+- CIS GCP Foundations 2.x — sections 3.6 / 3.7 (ensure no firewall rule allows ingress from 0.0.0.0/0 on admin or database ports)
+- NIST CSF 2.0 — `PR.AC-05` (Network integrity is protected)
+
+## Related repo skills
+
+- [`ingest-gcp-audit-ocsf`](../../ingestion/ingest-gcp-audit-ocsf/) — upstream
+- [`remediate-gcp-firewall-revoke`](../../remediation/remediate-gcp-firewall-revoke/) — paired closed-loop remediator
+- [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/) — periodic posture equivalent

--- a/skills/detection/detect-gcp-open-firewall/SKILL.md
+++ b/skills/detection/detect-gcp-open-firewall/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: detect-gcp-open-firewall
+description: >-
+  Use when GCP audit log shows compute.firewalls.insert or
+  compute.firewalls.patch opening 0.0.0.0/0 or ::/0 to risky admin / DB /
+  cache ports; ATT&CK T1190 (Exploit Public-Facing Application). Reads
+  OCSF 1.8 API Activity (class 6003) records emitted by
+  ingest-gcp-audit-ocsf, fires on successful Compute Engine firewall
+  insert/patch calls whose `unmapped.gcp.request` opens INGRESS from
+  0.0.0.0/0 or ::/0 to any of the configured risky ports (default: SSH,
+  RDP, MySQL, Postgres, Redis, Mongo, Cassandra, Kafka, Elasticsearch,
+  etc.) on a non-disabled rule, and emits an OCSF 1.8 Detection Finding
+  (class 2004) tagged with MITRE ATT&CK T1190. Pairs with
+  remediate-gcp-firewall-revoke. Do NOT use for AWS Security Groups
+  (different shape — see detect-aws-open-security-group), for Azure
+  Network Security Groups (separate detector planned), for private-only
+  source-range changes (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), for
+  EGRESS firewall changes, for rules created with `disabled: true`, or
+  as a posture check (CSPM evaluates state at rest; this detector fires
+  on the create/patch event so response can be near-real-time).
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file, emits OCSF 1.8 Detection Finding 2004 to stdout. No GCP
+  SDK; pairs with the existing ingest-gcp-audit-ocsf upstream and the
+  remediate-gcp-firewall-revoke downstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-gcp-open-firewall
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - CIS GCP Foundations
+  cloud: gcp
+  capability: read-only
+---
+
+# detect-gcp-open-firewall
+
+Streaming detector for GCP VPC firewall rules opened to the internet on risky
+ports. Pairs with [`remediate-gcp-firewall-revoke`](../../remediation/remediate-gcp-firewall-revoke/).
+
+## Use when
+
+- You stream GCP Cloud Audit Logs through `ingest-gcp-audit-ocsf` and want
+  near-real-time T1190 findings on `compute.firewalls.insert` and
+  `compute.firewalls.patch`
+- You want a streaming alternative to the periodic CSPM check that catches
+  firewall exposures the moment they land
+- You feed findings into the closed-loop remediator
+  (`remediate-gcp-firewall-revoke`)
+
+## Do NOT use
+
+- For AWS Security Groups (use `detect-aws-open-security-group`)
+- For Azure Network Security Groups (separate detector planned)
+- For private-only source-range changes (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+- For EGRESS firewall rule changes (different blast radius)
+- For rules created with `disabled: true` (no live traffic)
+- As a posture-at-rest scan (use `cspm-gcp-cis-benchmark`)
+
+## Rule
+
+A finding fires on every `compute.firewalls.insert` / `compute.firewalls.patch`
+event from `ingest-gcp-audit-ocsf` that:
+
+1. has `status_id == 1` (success)
+2. carries `unmapped.gcp.request.direction == "INGRESS"`
+3. is not disabled (`unmapped.gcp.request.disabled` is False / missing)
+4. carries at least one CIDR in `sourceRanges` that is `0.0.0.0/0` or `::/0`
+5. covers at least one risky port across its `allowed[]` entries (protocol
+   `all` or port range covering a risky port counts as a hit)
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`),
+with:
+
+- `finding_info.attacks[].tactic_uid = TA0001` (Initial Access)
+- `finding_info.attacks[].technique_uid = T1190` (Exploit Public-Facing Application)
+- `observables[]` includes `target.uid` (firewall rule name), `target.name`,
+  `target.type=GcpFirewallRule`, `account.uid` (project id), plus per-CIDR
+  and per-port observables for the remediator to consume
+
+## Run
+
+```bash
+# GCP audit logs → ingest → detect (default OCSF output)
+python skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-gcp-open-firewall/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-gcp-open-firewall/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-gcp-audit-ocsf`](../../ingestion/ingest-gcp-audit-ocsf/) — upstream ingester
+- [`remediate-gcp-firewall-revoke`](../../remediation/remediate-gcp-firewall-revoke/) — pair remediator
+- [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/) — posture-at-rest equivalent
+- [`detection-engineering/OCSF_CONTRACT.md`](../../detection-engineering/OCSF_CONTRACT.md)

--- a/skills/detection/detect-gcp-open-firewall/src/detect.py
+++ b/skills/detection/detect-gcp-open-firewall/src/detect.py
@@ -1,0 +1,508 @@
+"""Detect GCP VPC firewall rules opened to the internet (0.0.0.0/0 or ::/0).
+
+Reads OCSF 1.8 API Activity (class 6003) records emitted by
+`ingest-gcp-audit-ocsf` from stdin or a file. Fires on
+`compute.firewalls.insert` and `compute.firewalls.patch` calls that grant
+INGRESS access from 0.0.0.0/0 or ::/0 to a risky port on a non-disabled
+rule. Emits OCSF 1.8 Detection Finding (class 2004) tagged with MITRE
+ATT&CK T1190 (Exploit Public-Facing Application).
+
+GCP firewall rules differ from AWS Security Groups:
+- INGRESS / EGRESS direction is explicit; this detector is INGRESS-only
+- A rule may be `disabled: true`, in which case it grants nothing live
+- The grant is described by `allowed[]` entries (each carrying
+  `IPProtocol` + optional `ports[]`)
+- The targeting tuple is `(project, firewall_rule_name)` — there is no
+  region (firewalls are project-wide) and no AWS-style "security group id"
+
+Rule:
+1. event.api.operation in {compute.firewalls.insert, compute.firewalls.patch}
+2. event.status_id == 1 (success)
+3. unmapped.gcp.request.direction == "INGRESS"
+4. not unmapped.gcp.request.disabled
+5. unmapped.gcp.request.sourceRanges includes 0.0.0.0/0 OR ::/0
+6. unmapped.gcp.request.allowed[].ports overlaps a risky port (protocol
+   `all` or no `ports` means "all ports", which counts as a hit)
+
+Output: OCSF Detection Finding 2004, with `target.uid` = the firewall
+rule name and `target.name` = the same name. The remediator
+(`remediate-gcp-firewall-revoke`) consumes these findings to disable
+or delete the offending rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-gcp-open-firewall"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+# OCSF Detection Finding 2004
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+# MITRE ATT&CK v14
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0001"
+TACTIC_NAME = "Initial Access"
+TECHNIQUE_UID = "T1190"
+TECHNIQUE_NAME = "Exploit Public-Facing Application"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-gcp-audit-ocsf"})
+
+ACCEPTED_OPERATIONS = frozenset(
+    {
+        "compute.firewalls.insert",
+        "compute.firewalls.patch",
+        # Some audit-log emitters use bare method names; tolerate both.
+        "v1.compute.firewalls.insert",
+        "v1.compute.firewalls.patch",
+    }
+)
+
+# Default risky ports — admin / database / cache / search surfaces. Same
+# list as the AWS detector so operators see uniform behaviour across clouds.
+DEFAULT_RISKY_PORTS = (
+    22,     # SSH
+    23,     # Telnet
+    135,    # MSRPC
+    445,    # SMB
+    1433,   # MSSQL
+    1521,   # Oracle
+    2049,   # NFS
+    3306,   # MySQL
+    3389,   # RDP
+    5432,   # Postgres
+    5984,   # CouchDB
+    6379,   # Redis
+    8086,   # InfluxDB
+    9042,   # Cassandra
+    9092,   # Kafka
+    9200,   # Elasticsearch
+    11211,  # Memcached
+    27017,  # MongoDB
+)
+
+PUBLIC_CIDRS = frozenset({"0.0.0.0/0", "::/0"})
+
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == 1
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _request_payload(event: dict[str, Any]) -> dict[str, Any]:
+    """The compute.firewalls.insert/patch request body lives under
+    `unmapped.gcp.request` after ingest-gcp-audit-ocsf normalization
+    (or `api.request.data` on some emit paths).
+    """
+    unmapped = event.get("unmapped") or {}
+    if isinstance(unmapped, dict):
+        gcp = unmapped.get("gcp")
+        if isinstance(gcp, dict):
+            req = gcp.get("request")
+            if isinstance(req, dict):
+                return req
+    api = event.get("api") or {}
+    request = api.get("request") or {}
+    if isinstance(request, dict):
+        data = request.get("data")
+        if isinstance(data, dict):
+            return data
+    return {}
+
+
+def _firewall_name(event: dict[str, Any], request: dict[str, Any]) -> str:
+    """Firewall name lives in the request body (`name`) and/or the audit
+    log resourceName (`projects/<p>/global/firewalls/<name>`)."""
+    name = str(request.get("name") or "")
+    if name:
+        return name
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        rname = str(resource.get("name") or "")
+        if "/global/firewalls/" in rname:
+            return rname.rsplit("/", 1)[-1]
+        if "/firewalls/" in rname:
+            return rname.rsplit("/", 1)[-1]
+    return ""
+
+
+def _network_self_link(request: dict[str, Any]) -> str:
+    return str(request.get("network") or "")
+
+
+def _direction(request: dict[str, Any]) -> str:
+    return str(request.get("direction") or "INGRESS").upper()
+
+
+def _is_disabled(request: dict[str, Any]) -> bool:
+    val = request.get("disabled")
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.strip().lower() == "true"
+    return False
+
+
+def _source_ranges(request: dict[str, Any]) -> list[str]:
+    raw = request.get("sourceRanges") or []
+    if not isinstance(raw, list):
+        return []
+    return [str(item) for item in raw if isinstance(item, (str, bytes))]
+
+
+def _iter_allowed(request: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    raw = request.get("allowed") or []
+    if not isinstance(raw, list):
+        return
+    for item in raw:
+        if isinstance(item, dict):
+            yield item
+
+
+def _ports_overlap_risky(
+    allowed_entry: dict[str, Any], risky_ports: Iterable[int]
+) -> tuple[bool, list[int]]:
+    """A GCP `allowed[]` entry has `IPProtocol` and optional `ports[]`.
+    Each `ports[]` element is either `"22"` or `"1000-2000"`. If `ports`
+    is missing, the rule covers ALL ports for that protocol. Protocol
+    `all` covers all protocols + ports.
+    """
+    protocol = str(allowed_entry.get("IPProtocol") or "").lower()
+    risky_sorted = sorted(risky_ports)
+    if protocol == "all":
+        return True, risky_sorted
+    # GCP only carries ports[] meaningfully for tcp / udp / sctp; for
+    # icmp / esp / ah / etc. there is no port concept and the rule covers
+    # every packet of that protocol — but icmp/esp/ah are NOT TCP services
+    # at risky ports, so we don't fire on them here.
+    if protocol not in ("tcp", "udp", "sctp"):
+        return False, []
+    ports_field = allowed_entry.get("ports")
+    if not ports_field:
+        # No ports[] = all ports for this protocol = every risky port hit
+        return True, risky_sorted
+    if not isinstance(ports_field, list):
+        return False, []
+    hits: set[int] = set()
+    for spec in ports_field:
+        spec_str = str(spec).strip()
+        if not spec_str:
+            continue
+        if "-" in spec_str:
+            lo_s, hi_s = spec_str.split("-", 1)
+            try:
+                lo = int(lo_s)
+                hi = int(hi_s)
+            except ValueError:
+                continue
+            if lo > hi:
+                lo, hi = hi, lo
+            for p in risky_sorted:
+                if lo <= p <= hi:
+                    hits.add(p)
+        else:
+            try:
+                p = int(spec_str)
+            except ValueError:
+                continue
+            if p in risky_sorted:
+                hits.add(p)
+    return bool(hits), sorted(hits)
+
+
+def _actor(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    src = event.get("src_endpoint") or {}
+    return str(src.get("ip") or "")
+
+
+def _finding_uid(event_uid: str, fw_name: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{fw_name}|{time_ms}"
+    return f"gfw-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(
+    *,
+    event: dict[str, Any],
+    fw_name: str,
+    network: str,
+    public_cidrs_hit: list[str],
+    risky_ports_hit: list[int],
+    allowed_entry: dict[str, Any],
+) -> dict[str, Any]:
+    time_ms = int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+    event_uid = str((event.get("metadata") or {}).get("uid") or "")
+    finding_uid = _finding_uid(event_uid, fw_name, time_ms)
+    actor = _actor(event)
+    account = _account(event)
+    src_ip = _src_ip(event)
+
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "open-gcp-firewall-ingress",
+        "firewall_name": fw_name,
+        "network": network,
+        "actor_name": actor,
+        "account_uid": account,
+        "src_ip": src_ip,
+        "public_cidrs_hit": public_cidrs_hit,
+        "risky_ports_hit": risky_ports_hit,
+        "allowed": allowed_entry,
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a native finding as an OCSF 1.8 Detection Finding (class 2004)."""
+    title = (
+        f"GCP firewall rule {native['firewall_name']} opened to the internet on risky port(s) "
+        f"{native['risky_ports_hit']}"
+    )
+    description = (
+        f"Actor `{native['actor_name']}` in project `{native['account_uid']}` "
+        f"opened firewall rule `{native['firewall_name']}` to "
+        f"{native['public_cidrs_hit']} covering risky ports {native['risky_ports_hit']}. "
+        f"Source IP: {native['src_ip'] or '<unknown>'}."
+    )
+
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "GCP"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": "compute.firewalls.insert_or_patch"},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.uid", "type": "Other", "value": native["firewall_name"]},
+        {"name": "target.name", "type": "Other", "value": native["firewall_name"]},
+        {"name": "target.type", "type": "Other", "value": "GcpFirewallRule"},
+        {"name": "account.uid", "type": "Other", "value": native["account_uid"]},
+        {"name": "region", "type": "Other", "value": "global"},
+    ]
+    if native["network"]:
+        observables.append({"name": "target.network", "type": "Other", "value": native["network"]})
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    for cidr in native["public_cidrs_hit"]:
+        observables.append({"name": "permission.cidr", "type": "Other", "value": cidr})
+    protocol = str((native["allowed"] or {}).get("IPProtocol") or "")
+    if protocol:
+        observables.append({"name": "permission.protocol", "type": "Other", "value": protocol})
+    ports_field = (native["allowed"] or {}).get("ports")
+    if isinstance(ports_field, list):
+        for ps in ports_field:
+            observables.append({"name": "permission.port_spec", "type": "Other", "value": str(ps)})
+    for port in native["risky_ports_hit"]:
+        observables.append({"name": "permission.port", "type": "Other", "value": str(port)})
+
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["gcp", "firewall", "exposure"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": title,
+            "desc": description,
+            "types": ["open-gcp-firewall"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "allowed": native["allowed"],
+            "public_cidrs_hit": native["public_cidrs_hit"],
+            "risky_ports_hit": native["risky_ports_hit"],
+            "network": native["network"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+    risky_ports: Iterable[int] = DEFAULT_RISKY_PORTS,
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+    risky_ports = tuple(sorted(set(risky_ports)))
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME, level="warning", event="wrong_source",
+                message=f"skipping event from non-gcp-audit producer `{producer}`",
+            )
+            continue
+
+        op = _api_operation(event)
+        if op not in ACCEPTED_OPERATIONS:
+            continue
+        if not _is_success(event):
+            continue
+
+        request = _request_payload(event)
+        if not request:
+            continue
+
+        # Direction must be INGRESS (default per GCP API when missing)
+        if _direction(request) != "INGRESS":
+            continue
+        if _is_disabled(request):
+            continue
+
+        sources = _source_ranges(request)
+        public_hits = sorted(c for c in sources if c in PUBLIC_CIDRS)
+        if not public_hits:
+            continue
+
+        fw_name = _firewall_name(event, request)
+        if not fw_name:
+            emit_stderr_event(
+                SKILL_NAME, level="warning", event="no_firewall_name",
+                message="firewalls.insert/patch finding missing rule name; skipping",
+            )
+            continue
+
+        network = _network_self_link(request)
+
+        for allowed_entry in _iter_allowed(request):
+            overlaps, port_hits = _ports_overlap_risky(allowed_entry, risky_ports)
+            if not overlaps:
+                continue
+            native = _build_native_finding(
+                event=event, fw_name=fw_name, network=network,
+                public_cidrs_hit=public_hits, risky_ports_hit=port_hits,
+                allowed_entry=allowed_entry,
+            )
+            yield native if output_format == "native" else _to_ocsf(native)
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME, level="warning", event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}", line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect GCP VPC firewall rules opened to 0.0.0.0/0 or ::/0 on risky ports."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format", choices=sorted(OUTPUT_FORMATS), default="ocsf",
+        help="Emit OCSF Detection Finding (default) or native projection.",
+    )
+    parser.add_argument(
+        "--input-format", choices=("ocsf",), default="ocsf",
+        help="Only OCSF input is accepted; reserved for forward compatibility.",
+    )
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+            out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-gcp-open-firewall/tests/conftest.py
+++ b/skills/detection/detect-gcp-open-firewall/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover", "handler")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/detection/detect-gcp-open-firewall/tests/test_detect.py
+++ b/skills/detection/detect-gcp-open-firewall/tests/test_detect.py
@@ -1,0 +1,298 @@
+"""Tests for detect-gcp-open-firewall."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from detect import (  # type: ignore[import-not-found]
+    ACCEPTED_OPERATIONS,
+    ACCEPTED_PRODUCERS,
+    DEFAULT_RISKY_PORTS,
+    PUBLIC_CIDRS,
+    detect,
+)
+
+
+def _gcp_event(
+    *,
+    operation: str = "compute.firewalls.insert",
+    success: bool = True,
+    fw_name: str = "allow-ssh-world",
+    network: str = "projects/p-1/global/networks/default",
+    direction: str = "INGRESS",
+    disabled: bool = False,
+    source_ranges: list[str] | None = None,
+    allowed: list[dict] | None = None,
+    actor: str = "alice@example.com",
+    account_uid: str = "p-1",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-gcp-audit-ocsf",
+) -> dict:
+    if source_ranges is None:
+        source_ranges = ["0.0.0.0/0"]
+    if allowed is None:
+        allowed = [{"IPProtocol": "tcp", "ports": ["22"]}]
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1700000000000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "actor": {"user": {"name": actor}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation, "service": {"name": "compute.googleapis.com"}},
+        "cloud": {"provider": "GCP", "account": {"uid": account_uid}, "region": "global"},
+        "resources": [
+            {"name": f"projects/{account_uid}/global/firewalls/{fw_name}", "type": "gce_firewall_rule"}
+        ],
+        "unmapped": {
+            "gcp": {
+                "request": {
+                    "name": fw_name,
+                    "network": network,
+                    "direction": direction,
+                    "disabled": disabled,
+                    "sourceRanges": source_ranges,
+                    "allowed": allowed,
+                }
+            }
+        },
+    }
+
+
+# ---------- contract ----------
+
+
+def test_accepted_producer_is_gcp_audit():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-gcp-audit-ocsf"})
+
+
+def test_accepted_operations_cover_insert_and_patch():
+    assert "compute.firewalls.insert" in ACCEPTED_OPERATIONS
+    assert "compute.firewalls.patch" in ACCEPTED_OPERATIONS
+
+
+def test_default_risky_ports_cover_admin_and_database_classes():
+    for required in (22, 3389, 3306, 5432, 6379, 27017, 9200):
+        assert required in DEFAULT_RISKY_PORTS
+
+
+def test_public_cidrs_set():
+    assert PUBLIC_CIDRS == frozenset({"0.0.0.0/0", "::/0"})
+
+
+# ---------- positive findings ----------
+
+
+def test_fires_on_ssh_open_to_world():
+    findings = list(detect([_gcp_event()]))
+    assert len(findings) == 1
+    f = findings[0]
+    assert f["class_uid"] == 2004
+    assert f["severity_id"] == 4
+    assert f["finding_info"]["attacks"][0]["technique_uid"] == "T1190"
+    assert any(
+        obs["name"] == "target.uid" and obs["value"] == "allow-ssh-world"
+        for obs in f["observables"]
+    )
+    assert any(
+        obs["name"] == "permission.cidr" and obs["value"] == "0.0.0.0/0"
+        for obs in f["observables"]
+    )
+    assert any(
+        obs["name"] == "permission.port" and obs["value"] == "22"
+        for obs in f["observables"]
+    )
+    assert any(
+        obs["name"] == "permission.protocol" and obs["value"] == "tcp"
+        for obs in f["observables"]
+    )
+
+
+def test_fires_on_mssql_ipv6_world_open():
+    findings = list(
+        detect(
+            [
+                _gcp_event(
+                    fw_name="allow-mssql-v6",
+                    source_ranges=["::/0"],
+                    allowed=[{"IPProtocol": "tcp", "ports": ["1433"]}],
+                )
+            ]
+        )
+    )
+    assert len(findings) == 1
+    assert any(
+        obs["name"] == "permission.cidr" and obs["value"] == "::/0"
+        for obs in findings[0]["observables"]
+    )
+    assert any(
+        obs["name"] == "permission.port" and obs["value"] == "1433"
+        for obs in findings[0]["observables"]
+    )
+
+
+def test_fires_on_port_range_covering_risky_port():
+    """A 1-65535 range to 0.0.0.0/0 includes every risky port and must fire."""
+    findings = list(
+        detect(
+            [
+                _gcp_event(
+                    allowed=[{"IPProtocol": "tcp", "ports": ["1-65535"]}],
+                )
+            ]
+        )
+    )
+    assert len(findings) == 1
+    port_obs = [obs for obs in findings[0]["observables"] if obs["name"] == "permission.port"]
+    assert len(port_obs) >= 5
+
+
+def test_fires_on_protocol_all():
+    """IPProtocol=all means every protocol + port; must fire."""
+    findings = list(
+        detect(
+            [
+                _gcp_event(allowed=[{"IPProtocol": "all"}]),
+            ]
+        )
+    )
+    assert len(findings) == 1
+    assert any(
+        obs["name"] == "permission.protocol" and obs["value"] == "all"
+        for obs in findings[0]["observables"]
+    )
+
+
+def test_fires_on_tcp_no_ports_means_all_ports():
+    """tcp without ports[] means every TCP port — every risky tcp port hit."""
+    findings = list(
+        detect(
+            [
+                _gcp_event(allowed=[{"IPProtocol": "tcp"}]),
+            ]
+        )
+    )
+    assert len(findings) == 1
+
+
+def test_fires_on_patch_operation():
+    findings = list(detect([_gcp_event(operation="compute.firewalls.patch")]))
+    assert len(findings) == 1
+
+
+def test_native_output_format():
+    findings = list(detect([_gcp_event()], output_format="native"))
+    f = findings[0]
+    assert f["schema_mode"] == "native"
+    assert f["record_type"] == "detection_finding"
+    assert f["firewall_name"] == "allow-ssh-world"
+    assert "allowed" in f
+
+
+# ---------- negative cases ----------
+
+
+def test_no_finding_when_source_is_private():
+    findings = list(detect([_gcp_event(source_ranges=["10.0.0.0/8"])]))
+    assert findings == []
+
+
+def test_no_finding_for_world_open_to_non_risky_port():
+    """0.0.0.0/0 on port 123 (NTP) is not in risky list."""
+    findings = list(
+        detect(
+            [
+                _gcp_event(
+                    fw_name="allow-ntp-world",
+                    allowed=[{"IPProtocol": "udp", "ports": ["123"]}],
+                )
+            ]
+        )
+    )
+    assert findings == []
+
+
+def test_no_finding_for_disabled_rule():
+    """disabled=True means no live traffic; no finding."""
+    findings = list(detect([_gcp_event(disabled=True)]))
+    assert findings == []
+
+
+def test_no_finding_for_egress_direction():
+    findings = list(detect([_gcp_event(direction="EGRESS")]))
+    assert findings == []
+
+
+def test_no_finding_for_failed_event():
+    findings = list(detect([_gcp_event(success=False)]))
+    assert findings == []
+
+
+def test_no_finding_for_unrelated_operation():
+    findings = list(detect([_gcp_event(operation="compute.firewalls.delete")]))
+    assert findings == []
+
+
+def test_skips_event_from_wrong_producer(capsys):
+    findings = list(detect([_gcp_event(producer="ingest-cloudtrail-ocsf")]))
+    assert findings == []
+    assert "non-gcp-audit producer" in capsys.readouterr().err
+
+
+def test_skips_event_with_no_request_payload():
+    event = _gcp_event()
+    event["unmapped"] = {}
+    findings = list(detect([event]))
+    assert findings == []
+
+
+# ---------- multi-allowed ----------
+
+
+def test_one_event_with_multiple_allowed_emits_per_allowed():
+    event = _gcp_event(
+        allowed=[
+            {"IPProtocol": "tcp", "ports": ["22"]},
+            {"IPProtocol": "tcp", "ports": ["3306"]},
+        ]
+    )
+    findings = list(detect([event]))
+    assert len(findings) == 2
+    fw_names = {
+        obs["value"]
+        for f in findings
+        for obs in f["observables"]
+        if obs["name"] == "target.uid"
+    }
+    assert fw_names == {"allow-ssh-world"}
+
+
+def test_mixed_world_and_corp_source_ranges_only_emits_for_world():
+    findings = list(
+        detect([_gcp_event(source_ranges=["0.0.0.0/0", "10.0.0.0/8"])])
+    )
+    assert len(findings) == 1
+    cidr_obs = [
+        obs["value"] for obs in findings[0]["observables"] if obs["name"] == "permission.cidr"
+    ]
+    assert cidr_obs == ["0.0.0.0/0"]
+
+
+def test_unsupported_output_format_raises():
+    import pytest
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_gcp_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    e = _gcp_event()
+    a = list(detect([e]))[0]["finding_info"]["uid"]
+    b = list(detect([e]))[0]["finding_info"]["uid"]
+    assert a == b
+    assert a.startswith("gfw-")

--- a/skills/remediation/remediate-gcp-firewall-revoke/REFERENCES.md
+++ b/skills/remediation/remediate-gcp-firewall-revoke/REFERENCES.md
@@ -1,0 +1,39 @@
+# References — remediate-gcp-firewall-revoke
+
+## GCP
+
+- VPC firewall rules overview — https://cloud.google.com/firewall/docs/firewalls
+- Firewall rule components (direction, sourceRanges, allowed, disabled) — https://cloud.google.com/firewall/docs/firewalls#firewall_rule_components
+- Compute Engine API: `firewalls.get` — https://cloud.google.com/compute/docs/reference/rest/v1/firewalls/get
+- Compute Engine API: `firewalls.patch` — https://cloud.google.com/compute/docs/reference/rest/v1/firewalls/patch
+- Compute Engine API: `firewalls.delete` — https://cloud.google.com/compute/docs/reference/rest/v1/firewalls/delete
+- IAM permissions for Compute Engine firewalls (`compute.firewalls.get`, `compute.firewalls.patch`, `compute.firewalls.delete`) — https://cloud.google.com/compute/docs/access/iam
+- Predefined role `roles/compute.securityAdmin` — https://cloud.google.com/iam/docs/understanding-roles#compute-engine-roles
+
+## MITRE ATT&CK
+
+- T1190 — Exploit Public-Facing Application: https://attack.mitre.org/techniques/T1190/
+- M1037 — Filter Network Traffic: https://attack.mitre.org/mitigations/M1037/
+
+## OCSF 1.8
+
+- Detection Finding (class 2004): https://schema.ocsf.io/1.8.0/classes/detection_finding
+- Repo-pinned contract: [`skills/detection-engineering/OCSF_CONTRACT.md`](../../detection-engineering/OCSF_CONTRACT.md)
+
+## Audit infrastructure (shared with the AWS pair)
+
+- DynamoDB PutItem — https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
+- S3 server-side encryption with KMS — https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+- Audit table partition key is `rule_name`, sort key `action_at` (ISO-8601 UTC); rows carry `provider: "gcp"` and `project_id` for cross-cloud queries.
+
+## Compliance frameworks
+
+- NIST CSF 2.0 — `RS.MI` (Mitigation), `PR.AC-05` (Network integrity)
+- SOC 2 — CC6.6 (Logical and physical access controls)
+- CIS GCP Foundations 2.x — sections 3.6 / 3.7 (no firewall rule allows ingress from 0.0.0.0/0 on admin or database ports)
+
+## Related repo skills
+
+- [`detect-gcp-open-firewall`](../../detection/detect-gcp-open-firewall/) — paired source detector
+- [`remediate-aws-sg-revoke`](../remediate-aws-sg-revoke/) — AWS counterpart sharing the dual-audit pattern
+- [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/) — periodic posture equivalent (read-only); the streaming detector + this remediator close the loop in near-real-time

--- a/skills/remediation/remediate-gcp-firewall-revoke/SKILL.md
+++ b/skills/remediation/remediate-gcp-firewall-revoke/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: remediate-gcp-firewall-revoke
+description: >-
+  Use when a GCP VPC firewall rule has been flagged as opening 0.0.0.0/0
+  or ::/0 to risky admin / DB / cache ports and you need to contain it.
+  Consumes an OCSF 1.8 Detection Finding (class 2004) emitted by
+  detect-gcp-open-firewall (T1190 Exploit Public-Facing Application) and
+  surgically disables the offending firewall rule via Compute Engine
+  `firewalls.patch` (default safe action: `disabled: true`) or, opt-in
+  via `--mode delete`, removes it via `firewalls.delete`. Every action
+  is dry-run by default, deny-listed against rule names matching
+  `default-*`, rules whose `description` contains `intentionally-open`,
+  and any rule name in GCP_FIREWALL_REVOKE_DENY_RULE_NAMES. Apply
+  requires GCP_FIREWALL_REVOKE_INCIDENT_ID + GCP_FIREWALL_REVOKE_APPROVER.
+  Dual audit (DynamoDB + KMS-encrypted S3, same shared infra as the AWS
+  pair, with `provider: "gcp"`). Reverify re-reads the rule via
+  `firewalls.get` and emits VERIFIED if the rule is gone or remains
+  disabled, DRIFT (+ paired OCSF Detection Finding via the shared
+  remediation_verifier contract) if it re-appears or is re-enabled,
+  UNREACHABLE if the Compute API throws. Do NOT use to mass-delete
+  firewall rules, for AWS Security Groups (use remediate-aws-sg-revoke),
+  for Azure Network Security Groups (separate skill planned), to bypass
+  the deny-list, or to operate on rules outside the project the caller
+  has authenticated to.
+license: Apache-2.0
+capability: write-cloud
+approval_model: human_required
+execution_modes: jit, ci, mcp, persistent
+side_effects: writes-cloud, writes-storage, writes-audit
+input_formats: ocsf, native
+output_formats: native
+concurrency_safety: operator_coordinated
+network_egress: compute.googleapis.com, s3.amazonaws.com, dynamodb.amazonaws.com
+caller_roles: security_engineer, incident_responder, platform_engineer
+approver_roles: security_lead, incident_commander, platform_owner
+min_approvers: 1
+compatibility: >-
+  Requires Python 3.11+, google-api-python-client (lazy-imported only
+  under --apply / --reverify) and boto3 for the shared dual-audit sink.
+  GCP permissions: compute.firewalls.get + compute.firewalls.patch (and
+  compute.firewalls.delete only when --mode delete is used) on the
+  target project. The skill runs under whatever GCP credentials the
+  caller's environment provides; cross-project orchestration belongs in
+  the runner layer.
+metadata:
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/remediation/remediate-gcp-firewall-revoke
+  version: 0.1.0
+  frameworks:
+    - MITRE ATT&CK v14
+    - NIST CSF 2.0
+    - SOC 2
+    - CIS GCP Foundations
+  cloud:
+    - gcp
+---
+
+# remediate-gcp-firewall-revoke
+
+## What this closes
+
+Pair skill for [`detect-gcp-open-firewall`](../../detection/detect-gcp-open-firewall/) (MITRE ATT&CK T1190 — Exploit Public-Facing Application).
+
+This is the GCP counterpart to [`remediate-aws-sg-revoke`](../remediate-aws-sg-revoke/). Together with the detector, GCP firewall public exposure becomes a closed loop: detect → contain → audit → re-verify.
+
+## Why disable-by-default (not delete)
+
+GCP firewall rules are project-scoped, named, and frequently referenced by
+infrastructure-as-code, attached service descriptions, and operator playbooks.
+Deleting a rule by name is a destructive change that loses history and breaks
+references. The default action is `firewalls.patch` with `disabled: true`,
+which immediately stops the rule from granting traffic but preserves the
+object for forensics and rollback. Use `--mode delete` only when the operator
+explicitly accepts that loss of history.
+
+## Inputs
+
+OCSF 1.8 Detection Finding (class 2004) from `detect-gcp-open-firewall`. Required observables:
+
+- `target.uid` — the firewall rule name (REQUIRED)
+- `target.name` — same as `target.uid` for GCP
+- `account.uid` — the GCP project id (REQUIRED for audit context)
+- `permission.cidr[]`, `permission.port[]` — what the offending grant covers
+- `actor.name`, `rule` — audit context
+
+## Do NOT use
+
+- To mass-delete firewall rules (this skill is finding-driven and one-rule-at-a-time)
+- For AWS Security Groups (use `remediate-aws-sg-revoke`)
+- For Azure Network Security Groups (separate skill planned)
+- To bypass the deny-list, run `--apply` without an explicit human-approved incident window, or edit the audit trail by hand
+- For audit/discovery — this skill writes; for inventory use `discover-environment`
+- For rules outside the project the caller has authenticated to
+
+## Guardrails (enforced in code)
+
+| Layer | Mechanism |
+|---|---|
+| Source check | `ACCEPTED_PRODUCERS = {"detect-gcp-open-firewall"}` |
+| Default-rule protection | rule names beginning with `default-` (the GCP project default firewalls) refuse revoke |
+| Intentionally-open description | rules whose `description` contains `intentionally-open` refuse revoke; description is logged in the audit row |
+| Operator allowlist | `GCP_FIREWALL_REVOKE_DENY_RULE_NAMES` env var (comma-separated rule names) refuses revoke |
+| Apply gate | `--apply` requires `GCP_FIREWALL_REVOKE_INCIDENT_ID` + `GCP_FIREWALL_REVOKE_APPROVER` set out-of-band |
+| Mode gate | `--mode patch` (default, sets `disabled: true`) is non-destructive; `--mode delete` is opt-in and dual-logged |
+| Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER the patch/delete; failure paths still write the failure audit row |
+| Re-verify | Re-reads the rule via `firewalls.get`; emits VERIFIED if absent or `disabled: true`, DRIFT (+ paired OCSF finding) if re-enabled or re-created, UNREACHABLE if API throws — never silently downgrades |
+
+## Run
+
+```bash
+# Dry-run plan (default)
+python skills/remediation/remediate-gcp-firewall-revoke/src/handler.py findings.ocsf.jsonl
+
+# Apply (default mode = patch with disabled: true)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+export GCP_FIREWALL_REVOKE_INCIDENT_ID=INC-2026-04-19-006
+export GCP_FIREWALL_REVOKE_APPROVER=alice@security
+export GCP_FIREWALL_REVOKE_AUDIT_DYNAMODB_TABLE=gcp-firewall-revoke-audit
+export GCP_FIREWALL_REVOKE_AUDIT_BUCKET=acme-gcp-firewall-audit
+export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
+# Optional: pin rule names that should never be auto-revoked
+export GCP_FIREWALL_REVOKE_DENY_RULE_NAMES=allow-ops-bastion,allow-internal-lb
+python skills/remediation/remediate-gcp-firewall-revoke/src/handler.py findings.ocsf.jsonl --apply
+
+# Apply with delete (opt-in, more destructive)
+python skills/remediation/remediate-gcp-firewall-revoke/src/handler.py findings.ocsf.jsonl --apply --mode delete
+
+# Re-verify (read-only)
+python skills/remediation/remediate-gcp-firewall-revoke/src/handler.py findings.ocsf.jsonl --reverify
+```
+
+## Required GCP IAM
+
+The execution principal needs these Compute Engine permissions on the target project:
+
+- `compute.firewalls.get` — for re-verify and pre-check
+- `compute.firewalls.patch` — for default `--mode patch` (set `disabled: true`)
+- `compute.firewalls.delete` — only when `--mode delete` is used
+
+These are all included in the predefined role `roles/compute.securityAdmin`. A
+least-privilege custom role with just the three permissions above is the
+recommended path.
+
+## Non-goals
+
+- Deleting all firewall rules in a project (one-rule-at-a-time, finding-driven)
+- Tag-based discovery of rules to revoke (this skill is finding-driven)
+- Cross-project auto-revoke (operators run the skill under the right project credentials, or the runner does)
+- Posture-at-rest scanning (use `cspm-gcp-cis-benchmark`)
+
+## See also
+
+- [`detect-gcp-open-firewall`](../../detection/detect-gcp-open-firewall/) — paired source detector
+- [`remediate-aws-sg-revoke`](../remediate-aws-sg-revoke/) — AWS counterpart
+- [`remediate-okta-session-kill`](../remediate-okta-session-kill/), [`remediate-k8s-rbac-revoke`](../remediate-k8s-rbac-revoke/), [`remediate-entra-credential-revoke`](../remediate-entra-credential-revoke/) — sibling closed-loop remediation skills
+- [`_shared/remediation_verifier.py`](../../_shared/remediation_verifier.py) — verification contract
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — repo-wide HITL bar

--- a/skills/remediation/remediate-gcp-firewall-revoke/src/handler.py
+++ b/skills/remediation/remediate-gcp-firewall-revoke/src/handler.py
@@ -1,0 +1,727 @@
+"""Revoke a GCP VPC firewall rule flagged as open to the internet.
+
+Consumes an OCSF 1.8 Detection Finding (class 2004) emitted by
+detect-gcp-open-firewall (T1190 — Exploit Public-Facing Application).
+Plans (dry-run default), applies (--apply), or re-verifies (--reverify)
+removal of the offending firewall rule via Compute Engine
+`firewalls.patch` (default safe mode: `disabled: true`) or
+`firewalls.delete` (opt-in via `--mode delete`).
+
+Why disable-by-default (not delete):
+- Firewall rules are referenced by IaC, attached service descriptions,
+  and operator playbooks. Deleting drops history and breaks references.
+- `disabled: true` immediately stops the rule granting traffic but
+  preserves the object for forensics and rollback.
+- `--mode delete` remains available for operators who explicitly accept
+  the loss of history.
+
+Guardrails enforced in code:
+- ACCEPTED_PRODUCERS limits input to detect-gcp-open-firewall
+- Protected rule deny-list:
+    * any rule name beginning with `default-` (the GCP project default rules)
+    * any rule whose `description` contains `intentionally-open`
+    * any rule name in GCP_FIREWALL_REVOKE_DENY_RULE_NAMES env var
+- --apply requires GCP_FIREWALL_REVOKE_INCIDENT_ID + GCP_FIREWALL_REVOKE_APPROVER
+- The Compute client respects whatever credentials the operator's
+  environment provides; we never call cross-project from here
+- Dual audit BEFORE and AFTER each Patch/Delete
+- --reverify confirms the rule is absent or disabled; DRIFT (re-enabled
+  or re-created) emits paired OCSF Detection Finding via the shared
+  remediation_verifier contract
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Protocol
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.remediation_verifier import (  # noqa: E402
+    DEFAULT_VERIFICATION_SLA_MS,
+    RemediationReference,
+    VerificationResult,
+    VerificationStatus,
+    build_drift_finding,
+    build_verification_record,
+    sla_deadline,
+)
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "remediate-gcp-firewall-revoke"
+CANONICAL_VERSION = "2026-04"
+ACCEPTED_PRODUCERS = frozenset({"detect-gcp-open-firewall"})
+
+DEFAULT_PROTECTED_RULE_NAME_PREFIXES = ("default-",)
+DEFAULT_INTENTIONALLY_OPEN_DESCRIPTION_MARKER = "intentionally-open"
+
+MODE_PATCH = "patch"
+MODE_DELETE = "delete"
+SUPPORTED_MODES = frozenset({MODE_PATCH, MODE_DELETE})
+
+RECORD_PLAN = "remediation_plan"
+RECORD_ACTION = "remediation_action"
+RECORD_VERIFICATION = "remediation_verification"
+
+STEP_PATCH_DISABLE = "patch_firewall_disable"
+STEP_DELETE_FIREWALL = "delete_firewall"
+
+STATUS_PLANNED = "planned"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_VERIFIED = "verified"
+STATUS_DRIFT = "drift"
+STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
+STATUS_SKIPPED_PROTECTED = "skipped_protected_firewall"
+STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-firewall"
+STATUS_SKIPPED_NO_TARGET = "skipped_no_firewall_pointer"
+
+
+@dataclasses.dataclass(frozen=True)
+class Target:
+    rule_name: str
+    project_id: str
+    network: str
+    cidrs: tuple[str, ...]
+    ports: tuple[int, ...]
+    ip_protocol: str
+    actor: str
+    rule: str
+    producer_skill: str
+    finding_uid: str
+
+
+class ComputeClient(Protocol):
+    """Minimal Compute Engine surface this skill needs. Tests inject a stub."""
+
+    def get_firewall(self, project: str, rule_name: str) -> dict[str, Any] | None: ...
+    def patch_firewall_disable(self, project: str, rule_name: str) -> None: ...
+    def delete_firewall(self, project: str, rule_name: str) -> None: ...
+
+
+class AuditWriter(Protocol):
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]: ...
+
+
+@dataclasses.dataclass
+class GoogleComputeClient:
+    """Real Compute client. Lazy-imports googleapiclient so tests don't need it."""
+
+    def _client(self) -> Any:
+        from googleapiclient.discovery import build  # type: ignore[import-not-found]
+
+        # Credentials picked up from GOOGLE_APPLICATION_CREDENTIALS or ADC.
+        return build("compute", "v1", cache_discovery=False)
+
+    def get_firewall(self, project: str, rule_name: str) -> dict[str, Any] | None:
+        try:
+            return self._client().firewalls().get(project=project, firewall=rule_name).execute()
+        except Exception:
+            return None
+
+    def patch_firewall_disable(self, project: str, rule_name: str) -> None:
+        body = {"disabled": True}
+        self._client().firewalls().patch(
+            project=project, firewall=rule_name, body=body
+        ).execute()
+
+    def delete_firewall(self, project: str, rule_name: str) -> None:
+        self._client().firewalls().delete(project=project, firewall=rule_name).execute()
+
+
+@dataclasses.dataclass
+class DualAuditWriter:
+    dynamodb_table: str
+    s3_bucket: str
+    kms_key_arn: str
+
+    def record(
+        self,
+        *,
+        target: Target,
+        step: str,
+        status: str,
+        detail: str | None,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]:
+        import boto3
+
+        action_at = datetime.now(timezone.utc).isoformat()
+        row_uid = _deterministic_uid(target.rule_name, step, action_at)
+        evidence_key = (
+            "gcp-firewall-revoke/audit/"
+            f"{action_at[:4]}/{action_at[5:7]}/{action_at[8:10]}/"
+            f"{_safe_path_component(target.project_id)}/"
+            f"{_safe_path_component(target.rule_name)}/{action_at}-{step}.json"
+        )
+        evidence_uri = f"s3://{self.s3_bucket}/{evidence_key}"
+
+        envelope = {
+            "schema_mode": "native",
+            "canonical_schema_version": CANONICAL_VERSION,
+            "record_type": "remediation_audit",
+            "source_skill": SKILL_NAME,
+            "row_uid": row_uid,
+            "provider": "gcp",
+            "rule_name": target.rule_name,
+            "project_id": target.project_id,
+            "cloud": {
+                "provider": "GCP",
+                "account": {"uid": target.project_id},
+                "region": "global",
+            },
+            "network": target.network,
+            "cidrs": list(target.cidrs),
+            "ports": list(target.ports),
+            "ip_protocol": target.ip_protocol,
+            "actor": target.actor,
+            "rule": target.rule,
+            "producer_skill": target.producer_skill,
+            "finding_uid": target.finding_uid,
+            "step": step,
+            "status": status,
+            "status_detail": detail,
+            "incident_id": incident_id,
+            "approver": approver,
+            "action_at": action_at,
+        }
+        body = json.dumps(envelope, separators=(",", ":"))
+        boto3.client("s3").put_object(
+            Bucket=self.s3_bucket, Key=evidence_key, Body=body.encode("utf-8"),
+            ServerSideEncryption="aws:kms", SSEKMSKeyId=self.kms_key_arn,
+            ContentType="application/json",
+        )
+        boto3.client("dynamodb").put_item(
+            TableName=self.dynamodb_table,
+            Item={
+                "rule_name": {"S": target.rule_name}, "action_at": {"S": action_at},
+                "row_uid": {"S": row_uid}, "step": {"S": step}, "status": {"S": status},
+                "incident_id": {"S": incident_id}, "approver": {"S": approver},
+                "project_id": {"S": target.project_id}, "provider": {"S": "gcp"},
+                "actor": {"S": target.actor}, "rule": {"S": target.rule},
+                "producer_skill": {"S": target.producer_skill},
+                "finding_uid": {"S": target.finding_uid},
+                "s3_evidence_uri": {"S": evidence_uri},
+            },
+        )
+        return {"row_uid": row_uid, "s3_evidence_uri": evidence_uri}
+
+
+def _deterministic_uid(*parts: str) -> str:
+    return f"gfwrev-{hashlib.sha256('|'.join(parts).encode('utf-8')).hexdigest()[:16]}"
+
+
+def _safe_path_component(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in (value or "_"))
+    return safe[:120] or "_"
+
+
+def _finding_product(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _finding_uid(event: dict[str, Any]) -> str:
+    return str((event.get("finding_info") or {}).get("uid") or (event.get("metadata") or {}).get("uid") or "")
+
+
+def _observable_value(event: dict[str, Any], name: str) -> str:
+    for obs in event.get("observables") or []:
+        if isinstance(obs, dict) and obs.get("name") == name and obs.get("value"):
+            return str(obs["value"])
+    return ""
+
+
+def _observable_values(event: dict[str, Any], name: str) -> tuple[str, ...]:
+    values = []
+    for obs in event.get("observables") or []:
+        if isinstance(obs, dict) and obs.get("name") == name and obs.get("value"):
+            values.append(str(obs["value"]))
+    return tuple(values)
+
+
+def _safe_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_reference_time_ms(event: dict[str, Any]) -> int | None:
+    candidates = (
+        event.get("remediated_at_ms"),
+        event.get("time_ms"),
+        event.get("time"),
+        ((event.get("finding_info") or {}).get("last_seen_time")),
+        ((event.get("finding_info") or {}).get("first_seen_time")),
+    )
+    for value in candidates:
+        parsed = _safe_int(str(value)) if value is not None else None
+        if parsed is not None and parsed > 0:
+            return parsed
+    return None
+
+
+def _target_from_event(event: dict[str, Any]) -> Target | None:
+    producer = _finding_product(event)
+    if producer not in ACCEPTED_PRODUCERS:
+        emit_stderr_event(
+            SKILL_NAME, level="warning", event="wrong_source_skill",
+            message=f"skipping finding from unaccepted producer `{producer or '<missing>'}`",
+        )
+        return None
+
+    rule_name = _observable_value(event, "target.uid")
+    project_id = _observable_value(event, "account.uid")
+    network = _observable_value(event, "target.network")
+    actor = _observable_value(event, "actor.name")
+    rule = _observable_value(event, "rule")
+    ip_protocol = _observable_value(event, "permission.protocol") or "tcp"
+
+    cidrs = _observable_values(event, "permission.cidr")
+    port_strs = _observable_values(event, "permission.port")
+    ports: list[int] = []
+    for p in port_strs:
+        parsed = _safe_int(p)
+        if parsed is not None:
+            ports.append(parsed)
+
+    return Target(
+        rule_name=rule_name, project_id=project_id, network=network,
+        cidrs=cidrs, ports=tuple(ports), ip_protocol=ip_protocol,
+        actor=actor, rule=rule,
+        producer_skill=producer, finding_uid=_finding_uid(event),
+    )
+
+
+def parse_targets(events: Iterable[dict[str, Any]]) -> Iterator[tuple[Target | None, dict[str, Any]]]:
+    for event in events:
+        yield _target_from_event(event), event
+
+
+def load_protected_rule_names() -> tuple[str, ...]:
+    raw = os.getenv("GCP_FIREWALL_REVOKE_DENY_RULE_NAMES", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def is_protected_firewall(
+    target: Target,
+    *,
+    name_prefixes: Iterable[str],
+    rule_names: Iterable[str],
+    intentionally_open_marker: str,
+    firewall_get: dict[str, Any] | None,
+) -> tuple[bool, str]:
+    if target.rule_name and target.rule_name in set(rule_names):
+        return True, f"rule-name allowlist match `{target.rule_name}`"
+    name_lc = (target.rule_name or "").strip().lower()
+    if name_lc:
+        for prefix in name_prefixes:
+            if name_lc.startswith(prefix.lower()):
+                return True, f"rule-name prefix `{prefix}`"
+    # Description check requires a live get; if not provided, skip
+    if firewall_get is not None:
+        description = str(firewall_get.get("description") or "").lower()
+        if intentionally_open_marker.lower() in description:
+            return True, f"description contains `{intentionally_open_marker}`"
+    return False, ""
+
+
+def check_apply_gate() -> tuple[bool, str]:
+    incident_id = os.getenv("GCP_FIREWALL_REVOKE_INCIDENT_ID", "").strip()
+    approver = os.getenv("GCP_FIREWALL_REVOKE_APPROVER", "").strip()
+    if not incident_id:
+        return False, "GCP_FIREWALL_REVOKE_INCIDENT_ID is required for --apply"
+    if not approver:
+        return False, "GCP_FIREWALL_REVOKE_APPROVER is required for --apply"
+    return True, ""
+
+
+def _action_endpoint(target: Target, mode: str) -> str:
+    if mode == MODE_DELETE:
+        return f"DELETE compute.firewalls.delete project={target.project_id} firewall={target.rule_name}"
+    return (
+        f"PATCH compute.firewalls.patch project={target.project_id} "
+        f"firewall={target.rule_name} body={{'disabled': true}}"
+    )
+
+
+def _verify_endpoint(target: Target) -> str:
+    return f"GET compute.firewalls.get project={target.project_id} firewall={target.rule_name}"
+
+
+def _step_for_mode(mode: str) -> str:
+    return STEP_DELETE_FIREWALL if mode == MODE_DELETE else STEP_PATCH_DISABLE
+
+
+def _plan_record(
+    target: Target, *, status: str, detail: str | None, dry_run: bool, mode: str
+) -> dict[str, Any]:
+    step = _step_for_mode(mode)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "GCP",
+            "rule_name": target.rule_name,
+            "project_id": target.project_id,
+            "region": "global",
+            "network": target.network,
+            "cidrs": list(target.cidrs),
+            "ports": list(target.ports),
+            "ip_protocol": target.ip_protocol,
+            "actor": target.actor,
+            "rule": target.rule,
+        },
+        "actions": [{
+            "step": step,
+            "endpoint": _action_endpoint(target, mode),
+            "status": status,
+            "detail": detail,
+        }],
+        "status": status,
+        "mode": mode,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def _skip_record(
+    target: Target, *, status: str, detail: str, dry_run: bool, mode: str
+) -> dict[str, Any]:
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "target": {
+            "provider": "GCP", "rule_name": target.rule_name, "project_id": target.project_id,
+            "region": "global", "network": target.network,
+            "cidrs": list(target.cidrs), "ports": list(target.ports),
+            "ip_protocol": target.ip_protocol, "actor": target.actor, "rule": target.rule,
+        },
+        "actions": [],
+        "status": status,
+        "status_detail": detail,
+        "mode": mode,
+        "dry_run": dry_run,
+        "time_ms": int(datetime.now(timezone.utc).timestamp() * 1000),
+        "finding_uid": target.finding_uid,
+    }
+
+
+def revoke_firewall(
+    target: Target,
+    *,
+    compute_client: ComputeClient,
+    audit: AuditWriter,
+    incident_id: str,
+    approver: str,
+    mode: str,
+) -> dict[str, Any]:
+    step = _step_for_mode(mode)
+    action_word = "delete" if mode == MODE_DELETE else "disable"
+    first = audit.record(
+        target=target, step=step, status=STATUS_IN_PROGRESS,
+        detail=(
+            f"about to {action_word} firewall `{target.rule_name}` in project "
+            f"`{target.project_id}` (network={target.network or '<unknown>'})"
+        ),
+        incident_id=incident_id, approver=approver,
+    )
+    try:
+        if mode == MODE_DELETE:
+            compute_client.delete_firewall(target.project_id, target.rule_name)
+        else:
+            compute_client.patch_firewall_disable(target.project_id, target.rule_name)
+    except Exception as exc:
+        audit.record(
+            target=target, step=step, status=STATUS_FAILURE,
+            detail=str(exc), incident_id=incident_id, approver=approver,
+        )
+        rec = _plan_record(target, status=STATUS_FAILURE, detail=str(exc), dry_run=False, mode=mode)
+        rec["audit"] = first
+        return rec
+
+    last = audit.record(
+        target=target, step=step, status=STATUS_SUCCESS,
+        detail=(
+            f"{action_word}d firewall `{target.rule_name}` in project "
+            f"`{target.project_id}`"
+        ),
+        incident_id=incident_id, approver=approver,
+    )
+    rec = _plan_record(target, status=STATUS_SUCCESS, detail=None, dry_run=False, mode=mode)
+    rec["audit"] = last
+    rec["incident_id"] = incident_id
+    rec["approver"] = approver
+    return rec
+
+
+def reverify_target(
+    target: Target,
+    *,
+    compute_client: ComputeClient,
+    now_ms: int | None = None,
+    remediated_at_ms: int | None = None,
+) -> list[dict[str, Any]]:
+    """Re-verify the offending firewall is absent or disabled.
+    Emits one verification record; on DRIFT also emits OCSF Detection Finding."""
+    checked_at_ms = now_ms if now_ms is not None else int(datetime.now(timezone.utc).timestamp() * 1000)
+    remediated_at_ms_resolved = remediated_at_ms if remediated_at_ms is not None else checked_at_ms
+
+    reference = RemediationReference(
+        remediation_skill=SKILL_NAME,
+        remediation_action_uid=_deterministic_uid(
+            "revoke",
+            target.project_id,
+            target.rule_name,
+            ",".join(target.cidrs),
+            target.ip_protocol or "tcp",
+        ),
+        target_provider="GCP",
+        target_identifier=f"{target.project_id}/global/firewalls/{target.rule_name}",
+        original_finding_uid=target.finding_uid,
+        remediated_at_ms=remediated_at_ms_resolved,
+    )
+    expected = (
+        f"firewall rule `{target.rule_name}` in project `{target.project_id}` "
+        "is absent or `disabled: true`"
+    )
+
+    try:
+        firewall = compute_client.get_firewall(target.project_id, target.rule_name)
+    except Exception as exc:
+        result = VerificationResult(
+            status=VerificationStatus.UNREACHABLE,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="compute.firewalls.get raised; cannot determine state",
+            detail=str(exc),
+        )
+        record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
+        record["target"] = {"provider": "GCP", "rule_name": target.rule_name, "project_id": target.project_id}
+        return [record]
+
+    if firewall is None:
+        # Rule gone entirely → stronger than disabled; counts as VERIFIED
+        result = VerificationResult(
+            status=VerificationStatus.VERIFIED,
+            checked_at_ms=checked_at_ms,
+            sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+            expected_state=expected,
+            actual_state="firewall rule not found (deleted) — stronger than disabled",
+            detail="containment confirmed via absence",
+        )
+    else:
+        disabled = bool(firewall.get("disabled"))
+        if disabled:
+            result = VerificationResult(
+                status=VerificationStatus.VERIFIED,
+                checked_at_ms=checked_at_ms,
+                sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+                expected_state=expected,
+                actual_state="firewall rule present and `disabled: true`",
+                detail="patch confirmed",
+            )
+        else:
+            result = VerificationResult(
+                status=VerificationStatus.DRIFT,
+                checked_at_ms=checked_at_ms,
+                sla_deadline_ms=sla_deadline(remediated_at_ms_resolved, DEFAULT_VERIFICATION_SLA_MS),
+                expected_state=expected,
+                actual_state="firewall rule present and NOT disabled (re-enabled or re-created)",
+                detail="ingress was re-enabled or never landed",
+            )
+
+    record = build_verification_record(reference=reference, result=result, verifier_skill=SKILL_NAME)
+    record["target"] = {"provider": "GCP", "rule_name": target.rule_name, "project_id": target.project_id}
+    outputs: list[dict[str, Any]] = [record]
+    if result.status == VerificationStatus.DRIFT:
+        outputs.append(build_drift_finding(reference=reference, result=result, verifier_skill=SKILL_NAME))
+    return outputs
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME, level="warning", event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}", line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def run(
+    events: Iterable[dict[str, Any]],
+    *,
+    compute_client: ComputeClient,
+    apply: bool = False,
+    reverify: bool = False,
+    audit: AuditWriter | None = None,
+    name_prefixes: Iterable[str] = DEFAULT_PROTECTED_RULE_NAME_PREFIXES,
+    rule_names: Iterable[str] = (),
+    intentionally_open_marker: str = DEFAULT_INTENTIONALLY_OPEN_DESCRIPTION_MARKER,
+    incident_id: str = "",
+    approver: str = "",
+    mode: str = MODE_PATCH,
+) -> Iterator[dict[str, Any]]:
+    if mode not in SUPPORTED_MODES:
+        raise ValueError(f"unsupported mode `{mode}`; expected one of {sorted(SUPPORTED_MODES)}")
+
+    name_prefixes = tuple(name_prefixes)
+    rule_names = tuple(rule_names)
+
+    for target, event in parse_targets(events):
+        if target is None:
+            continue
+
+        dry_run = not apply and not reverify
+
+        if not target.rule_name or not target.project_id:
+            yield _skip_record(
+                target, status=STATUS_SKIPPED_NO_TARGET,
+                detail="finding did not carry a target.uid (rule name) and account.uid (project) observable",
+                dry_run=dry_run, mode=mode,
+            )
+            continue
+
+        # Live description check requires a get call. We do it once per target.
+        firewall_get: dict[str, Any] | None = None
+        try:
+            firewall_get = compute_client.get_firewall(target.project_id, target.rule_name)
+        except Exception:
+            firewall_get = None
+
+        protected, why = is_protected_firewall(
+            target, name_prefixes=name_prefixes, rule_names=rule_names,
+            intentionally_open_marker=intentionally_open_marker, firewall_get=firewall_get,
+        )
+        if protected:
+            status = STATUS_SKIPPED_PROTECTED if apply else STATUS_WOULD_VIOLATE_PROTECTED
+            yield _skip_record(
+                target, status=status, detail=f"target is protected: {why}", dry_run=dry_run, mode=mode,
+            )
+            continue
+
+        if reverify:
+            yield from reverify_target(
+                target,
+                compute_client=compute_client,
+                remediated_at_ms=_event_reference_time_ms(event),
+            )
+            continue
+
+        if not apply:
+            action_word = "delete" if mode == MODE_DELETE else "disable (patch disabled=true)"
+            yield _plan_record(
+                target, status=STATUS_PLANNED,
+                detail=(
+                    f"dry-run: would {action_word} firewall `{target.rule_name}` "
+                    f"in project `{target.project_id}` to revoke "
+                    f"{list(target.cidrs)} on protocol {target.ip_protocol or 'tcp'}"
+                ),
+                dry_run=True, mode=mode,
+            )
+            continue
+
+        if audit is None:
+            raise ValueError("audit writer is required under --apply")
+        yield revoke_firewall(
+            target, compute_client=compute_client, audit=audit,
+            incident_id=incident_id, approver=approver, mode=mode,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Plan, apply, or re-verify GCP VPC firewall rule revocation."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument("--apply", action="store_true",
+        help="Patch (disable) or delete the offending firewall after approval gates pass.")
+    parser.add_argument("--reverify", action="store_true",
+        help="Read-only verification: confirm offending firewall is gone or disabled.")
+    parser.add_argument(
+        "--mode", choices=sorted(SUPPORTED_MODES), default=MODE_PATCH,
+        help="`patch` (default, sets disabled: true) or `delete` (opt-in, removes the rule).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply and args.reverify:
+        print("--apply and --reverify are mutually exclusive", file=sys.stderr)
+        return 2
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    try:
+        compute_client: ComputeClient = GoogleComputeClient()
+        audit: AuditWriter | None = None
+        incident_id = ""
+        approver = ""
+        if args.apply:
+            ok, reason = check_apply_gate()
+            if not ok:
+                print(reason, file=sys.stderr)
+                return 2
+            incident_id = os.environ["GCP_FIREWALL_REVOKE_INCIDENT_ID"].strip()
+            approver = os.environ["GCP_FIREWALL_REVOKE_APPROVER"].strip()
+            audit = DualAuditWriter(
+                dynamodb_table=os.environ["GCP_FIREWALL_REVOKE_AUDIT_DYNAMODB_TABLE"],
+                s3_bucket=os.environ["GCP_FIREWALL_REVOKE_AUDIT_BUCKET"],
+                kms_key_arn=os.environ["KMS_KEY_ARN"],
+            )
+
+        for record in run(
+            load_jsonl(in_stream), compute_client=compute_client,
+            apply=args.apply, reverify=args.reverify, audit=audit,
+            rule_names=load_protected_rule_names(),
+            incident_id=incident_id, approver=approver, mode=args.mode,
+        ):
+            out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/remediation/remediate-gcp-firewall-revoke/src/handler.py
+++ b/skills/remediation/remediate-gcp-firewall-revoke/src/handler.py
@@ -127,7 +127,7 @@ class GoogleComputeClient:
     """Real Compute client. Lazy-imports googleapiclient so tests don't need it."""
 
     def _client(self) -> Any:
-        from googleapiclient.discovery import build  # type: ignore[import-not-found]
+        from googleapiclient.discovery import build
 
         # Credentials picked up from GOOGLE_APPLICATION_CREDENTIALS or ADC.
         return build("compute", "v1", cache_discovery=False)

--- a/skills/remediation/remediate-gcp-firewall-revoke/tests/conftest.py
+++ b/skills/remediation/remediate-gcp-firewall-revoke/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Per-skill pytest conftest: isolate this skill's src/ from sibling skills."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SIBLING_MODULE_NAMES = ("ingest", "detect", "checks", "convert", "discover", "handler")
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SRC_DIR = _TESTS_DIR.parent / "src"
+
+for _name in _SIBLING_MODULE_NAMES:
+    sys.modules.pop(_name, None)
+
+sys.path[:] = [p for p in sys.path if not p.endswith("/src")]
+sys.path.insert(0, str(_SRC_DIR))

--- a/skills/remediation/remediate-gcp-firewall-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-gcp-firewall-revoke/tests/test_handler.py
@@ -1,0 +1,473 @@
+"""Tests for remediate-gcp-firewall-revoke."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from handler import (  # type: ignore[import-not-found]
+    ACCEPTED_PRODUCERS,
+    DEFAULT_INTENTIONALLY_OPEN_DESCRIPTION_MARKER,
+    DEFAULT_PROTECTED_RULE_NAME_PREFIXES,
+    MODE_DELETE,
+    MODE_PATCH,
+    STATUS_FAILURE,
+    STATUS_IN_PROGRESS,
+    STATUS_PLANNED,
+    STATUS_SKIPPED_NO_TARGET,
+    STATUS_SKIPPED_PROTECTED,
+    STATUS_SUCCESS,
+    STATUS_WOULD_VIOLATE_PROTECTED,
+    GoogleComputeClient,
+    Target,
+    check_apply_gate,
+    is_protected_firewall,
+    parse_targets,
+    run,
+)
+
+
+def _finding(
+    *,
+    rule_name: str = "allow-ssh-world",
+    project_id: str = "p-1",
+    network: str = "projects/p-1/global/networks/default",
+    cidrs: list[str] | None = None,
+    ports: list[int] | None = None,
+    ip_protocol: str = "tcp",
+    omit_target: bool = False,
+) -> dict:
+    cidrs = cidrs if cidrs is not None else ["0.0.0.0/0"]
+    ports = ports if ports is not None else [22]
+    obs: list[dict] = [
+        {"name": "cloud.provider", "type": "Other", "value": "GCP"},
+        {"name": "actor.name", "type": "Other", "value": "alice@example.com"},
+        {"name": "api.operation", "type": "Other", "value": "compute.firewalls.insert_or_patch"},
+        {"name": "rule", "type": "Other", "value": "open-gcp-firewall-ingress"},
+        {"name": "target.name", "type": "Other", "value": rule_name},
+        {"name": "target.type", "type": "Other", "value": "GcpFirewallRule"},
+        {"name": "account.uid", "type": "Other", "value": project_id},
+        {"name": "region", "type": "Other", "value": "global"},
+        {"name": "permission.protocol", "type": "Other", "value": ip_protocol},
+        {"name": "target.network", "type": "Other", "value": network},
+    ]
+    if not omit_target:
+        obs.append({"name": "target.uid", "type": "Other", "value": rule_name})
+    for c in cidrs:
+        obs.append({"name": "permission.cidr", "type": "Other", "value": c})
+    for p in ports:
+        obs.append({"name": "permission.port", "type": "Other", "value": str(p)})
+    return {
+        "class_uid": 2004,
+        "metadata": {"uid": "find-1",
+                     "product": {"feature": {"name": "detect-gcp-open-firewall"}}},
+        "finding_info": {"uid": "find-1"},
+        "observables": obs,
+    }
+
+
+@dataclass
+class _FakeAudit:
+    writes: list[dict] = field(default_factory=list)
+
+    def record(self, *, target, step, status, detail, incident_id, approver):
+        self.writes.append({
+            "rule_name": target.rule_name, "project_id": target.project_id,
+            "step": step, "status": status, "detail": detail,
+            "incident_id": incident_id, "approver": approver,
+        })
+        return {"row_uid": f"row-{len(self.writes)}",
+                "s3_evidence_uri": f"s3://bucket/{target.rule_name}-{len(self.writes)}.json"}
+
+
+@dataclass
+class _FakeCompute:
+    firewalls: dict[tuple[str, str], dict] = field(default_factory=dict)
+    raise_on_get: bool = False
+    raise_on_patch: bool = False
+    raise_on_delete: bool = False
+    patches: list[tuple[str, str]] = field(default_factory=list)
+    deletes: list[tuple[str, str]] = field(default_factory=list)
+
+    def get_firewall(self, project, rule_name):
+        if self.raise_on_get:
+            raise RuntimeError("simulated compute 502")
+        return self.firewalls.get((project, rule_name))
+
+    def patch_firewall_disable(self, project, rule_name):
+        if self.raise_on_patch:
+            raise RuntimeError("simulated compute 403")
+        self.patches.append((project, rule_name))
+        fw = self.firewalls.setdefault(
+            (project, rule_name),
+            {"name": rule_name, "disabled": False, "description": ""},
+        )
+        fw["disabled"] = True
+
+    def delete_firewall(self, project, rule_name):
+        if self.raise_on_delete:
+            raise RuntimeError("simulated compute 403")
+        self.deletes.append((project, rule_name))
+        self.firewalls.pop((project, rule_name), None)
+
+
+# ---------- contract ----------
+
+
+def test_accepted_producers_set():
+    assert ACCEPTED_PRODUCERS == frozenset({"detect-gcp-open-firewall"})
+
+
+def test_default_protected_name_prefixes_cover_default_rules():
+    assert "default-" in DEFAULT_PROTECTED_RULE_NAME_PREFIXES
+
+
+def test_intentionally_open_description_marker_default():
+    assert DEFAULT_INTENTIONALLY_OPEN_DESCRIPTION_MARKER == "intentionally-open"
+
+
+def test_check_apply_gate_requires_both_envs(monkeypatch):
+    monkeypatch.delenv("GCP_FIREWALL_REVOKE_INCIDENT_ID", raising=False)
+    monkeypatch.delenv("GCP_FIREWALL_REVOKE_APPROVER", raising=False)
+    ok, _ = check_apply_gate()
+    assert ok is False
+    monkeypatch.setenv("GCP_FIREWALL_REVOKE_INCIDENT_ID", "INC-1")
+    ok, _ = check_apply_gate()
+    assert ok is False
+    monkeypatch.setenv("GCP_FIREWALL_REVOKE_APPROVER", "alice")
+    ok, _ = check_apply_gate()
+    assert ok is True
+
+
+# ---------- parse_targets ----------
+
+
+def test_parse_targets_extracts_full_target():
+    target, _ = next(
+        parse_targets([_finding(cidrs=["0.0.0.0/0", "::/0"], ports=[22, 3306])])
+    )
+    assert target.rule_name == "allow-ssh-world"
+    assert target.project_id == "p-1"
+    assert target.cidrs == ("0.0.0.0/0", "::/0")
+    assert target.ports == (22, 3306)
+    assert target.ip_protocol == "tcp"
+
+
+def test_parse_targets_rejects_wrong_producer(capsys):
+    e = _finding()
+    e["metadata"]["product"]["feature"]["name"] = "detect-aws-open-security-group"
+    target, _ = next(parse_targets([e]))
+    assert target is None
+    assert "unaccepted producer" in capsys.readouterr().err
+
+
+# ---------- protected check ----------
+
+
+def _t(**overrides) -> Target:
+    base = dict(rule_name="allow-x", project_id="p-1", network="n",
+                cidrs=("0.0.0.0/0",), ports=(22,), ip_protocol="tcp",
+                actor="a", rule="r",
+                producer_skill="detect-gcp-open-firewall", finding_uid="f")
+    base.update(overrides)
+    return Target(**base)
+
+
+def test_protected_default_rule_by_name_prefix():
+    p, why = is_protected_firewall(
+        _t(rule_name="default-allow-internal"),
+        name_prefixes=("default-",), rule_names=(),
+        intentionally_open_marker="intentionally-open", firewall_get=None,
+    )
+    assert p is True
+    assert "default-" in why
+
+
+def test_protected_via_env_rule_name_allowlist():
+    p, why = is_protected_firewall(
+        _t(rule_name="allow-bootstrap"),
+        name_prefixes=(), rule_names=("allow-bootstrap",),
+        intentionally_open_marker="intentionally-open", firewall_get=None,
+    )
+    assert p is True
+    assert "allow-bootstrap" in why
+
+
+def test_protected_via_intentionally_open_description():
+    fw = {"name": "x", "description": "PUBLIC api - intentionally-open per ARCH-123"}
+    p, why = is_protected_firewall(
+        _t(), name_prefixes=(), rule_names=(),
+        intentionally_open_marker="intentionally-open", firewall_get=fw,
+    )
+    assert p is True
+    assert "intentionally-open" in why
+
+
+def test_unprotected_when_no_match():
+    p, _ = is_protected_firewall(
+        _t(rule_name="my-prod-allow"),
+        name_prefixes=("default-",), rule_names=(),
+        intentionally_open_marker="intentionally-open",
+        firewall_get={"description": ""},
+    )
+    assert p is False
+
+
+# ---------- run: dry-run ----------
+
+
+def test_run_dry_run_emits_plan():
+    records = list(run([_finding()], compute_client=_FakeCompute()))
+    rec = records[0]
+    assert rec["record_type"] == "remediation_plan"
+    assert rec["status"] == STATUS_PLANNED
+    assert rec["dry_run"] is True
+    assert rec["mode"] == MODE_PATCH
+    assert rec["target"]["rule_name"] == "allow-ssh-world"
+    assert rec["target"]["project_id"] == "p-1"
+    assert rec["target"]["cidrs"] == ["0.0.0.0/0"]
+    assert "dry-run" in rec["actions"][0]["detail"]
+
+
+def test_run_dry_run_does_not_call_patch_or_delete():
+    compute = _FakeCompute()
+    list(run([_finding()], compute_client=compute))
+    assert compute.patches == []
+    assert compute.deletes == []
+
+
+def test_run_dry_run_delete_mode_emits_delete_endpoint():
+    records = list(run([_finding()], compute_client=_FakeCompute(), mode=MODE_DELETE))
+    rec = records[0]
+    assert rec["mode"] == MODE_DELETE
+    assert "compute.firewalls.delete" in rec["actions"][0]["endpoint"]
+
+
+# ---------- run: skip paths ----------
+
+
+def test_run_skips_finding_without_target_pointers():
+    records = list(run([_finding(omit_target=True)], compute_client=_FakeCompute()))
+    assert records[0]["status"] == STATUS_SKIPPED_NO_TARGET
+
+
+def test_run_skips_default_named_rule_in_dry_run():
+    records = list(
+        run([_finding(rule_name="default-allow-internal")], compute_client=_FakeCompute())
+    )
+    assert records[0]["status"] == STATUS_WOULD_VIOLATE_PROTECTED
+    assert "default-" in records[0]["status_detail"]
+
+
+def test_run_skips_intentionally_open_described_rule_in_apply():
+    audit = _FakeAudit()
+    compute = _FakeCompute(
+        firewalls={
+            ("p-1", "allow-ssh-world"): {
+                "name": "allow-ssh-world",
+                "description": "ALB front door - intentionally-open per #777",
+                "disabled": False,
+            }
+        }
+    )
+    records = list(
+        run([_finding()], compute_client=compute, apply=True, audit=audit,
+            incident_id="INC-1", approver="alice")
+    )
+    assert records[0]["status"] == STATUS_SKIPPED_PROTECTED
+    assert compute.patches == []
+    assert compute.deletes == []
+    assert audit.writes == []
+
+
+def test_run_skips_via_env_protected_rule_name():
+    records = list(
+        run([_finding(rule_name="allow-bootstrap")], compute_client=_FakeCompute(),
+            rule_names=("allow-bootstrap",))
+    )
+    assert records[0]["status"] == STATUS_WOULD_VIOLATE_PROTECTED
+
+
+# ---------- run: apply: missing env vars rejected ----------
+
+
+def test_run_apply_requires_audit_writer():
+    import pytest
+    with pytest.raises(ValueError, match="audit writer is required"):
+        list(run([_finding()], compute_client=_FakeCompute(), apply=True, audit=None))
+
+
+def test_check_apply_gate_rejects_missing_envs(monkeypatch):
+    monkeypatch.delenv("GCP_FIREWALL_REVOKE_INCIDENT_ID", raising=False)
+    monkeypatch.delenv("GCP_FIREWALL_REVOKE_APPROVER", raising=False)
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "GCP_FIREWALL_REVOKE_INCIDENT_ID" in reason
+
+
+# ---------- run: apply happy path ----------
+
+
+def test_run_apply_patches_with_dual_audit():
+    audit = _FakeAudit()
+    compute = _FakeCompute(
+        firewalls={
+            ("p-1", "allow-ssh-world"): {
+                "name": "allow-ssh-world", "disabled": False, "description": "",
+            }
+        }
+    )
+    records = list(
+        run([_finding()], compute_client=compute, apply=True, audit=audit,
+            incident_id="INC-1", approver="alice@security")
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SUCCESS
+    assert rec["dry_run"] is False
+    assert rec["mode"] == MODE_PATCH
+    assert compute.patches == [("p-1", "allow-ssh-world")]
+    assert compute.deletes == []
+    # Verify rule is now disabled in fake state
+    assert compute.firewalls[("p-1", "allow-ssh-world")]["disabled"] is True
+    assert len(audit.writes) == 2
+    assert audit.writes[0]["status"] == STATUS_IN_PROGRESS
+    assert audit.writes[1]["status"] == STATUS_SUCCESS
+
+
+def test_run_apply_delete_mode_calls_delete():
+    audit = _FakeAudit()
+    compute = _FakeCompute(
+        firewalls={
+            ("p-1", "allow-ssh-world"): {"name": "allow-ssh-world", "disabled": False}
+        }
+    )
+    records = list(
+        run([_finding()], compute_client=compute, apply=True, audit=audit,
+            incident_id="INC-1", approver="alice", mode=MODE_DELETE)
+    )
+    assert records[0]["status"] == STATUS_SUCCESS
+    assert compute.deletes == [("p-1", "allow-ssh-world")]
+    assert compute.patches == []
+
+
+def test_run_apply_writes_failure_audit_when_patch_throws():
+    audit = _FakeAudit()
+    compute = _FakeCompute(raise_on_patch=True)
+    records = list(
+        run([_finding()], compute_client=compute, apply=True, audit=audit,
+            incident_id="INC-1", approver="alice")
+    )
+    assert records[0]["status"] == STATUS_FAILURE
+    assert len(audit.writes) == 2
+    assert audit.writes[1]["status"] == STATUS_FAILURE
+
+
+def test_run_unsupported_mode_raises():
+    import pytest
+    with pytest.raises(ValueError, match="unsupported mode"):
+        list(run([_finding()], compute_client=_FakeCompute(), mode="purge"))
+
+
+# ---------- run: re-verify ----------
+
+
+def test_run_reverify_verified_when_rule_disabled():
+    compute = _FakeCompute(
+        firewalls={
+            ("p-1", "allow-ssh-world"): {"name": "allow-ssh-world", "disabled": True}
+        }
+    )
+    records = list(run([_finding()], compute_client=compute, reverify=True))
+    assert len(records) == 1
+    assert records[0]["status"] == "verified"
+    assert "disabled: true" in records[0]["actual_state"]
+
+
+def test_run_reverify_verified_when_rule_deleted():
+    """Absent rule = stronger than disabled = verified containment."""
+    compute = _FakeCompute(firewalls={})
+    records = list(run([_finding()], compute_client=compute, reverify=True))
+    assert len(records) == 1
+    assert records[0]["status"] == "verified"
+    assert "not found" in records[0]["actual_state"]
+
+
+def test_run_reverify_drift_emits_ocsf_finding_alongside_verification():
+    compute = _FakeCompute(
+        firewalls={
+            ("p-1", "allow-ssh-world"): {"name": "allow-ssh-world", "disabled": False}
+        }
+    )
+    records = list(run([_finding()], compute_client=compute, reverify=True))
+    assert len(records) == 2
+    verification, finding = records
+    assert verification["status"] == "drift"
+    assert finding["class_uid"] == 2004
+    assert finding["category_uid"] == 2
+    assert finding["severity_id"] == 4
+    assert finding["finding_info"]["types"] == ["remediation-drift"]
+    assert any(
+        obs["name"] == "remediation.skill" and obs["value"] == "remediate-gcp-firewall-revoke"
+        for obs in finding["observables"]
+    )
+
+
+def test_run_reverify_uses_finding_time_as_remediation_reference():
+    compute = _FakeCompute(
+        firewalls={
+            ("p-1", "allow-ssh-world"): {"name": "allow-ssh-world", "disabled": True}
+        }
+    )
+    event = _finding()
+    event["time"] = 1700000000123
+    records = list(run([event], compute_client=compute, reverify=True))
+    assert records[0]["reference"]["remediated_at_ms"] == 1700000000123
+
+
+def test_run_reverify_unreachable_never_silently_downgrades():
+    compute = _FakeCompute(raise_on_get=True)
+    records = list(run([_finding()], compute_client=compute, reverify=True))
+    assert any(r["status"] == "unreachable" for r in records)
+
+
+# ---------- google client mocking ----------
+
+
+def test_google_compute_client_uses_googleapiclient_discovery():
+    """Ensure the real client lazily imports and calls googleapiclient.discovery.build."""
+    fake_discovery = MagicMock()
+    fake_service = MagicMock()
+    fake_discovery.build.return_value = fake_service
+    fake_firewalls = MagicMock()
+    fake_service.firewalls.return_value = fake_firewalls
+    fake_get = MagicMock()
+    fake_firewalls.get.return_value = fake_get
+    fake_get.execute.return_value = {"name": "allow-ssh-world", "disabled": True}
+
+    with patch.dict(sys.modules, {"googleapiclient": MagicMock(),
+                                   "googleapiclient.discovery": fake_discovery}):
+        client = GoogleComputeClient()
+        result = client.get_firewall("p-1", "allow-ssh-world")
+        assert result == {"name": "allow-ssh-world", "disabled": True}
+        fake_discovery.build.assert_called_with("compute", "v1", cache_discovery=False)
+        fake_firewalls.get.assert_called_with(project="p-1", firewall="allow-ssh-world")
+
+
+def test_google_compute_client_patch_sets_disabled_true():
+    fake_discovery = MagicMock()
+    fake_service = MagicMock()
+    fake_discovery.build.return_value = fake_service
+    fake_firewalls = MagicMock()
+    fake_service.firewalls.return_value = fake_firewalls
+
+    with patch.dict(sys.modules, {"googleapiclient": MagicMock(),
+                                   "googleapiclient.discovery": fake_discovery}):
+        client = GoogleComputeClient()
+        client.patch_firewall_disable("p-1", "allow-ssh-world")
+        fake_firewalls.patch.assert_called_with(
+            project="p-1", firewall="allow-ssh-world", body={"disabled": True}
+        )


### PR DESCRIPTION
## Summary

Mirror of phase A (AWS Security Group, [#314](https://github.com/msaad00/cloud-ai-security-skills/pull/314)) for GCP VPC firewalls. Closes the GCP half of the network-exposure stack; Azure NSG ships separately as phase B-2.

### detect-gcp-open-firewall

Reads OCSF API Activity 6003 (output of \`ingest-gcp-audit-ocsf\`). Detects \`compute.firewalls.insert\` / \`compute.firewalls.patch\` audit log entries that open \`0.0.0.0/0\` or \`::/0\` to risky admin/DB/cache ports (22, 23, 3389, 3306, 5432, 6379, 11211, 27017, 9200, 5984). MITRE **T1190** (Exploit Public-Facing Application). Emits OCSF Detection Finding 2004 with deterministic \`gfw-<sha256[:16]>\` UID.

**Excluded by design**: EGRESS direction, disabled rules, private CIDRs.

### remediate-gcp-firewall-revoke

Surgical revoke of the offending firewall rule. Default \`--mode patch\` sets \`disabled: true\` (reversible). \`--mode delete\` is opt-in. Uses \`googleapiclient.discovery\` for \`compute.firewalls.patch\` / \`.delete\` / \`.get\` — lazily loaded, mocked in tests.

**HITL gate**: \`GCP_FIREWALL_REVOKE_INCIDENT_ID\` + \`GCP_FIREWALL_REVOKE_APPROVER\` (matches the env-var pattern [#319](https://github.com/msaad00/cloud-ai-security-skills/pull/319)'s HITL validator enforces).

**Deny list**: \`default-*\` rule names, \`intentionally-open\` description marker, \`GCP_FIREWALL_REVOKE_DENY_RULE_NAMES\` env-pinned. Dual audit (DynamoDB + KMS S3) BEFORE + AFTER, plus failure rows. \`_shared/remediation_verifier.py\` integration: \`--reverify\` reads back via \`compute.firewalls.get\` and emits OCSF **DRIFT** finding if the rule re-appears or is re-enabled within the verification window.

### Closed-loop ratio: 11/12 → 12/13

Lateral-movement remains detection-only by design (cross-cloud per-arm fan-out).

## Test plan
- [x] \`pytest skills/detection/detect-gcp-open-firewall/tests -q\` — 23/23
- [x] \`pytest skills/remediation/remediate-gcp-firewall-revoke/tests -q\` — 30/30
- [x] \`python scripts/validate_skill_contract.py\` — 56 skills passed
- [x] \`python scripts/validate_safe_skill_bar.py\` — passed
- [x] \`python scripts/validate_skill_integrity.py\` — passed
- [ ] No new runtime deps (\`googleapiclient\` loaded lazily, mocked in tests)

Closes part 1 of #307 phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)