### PR TITLE
[codex] Align repo agent instructions with shipped skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,25 +24,22 @@ Claude-specific, and `SKILL.md` stays the per-skill source of truth.
 
 Skills are organised into layered categories. See [`skills/README.md`](skills/README.md) for the full catalog.
 
-**`ingestion/`** (raw source → OCSF or native)
-- `ingest-cloudtrail-ocsf`, `ingest-vpc-flow-logs-ocsf`, `ingest-vpc-flow-logs-gcp-ocsf`, `ingest-nsg-flow-logs-azure-ocsf`, `ingest-guardduty-ocsf`, `ingest-security-hub-ocsf`, `ingest-gcp-scc-ocsf`, `ingest-azure-defender-for-cloud-ocsf`, `ingest-gcp-audit-ocsf`, `ingest-azure-activity-ocsf`, `ingest-k8s-audit-ocsf`, `ingest-mcp-proxy-ocsf`, `ingest-okta-system-log-ocsf`, `ingest-entra-directory-audit-ocsf`, `ingest-google-workspace-login-ocsf`
+Current shipped surface on `main`:
 
-**`discovery/`** (point-in-time inventory / graph / BOM)
-- `discover-environment`, `discover-ai-bom`, `discover-control-evidence`, `discover-cloud-control-evidence`
+- **`ingestion/`**: 15 ingest skills plus 3 source adapters
+- **`discovery/`**: 5 read-only skills including `iam-departures-reconciler`
+- **`detection/`**: 14 deterministic ATT&CK-tagged detectors
+- **`evaluation/`**: 7 posture / benchmark families
+- **`view/`**: 2 render/export skills
+- **`remediation/`**: 12 HITL-gated write skills across AWS, GCP, Azure, Kubernetes, Okta, Workspace, Entra, and MCP
+- **`output/`**: 3 append-only sinks
 
-**`detection/`** (OCSF → OCSF Detection Finding 2004 + MITRE)
-- `detect-mcp-tool-drift`, `detect-container-escape-k8s`, `detect-privilege-escalation-k8s`, `detect-sensitive-secret-read-k8s`, `detect-lateral-movement`, `detect-okta-mfa-fatigue`, `detect-entra-credential-addition`, `detect-entra-role-grant-escalation`, `detect-google-workspace-suspicious-login`
+Notable current skills that older agent memory often misses:
 
