### PR TITLE
[codex] Release v0.7.0 repo alignment and visual polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is loosely based on Keep a Changelog.
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-04-23 — Release alignment and coverage hardening
+
+Skills count: **61** (15 ingest, 5 discover, 14 detect, 7 evaluate, 12 remediate,
+2 view, 3 output, 3 sources).
+
 ### Added
 
 - **Correlation of worker actions with CloudTrail** — STS
@@ -36,6 +41,16 @@ The format is loosely based on Keep a Changelog.
   `step_function.asl.json` Map `MaxConcurrency`. Prevents the Map
   fan-out from starving other functions in the account, and prevents
   unrelated burst traffic from starving the remediation pipeline.
+- **Standalone IAM departures planner skill** —
+  [`skills/discovery/iam-departures-reconciler`](skills/discovery/iam-departures-reconciler/)
+  now owns the shared read-only manifest-planning boundary. Rehire,
+  grace-window, hash, and canonical-manifest logic are no longer mixed
+  into the AWS write-path bundle.
+- **Provider-scoped control evidence depth** —
+  [`discover-cloud-control-evidence`](skills/discovery/discover-cloud-control-evidence/)
+  now carries clearer provider-native evidence depth for logging,
+  segmentation, encryption, and key-management surfaces instead of
+  flattening them into one cross-cloud coverage story.
 
 ### Fixed
 
@@ -61,6 +76,32 @@ The format is loosely based on Keep a Changelog.
   errors raise `RuntimeError(f"... returned HTTP {status_code}")`.
   Response bodies and inner exception messages are never re-raised or
   logged. `health_check` now logs only the exception type name.
+- **`detect-lateral-movement` runtime metadata now matches the
+  documented provider scope** — the machine-readable coverage metadata
+  no longer advertises generic identity coverage where the shipped
+  detector is explicitly scoped to AWS role sessions, GCP IAM
+  Credentials and service-account keys, and Azure control-plane / Entra
+  pivots.
+- **`discover-environment` provider tests no longer fail lightweight CI
+  lanes on missing `moto`** — AWS-specific provider coverage now skips
+  cleanly when `moto` is absent instead of failing import-time
+  collection in jobs that intentionally install only the cloud SDK set.
+
+### Changed
+
+- **ATT&CK provider-scope language is now explicit in the docs** — the
+  AWS slice of `detect-lateral-movement` is pinned to shipped
+  role-session anchors, and the GCP slice is pinned to service-account
+  and IAM Credentials anchors, so roadmap depth is tracked without
+  overstating current provider coverage.
+- **Coverage depth across shipped evaluation and discovery skills is
+  materially higher** — new test suites now cover the runner, CLI, and
+  error branches for the AWS, GCP, and Azure CIS benchmark skills plus
+  the provider-specific discovery paths in `discover-environment`.
+- **README release state and shipped-surface visuals are aligned to
+  current `main`** — the repo badge, release metadata, skill counts,
+  coverage captions, and the core SVG diagrams now agree on the current
+  61-skill surface and render without footer text collisions.
 
 ## [0.6.0] — 2026-04-18 — Closed-loop hardening
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.6.0-0ea5e9"></a>
+  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.7.0-0ea5e9"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11+-blue.svg"></a>
   <a href="https://schema.ocsf.io/1.8.0"><img alt="OCSF 1.8" src="https://img.shields.io/badge/OCSF-1.8-22d3ee"></a>
@@ -16,7 +16,7 @@
 
 ## What this repo gives you
 
