### PR TITLE
[codex] Pin AWS ATT&CK identity-pivot coverage to shipped scope

### DIFF
--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -48,7 +48,7 @@ Shipped skills mapped: **40**
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
-| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
+| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
 | [`detect-okta-mfa-fatigue`](../skills/detection/detect-okta-mfa-fatigue) | detection | okta | identities, authentication, mfa, sessions |
 | [`detect-privilege-escalation-k8s`](../skills/detection/detect-privilege-escalation-k8s) | detection | kubernetes | clusters, containers, identities, secrets |
@@ -100,7 +100,7 @@ Shipped skills mapped: **38**
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
-| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
+| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
 | [`detect-okta-mfa-fatigue`](../skills/detection/detect-okta-mfa-fatigue) | detection | okta | identities, authentication, mfa, sessions |
 | [`detect-privilege-escalation-k8s`](../skills/detection/detect-privilege-escalation-k8s) | detection | kubernetes | clusters, containers, identities, secrets |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -48,7 +48,7 @@ Strongest current ATT&CK coverage:
 
 | Skill | Coverage |
 |---|---|
-| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; GCP workload-identity federation abuse remains a tracked follow-up gap |
+| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; AWS IAM-user/access-key pivots and GCP workload-identity federation abuse remain tracked follow-up gaps |
 | `detect-okta-mfa-fatigue` | T1621 for repeated Okta Verify push challenge + deny bursts |
 | `detect-entra-credential-addition` | T1098.001 for successful Entra application or service-principal credential additions and federated identity credential creation |
 | `detect-entra-role-grant-escalation` | T1098.003 for successful Entra app-role assignments that grant additional application permissions to service principals |
@@ -67,6 +67,7 @@ Notes:
 - ATT&CK mappings belong inside `finding_info.attacks[]` for OCSF 1.8 outputs, not as loose side metadata.
 - Current cross-cloud identity depth is strongest in `detect-lateral-movement`; the Azure slice now distinguishes Azure Activity control-plane pivots from Entra / Graph application-service-principal credential pivots.
 - The GCP slice in `detect-lateral-movement` is currently pinned to service-account and IAM Credentials anchors; workload-identity federation abuse is tracked separately so the docs do not overstate provider depth.
+- The AWS slice in `detect-lateral-movement` is currently role-session-centric; IAM users, access keys, and temporary-credential pivots are tracked separately so the docs do not overstate provider depth.
 
 ## OCSF identity normalization
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,7 +151,7 @@ Open roadmap issues should be:
 Good examples:
 
 - `ATT&CK gap: Azure Entra and service principal credential detections`
-- `ATT&CK gap: AWS IAM user and access-key identity pivots`
+- `ATT&CK gap: AWS IAM users, access keys, and temporary-credential identity pivots`
 - `ATT&CK gap: GCP service accounts, service-account keys, and workload-identity federation abuse detections`
 - `ATLAS gap: AI endpoint and model registry evaluation coverage`
 - `PCI and SOC 2 gap: remaining cross-cloud evidence depth beyond provider-native logging, segmentation, encryption, and key-management inventory`

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -671,7 +671,8 @@
         "multi"
       ],
       "asset_classes": [
-        "identities",
+        "iam-roles",
+        "role-sessions",
         "applications",
         "service-accounts",
         "service-account-keys",

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -84,11 +84,25 @@ event family.
 - Azure Entra / Microsoft Graph coverage here is limited to high-signal
   application and service-principal credential changes plus app-role grants. It
   is **not** a complete Entra administrative drift detector.
-- AWS IAM user access-key creation and policy-document drift are roadmap work,
-  not current detector anchors.
+- AWS IAM user and access-key identity pivots are roadmap work, not current
+  detector anchors. Today the AWS slice is explicitly limited to role-session
+  pivots observed through STS.
 - GCP service-account pivots are currently anchored to IAM Credentials and
   service-account key events. Workload-identity federation abuse beyond those
   signals remains a separate roadmap item.
+
+### AWS roadmap slice
+
+The next explicit AWS ATT&CK expansion for this detector is:
+
+- IAM user access-key creation and proliferation sequences
+- temporary-credential pivots such as `GetFederationToken` when the surrounding
+  signal is strong enough to support `T1078.004`
+- policy-change anchors that materially widen identity reach, such as
+  trust-policy or role-policy drift associated with a subsequent east-west move
+
+That work is intentionally tracked as a separate gap so the current detector
+does not over-claim AWS identity coverage beyond role-session pivots.
 
 ### GCP roadmap slice
 


### PR DESCRIPTION
## What changed

- narrowed the documented AWS slice of `detect-lateral-movement` to the role-session anchors it actually ships today
- added an explicit AWS roadmap subsection for IAM-user, access-key, and temporary-credential identity pivots
- updated ATT&CK mappings, roadmap wording, and the framework coverage registry/doc so AWS coverage claims stay pinned to the implemented asset classes

## Why

The repo already had strong cross-cloud identity coverage language, but the AWS part was still easy to over-read as broader IAM coverage than the detector actually ships. This PR makes the current AWS scope explicit and measurable.

## Validation

- `python scripts/generate_framework_coverage_doc.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_count_consistency.py`

Closes #95
