### PR TITLE
fix(iam-departures): add HR-source retries, redact Workday errors, set Lambda reserved concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ The format is loosely based on Keep a Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- **Correlation of worker actions with CloudTrail** — STS
+  `AssumeRole` in the IAM departures worker Lambda now embeds the
+  first 8 characters of the Lambda `aws_request_id` in the
+  `RoleSessionName`, so CloudTrail `AssumeRole` events, DynamoDB audit
+  rows, and S3 audit objects can be cross-referenced during incident
+  response.
+- **Retries on transient HR-source failures** —
+  `skills/remediation/iam-departures-aws/src/reconciler/sources.py`
+  `fetch_departures` in all four sources (Snowflake, Databricks,
+  ClickHouse, Workday) now wraps its query in a shared `_with_retry`
+  helper: 3 attempts by default, exponential backoff starting at
+  1.5 s. Tunable via the `HR_SOURCE_FETCH_ATTEMPTS` and
+  `HR_SOURCE_FETCH_BASE_DELAY` env vars. Previously a single transient
+  connection or query hiccup would drop a whole reconciler run,
+  extending the departure-remediation window by up to a full scheduler
+  interval.
+- **Lambda reserved concurrency on Parser and Worker** — both the
+  CloudFormation template and the Terraform module now declare
+  `ReservedConcurrentExecutions` on the two IAM-departures Lambdas.
+  Parser=1 (single-shot per manifest), Worker=10 to match the
+  `step_function.asl.json` Map `MaxConcurrency`. Prevents the Map
+  fan-out from starving other functions in the account, and prevents
+  unrelated burst traffic from starving the remediation pipeline.
+
 ### Fixed
 
 - **Worker Lambda audit writes no longer silently swallowed** —
@@ -25,15 +51,16 @@ The format is loosely based on Keep a Changelog.
   DLQ / alerting fires on audit gaps instead of masking them. Dual-write
   redundancy is preserved: a single-store failure no longer raises as
   long as the other store succeeded.
-
-### Added
-
-- **Correlation of worker actions with CloudTrail** — STS
-  `AssumeRole` in the IAM departures worker Lambda now embeds the
-  first 8 characters of the Lambda `aws_request_id` in the
-  `RoleSessionName`, so CloudTrail `AssumeRole` events, DynamoDB audit
-  rows, and S3 audit objects can be cross-referenced during incident
-  response.
+- **Workday OAuth error handling cannot leak response bodies** —
+  `WorkdayAPISource._get_token` previously called
+  `resp.raise_for_status()`, which surfaces an `httpx.HTTPStatusError`
+  whose repr may include tenant URLs. On failure the `health_check`
+  caller logged via `logger.exception`, which writes the traceback and
+  the exception's repr. Replaced with an explicit check: network
+  errors raise `RuntimeError(f"... unreachable ({ExcType})")` and HTTP
+  errors raise `RuntimeError(f"... returned HTTP {status_code}")`.
+  Response bodies and inner exception messages are never re-raised or
+  logged. `health_check` now logs only the exception type name.
 
 ## [0.6.0] — 2026-04-18 — Closed-loop hardening
 

--- a/skills/remediation/iam-departures-aws/infra/cloudformation.yaml
+++ b/skills/remediation/iam-departures-aws/infra/cloudformation.yaml
@@ -471,6 +471,9 @@ Resources:
       Role: !GetAtt ParserExecutionRole.Arn
       Timeout: 300
       MemorySize: 256
+      # Parser runs once per manifest; 1 reserved slot isolates it from
+      # the Worker Map fan-out and any other functions in the account.
+      ReservedConcurrentExecutions: 1
       DeadLetterConfig:
         TargetArn: !GetAtt PipelineFailureDlq.Arn
       Environment:
@@ -496,6 +499,10 @@ Resources:
       Role: !GetAtt WorkerExecutionRole.Arn
       Timeout: 900
       MemorySize: 256
+      # Matches step_function.asl.json MaxConcurrency (10). Reserving
+      # exactly the Map fan-out cap gives predictable throughput and
+      # prevents the worker from consuming the account's burst pool.
+      ReservedConcurrentExecutions: 10
       DeadLetterConfig:
         TargetArn: !GetAtt PipelineFailureDlq.Arn
       Environment:

