### PR TITLE
[codex] Enforce MCP HITL approval contract

### DIFF
--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -104,7 +104,7 @@ Rules:
 - `approver_roles`, when present, should name the roles allowed to approve write-capable actions
 - `min_approvers`, when present, must be an integer greater than or equal to 1
 - `mcp_timeout_seconds`, when present, must be an integer between 1 and 900 and names the per-call subprocess timeout the MCP wrapper should apply to this skill. It is opt-in; skills that do not declare it inherit the global default (60 seconds) or whatever the operator sets via the `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` env var. The env var wins over the per-skill value so on-call can widen or tighten the window without editing `SKILL.md`
-- write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy
+- write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy; the repo MCP wrapper uses them to require `_approval_context` and enforce approver count
 - write-capable skills should preserve caller, approver, and request or session identifiers in their audit trail when the runtime provides them
 
 ## Required language

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -24,6 +24,21 @@ Audit behavior:
 - every call also gets a wrapper-generated `correlation_id` that is recorded in
   the MCP audit event and forwarded into the skill as `SKILL_CORRELATION_ID`
   so structured `stderr` can be joined back to the audited tool invocation
+- the wrapper accepts optional `_caller_context` and `_approval_context`
+  objects so a trusted client wrapper can propagate identity, ticket, and
+  approver metadata into both MCP audit logs and the spawned skill process
+
+Approval behavior:
+
+- write-capable tools still require `--dry-run`; the wrapper refuses bare
+  apply-style invocations
+- if a skill declares `approver_roles`, the caller must provide
+  `_approval_context`
+- if a skill declares `min_approvers > 1`, `_approval_context` must carry that
+  many distinct approvers via `approver_ids` or `approver_emails`
+- the wrapper forwards those values into the subprocess as
+  `SKILL_APPROVER_ID`, `SKILL_APPROVER_EMAIL`, `SKILL_APPROVER_IDS`,
+  `SKILL_APPROVER_EMAILS`, and `SKILL_APPROVAL_TICKET`
 
 Timeout behavior:
 

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -164,6 +164,20 @@ def _validate_context(raw_context: Any, field_name: str) -> dict[str, Any] | Non
     return validated
 
 
+def _approval_count(approval_context: dict[str, Any] | None) -> int:
+    if not approval_context:
+        return 0
+    approver_ids = approval_context.get("approver_ids")
+    if isinstance(approver_ids, list):
+        return len([item for item in approver_ids if item])
+    approver_emails = approval_context.get("approver_emails")
+    if isinstance(approver_emails, list):
+        return len([item for item in approver_emails if item])
+    if approval_context.get("approver_id") or approval_context.get("approver_email"):
+        return 1
+    return 0
+
+
 def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     tools = _filtered_tool_map()
     if name not in tools:
@@ -192,6 +206,7 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
         "input_length": len(stdin_text),
         "caller_context_provided": caller_context is not None,
         "approval_context_provided": approval_context is not None,
+        "approval_count": _approval_count(approval_context),
         "caller_id": caller_context.get("user_id", "") if caller_context else "",
         "caller_session_id": caller_context.get("session_id", "") if caller_context else "",
         "approval_ticket": approval_context.get("ticket_id", "") if approval_context else "",
@@ -203,6 +218,10 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
             raise ValueError("write-capable tools must be called with `--dry-run`")
         if not skill.read_only and skill.approver_roles and approval_context is None:
             raise ValueError("write-capable tools with approver_roles require `_approval_context`")
+        if not skill.read_only and (skill.min_approvers or 0) > _approval_count(approval_context):
+            raise ValueError(
+                f"tool `{skill.name}` requires at least {skill.min_approvers} approver(s) in `_approval_context`"
+            )
 
         env = os.environ.copy()
         env.setdefault("PYTHONUNBUFFERED", "1")
@@ -221,6 +240,10 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
                 env["SKILL_APPROVER_ID"] = approval_context["approver_id"]
             if "approver_email" in approval_context:
                 env["SKILL_APPROVER_EMAIL"] = approval_context["approver_email"]
