### PR TITLE
[codex] Expose standalone remediation handlers over MCP

### DIFF
--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -153,7 +153,9 @@ Before the subprocess runs, the wrapper enforces:
 - `output_format` must be a string when present
 - `_caller_context` and `_approval_context` must be objects with string values
   or string arrays
-- write-capable tools must be invoked with `--dry-run`
+- write-capable tools must stay in safe mode at the wrapper boundary:
+  `--dry-run` for generic write tools, or no `--apply` for standalone
+  remediation `handler.py` entrypoints that are dry-run by default
 - write-capable tools with `approver_roles` must receive `_approval_context`
 
 These checks are part of the audited lifecycle. A failure here still produces an

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -7,6 +7,10 @@ This server does not replace the existing skills model. It auto-discovers
 entrypoint, and exposes those skills as MCP tools for Claude Code, Codex,
 Cursor, Windsurf, Cortex Code CLI, and other MCP clients.
 
+Supported entrypoints today are fixed repo-owned Python surfaces:
+`src/ingest.py`, `src/detect.py`, `src/convert.py`, `src/checks.py`,
+`src/discover.py`, `src/handler.py`, and `src/sink.py`.
+
 Design rules:
 
 - no arbitrary shell execution
@@ -14,6 +18,16 @@ Design rules:
 - no hidden runtime install path
 - fixed local repo-owned entrypoints only
 - direct CLI usage of skills stays unchanged
+
+Remediation parity:
+
+- standalone remediation skills with a single `src/handler.py` entrypoint are
+  exposed over MCP
+- those tools stay dry-run/re-verify only at the wrapper boundary; the MCP
+  wrapper rejects `--apply`
+- multi-handler orchestration workflows such as `iam-departures-*` are still
+  not exposed as one MCP tool because they do not have a single repo-owned
+  top-level entrypoint
 
 Audit behavior:
 

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -164,6 +164,22 @@ def _validate_context(raw_context: Any, field_name: str) -> dict[str, Any] | Non
     return validated
 
 
+def _is_safe_write_invocation(skill: SkillSpec, args: list[str]) -> bool:
+    """Return True when the requested invocation is dry-run/read-only at the
+    wrapper boundary.
+
+    Remediation `handler.py` entrypoints are dry-run by default and only write
+    when `--apply` is present, so allow handler-based remediation tools to run
+    as long as `--apply` is absent. Other write-capable categories keep the
+    stricter explicit `--dry-run` requirement.
+    """
+    if skill.read_only:
+        return True
+    if skill.category == "remediation" and skill.entrypoint and skill.entrypoint.name == "handler.py":
+        return "--apply" not in args
+    return "--dry-run" in args
+
+
 def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     tools = _filtered_tool_map()
     if name not in tools:
@@ -199,8 +215,11 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     }
 
     try:
-        if not skill.read_only and "--dry-run" not in args:
-            raise ValueError("write-capable tools must be called with `--dry-run`")
+        if not _is_safe_write_invocation(skill, args):
+            raise ValueError(
+                "write-capable tools must stay in dry-run/read-only mode under MCP "
+                "(`--dry-run`, or no `--apply` for handler-based remediation tools)"
+            )
         if not skill.read_only and skill.approver_roles and approval_context is None:
             raise ValueError("write-capable tools with approver_roles require `_approval_context`")
 

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -13,6 +13,7 @@ ENTRYPOINT_CANDIDATES = (
     "src/convert.py",
     "src/checks.py",
     "src/discover.py",
+    "src/handler.py",
     "src/sink.py",
 )
 

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -65,7 +65,64 @@ class TestMcpServer:
             assert "detect-entra-role-grant-escalation" in names
             assert "detect-google-workspace-suspicious-login" in names
             assert "model-serving-security" in names
+            assert "remediate-mcp-tool-quarantine" in names
             assert "iam-departures-aws" not in names
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    def test_can_call_handler_based_remediation_in_dry_run_mode(self):
+        proc = _start_server()
+        try:
+            _initialize(proc)
+            finding = json.dumps(
+                {
+                    "class_uid": 2004,
+                    "metadata": {
+                        "uid": "find-1",
+                        "product": {"feature": {"name": "detect-mcp-tool-drift"}},
+                    },
+                    "finding_info": {"uid": "find-1"},
+                    "observables": [
+                        {"name": "session.uid", "type": "Other", "value": "sess-1"},
+                        {"name": "tool.name", "type": "Other", "value": "rogue-search"},
+                        {
+                            "name": "tool.after_fingerprint",
+                            "type": "Fingerprint",
+                            "value": "sha256:abcd",
+                        },
+                    ],
+                }
+            )
+            _send_message(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "remediate-mcp-tool-quarantine",
+                        "arguments": {
+                            "input": finding,
+                            "_approval_context": {
+                                "approver_id": "ap-1",
+                                "approver_email": "lead@example.com",
+                                "ticket_id": "SEC-1",
+                            },
+                        },
+                    },
+                },
+            )
+            response = _read_message(proc)
+            assert response["result"]["isError"] is False
+            output_lines = [
+                json.loads(line)
+                for line in response["result"]["structuredContent"]["stdout"].splitlines()
+                if line.strip()
+            ]
+            assert output_lines[0]["source_skill"] == "remediate-mcp-tool-quarantine"
+            assert output_lines[0]["status"] == "planned"
+            assert output_lines[0]["dry_run"] is True
         finally:
             proc.terminate()
             proc.wait(timeout=5)

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -36,13 +36,16 @@ class _FakeSkill:
         read_only: bool = True,
         approver_roles: tuple[str, ...] = (),
         mcp_timeout_seconds: int | None = None,
