### PR TITLE
[codex] Align lateral movement coverage metadata with provider scope

### DIFF
--- a/skills/detection/detect-lateral-movement/src/detect.py
+++ b/skills/detection/detect-lateral-movement/src/detect.py
@@ -107,9 +107,12 @@ AZURE_ENTRA_EXACT_OPERATIONS = {
 FRAMEWORKS = ("OCSF 1.8.0", "MITRE ATT&CK v14")
 PROVIDERS = ("aws", "azure", "gcp", "multi")
 ASSET_CLASSES = (
-    "identities",
+    "iam-roles",
+    "role-sessions",
     "applications",
     "service-accounts",
+    "service-account-keys",
+    "iam-credentials",
     "service-principals",
     "managed-identities",
     "federated-credentials",

--- a/skills/detection/detect-lateral-movement/tests/test_detect.py
+++ b/skills/detection/detect-lateral-movement/tests/test_detect.py
@@ -560,8 +560,12 @@ class TestCrossCloudAnchors:
         metadata = coverage_metadata()
         assert "MITRE ATT&CK v14" in metadata["frameworks"]
         assert "azure" in metadata["providers"]
+        assert "iam-roles" in metadata["asset_classes"]
+        assert "role-sessions" in metadata["asset_classes"]
         assert "managed-identities" in metadata["asset_classes"]
         assert "applications" in metadata["asset_classes"]
+        assert "service-account-keys" in metadata["asset_classes"]
+        assert "iam-credentials" in metadata["asset_classes"]
         assert "service-principals" in metadata["attack_coverage"]["azure"]["principal_types"]
         assert "entra-graph" in metadata["attack_coverage"]["azure"]["operation_families"]
         assert "POST /applications/{id}/addPassword" in metadata["attack_coverage"]["azure"]["operation_families"]["entra-graph"]


### PR DESCRIPTION
## What changed

- updated `detect-lateral-movement` machine-readable `coverage_metadata()` asset classes to use the provider-specific identity surfaces the detector already documents and exposes under `attack_coverage`
- added assertions for AWS role-session and GCP IAM Credentials / service-account-key asset classes in the detector metadata test

## Why

The merged ATT&CK scope docs narrowed `detect-lateral-movement` to provider-specific identity pivots, but the runtime metadata still advertised a generic `identities` asset class. This keeps the code path aligned with the shipped coverage story and avoids doc-vs-runtime drift.

## Validation

- `pytest skills/detection/detect-lateral-movement/tests/test_detect.py -q`
- `ruff check skills/detection/detect-lateral-movement`