+            if "approver_ids" in approval_context:
+                env["SKILL_APPROVER_IDS"] = ",".join(approval_context["approver_ids"])
+            if "approver_emails" in approval_context:
+                env["SKILL_APPROVER_EMAILS"] = ",".join(approval_context["approver_emails"])
             if "ticket_id" in approval_context:
                 env["SKILL_APPROVAL_TICKET"] = approval_context["ticket_id"]
             if "approval_timestamp" in approval_context:

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -199,6 +199,34 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
             "items": {"type": "string"},
             "description": "Explicit CLI arguments forwarded to the fixed skill entrypoint.",
         },
+        "_caller_context": {
+            "type": "object",
+            "description": "Optional wrapper-supplied caller identity context for audit propagation.",
+            "properties": {
+                "user_id": {"type": "string"},
+                "email": {"type": "string"},
+                "session_id": {"type": "string"},
+                "roles": {"type": "array", "items": {"type": "string"}},
+            },
+            "additionalProperties": True,
+        },
+        "_approval_context": {
+            "type": "object",
+            "description": (
+                "Optional wrapper-supplied approval context for HITL-gated tools. "
+                "For multi-approver actions, populate `approver_ids` or `approver_emails` "
+                "with one entry per distinct approver."
+            ),
+            "properties": {
+                "approver_id": {"type": "string"},
+                "approver_email": {"type": "string"},
+                "ticket_id": {"type": "string"},
+                "approval_timestamp": {"type": "string"},
+                "approver_ids": {"type": "array", "items": {"type": "string"}},
+                "approver_emails": {"type": "array", "items": {"type": "string"}},
+            },
+            "additionalProperties": True,
+        },
     }
     if skill.output_formats:
         properties["output_format"] = {

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -35,6 +35,7 @@ class _FakeSkill:
         self,
         read_only: bool = True,
         approver_roles: tuple[str, ...] = (),
+        min_approvers: int | None = None,
         mcp_timeout_seconds: int | None = None,
     ) -> None:
         self.name = "fake-skill"
@@ -42,6 +43,7 @@ class _FakeSkill:
         self.capability = "read-only" if read_only else "write-remediation"
         self.read_only = read_only
         self.approver_roles = approver_roles
+        self.min_approvers = min_approvers
         self.mcp_timeout_seconds = mcp_timeout_seconds
 
 
@@ -125,6 +127,84 @@ def test_call_tool_requires_approval_context_for_write_skill(monkeypatch):
     assert audit_events[0]["error_type"] == "ValueError"
     assert audit_events[0]["args_hash"] == MODULE._stable_hash(["--dry-run"])
     assert audit_events[0]["approval_context_provided"] is False
