### PR TITLE
docs(visuals): drop arrow-label clutter in IAM diagram post-band strip

### DIFF
--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -259,14 +259,9 @@
       <text x="848" y="642" fill="#fb923c" font-size="10" font-style="italic">ClickHouse uses the same pattern</text>
     </g>
 
-    <path d="M790,470 C790,508 500,520 250,548" fill="none" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
-    <text x="520" y="516" fill="#93c5fd" font-size="10" font-weight="800">write audit</text>
+    <path d="M810,470 C810,492 486,492 486,358" fill="none" stroke="#2dd4bf" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#arrowSink)"/>
 
-    <path d="M834,470 C834,500 620,502 486,340" fill="none" stroke="#2dd4bf" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#arrowSink)"/>
-    <text x="636" y="498" fill="#5eead4" font-size="10" font-weight="800">audit → same bucket · audit/ prefix</text>
-
-    <path d="M630,548 L630,528 L24,528 L24,216 L46,216" fill="none" stroke="#ec4899" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowLoop)"/>
-    <text x="56" y="522" fill="#f9a8d4" font-size="10" font-weight="800">closed-loop drift · warehouse → next reconciler</text>
+    <path d="M250,548 C250,510 150,510 24,510 L24,214 L46,214" fill="none" stroke="#ec4899" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowLoop)"/>
 
     <g font-size="11" fill="#64748b">
       <text x="46" y="710">AWS-only flagship. Azure Entra and GCP IAM use separate native pipelines. No worker crosses cloud boundaries.</text>


### PR DESCRIPTION
The 78px strip between the VPC band and the REPORT BACK sinks band was stacking three arrow labels on top of each other AND on top of the `REPORT BACK · configurable sinks · one or many` zone title:

- `write audit` (blue)
- `audit → same bucket · audit/ prefix` (teal)
- `closed-loop drift · warehouse → next reconciler` (pink)

On top of that, the worker→DynamoDB \"write audit\" arrow curved across the full width, crossing every tile below.

All three labels are redundant with the sink-tile body text, which already carries the information:

- DynamoDB audit · **written by worker directly**
- Snowflake · **Snowpipe on departures/audit/**
- Databricks · **Auto Loader on departures/audit/**

## What changed

Dropped all three labels. Kept two arrows:

1. A short teal dashed arrow from Worker back to the S3 bucket's `audit/` chip.
2. A single pink dashed closed-loop arrow routed up the left gutter (x=24) from the DynamoDB tile top into Sources.

No labels on arrows; chip and tile text carry the meaning. The post-band strip is empty again, so the `REPORT BACK` zone title has room to breathe.

## Diff

`1 file changed, 2 insertions(+), 7 deletions(-)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)