### PR TITLE
docs(visuals): fix diagram overflows, refresh counts, purge macOS dupes

### DIFF
--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -102,7 +102,7 @@
     <g filter="url(#shadow)">
       <rect x="962" y="228" width="260" height="180" rx="28" fill="#4a2d09" stroke="#fbbf24" stroke-width="1.6"/>
       <text x="994" y="270" font-size="18" font-weight="800" fill="#fde68a">L5 Remediate</text>
-      <text x="994" y="332" font-size="56" font-weight="900" fill="#ffffff">10</text>
+      <text x="994" y="332" font-size="56" font-weight="900" fill="#ffffff">12</text>
       <text x="994" y="364" font-size="15" fill="#fde68a">HITL · dry-run-first</text>
       <text x="994" y="386" font-size="15" fill="#fde68a">dual-audited write paths</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1016" viewBox="0 0 1200 1016" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1016" viewBox="0 0 1400 1016" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix with MITRE ATT&amp;CK mapping</title>
   <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with the MITRE ATT&amp;CK technique IDs (or MITRE ATLAS for AI threats) that each detection emits in OCSF finding_info.attacks. Rows list every detection (14) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, MITRE technique IDs, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of fourteen detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1200" height="1016" fill="url(#bg2)"/>
-  <rect width="1200" height="1016" fill="url(#grid2)"/>
+  <rect width="1400" height="1016" fill="url(#bg2)"/>
+  <rect width="1400" height="1016" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -48,7 +48,7 @@
     <text x="900"  y="200" text-anchor="middle">Remediation</text>
     <text x="1020" y="200">Status / issue</text>
   </g>
-  <line x1="48" y1="212" x2="1152" y2="212" stroke="#334155" stroke-width="1.5"/>
+  <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
   <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (14)</text>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -45,8 +45,8 @@
     </g>
 
     <!-- Main panels -->
-    <rect x="56" y="84" width="772" height="248" rx="22" fill="#0b1628" stroke="#22314d"/>
-    <rect x="856" y="84" width="488" height="248" rx="22" fill="#0b1628" stroke="#22314d"/>
+    <rect x="56" y="84" width="772" height="300" rx="22" fill="#0b1628" stroke="#22314d"/>
+    <rect x="856" y="84" width="488" height="300" rx="22" fill="#0b1628" stroke="#22314d"/>
 
     <!-- Left panel -->
     <text x="88" y="142" font-size="58" font-weight="900" fill="url(#wordmark)" letter-spacing="-1.2">cloud-ai-security-skills</text>
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="162" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">54</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">60</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(174,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">12</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">14</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
@@ -117,7 +117,7 @@
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
         <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L5 Remediate</text>
-        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">8</text>
+        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">12</text>
       </g>
       <g transform="translate(222,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -86,11 +86,11 @@
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
       <!-- Counts: 58 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">58</text>
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">60</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
       <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 14 detect · 4 discover · 7 eval</text>
-      <text x="704" y="300" font-size="11" fill="#5eead4">10 remediate · 2 view · 3 sink · 3 source</text>
+      <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>
 


### PR DESCRIPTION
Bundles four related visual/cleanup items into one PR per request.

## 1. Coverage matrix overflow
`docs/images/coverage-matrix.svg` — the Status / issue column (starting at x=1020) had status labels like `→ remediate-gcp-firewall-revoke (#307 phase B-1)` whose rendered width extended past the viewBox right edge (1200), so tooling that respects the viewBox would clip them.

- viewBox widened `0 0 1200 1016` → `0 0 1400 1016`.
- Background rects and header divider extended to match.
- No text or column moves; just more room.

## 2. Hero banner right-panel overflow
`docs/images/hero-banner.svg` — the two main panel `rect`s were `h=248` (ending at y=332), but the layer grid had a 4th row ending at y=370. The last row (`L7 Output` / `L0 Source adapters`) was floating outside its parent panel.

- Both panel heights `248 → 300`, so all four rows sit inside.
- Footer divider untouched (still at y=408).

## 3. Stale skill counts
Refreshed the visible numbers in three diagrams to match current `git ls-tree HEAD` reality:

| Diagram | Field | Before | After |
|---|---|---|---|
| hero-banner | total shipped | 54 | **60** |
| hero-banner | L3 Detect | 12 | **14** |
| hero-banner | L5 Remediate | 8 | **12** |
| architecture-layers | L5 Remediate | 10 | **12** |
| runtime-surfaces | total shipped | 58 | **60** |
| runtime-surfaces | remediate | 10 | **12** |

Derived from: `ingestion=18 (15+3) · discovery=4 · detection=14 · evaluation=7 · remediation=12 · view=2 · output=3`.

_Note: `<desc>` text and other narrative copy still referencing old counts can be swept in a later pass — this PR limits the text edits to on-canvas numbers that render._

## 4. macOS duplicate cleanup
Removed 7 `docs/images/*" 2.svg"` files, `docs/DIAGRAMS 2.md`, and four untracked `skills/remediation/*` directories (`iam-departures-remediation`, `sink-s3-jsonl`, `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`). Those four dirs contained **only** `" 2.py"` / `" 2.md"` copies and `__pycache__` files — no real source. Not WIP, just iCloud/Finder sync detritus.

## Other diagrams audited (no change)
- `architecture-layers.svg` — layout clean apart from the one count.
- `runtime-surfaces.svg` — layout clean apart from the one count.
- `iam-departures-aws.svg` — already rebuilt in #334.

## Test plan
- [ ] README renders all five diagrams without clipping or floating elements.
- [ ] Open `coverage-matrix.svg` in a browser — Status column fully visible on every row.
- [ ] Open `hero-banner.svg` — right panel visibly contains the L7/L0 row.
- [ ] Grep for stale `54 shipped` / `12 detect` / `8 remediate` / `10 remediate` / `58 skills` strings in the 4 edited SVGs — none should remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)