+
+
+def test_call_tool_requires_minimum_approver_count(monkeypatch):
+    audit_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        MODULE,
+        "tool_map",
+        lambda: {
+            "fake-skill": _FakeSkill(
+                read_only=False,
+                approver_roles=("security_lead", "incident_commander"),
+                min_approvers=2,
+            )
+        },
+    )
+    monkeypatch.setattr(MODULE, "_emit_audit_event", lambda event: audit_events.append(event))
+
+    try:
+        MODULE._call_tool(
+            "fake-skill",
+            {
+                "args": ["--dry-run"],
+                "_approval_context": {
+                    "approver_id": "a-456",
+                    "ticket_id": "SEC-123",
+                },
+            },
+        )
+    except ValueError as exc:
+        assert "requires at least 2 approver" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+    assert audit_events[0]["approval_context_provided"] is True
+    assert audit_events[0]["approval_count"] == 1
+
+
+def test_call_tool_accepts_multi_approver_context(monkeypatch):
+    captured: dict[str, object] = {}
+    audit_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        MODULE,
+        "tool_map",
+        lambda: {
+            "fake-skill": _FakeSkill(
+                read_only=False,
+                approver_roles=("security_lead", "incident_commander"),
+                min_approvers=2,
+            )
+        },
+    )
+    monkeypatch.setattr(MODULE, "build_command", lambda skill, args, output_format=None: ["python", "fake.py"])
+    monkeypatch.setattr(MODULE, "_emit_audit_event", lambda event: audit_events.append(event))
+
+    def _fake_run(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _FakeCompleted()
+
+    monkeypatch.setattr(MODULE.subprocess, "run", _fake_run)
+
+    result = MODULE._call_tool(
+        "fake-skill",
+        {
+            "args": ["--dry-run"],
+            "_approval_context": {
+                "approver_ids": ["a-456", "b-789"],
+                "approver_emails": ["a@example.com", "b@example.com"],
+                "ticket_id": "SEC-123",
+            },
+        },
+    )
+
+    env = captured["env"]
+    assert env["SKILL_APPROVER_IDS"] == "a-456,b-789"
+    assert env["SKILL_APPROVER_EMAILS"] == "a@example.com,b@example.com"
+    assert result["isError"] is False
+    assert audit_events[0]["approval_count"] == 2
 
 
 def test_resolve_timeout_prefers_env_override():

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -116,6 +116,18 @@ class TestToolDefinition:
         assert remediation.approver_roles == ("security_lead", "cis_officer")
         assert remediation.min_approvers == 1
 
+    def test_tool_input_schema_exposes_wrapper_context_fields(self):
+        skill = tool_map(REPO_ROOT)["ingest-cloudtrail-ocsf"]
+        schema = tool_definition(skill)["inputSchema"]
+        assert "_caller_context" in schema["properties"]
+        assert "_approval_context" in schema["properties"]
+
+    def test_mcp_tool_quarantine_requires_two_approvers_in_metadata(self):
+        remediation = next(
+            skill for skill in discover_skills(REPO_ROOT) if skill.name == "remediate-mcp-tool-quarantine"
+        )
+        assert remediation.min_approvers == 2
+
     def test_source_snowflake_query_exposes_raw_output(self):
         skill = tool_map(REPO_ROOT)["source-snowflake-query"]
         tool = tool_definition(skill)

--- a/scripts/validate_safe_skill_bar.py
+++ b/scripts/validate_safe_skill_bar.py
@@ -23,6 +23,13 @@ WILDCARD_PATTERNS = (
 
 POLICY_SUFFIXES = (".json", ".tf", ".yaml", ".yml")
 
+# Policy floors from docs/HITL_POLICY.md that are stricter than the generic
+# "write-capable skills need human approval" bar. Keep the set explicit so CI
+# fails when a shipped skill drifts from the published policy matrix.
+POLICY_MIN_APPROVERS: dict[str, int] = {
+    "remediate-mcp-tool-quarantine": 2,
+}
+
 
 def validate_read_only_no_subprocess(skill: object) -> list[str]:
     errors: list[str] = []
@@ -415,6 +422,33 @@ def validate_remediation_hitl_env_vars(skill: object) -> list[str]:
     return errors
 
 
+def validate_policy_min_approvers(skill: object) -> list[str]:
+    errors: list[str] = []
+    skill_name = getattr(skill, "name", "")
+    required = POLICY_MIN_APPROVERS.get(skill_name)
+    if required is None:
+        return errors
+
+    frontmatter = getattr(skill, "frontmatter", {})
+    raw_value = str(frontmatter.get("min_approvers", "")).strip()
+    rel = getattr(skill, "skill_dir").relative_to(ROOT)
+    if not raw_value:
+        errors.append(
+            f"{rel}: min_approvers must be set to {required} to match docs/HITL_POLICY.md"
+        )
+        return errors
+    try:
+        actual = int(raw_value)
+    except ValueError:
+        errors.append(f"{rel}: min_approvers must be an integer to match docs/HITL_POLICY.md")
+        return errors
+    if actual < required:
+        errors.append(
+            f"{rel}: min_approvers={actual} is below the policy floor {required} from docs/HITL_POLICY.md"
+        )
+    return errors
+
+
 def main() -> int:
     errors: list[str] = []
     for skill in discover_skill_contracts():
@@ -423,6 +457,7 @@ def main() -> int:
         errors.extend(validate_write_skill_dry_run(skill))
         errors.extend(validate_write_skill_source_guards(skill))
         errors.extend(validate_remediation_hitl_env_vars(skill))
+        errors.extend(validate_policy_min_approvers(skill))
     errors.extend(validate_wildcards())
     errors.extend(validate_assume_role_boundaries())
 

--- a/skills/remediation/remediate-mcp-tool-quarantine/REFERENCES.md
+++ b/skills/remediation/remediate-mcp-tool-quarantine/REFERENCES.md
@@ -32,7 +32,7 @@
 
 - [`_shared/remediation_verifier.py`](../../_shared/remediation_verifier.py) — `build_verification_record()` + `build_drift_finding()` integration (per workflow convention, integrated from day one — see PR #305)
 - [`SECURITY_BAR.md`](../../../SECURITY_BAR.md) — 11-principle contract; this skill satisfies all destructive-write principles
-- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — `human_required` approval model with `min_approvers: 1`
+- [`docs/HITL_POLICY.md`](../../../docs/HITL_POLICY.md) — `human_required` approval model with `min_approvers: 2`
 - [`scripts/validate_safe_skill_bar.py`](../../../scripts/validate_safe_skill_bar.py) — enforces dry-run default, deny-list presence
 
 ## Compliance frameworks

--- a/skills/remediation/remediate-mcp-tool-quarantine/SKILL.md
+++ b/skills/remediation/remediate-mcp-tool-quarantine/SKILL.md
@@ -30,7 +30,7 @@ concurrency_safety: operator_coordinated
 network_egress: s3.amazonaws.com, dynamodb.amazonaws.com
 caller_roles: security_engineer, incident_responder, platform_engineer
 approver_roles: security_lead, incident_commander, platform_owner
-min_approvers: 1
+min_approvers: 2
 compatibility: >-
   Requires Python 3.11+. Dry-run and re-verify need only filesystem read
   access to the quarantine file. Apply additionally requires write access


### PR DESCRIPTION
## What changed
- exposed `_caller_context` and `_approval_context` in the MCP tool input schema instead of relying on undocumented hidden fields
- taught the MCP wrapper to count approvers from `_approval_context` and enforce each skill's `min_approvers` before spawning the subprocess
- forwarded multi-approver metadata into the spawned skill environment for downstream audit correlation
- aligned `remediate-mcp-tool-quarantine` with the repo HITL policy by changing `min_approvers` from `1` to `2` and updated its references
- added a safe-skill-bar policy floor so CI now fails if that skill drifts below the documented two-approver requirement again
- added MCP unit tests and tool-registry tests covering the new approval contract

## Why
The audit found a contract gap: the repo documented stronger HITL approval policy than the MCP wrapper and skill metadata actually enforced. In particular, the wrapper accepted hidden approval fields not present in the schema, only checked for the existence of approval context, and the MCP-tool-quarantine skill advertised `min_approvers: 1` even though `docs/HITL_POLICY.md` requires `2`.

## Impact
- machine-readable MCP tool metadata now matches the wrapper's actual approval inputs
- multi-approver skills can be enforced at the MCP boundary instead of relying purely on prose
- CI now protects the documented two-approver policy for MCP tool quarantine from future drift

## Validation
- `pytest mcp-server/tests/test_server_unit.py mcp-server/tests/test_tool_registry.py skills/remediation/remediate-mcp-tool-quarantine/tests/test_handler.py -q`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_safe_skill_bar.py`
- `python scripts/validate_skill_count_consistency.py`
- `ruff check mcp-server/src mcp-server/tests scripts/validate_safe_skill_bar.py skills/remediation/remediate-mcp-tool-quarantine`
