### PR TITLE
[codex] Clarify approver policy vs runtime enforcement

### DIFF
--- a/docs/HITL_POLICY.md
+++ b/docs/HITL_POLICY.md
@@ -127,6 +127,12 @@ min_approvers: 1
 `network_egress` is orthogonal to HITL — it lists the exact domains a skill
 is allowed to reach. Scope it to the minimum set the skill actually uses.
 
+`approver_roles` and `min_approvers` define the policy floor. Runtime wrappers
+or surrounding approval systems may enforce approver identity and role
+membership separately from the local CLI gate, so a skill should not claim
+in-code approver-role validation unless its shipped handler or wrapper
+actually performs that check.
+
 ## Related
 
 - [`SECURITY_BAR.md`](../SECURITY_BAR.md) — the full eleven-principle contract

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -105,6 +105,7 @@ Rules:
 - `min_approvers`, when present, must be an integer greater than or equal to 1
 - `mcp_timeout_seconds`, when present, must be an integer between 1 and 900 and names the per-call subprocess timeout the MCP wrapper should apply to this skill. It is opt-in; skills that do not declare it inherit the global default (60 seconds) or whatever the operator sets via the `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` env var. The env var wins over the per-skill value so on-call can widen or tighten the window without editing `SKILL.md`
 - write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy
+- `approver_roles` is policy metadata, not proof that every local CLI path validates role membership itself; a `SKILL.md` body should only claim in-code role enforcement when the shipped handler or wrapper actually performs that check
 - write-capable skills should preserve caller, approver, and request or session identifiers in their audit trail when the runtime provides them
 
 ## Required language

--- a/skills/remediation/remediate-okta-session-kill/SKILL.md
+++ b/skills/remediation/remediate-okta-session-kill/SKILL.md
@@ -98,7 +98,7 @@ Without `--apply`, the skill prints the exact API calls it WOULD make (Okta user
 
 ### 3. `--apply` requires a declared incident window
 
-The skill refuses to execute unless env var `OKTA_SESSION_KILL_INCIDENT_ID` is set to a non-empty string AND env var `OKTA_SESSION_KILL_APPROVER` is set (both checked before the first API call). The incident ID must be a valid UUID or an operator-assigned string; the approver must be one of the `approver_roles` listed in frontmatter. Both land in the audit record.
+The skill refuses to execute unless env var `OKTA_SESSION_KILL_INCIDENT_ID` is set to a non-empty string AND env var `OKTA_SESSION_KILL_APPROVER` is set (both checked before the first API call). The incident ID must be a valid UUID or an operator-assigned string; the approver identity is recorded in the audit trail, and enterprise wrappers should enforce membership in the `approver_roles` policy declared in frontmatter. Both values land in the audit record.
 
 The intent: a skill invocation that lands in a SIEM alert or a naive agent loop STILL requires an operator to register an incident before writes happen. The gate sits outside the agent loop.
 


### PR DESCRIPTION
What changed
- clarified in `docs/SKILL_CONTRACT.md` that `approver_roles` is machine-readable policy metadata and should not be described as in-code role enforcement unless the shipped handler or wrapper actually performs that check
- added the same policy/runtime boundary note to `docs/HITL_POLICY.md`
- corrected `remediate-okta-session-kill/SKILL.md` so it no longer claims the local handler verifies frontmatter role membership

Why
The repo audit found doc drift: the Okta remediation skill said the approver "must be one of the approver_roles listed in frontmatter," but the shipped handler only checks that the required env vars are present. That kind of overstatement is risky in an agent-facing repo because it changes the safety story operators think they are getting.

Impact
Agent instructions and skill docs now distinguish between:
- local apply gates enforced by the shipped handler
- policy metadata declared in frontmatter
- stronger role/identity enforcement done by wrappers or enterprise approval systems

Validation
- python scripts/validate_skill_contract.py
- python scripts/validate_skill_count_consistency.py