-**61 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus ten guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**61 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 3 of 11 detections shipped as closed loops; 5 of the remaining 8 gaps planned via tracking issues; 3 detections still need new remediation skills.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 14 shipped detections are closed loops today; lateral movement is intentionally detection-only, and CSPM auto-remediation for AWS, GCP, and Azure is tracked separately.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -204,7 +204,7 @@ Native wire format is the same content in a repo-owned envelope — see [docs/NA
 
 The flagship shipped write path. Guarded, event-driven, dual-audited — and **one cloud per worker**, never cross-cloud.
 
-![Simplified AWS-only IAM departures workflow. Snowflake or Databricks feed the reconciler, which applies rehire, grace-period, and diff logic before writing an S3 manifest. S3 ObjectCreated triggers EventBridge and a Step Function map, which runs parser and worker Lambdas with separate roles. The worker assumes a scoped cross-account role guarded by aws:PrincipalOrgID, executes the IAM cleanup sequence, and dual-audits each action to DynamoDB and KMS-encrypted S3. Ingest-back closes the loop into the next reconciler run, and the footer makes clear that other clouds use separate native pipelines.](docs/images/iam-departures-aws.svg)
+![Simplified AWS-only IAM departures workflow. Snowflake, Workday, Databricks, or ClickHouse feed the shared reconciler, which applies rehire, grace-period, and diff logic before writing an S3 manifest. S3 ObjectCreated triggers EventBridge and a Step Function map, which runs parser and worker Lambdas with separate roles. The worker assumes a scoped cross-account role guarded by aws:PrincipalOrgID, executes the IAM cleanup sequence, and dual-audits each action to DynamoDB and KMS-encrypted S3. Audit sinks feed the next reconciler run, and the footer makes clear that other clouds use separate native pipelines.](docs/images/iam-departures-aws.svg)
 
 - **scope first** — rehire and grace-window logic run in the reconciler before the manifest is written
 - **separate principals** — EventBridge, Step Function, parser Lambda, worker Lambda each have their own execution role

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers (L1 Ingest with 15 ingesters plus 3 source adapters and L2 Discover with 4 inventory and evidence skills). Intake feeds two analyze layers (L3 Detect with 14 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004 and L4 Evaluate with 7 benchmark families covering 82 checks). Analyze feeds two act layers (L5 Remediate with 10 HITL dual-audited write paths and L6 View with 2 OCSF-to-render converters). L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 14 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 82 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -78,7 +78,7 @@
 
       <rect x="322" y="440" width="260" height="180" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
       <text x="354" y="482" font-size="18" font-weight="800" fill="#dbeafe">L2 Discover</text>
-      <text x="354" y="544" font-size="56" font-weight="900" fill="#ffffff">4</text>
+      <text x="354" y="544" font-size="56" font-weight="900" fill="#ffffff">5</text>
       <text x="354" y="576" font-size="15" fill="#bfdbfe">inventory · graph · AI BOM</text>
       <text x="354" y="598" font-size="15" fill="#bfdbfe">CycloneDX · evidence</text>
     </g>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 54 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 4 discover, 12 detect, 7 evaluate, 8 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 61 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 14 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -56,15 +56,15 @@
 
     <g transform="translate(88,252)">
       <g>
-        <rect x="0" y="0" width="162" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">60</text>
+        <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">61</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
-      <g transform="translate(174,0)">
+      <g transform="translate(182,0)">
         <rect x="0" y="0" width="134" height="36" rx="12" fill="#0f2235" stroke="#22d3ee"/>
         <text x="16" y="23" fill="#67e8f9" font-size="14" font-weight="900">OCSF 1.8</text>
       </g>
-      <g transform="translate(320,0)">
+      <g transform="translate(328,0)">
         <rect x="0" y="0" width="186" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">82</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">benchmark checks</text>
@@ -102,7 +102,7 @@
       <g transform="translate(222,0)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
         <text x="14" y="23" fill="#dbeafe" font-size="13" font-weight="800">L2 Discover</text>
-        <text x="182" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">4</text>
+        <text x="182" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">5</text>
       </g>
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" role="img" aria-labelledby="title desc">
   <title id="title">IAM departures remediation · AWS flagship workflow</title>
-  <desc id="desc">Configurable-source, configurable-sink AWS IAM departures workflow. Any one source — Snowflake, Workday, Databricks, ClickHouse, or S3 — normalizes each departure into a five-field record: timestamp, email, username, iam, account. The record lands as an S3 manifest in the AWS Corporate account. S3 ObjectCreated triggers EventBridge, which starts a Step Function inside the VPC. The parser Lambda fetches the record and resolves the target IAM principal and account. The worker Lambda assumes a scoped cross-account role guarded by aws:PrincipalOrgID and performs the revoke, strip, quarantine, and delete sequence against the target accounts. Every worker action is reported back to one or more configurable audit and state sinks: S3 evidence, DynamoDB audit, or re-ingest into Snowflake or Databricks. The next reconciler run closes the loop. Azure Entra and GCP IAM use separate native pipelines.</desc>
+  <desc id="desc">AWS IAM departures flagship workflow. Snowflake, Workday, Databricks, or ClickHouse feed the shared read-only reconciler, which normalizes each departure into the canonical record and writes an S3 manifest after rehire, grace-period, and diff checks. S3 ObjectCreated triggers EventBridge, which starts a Step Function inside the VPC. The parser Lambda fetches the record and resolves the target IAM principal and account. The worker Lambda assumes a scoped cross-account role guarded by aws:PrincipalOrgID and performs the revoke, strip, quarantine, and delete sequence against the target accounts. Worker actions audit to DynamoDB and S3-backed warehouse sinks so the next reconciler run can verify closure. Azure Entra and GCP IAM use separate native pipelines.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -196,7 +196,7 @@
       <text x="834" y="455" text-anchor="middle" fill="#fde68a" font-size="11" font-weight="700">AssumeRole + OrgID</text>
     </g>
 
-    <text x="530" y="478" fill="#64748b" font-size="10" font-weight="700">separate IAM roles: parser ≠ worker ≠ cross-account target</text>
+    <text x="720" y="494" text-anchor="middle" fill="#64748b" font-size="9" font-weight="700">separate IAM roles: parser ≠ worker ≠ cross-account target</text>
 
     <g>
       <rect x="968" y="240" width="250" height="230" rx="14" fill="url(#panel)" stroke="#f87171" stroke-width="1.4"/>
@@ -234,7 +234,7 @@
       <rect x="46" y="510" width="1188" height="170" rx="16"/>
     </g>
     <text x="62" y="532" fill="#5eead4" font-size="12" font-weight="800" letter-spacing="1.2">REPORT BACK · configurable sinks · one or many</text>
-    <text x="470" y="532" fill="#64748b" font-size="11">worker writes every action · next reconciler run closes the loop</text>
+    <text x="62" y="696" fill="#64748b" font-size="11">worker writes every action; the next reconciler run verifies closure from audit/state sinks</text>
 
     <g filter="url(#shadow)">
       <rect x="70" y="548" width="360" height="116" rx="14" fill="url(#panel)" stroke="#60a5fa" stroke-width="1.4"/>
@@ -258,8 +258,6 @@
       <text x="848" y="624" fill="#94a3b8" font-size="11">same close-loop via lakehouse</text>
       <text x="848" y="642" fill="#fb923c" font-size="10" font-style="italic">ClickHouse uses the same pattern</text>
     </g>
-
-    <path d="M810,470 C810,492 486,492 486,358" fill="none" stroke="#2dd4bf" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#arrowSink)"/>
 
     <path d="M250,548 C250,510 150,510 24,510 L24,214 L46,214" fill="none" stroke="#ec4899" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowLoop)"/>
 

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 58 shipped skills — 15 ingest, 14 detect, 4 discover, 7 eval, 10 remediate, 2 view, 3 sink.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 61 shipped skills — 15 ingest, 14 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 58 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">60</text>
+      <!-- Counts: 61 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">61</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 14 detect · 4 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 14 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>
@@ -154,9 +154,9 @@
 
     <!-- ============================= FOOTER ============================= -->
     <!-- Replaces the old dashed box. Three short lines, plenty of space, no overlap. -->
