### PR TITLE
[codex] Pin GCP ATT&CK identity-pivot coverage to shipped scope

### DIFF
--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -48,7 +48,7 @@ Shipped skills mapped: **40**
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
-| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
+| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
 | [`detect-okta-mfa-fatigue`](../skills/detection/detect-okta-mfa-fatigue) | detection | okta | identities, authentication, mfa, sessions |
 | [`detect-privilege-escalation-k8s`](../skills/detection/detect-privilege-escalation-k8s) | detection | kubernetes | clusters, containers, identities, secrets |
@@ -100,7 +100,7 @@ Shipped skills mapped: **37**
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
-| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
+| [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | identities, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
 | [`detect-okta-mfa-fatigue`](../skills/detection/detect-okta-mfa-fatigue) | detection | okta | identities, authentication, mfa, sessions |
 | [`detect-privilege-escalation-k8s`](../skills/detection/detect-privilege-escalation-k8s) | detection | kubernetes | clusters, containers, identities, secrets |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -48,7 +48,7 @@ Strongest current ATT&CK coverage:
 
 | Skill | Coverage |
 |---|---|
-| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots |
+| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; GCP workload-identity federation abuse remains a tracked follow-up gap |
 | `detect-okta-mfa-fatigue` | T1621 for repeated Okta Verify push challenge + deny bursts |
 | `detect-entra-credential-addition` | T1098.001 for successful Entra application or service-principal credential additions and federated identity credential creation |
 | `detect-entra-role-grant-escalation` | T1098.003 for successful Entra app-role assignments that grant additional application permissions to service principals |
@@ -66,6 +66,7 @@ Notes:
 - ATT&CK is pinned in the shared OCSF contract.
 - ATT&CK mappings belong inside `finding_info.attacks[]` for OCSF 1.8 outputs, not as loose side metadata.
 - Current cross-cloud identity depth is strongest in `detect-lateral-movement`; the Azure slice now distinguishes Azure Activity control-plane pivots from Entra / Graph application-service-principal credential pivots.
+- The GCP slice in `detect-lateral-movement` is currently pinned to service-account and IAM Credentials anchors; workload-identity federation abuse is tracked separately so the docs do not overstate provider depth.
 
 ## OCSF identity normalization
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -152,7 +152,7 @@ Good examples:
 
 - `ATT&CK gap: Azure Entra and service principal credential detections`
 - `ATT&CK gap: AWS IAM user and access-key identity pivots`
-- `ATT&CK gap: GCP service-account and workload-identity abuse detections`
+- `ATT&CK gap: GCP service accounts, service-account keys, and workload-identity federation abuse detections`
 - `ATLAS gap: AI endpoint and model registry evaluation coverage`
 - `PCI gap: logging and segmentation evidence for cross-cloud discovery`
 - `NIST AI RMF gap: provider-native AI control evidence expansion`

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -646,6 +646,8 @@
         "identities",
         "applications",
         "service-accounts",
+        "service-account-keys",
+        "iam-credentials",
         "service-principals",
         "managed-identities",
         "federated-credentials",

--- a/skills/detection/detect-lateral-movement/SKILL.md
+++ b/skills/detection/detect-lateral-movement/SKILL.md
@@ -86,8 +86,24 @@ event family.
   is **not** a complete Entra administrative drift detector.
 - AWS IAM user access-key creation and policy-document drift are roadmap work,
   not current detector anchors.
-- GCP workload-identity federation abuse beyond the current IAM Credentials
-  events remains a roadmap item.
+- GCP service-account pivots are currently anchored to IAM Credentials and
+  service-account key events. Workload-identity federation abuse beyond those
+  signals remains a separate roadmap item.
+
+### GCP roadmap slice
+
+The next explicit GCP ATT&CK expansion for this detector is:
+
+- repeated IAM Credentials impersonation patterns beyond the current single
+  anchor join
+- service-account key proliferation sequences where key creation or reuse
+  widens identity reach
+- workload-identity federation abuse once the authoritative signal quality is
+  strong enough to keep the detector measurable
+
+That split keeps the shipped detector honest about what it already covers in
+GCP today: service-account and IAM Credentials pivots, not generic
+workload-identity abuse.
 
 ### Window semantics
 


### PR DESCRIPTION
## What changed

- narrowed the documented GCP slice of `detect-lateral-movement` to the service-account and IAM Credentials anchors it actually ships today
- added an explicit GCP roadmap subsection for service-account key proliferation and workload-identity federation abuse
- updated ATT&CK mappings, roadmap wording, and the framework coverage registry/doc so GCP claims stay pinned to implemented signals and asset classes

## Why

The repo already described strong cross-cloud identity coverage, but the GCP part still needed a clearer split between shipped IAM Credentials / service-account depth and the missing workload-identity federation coverage.

## Validation

- `python scripts/generate_framework_coverage_doc.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_count_consistency.py`

Closes #93