-**`evaluation/`** (read-only posture / benchmark checks)
-- `cspm-aws-cis-benchmark`, `cspm-gcp-cis-benchmark`, `cspm-azure-cis-benchmark`, `k8s-security-benchmark`, `container-security`, `model-serving-security`, `gpu-cluster-security`
-
-**`view/`** (OCSF export / rendering)
-- `convert-ocsf-to-sarif`, `convert-ocsf-to-mermaid-attack-flow`
-
-**`remediation/`** (active fix workflows, HITL-gated, dual-audited)
-- `iam-departures-aws`
-- `remediate-okta-session-kill`
-- `remediate-container-escape-k8s`
+- `iam-departures-reconciler` under `discovery/` is the standalone read-only manifest planner
+- network closed loops now include `remediate-aws-sg-revoke`, `remediate-azure-nsg-revoke`, and `remediate-gcp-firewall-revoke`
+- identity / SaaS containment now includes `remediate-entra-credential-revoke`, `remediate-workspace-session-kill`, and `iam-departures-azure-entra` / `iam-departures-gcp`
+- MCP / AI-native coverage includes both `detect-prompt-injection-mcp-proxy` and `remediate-mcp-tool-quarantine`
 
 Compose via stdin/stdout pipes. The shared wire contract is pinned in
 [`skills/detection-engineering/OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md).
@@ -80,6 +77,8 @@ These rules are enforced in code, IAM, and infra. They are not optional:
 7. **No new IAM grants.** Do not edit `iam_policies/` or any role policy to broaden permissions. Each role is least-privilege by design.
 8. **No telemetry.** Nothing in this repo phones home. Do not add SDK clients to external services unless the user explicitly asks for them, and even then keep the egress inside the customer's VPC.
 
+When in doubt, trust per-skill frontmatter and [`docs/HITL_POLICY.md`](docs/HITL_POLICY.md) over any shorthand examples in this file.
+
 ## Execution and approval model
 
 | Mode | Driver | Typical use | What does not change |
@@ -101,6 +100,7 @@ Approval rules:
 - **write-capable skills** must expose dry-run and blast-radius language
 - **destructive actions** require human approval and an audit trail
 - **incoming findings are untrusted input** until validated against the skill contract
+- `min_approvers` and `approver_roles` in `SKILL.md` are the machine-readable source of truth for wrapper policy
 
 ## What an agent actually calls
 
@@ -151,7 +151,7 @@ Shipped:
 Not yet:
 - Hosted HTTP/SSE transport for remote MCP deployments
 - Tight per-skill input schemas derived from each CLI instead of the current conservative `input` + `args` wrapper
-- A direct MCP wrapper for the serverless remediation workflow
+- Full automatic parity between every possible local entrypoint shape and the MCP wrapper; check `mcp-server/README.md` for current wrapper behavior
 
 ## Secure coding expectations
 
@@ -172,9 +172,9 @@ Not yet:
 
 ## Failure handling
 
-- Lambda async failure → SQS DLQ (`iam-departures-dlq`).
-- Step Function `FAILED` / `TIMED_OUT` / `ABORTED` → SNS `iam-departures-alerts` topic.
-- Re-drive a stuck execution by re-emitting an `Object Created` event for the manifest. The pipeline is idempotent.
+- AWS IAM departures: Lambda async failure → SQS DLQ (`iam-departures-dlq`).
+- AWS IAM departures: Step Function `FAILED` / `TIMED_OUT` / `ABORTED` → SNS `iam-departures-alerts` topic.
+- Event-driven runners and per-cloud remediation skills have their own provider-native failure surfaces; check each skill's `SKILL.md` / `RUNBOOK.md` before proposing recovery.
 
 If you see a remediation step that succeeded but no audit row, treat it as a failure and surface the discrepancy to the user.
 
@@ -183,7 +183,7 @@ If you see a remediation step that succeeded but no audit row, treat it as a fai
 - Use this `AGENTS.md` as the repo-level instruction file.
 - Use [`CLAUDE.md`](CLAUDE.md) as Claude's project memory.
 - Use each `SKILL.md` as the task-specific contract for the nearest skill directory.
-- Treat the benchmark scripts as read-only assessment tools and the IAM departures automation as a controlled remediation workflow.
+- Treat benchmark and discovery scripts as read-only assessment tools, and treat remediation skills as controlled HITL-gated workflows whose exact guardrails live in each skill bundle.
 
 Claude-specific best practices:
 - keep skills explicit, bounded, and composable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ skills/
 │   ├── discover-environment/
 │   ├── discover-ai-bom/
 │   ├── discover-control-evidence/
-│   └── discover-cloud-control-evidence/
+│   ├── discover-cloud-control-evidence/
+│   └── iam-departures-reconciler/
 │
 ├── detection/                     # OCSF → Detection Finding 2004 + MITRE
 │   ├── detect-mcp-tool-drift/
@@ -53,7 +54,9 @@ skills/
 │   ├── detect-entra-credential-addition/
 │   ├── detect-entra-role-grant-escalation/
 │   ├── detect-google-workspace-suspicious-login/
-│   └── detect-aws-open-security-group/
+│   ├── detect-aws-open-security-group/
+│   ├── detect-azure-open-nsg/
+│   └── detect-gcp-open-firewall/
 │
 ├── evaluation/                    # posture and benchmark checks
 │   ├── cspm-aws-cis-benchmark/
@@ -70,13 +73,17 @@ skills/
 │
 ├── remediation/                   # active fix workflows, gated and audited
 │   ├── iam-departures-aws/
+│   ├── iam-departures-azure-entra/
+│   ├── iam-departures-gcp/
 │   ├── remediate-okta-session-kill/
 │   ├── remediate-container-escape-k8s/
 │   ├── remediate-k8s-rbac-revoke/
 │   ├── remediate-mcp-tool-quarantine/
 │   ├── remediate-entra-credential-revoke/
 │   ├── remediate-workspace-session-kill/
-│   └── remediate-aws-sg-revoke/
+│   ├── remediate-aws-sg-revoke/
+│   ├── remediate-azure-nsg-revoke/
+│   └── remediate-gcp-firewall-revoke/
 │
 ├── output/                        # append-only persistence sinks
 │   ├── sink-s3-jsonl/
@@ -88,7 +95,12 @@ skills/
     └── golden/
 ```
 
-Every skill in every category is a closed loop: **detect → act → audit → re-verify**.
+Current shipped counts: 61 total skills — 15 ingest, 5 discover, 14 detect,
+7 evaluate, 12 remediate, 2 view, 3 output, 3 source.
+
+Not every detection has a paired remediation. The source of truth for detect →
+act parity is [`README.md`](README.md#closed-loop-coverage-at-a-glance) and
+[`docs/FRAMEWORK_COVERAGE.md`](docs/FRAMEWORK_COVERAGE.md), not this file.
 
 ## Which file to trust for what
 
@@ -101,10 +113,10 @@ Every skill in every category is a closed loop: **detect → act → audit → r
 | `skills/<layer>/<skill>/REFERENCES.md` | official APIs, schemas, and framework sources |
 
 The full layered architecture (Sources → Ingestion → Discovery / Enrich → Detection / Evaluation → View → Remediation) is documented in [`ARCHITECTURE.md`](ARCHITECTURE.md). The eleven-principle security contract is in [`SECURITY_BAR.md`](SECURITY_BAR.md). Per-skill official references and IAM policies live in each skill's `REFERENCES.md`.
-The CSPM skills are detection-only and re-verify the same `control_id` on the next run.
-The remediation skills (IAM departures, Okta session kill, K8s quarantine) write back to a dual audit
-trail (DynamoDB + S3) and ingest results into the source warehouse so the next
-reconciler run *cross-checks* the previous remediation actually landed.
+The CSPM skills are read-only posture checks. The remediation skills write native
+action + audit records, and many of them re-verify their own post-action state.
+AWS IAM departures additionally ingest audit back into the source warehouse so
+the next reconciler run cross-checks closure.
 
 **OCSF 1.8 is the SIEM interop wire format, not the universal internal format.** It's the default for **ingest** and **detect** (that's where downstream SIEM/SOAR integration pays off). **Discover** emits native / CycloneDX / bridge (inventory and AI BOM don't map cleanly to OCSF). **Remediate** emits native (state changes + audit records, not findings). **Evaluate** is native today with OCSF Compliance Finding 2003 planned as opt-in. Pick the format that fits the layer's semantic; the `--output-format` flag is the runtime switch where both are supported. Full table: [`docs/ARCHITECTURE.md#31-ocsf-applicability-by-layer`](docs/ARCHITECTURE.md).
 
@@ -124,20 +136,23 @@ to attempt them.
   `roles/viewer`, `iam.securityReviewer`, and Azure `Reader`. They have **zero**
   write permissions to any cloud account. Never wrap them in code that mutates
   state — that would be outside the skill contract.
-- **`iam-departures-aws` reconciler** is read-only against HR sources
-  and only *writes a manifest* to S3. The Step Function is the only thing that
-  touches IAM.
+- **`iam-departures-reconciler`** is the read-only planner for IAM departures.
+  It fetches HR / warehouse inputs, applies rehire + grace + diff logic, and
+  emits the canonical manifest body. Cloud-specific write paths consume that
+  manifest separately.
 
 ### 2. Human-in-the-loop (HITL) for destructive actions
 
-The IAM departures pipeline is the only destructive workflow. HITL is enforced
-at three layers:
+There are now 12 destructive or write-capable remediation workflows, not just
+IAM departures. The source of truth for approval level, approver count, and
+where the gate sits is [`docs/HITL_POLICY.md`](docs/HITL_POLICY.md) plus each
+skill's frontmatter (`approval_model`, `approver_roles`, `min_approvers`).
 
-| Layer | Mechanism | Override |
-|-------|-----------|----------|
-| **Grace period** | 7-day default window before remediation runs (configurable per env) | HR can revert termination during the grace period and the manifest will reflect it |
-| **Deny policies** | Explicit IAM `Deny` on `root`, `break-glass-*`, `emergency-*` and all `:role/*` ARNs in `WorkerExecutionRole` | None — these can never be remediated by this pipeline |
-| **Rehire filter** | Parser Lambda checks 8 rehire scenarios before generating the work item | None — handled in code (`should_remediate()`) |
+Patterns to remember:
+
+- IAM departures skills are grace-period gated, rehire-aware, and protected-principal denied
+- account-takeover containment skills are time-sensitive but still require a declared incident window
+- Kubernetes node drain and MCP tool quarantine have stricter approval semantics than baseline single-approver containment
 
 ### 3. Dry-run is supported everywhere
 
@@ -158,11 +173,15 @@ closed.
 
 ### 5. Audit guarantees (closed loop)
 
-Every destructive action is dual-written:
-1. DynamoDB row keyed by `(iam_username, remediated_at)` for fast lookup.
-2. S3 evidence object under `departures/audit/` with KMS encryption.
-3. Ingest-back to the source HR warehouse so the *next* reconciler run can
-   prove the user is closed across all systems.
+Most shipped remediation skills dual-audit to a DynamoDB-style fast lookup
+store plus KMS-encrypted object storage evidence. Per-cloud IAM departures use
+provider-native equivalents where needed:
+
+1. AWS IAM departures: DynamoDB + KMS-encrypted S3 + warehouse ingest-back
+2. GCP IAM departures: Firestore + CMEK-encrypted GCS
+3. Azure Entra departures: Cosmos DB + CMK-encrypted Blob Storage
+4. Network / IdP / K8s / MCP remediation skills generally use DynamoDB + S3 in
+   the reference implementations
 
 If an agent invokes a remediation step and there is no corresponding audit row
 within the SLA window, treat that as a failure. The next run should detect drift.
@@ -184,7 +203,9 @@ finding list and no error, that's a real "all clear" — not a hidden failure.
 - CSPM results stay local. No HTTP egress beyond the cloud SDKs.
 - Reconciler reads HR data, hashes rows with SHA-256, exports a manifest.
   Nothing leaves the security OU account.
-- Lambda functions run in a VPC with no public NAT for non-AWS-API calls.
+- The flagship AWS departures Lambdas run in a VPC with no public NAT for
+  non-AWS-API calls. Other cloud-native skills document their own egress in
+  `network_egress` frontmatter.
 
 ### 8. What an agent should NEVER do with these skills
 


### PR DESCRIPTION
## What changed
- replaced stale hand-written skill subsets in `AGENTS.md` with the current shipped layer counts and the notable skills that were missing from agent memory
- updated `CLAUDE.md` to include the current discovery, detection, and remediation surface
- removed outdated claims that every skill is a closed loop and that IAM departures is the only destructive workflow
- clarified that `iam-departures-reconciler` is the read-only planner boundary and that `docs/HITL_POLICY.md` plus per-skill frontmatter are the approval source of truth

## Why
The audit found that repo-level agent instructions were materially behind the shipped repo state. That creates real routing and guardrail risk for LLM-driven workflows, because models use these files as summary memory before they read individual skill bundles.

## Validation
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_skill_contract.py`