-    <rect x="48" y="556" width="1224" height="62" rx="12" fill="#0b1220" stroke="#1e293b" stroke-width="1"/>
+    <rect x="48" y="552" width="1224" height="70" rx="12" fill="#0b1220" stroke="#1e293b" stroke-width="1"/>
     <text x="64" y="580" font-size="12" font-weight="700" fill="#e2e8f0">Surfaces differ only in transport.</text>
-    <text x="240" y="580" font-size="12" fill="#94a3b8">Skills, audit contract, and HITL gates are identical across all four paths.</text>
-    <text x="64" y="602" font-size="11" fill="#64748b">CLI · CI · cloud runners skip the MCP transport layer and import the same skills directly — no second contract to maintain.</text>
+    <text x="64" y="598" font-size="12" fill="#94a3b8">Skills, audit contract, and HITL gates are identical across all four paths.</text>
+    <text x="64" y="614" font-size="11" fill="#64748b">CLI · CI · cloud runners skip the MCP transport layer and import the same skills directly — no second contract to maintain.</text>
   </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloud-ai-security-skills"
-version = "0.6.0"
+version = "0.7.0"
 description = "Security skills for cloud and AI with repo-native and OCSF modes."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "cloud-ai-security-skills"
-version = "0.6.0"
+version = "0.7.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What changed
- bumped the repo version to `0.7.0` in `pyproject.toml` and `uv.lock`
- added a `0.7.0` changelog entry that captures the shipped planner split, coverage hardening, metadata alignment, and release polish work
- aligned the README copy and image alt text with the current 61-skill shipped surface and the current remediation count
- refreshed the core SVGs (`hero-banner`, `runtime-surfaces`, `architecture-layers`, `iam-departures-aws`) so counts match the repo and rendered text no longer overlaps borders or footer containers

## Why
The repo had drift between shipped code, skill counts, README language, version metadata, and the visuals used on the landing page. This release branch brings the docs, diagrams, and package metadata back to the actual state of `main` so the release can be cut cleanly.

## Impact
- release metadata now matches the current repo state
- README visuals render cleanly on GitHub without footer collisions or text sitting on container strokes
- the flagship IAM departures diagram now matches the extracted read-only reconciler boundary and the shipped AWS-only worker model

## Validation
- `xmllint --noout docs/images/*.svg`
- `rsvg-convert` render checks for `hero-banner.svg`, `runtime-surfaces.svg`, `architecture-layers.svg`, and `iam-departures-aws.svg`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_dependency_consistency.py`
- `python scripts/validate_ocsf_metadata.py`
- `python scripts/validate_safe_skill_bar.py`
- `python scripts/generate_framework_coverage_doc.py --check`
- `bash scripts/run_mypy.sh`
- `bandit -r skills mcp-server scripts -c pyproject.toml --severity-level medium`