--- a/skills/remediation/iam-departures-aws/infra/terraform/main.tf
+++ b/skills/remediation/iam-departures-aws/infra/terraform/main.tf
@@ -573,6 +573,10 @@ resource "aws_lambda_function" "parser" {
   timeout       = 300
   memory_size   = 256
 
+  # Parser runs once per manifest; 1 reserved slot isolates it from the
+  # Worker Map fan-out and other functions in the account.
+  reserved_concurrent_executions = 1
+
   dead_letter_config {
     target_arn = aws_sqs_queue.pipeline_failures.arn
   }
@@ -601,6 +605,11 @@ resource "aws_lambda_function" "worker" {
   role          = aws_iam_role.worker.arn
   timeout       = 900
   memory_size   = 256
+
+  # Matches step_function.asl.json MaxConcurrency (10). Reserving exactly
+  # the Map fan-out cap gives predictable throughput and prevents the
+  # worker from draining the account's burst pool.
+  reserved_concurrent_executions = 10
 
   dead_letter_config {
     target_arn = aws_sqs_queue.pipeline_failures.arn

--- a/skills/remediation/iam-departures-aws/src/reconciler/sources.py
+++ b/skills/remediation/iam-departures-aws/src/reconciler/sources.py
@@ -21,13 +21,53 @@ import hashlib
 import logging
 import os
 import re
+import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import Any, TypeVar
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+SOURCE_FETCH_ATTEMPTS = int(os.environ.get("HR_SOURCE_FETCH_ATTEMPTS", "3"))
+SOURCE_FETCH_BASE_DELAY = float(os.environ.get("HR_SOURCE_FETCH_BASE_DELAY", "1.5"))
+
+
+def _with_retry(fn: Callable[[], _T], what: str) -> _T:
+    """Retry a transient-failure-prone read-only callable with exponential backoff.
+
+    Used for HR source `fetch_departures` bodies so that a single transient
+    network/availability hiccup does not drop a whole reconciler run. The
+    callable must be idempotent — we only use it for reads against
+    Snowflake / Databricks / ClickHouse / Workday.
+
+    Delay doubles per attempt starting from ``SOURCE_FETCH_BASE_DELAY``.
+    Default is 3 attempts over roughly 4.5 seconds. Override via env vars
+    ``HR_SOURCE_FETCH_ATTEMPTS`` and ``HR_SOURCE_FETCH_BASE_DELAY``.
+    """
+    attempts = max(1, SOURCE_FETCH_ATTEMPTS)
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:
+            if attempt == attempts:
+                raise
+            delay = SOURCE_FETCH_BASE_DELAY * (2 ** (attempt - 1))
+            logger.warning(
+                "%s failed on attempt %d/%d (%s); retrying in %.1fs",
+                what,
+                attempt,
+                attempts,
+                type(exc).__name__,
+                delay,
+            )
+            time.sleep(delay)
+    # Unreachable: the final attempt either returns or raises above.
+    raise RuntimeError(f"{what}: retry loop exhausted without result")
 SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -228,6 +268,9 @@ class SnowflakeSource(HRSource):
         )
 
     def fetch_departures(self) -> list[DepartureRecord]:
+        return _with_retry(self._fetch_departures_once, "Snowflake.fetch_departures")
+
+    def _fetch_departures_once(self) -> list[DepartureRecord]:
         query = self.QUERY.format(
             hr_database=self.hr_database,
             hr_schema=self.hr_schema,
@@ -330,6 +373,9 @@ class DatabricksSource(HRSource):
         )
 
     def fetch_departures(self) -> list[DepartureRecord]:
+        return _with_retry(self._fetch_departures_once, "Databricks.fetch_departures")
+
+    def _fetch_departures_once(self) -> list[DepartureRecord]:
         query = self.QUERY.format(
             hr_catalog=self.hr_catalog,
             hr_schema=self.hr_schema,
@@ -429,6 +475,9 @@ class ClickHouseSource(HRSource):
         )
 
     def fetch_departures(self) -> list[DepartureRecord]:
+        return _with_retry(self._fetch_departures_once, "ClickHouse.fetch_departures")
+
+    def _fetch_departures_once(self) -> list[DepartureRecord]:
         query = self.QUERY.format(
             hr_database=self.hr_database,
             iam_database=self.iam_database,
@@ -490,18 +539,38 @@ class WorkdayAPISource(HRSource):
         self.token_url = os.environ.get("WORKDAY_TOKEN_URL", "")
 
     def _get_token(self) -> str:
+        """Fetch an OAuth access token.
+
+        On failure, raises a sanitized ``RuntimeError`` carrying only the
+        HTTP status (or ``network-error`` when no response was received).
+        The raw ``httpx.Response`` body is never logged or re-raised — it
+        can contain tenant metadata or echoed credentials and downstream
+        log sinks would not have the context to redact it.
+        """
         import httpx
 
-        resp = httpx.post(
-            self.token_url,
-            data={"grant_type": "client_credentials"},
-            auth=(self.client_id, self.client_secret),
-            timeout=30,
-        )
-        resp.raise_for_status()
+        try:
+            resp = httpx.post(
+                self.token_url,
+                data={"grant_type": "client_credentials"},
+                auth=(self.client_id, self.client_secret),
+                timeout=30,
+            )
+        except httpx.HTTPError as exc:
+            raise RuntimeError(
+                f"Workday token endpoint unreachable ({type(exc).__name__})"
+            ) from None
+        if resp.status_code >= 400:
+            # Do NOT include response text — potentially sensitive.
+            raise RuntimeError(
+                f"Workday token endpoint returned HTTP {resp.status_code}"
+            )
         return resp.json()["access_token"]
 
     def fetch_departures(self) -> list[DepartureRecord]:
+        return _with_retry(self._fetch_departures_once, "Workday.fetch_departures")
+
+    def _fetch_departures_once(self) -> list[DepartureRecord]:
         import httpx
 
         token = self._get_token()
@@ -537,8 +606,10 @@ class WorkdayAPISource(HRSource):
         try:
             self._get_token()
             return True
-        except Exception:
-            logger.exception("Workday API health check failed")
+        except Exception as exc:
+            # _get_token raises sanitized RuntimeError; other exceptions are
+            # type-only logged so auth responses never reach log sinks.
+            logger.warning("Workday API health check failed: %s", type(exc).__name__)
             return False
 
 

--- a/skills/remediation/iam-departures-aws/tests/test_reconciler.py
+++ b/skills/remediation/iam-departures-aws/tests/test_reconciler.py
@@ -8,6 +8,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -270,3 +271,90 @@ class TestSnowflakeLogging:
 
         mock_get_logger.assert_called_once_with("snowflake.connector")
         connector_logger.setLevel.assert_called_once_with(sources.logging.WARNING)
+
+
+class TestWithRetry:
+    """Transient failures in HR source reads should not drop a reconciler run."""
+
+    def test_returns_first_successful_call(self):
+        from reconciler import sources
+
+        fn = MagicMock(return_value="ok")
+        assert sources._with_retry(fn, "test") == "ok"
+        assert fn.call_count == 1
+
+    def test_retries_then_succeeds(self):
+        from reconciler import sources
+
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError("transient")
+            return "ok"
+
+        with patch.object(sources.time, "sleep"):
+            assert sources._with_retry(flaky, "flaky.read") == "ok"
+        assert calls["n"] == 3
+
+    def test_raises_after_exhausting_attempts(self):
+        from reconciler import sources
+
+        fn = MagicMock(side_effect=RuntimeError("down"))
+        with patch.object(sources.time, "sleep"), pytest.raises(RuntimeError, match="down"):
+            sources._with_retry(fn, "dead.read")
+        assert fn.call_count == sources.SOURCE_FETCH_ATTEMPTS
+
+
+class TestWorkdayRedaction:
+    """Workday token errors must never leak response bodies or credentials."""
+
+    def test_http_error_does_not_include_response_body(self):
+        from reconciler import sources
+
+        with patch.dict(os.environ, {
+            "WORKDAY_API_URL": "https://example.com/report",
+            "WORKDAY_CLIENT_ID": "cid",
+            "WORKDAY_CLIENT_SECRET": "topsecret-password-9999",
+            "WORKDAY_TOKEN_URL": "https://example.com/token",
+        }):
+            source = sources.WorkdayAPISource()
+
+        # Simulate a 401 with a "leaky" body that echoes the credential.
+        leaky_response = MagicMock(spec=httpx.Response)
+        leaky_response.status_code = 401
+        leaky_response.text = "invalid_client: topsecret-password-9999"
+
+        with patch("httpx.post", return_value=leaky_response):
+            with pytest.raises(RuntimeError) as excinfo:
+                source._get_token()
+
+        msg = str(excinfo.value)
+        assert "401" in msg
+        assert "topsecret-password-9999" not in msg
+        assert "invalid_client" not in msg
+
+    def test_network_error_hides_exception_detail(self):
+        from reconciler import sources
+
+        with patch.dict(os.environ, {
+            "WORKDAY_API_URL": "https://example.com/report",
+            "WORKDAY_CLIENT_ID": "cid",
+            "WORKDAY_CLIENT_SECRET": "secret",
+            "WORKDAY_TOKEN_URL": "https://example.com/token",
+        }):
+            source = sources.WorkdayAPISource()
+
+        class _FakeConnectError(httpx.HTTPError):
+            pass
+
+        leaky = _FakeConnectError("DNS lookup failed for secret-tenant.workday.com")
+        with patch("httpx.post", side_effect=leaky):
+            with pytest.raises(RuntimeError) as excinfo:
+                source._get_token()
+
+        msg = str(excinfo.value)
+        assert "unreachable" in msg
+        assert "secret-tenant" not in msg
+        assert "DNS lookup" not in msg


### PR DESCRIPTION
Second of two PRs from the P0/P1 audit sweep. Reconciler-side correctness, defensive logging, and infra hardening. Companion to [#337](https://github.com/msaad00/cloud-ai-security-skills/pull/337).

## P1 — HR source reads had no retry or backoff

`skills/remediation/iam-departures-aws/src/reconciler/sources.py::fetch_departures` in all four sources (Snowflake, Databricks, ClickHouse, Workday) executed exactly one query and raised on any exception. A single transient network hiccup or warehouse throttle would drop an entire reconciler run, extending the departure-remediation window by up to a full scheduler interval.

**Fix:** a shared `_with_retry` helper (3 attempts, exponential backoff starting at 1.5 s, tunable via `HR_SOURCE_FETCH_ATTEMPTS` / `HR_SOURCE_FETCH_BASE_DELAY`) applied uniformly to all four sources by extracting each method body into a private `_fetch_departures_once`. Only reads are retried — nothing on the worker write path.

## P1 — Workday OAuth error handling could leak tenant data

`WorkdayAPISource._get_token` used `resp.raise_for_status()` and `health_check` caught with `logger.exception(...)`. The exception's repr may include tenant URLs that auth endpoints sometimes echo back.

**Fix:** explicit branches.
- Network failure → `RuntimeError(f\"... unreachable ({ExcType})\")`
- HTTP failure → `RuntimeError(f\"... returned HTTP {status_code}\")`

Response bodies and inner exception messages are never re-raised or logged. `health_check` now logs only `type(exc).__name__`.

## P1 — Lambda reserved concurrency was unset

`step_function.asl.json` Map state has `MaxConcurrency: 10`, so the Map can fan out 10 worker invocations. Neither CloudFormation nor Terraform set `ReservedConcurrentExecutions`, so both Lambdas compete with everything else in the account for the burst pool.

**Fix:**
- Parser: `ReservedConcurrentExecutions: 1` (single-shot per manifest).
- Worker: `ReservedConcurrentExecutions: 10` (matches Map `MaxConcurrency`).

Applied to both `infra/cloudformation.yaml` and `infra/terraform/main.tf`. CloudFormation template re-parses cleanly with the new properties present (verified with a PyYAML loader that knows the CFN short-form tags).

## Tests

- `TestWithRetry::test_returns_first_successful_call`
- `TestWithRetry::test_retries_then_succeeds`
- `TestWithRetry::test_raises_after_exhausting_attempts`
- `TestWorkdayRedaction::test_http_error_does_not_include_response_body` — asserts a credential echoed in a 401 response body does not appear in the raised error message.
- `TestWorkdayRedaction::test_network_error_hides_exception_detail` — asserts DNS-failure detail does not appear in the raised error message.

All 98 iam-departures-aws tests pass.

## CHANGELOG

Entries added under `[Unreleased]`. If this PR merges after [#337](https://github.com/msaad00/cloud-ai-security-skills/pull/337), the two `[Unreleased]` sections merge naturally.

## P0/P1 audit scorecard

With this PR and #337, the actionable P0/P1 findings from the post-pull audit are addressed:

- ✅ P0 audit-write silent-swallow (#337)
- ✅ P0 test coverage for audit failure (#337)
- ✅ P1 STS session name request-id correlation (#337)
- ✅ P1 HR source retries (this PR)
- ✅ P1 Workday token log redaction (this PR)
- ✅ P1 Lambda reserved concurrency (this PR)

The scan's P0 on \"SQL injection via .format()\" was downgraded — `_validate_sql_identifier` rejects anything outside `^[A-Za-z_][A-Za-z0-9_]*$`, which makes the .format() pattern defense-in-depth rather than exploitable. The P2 KMS ViaService tightening was left for a separate infra hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)