+        category: str = "detection",
+        entrypoint_name: str | None = None,
     ) -> None:
         self.name = "fake-skill"
-        self.category = "detection"
+        self.category = category
         self.capability = "read-only" if read_only else "write-remediation"
         self.read_only = read_only
         self.approver_roles = approver_roles
         self.mcp_timeout_seconds = mcp_timeout_seconds
+        self.entrypoint = None if entrypoint_name is None else Path(entrypoint_name)
 
 
 def test_call_tool_injects_caller_and_approval_context(monkeypatch):
@@ -125,6 +128,34 @@ def test_call_tool_requires_approval_context_for_write_skill(monkeypatch):
     assert audit_events[0]["error_type"] == "ValueError"
     assert audit_events[0]["args_hash"] == MODULE._stable_hash(["--dry-run"])
     assert audit_events[0]["approval_context_provided"] is False
+
+
+def test_safe_write_invocation_allows_handler_remediation_without_apply():
+    skill = _FakeSkill(
+        read_only=False,
+        category="remediation",
+        entrypoint_name="handler.py",
+    )
+    assert MODULE._is_safe_write_invocation(skill, []) is True
+
+
+def test_safe_write_invocation_rejects_apply_for_handler_remediation():
+    skill = _FakeSkill(
+        read_only=False,
+        category="remediation",
+        entrypoint_name="handler.py",
+    )
+    assert MODULE._is_safe_write_invocation(skill, ["--apply"]) is False
+
+
+def test_safe_write_invocation_still_requires_dry_run_for_non_handler_writes():
+    skill = _FakeSkill(
+        read_only=False,
+        category="sinks",
+        entrypoint_name="sink.py",
+    )
+    assert MODULE._is_safe_write_invocation(skill, []) is False
+    assert MODULE._is_safe_write_invocation(skill, ["--dry-run"]) is True
 
 
 def test_resolve_timeout_prefers_env_override():

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -55,6 +55,12 @@ class TestDiscovery:
         assert skills["iam-departures-aws"].supported is False
         assert skills["iam-departures-aws"].capability == "write-remediation"
 
+    def test_supports_standalone_handler_based_remediation_skill(self):
+        skills = {skill.name: skill for skill in discover_skills(REPO_ROOT)}
+        assert skills["remediate-mcp-tool-quarantine"].supported is True
+        assert skills["remediate-mcp-tool-quarantine"].entrypoint is not None
+        assert skills["remediate-mcp-tool-quarantine"].entrypoint.name == "handler.py"
+
     def test_supported_tools_include_ingest_detect_and_evaluate(self):
         tools = tool_map(REPO_ROOT)
         assert "source-s3-select" in tools
@@ -76,6 +82,8 @@ class TestDiscovery:
         assert "discover-ai-bom" in tools
         assert "discover-control-evidence" in tools
         assert "discover-cloud-control-evidence" in tools
+        assert "remediate-mcp-tool-quarantine" in tools
+        assert "iam-departures-aws" not in tools
 
 
 class TestToolDefinition:

--- a/scripts/skill_validation_common.py
+++ b/scripts/skill_validation_common.py
@@ -60,6 +60,7 @@ ENTRYPOINT_CANDIDATES = (
     "src/convert.py",
     "src/checks.py",
     "src/discover.py",
+    "src/handler.py",
     "src/sink.py",
 )
 


### PR DESCRIPTION
What changed
- taught the MCP registry to discover standalone `src/handler.py` remediation skills
- updated the MCP wrapper dry-run gate so handler-based remediation stays callable in safe mode without requiring a literal `--dry-run` flag
- added MCP integration/unit/registry coverage proving `remediate-mcp-tool-quarantine` is exposed while `iam-departures-aws` stays unsupported
- documented the current parity boundary in `mcp-server/README.md`

Why
The repo's MCP docs said the wrapper exposed repo-owned skill entrypoints, but standalone remediation handlers were missing because the registry only knew about ingest/detect/discover/checks/convert/sink entrypoints. Those skills are dry-run by default and only mutate on `--apply`, so the old wrapper gate also blocked them even if they were discovered.

Impact
Standalone remediation skills with a single `src/handler.py` entrypoint are now reachable over MCP in dry-run/re-verify mode. Multi-handler orchestration flows like `iam-departures-*` are still intentionally excluded until they get a dedicated wrapper.

Validation
- pytest mcp-server/tests/test_server.py mcp-server/tests/test_server_unit.py mcp-server/tests/test_tool_registry.py -q
- pytest skills/remediation/remediate-mcp-tool-quarantine/tests/test_handler.py -q
- ruff check mcp-server/src mcp-server/tests
- python scripts/validate_skill_contract.py
- python scripts/validate_safe_skill_bar.py
