### PR TITLE
[codex] Add guarded AWS CSPM auto-remediation

### DIFF
--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -67,7 +67,7 @@ is the row you can take to your auditor.
 | `detect-prompt-injection-mcp-proxy` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-sensitive-secret-read-k8s` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `container-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
-| `cspm-aws-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `cspm-aws-cis-benchmark` | evaluation | ⚠️ write-capable | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `cspm-azure-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `cspm-gcp-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `gpu-cluster-security` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |

--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -153,7 +153,9 @@ Before the subprocess runs, the wrapper enforces:
 - `output_format` must be a string when present
 - `_caller_context` and `_approval_context` must be objects with string values
   or string arrays
-- write-capable tools must be invoked with `--dry-run`
+- write-capable tools must stay in safe mode at the wrapper boundary:
+  `--dry-run` for generic write tools, or no `--apply` for dry-run-default
+  `handler.py` / `checks.py` entrypoints
 - write-capable tools with `approver_roles` must receive `_approval_context`
 
 These checks are part of the audited lifecycle. A failure here still produces an

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -30,8 +30,10 @@ Audit behavior:
 
 Approval behavior:
 
-- write-capable tools still require `--dry-run`; the wrapper refuses bare
-  apply-style invocations
+- write-capable tools stay in safe mode at the wrapper boundary:
+  generic write tools still require `--dry-run`, while dry-run-default
+  `handler.py` and `checks.py` entrypoints are allowed as long as `--apply`
+  is absent
 - if a skill declares `approver_roles`, the caller must provide
   `_approval_context`
 - if a skill declares `min_approvers > 1`, `_approval_context` must carry that

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -178,6 +178,24 @@ def _approval_count(approval_context: dict[str, Any] | None) -> int:
     return 0
 
 
+def _is_safe_write_invocation(skill: SkillSpec, args: list[str]) -> bool:
+    if skill.read_only:
+        return True
+    if skill.category == "remediation" and skill.entrypoint and skill.entrypoint.name == "handler.py":
+        return "--apply" not in args
+    if skill.category == "evaluation" and skill.entrypoint and skill.entrypoint.name == "checks.py":
+        return "--apply" not in args
+    return "--dry-run" in args
+
+
+def _requires_approval_context(skill: SkillSpec, args: list[str]) -> bool:
+    if skill.read_only or not skill.approver_roles:
+        return False
+    if skill.category == "evaluation" and skill.entrypoint and skill.entrypoint.name == "checks.py":
+        return "--apply" in args
+    return True
+
+
 def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     tools = _filtered_tool_map()
     if name not in tools:
@@ -214,11 +232,14 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
     }
 
     try:
-        if not skill.read_only and "--dry-run" not in args:
-            raise ValueError("write-capable tools must be called with `--dry-run`")
-        if not skill.read_only and skill.approver_roles and approval_context is None:
+        if not _is_safe_write_invocation(skill, args):
+            raise ValueError(
+                "write-capable tools must stay in dry-run/read-only mode under MCP "
+                "(`--dry-run`, or no `--apply` for dry-run-default handler/checks entrypoints)"
+            )
+        if _requires_approval_context(skill, args) and approval_context is None:
             raise ValueError("write-capable tools with approver_roles require `_approval_context`")
-        if not skill.read_only and (skill.min_approvers or 0) > _approval_count(approval_context):
+        if _requires_approval_context(skill, args) and (skill.min_approvers or 0) > _approval_count(approval_context):
             raise ValueError(
                 f"tool `{skill.name}` requires at least {skill.min_approvers} approver(s) in `_approval_context`"
             )

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -37,14 +37,17 @@ class _FakeSkill:
         approver_roles: tuple[str, ...] = (),
         min_approvers: int | None = None,
         mcp_timeout_seconds: int | None = None,
+        category: str = "detection",
+        entrypoint_name: str | None = None,
     ) -> None:
         self.name = "fake-skill"
-        self.category = "detection"
+        self.category = category
         self.capability = "read-only" if read_only else "write-remediation"
         self.read_only = read_only
         self.approver_roles = approver_roles
         self.min_approvers = min_approvers
         self.mcp_timeout_seconds = mcp_timeout_seconds
+        self.entrypoint = None if entrypoint_name is None else Path(entrypoint_name)
 
 
 def test_call_tool_injects_caller_and_approval_context(monkeypatch):
@@ -205,6 +208,54 @@ def test_call_tool_accepts_multi_approver_context(monkeypatch):
     assert env["SKILL_APPROVER_EMAILS"] == "a@example.com,b@example.com"
     assert result["isError"] is False
     assert audit_events[0]["approval_count"] == 2
+
+
+def test_safe_write_invocation_allows_handler_remediation_without_apply():
+    skill = _FakeSkill(
+        read_only=False,
+        category="remediation",
+        entrypoint_name="handler.py",
+    )
+    assert MODULE._is_safe_write_invocation(skill, []) is True
+
+
+def test_safe_write_invocation_allows_checks_evaluation_without_apply():
+    skill = _FakeSkill(
+        read_only=False,
+        category="evaluation",
+        entrypoint_name="checks.py",
+    )
+    assert MODULE._is_safe_write_invocation(skill, ["--auto-remediate"]) is True
+    assert MODULE._is_safe_write_invocation(skill, ["--auto-remediate", "--apply"]) is False
+
+
+def test_safe_write_invocation_still_requires_dry_run_for_other_write_surfaces():
+    skill = _FakeSkill(
+        read_only=False,
+        category="output",
+        entrypoint_name="sink.py",
+    )
+    assert MODULE._is_safe_write_invocation(skill, []) is False
+    assert MODULE._is_safe_write_invocation(skill, ["--dry-run"]) is True
+
+
+def test_checks_evaluation_dry_run_does_not_require_approval_context(monkeypatch):
+    monkeypatch.setattr(
+        MODULE,
+        "tool_map",
+        lambda: {
+            "fake-skill": _FakeSkill(
+                read_only=False,
+                approver_roles=("security_lead",),
+                category="evaluation",
+                entrypoint_name="checks.py",
+            )
+        },
+    )
+    monkeypatch.setattr(MODULE, "build_command", lambda skill, args, output_format=None: ["python", "fake.py"])
+    monkeypatch.setattr(MODULE.subprocess, "run", lambda *args, **kwargs: _FakeCompleted())
+    result = MODULE._call_tool("fake-skill", {"args": []})
+    assert result["isError"] is False
 
 
 def test_resolve_timeout_prefers_env_override():

--- a/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
@@ -3,22 +3,31 @@ name: cspm-aws-cis-benchmark
 description: >-
   Assess AWS accounts against CIS AWS Foundations Benchmark v3.0. Runs 18 automated
   read-only checks across IAM, Storage, Logging, and Networking. Produces per-control
-  pass/fail results with remediation commands. Use when the user mentions AWS CIS
-  benchmark, cloud security posture, IAM hygiene audit, S3 public access check, or
-  CloudTrail validation. Do NOT use for GCP, Azure, or on-prem; do NOT use this skill
-  to remediate findings (it is assessment-only and has zero write permissions) — pair
-  with iam-departures-aws for IAM cleanup, or open a ticket in your remediation
-  workflow for other findings.
+  pass/fail results with remediation commands. Optional `--auto-remediate` support
+  adds dry-run-first plans for a narrow AWS-first control set (S3 encryption, S3 public
+  access block, S3 versioning, unrestricted SSH/RDP SG rules), with `--apply` gated by
+  incident + approver env vars, CLI confirmation, and dual audit. Use when the user
+  mentions AWS CIS benchmark, cloud security posture, IAM hygiene audit, S3 public
+  access check, or CloudTrail validation. Do NOT use for GCP, Azure, or on-prem; do
+  NOT use `--auto-remediate` for unsupported controls, for CloudTrail bootstrap, or to
+  bypass protected-resource deny-lists.
 license: Apache-2.0
-approval_model: none
+capability: write-cloud
+approval_model: human_required
 execution_modes: jit, ci, mcp, persistent
-side_effects: none
+side_effects: writes-cloud, writes-audit
 input_formats: raw
 output_formats: native, ocsf
 concurrency_safety: operator_coordinated
+network_egress: "*.amazonaws.com"
+caller_roles: security_engineer, incident_responder, platform_engineer
+approver_roles: security_lead
+min_approvers: 1
 compatibility: >-
   Requires Python 3.11+, boto3, and AWS credentials with SecurityAudit managed policy
-  (read-only). No write permissions needed — assessment only.
+  (read-only) for assessment. `--auto-remediate --apply` additionally needs targeted
+  write scope for S3 bucket configuration and/or EC2 security-group ingress revoke,
+  plus dual-audit write access to DynamoDB, S3, and KMS.
 metadata:
   author: msaad00
   homepage: https://github.com/msaad00/cloud-ai-security-skills
@@ -38,47 +47,60 @@ metadata:
 Automated assessment of AWS accounts against the CIS AWS Foundations Benchmark v3.0.
 18 checks across 4 domains, each mapped to NIST CSF 2.0, ISO 27001:2022, and SOC 2.
 
-## When to Use
+## Use when
 
 - Periodic cloud security posture assessment (monthly/quarterly)
 - Pre-audit preparation for SOC 2, ISO 27001, or PCI DSS
 - Post-incident validation that security controls are intact
 - New account baseline — verify guardrails before workloads deploy
 - Compliance evidence generation for auditors
+- You want dry-run remediation planning for supported AWS CIS failures without leaving the benchmark workflow
+
+## Do NOT use
+
+- For GCP, Azure, or on-prem posture checks
+- To bootstrap missing CloudTrail infrastructure or other unsupported controls
+- To bypass protected-resource deny-lists for break-glass or intentionally open assets
+- To run `--apply` without a declared incident window, approver identity, and explicit confirmation
 
 ## Architecture
 
 ```mermaid
 flowchart TD
-    subgraph AWS["AWS Account — read-only"]
+    subgraph AWS["AWS Account"]
         IAM["IAM<br/>7 checks"]
         S3["S3 Storage<br/>4 checks"]
         CT["CloudTrail<br/>4 checks"]
         VPC["VPC/Network<br/>3 checks"]
     end
 
-    CHK["checks.py<br/>18 CIS v3.0 controls<br/>SecurityAudit policy only"]
+    CHK["checks.py<br/>18 CIS v3.0 controls<br/>dry-run auto-remediate for supported failures"]
 
     IAM --> CHK
     S3 --> CHK
     CT --> CHK
     VPC --> CHK
 
-    CHK --> JSON["JSON<br/>per-control results"]
-    CHK --> CON["Console<br/>pass/fail summary"]
-    CHK --> SARIF["SARIF<br/>GitHub Security tab"]
+    CHK --> JSON["JSON<br/>findings or findings+plans"]
+    CHK --> CON["Console<br/>pass/fail + remediation plan"]
+    CHK --> SARIF["SARIF/OCSF<br/>assessment output"]
+    CHK --> AUD["Dual audit<br/>only under --apply"]
 
     style AWS fill:#1e293b,stroke:#475569,color:#e2e8f0
     style CHK fill:#172554,stroke:#3b82f6,color:#e2e8f0
+    style AUD fill:#3f1d2e,stroke:#fb7185,color:#fde7f3
 ```
 
 ## Security Guardrails
 
-- **Read-only**: Requires only `SecurityAudit` managed policy. Zero write permissions.
+- **Dry-run by default**: assessment mode stays read-only unless `--auto-remediate --apply` is explicitly requested.
+- **Guarded write scope**: the shipped AWS-first slice only supports controls `2.1`, `2.3`, `2.4`, `4.1`, and `4.2`.
+- **Protected resources fail closed**: buckets in `CSPM_AWS_AUTOREMEDIATE_PROTECTED_BUCKETS`, security groups in `CSPM_AWS_AUTOREMEDIATE_PROTECTED_SECURITY_GROUPS`, protected tags, and default SGs emit `would-violate-protected-resource` instead of planning/applying.
+- **HITL gate**: `--apply` requires `CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID` + `CSPM_AWS_AUTOREMEDIATE_APPROVER` and CLI confirmation.
+- **Dual audit**: every apply writes before/after audit rows to DynamoDB + KMS-encrypted S3 via `CSPM_AWS_AUTOREMEDIATE_AUDIT_*` env vars.
 - **No credentials stored**: AWS credentials come from environment/instance profile only.
-- **No data exfiltration**: Check results stay local. No external API calls beyond AWS SDK.
-- **Safe to run in production**: Cannot modify any AWS resources.
-- **Idempotent**: Run as often as needed with no side effects.
+- **No data exfiltration**: results stay local. No external API calls beyond AWS SDK.
+- **Safe assessment path**: running without `--auto-remediate --apply` cannot modify any AWS resources.
 
 ## Controls — CIS AWS Foundations v3.0 (key controls)
 
@@ -139,27 +161,39 @@ python src/checks.py --output json --output-format ocsf > cis-aws-results.json
 
 # Specific region
 python src/checks.py --region us-east-1
+
+# Dry-run remediation plans for supported failures
+python src/checks.py --section storage --auto-remediate --output json
+
+# Apply supported remediation actions (CLI-confirmed)
+export CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID=INC-2026-04-24-001
+export CSPM_AWS_AUTOREMEDIATE_APPROVER=alice@security
+export CSPM_AWS_AUTOREMEDIATE_AUDIT_DYNAMODB_TABLE=cloud-sec-remediation-audit
+export CSPM_AWS_AUTOREMEDIATE_AUDIT_BUCKET=cloud-sec-remediation-audit
+export CSPM_AWS_AUTOREMEDIATE_AUDIT_KMS_KEY_ARN=arn:aws:kms:us-east-1:123456789012:key/abc123
+python src/checks.py --section storage --auto-remediate --apply
 ```
 
-## Remediation — Critical Findings
+## Auto-remediation Scope
 
-```
-  FINDING: Root account has access keys (1.6)
-  ────────────────────────────────────────────
-  WHY:     Root keys = unlimited blast radius. Compromised root = full account takeover.
-  FIX:     aws iam delete-access-key --user-name root --access-key-id AKIA...
-  VERIFY:  python src/checks.py --section iam | grep "1.6"
-```
+Supported in this AWS-first slice:
 
-```
-  FINDING: S3 bucket publicly accessible (2.3)
-  ─────────────────────────────────────────────
-  WHY:     Public S3 = data exfiltration. #1 source of cloud data breaches.
-  FIX:     aws s3api put-public-access-block --bucket BUCKET \
-             --public-access-block-configuration \
-             BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
-  VERIFY:  python src/checks.py --section storage | grep "2.3"
-```
+- `2.1` enable bucket default encryption (`put_bucket_encryption`, AES256)
+- `2.3` enable full S3 public access block (`put_public_access_block`)
+- `2.4` enable bucket versioning (`put_bucket_versioning`)
+- `4.1` revoke unrestricted SSH ingress (`revoke_security_group_ingress`)
+- `4.2` revoke unrestricted RDP ingress (`revoke_security_group_ingress`)
+
+Not yet supported:
+
+- IAM/user controls like MFA and root-key cleanup
+- CloudTrail bootstrap / trail creation / alarm creation
+- VPC flow-log provisioning
+
+Under `--output json --auto-remediate`, the skill emits:
+
+- `findings`: the normal benchmark results
+- `remediation`: native `remediation_plan` or `remediation_action` records for supported failed controls
 
 ## Validate with agent-bom
 

--- a/skills/evaluation/cspm-aws-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-aws-cis-benchmark/src/checks.py
@@ -15,7 +15,9 @@ Frameworks:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -35,6 +37,22 @@ SKILL_NAME = "cspm-aws-cis-benchmark"
 BENCHMARK_NAME = "CIS AWS Foundations Benchmark v3.0"
 PROVIDER_NAME = "AWS"
 OUTPUT_FORMATS = ("native", "ocsf")
+CONFIRM_APPLY_PHRASE = "APPLY"
+SUPPORTED_AUTOREMEDIATE_CONTROLS = frozenset({"2.1", "2.3", "2.4", "4.1", "4.2"})
+RECORD_PLAN = "remediation_plan"
+RECORD_ACTION = "remediation_action"
+STATUS_PLANNED = "planned"
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_SKIPPED_UNSUPPORTED = "skipped_unsupported_control"
+STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-resource"
+DEFAULT_PROTECTED_BUCKET_PREFIXES = ("break-glass-",)
+DEFAULT_PROTECTED_SECURITY_GROUP_PREFIXES = ("default", "break-glass-")
+DEFAULT_PROTECTED_TAG_KEYS = (
+    "cspm:auto-remediate-protected",
+    "security.company.io/protected",
+)
+DEFAULT_INTENTIONALLY_OPEN_TAG = "intentionally-open"
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -54,6 +72,107 @@ class Finding:
     resources: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class RemediationTarget:
+    control_id: str
+    title: str
+    resource_type: str
+    resource_id: str
+    resource_name: str
+    section: str
+    severity: str
+    region: str
+    account_id: str
+    action: str
+    detail: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DualAuditWriter:
+    dynamodb_table: str
+    s3_bucket: str
+    kms_key_arn: str
+
+    def record(
+        self,
+        *,
+        target: RemediationTarget,
+        status: str,
+        detail: str,
+        incident_id: str,
+        approver: str,
+    ) -> dict[str, str]:
+        action_at = datetime.now(UTC).isoformat()
+        row_uid = _deterministic_uid(target.control_id, target.resource_id, target.action, action_at)
+        evidence_key = (
+            "cspm-aws-cis-benchmark/audit/"
+            f"{action_at[:4]}/{action_at[5:7]}/{action_at[8:10]}/"
+            f"{_safe_path_component(target.control_id)}/{_safe_path_component(target.resource_id)}-{action_at}.json"
+        )
+        evidence_uri = f"s3://{self.s3_bucket}/{evidence_key}"
+        envelope = {
+            "schema_mode": "native",
+            "record_type": "remediation_audit",
+            "source_skill": SKILL_NAME,
+            "benchmark": BENCHMARK_NAME,
+            "provider": PROVIDER_NAME,
+            "row_uid": row_uid,
+            "control_id": target.control_id,
+            "title": target.title,
+            "resource_type": target.resource_type,
+            "resource_id": target.resource_id,
+            "resource_name": target.resource_name,
+            "region": target.region,
+            "account_id": target.account_id,
+            "action": target.action,
+            "detail": detail,
+            "parameters": target.parameters,
+            "status": status,
+            "incident_id": incident_id,
+            "approver": approver,
+            "action_at": action_at,
+        }
+        body = json.dumps(envelope, separators=(",", ":")).encode("utf-8")
+        boto3.client("s3").put_object(
+            Bucket=self.s3_bucket,
+            Key=evidence_key,
+            Body=body,
+            ServerSideEncryption="aws:kms",
+            SSEKMSKeyId=self.kms_key_arn,
+            ContentType="application/json",
+        )
+        boto3.client("dynamodb").put_item(
+            TableName=self.dynamodb_table,
+            Item={
+                "resource_id": {"S": target.resource_id},
+                "action_at": {"S": action_at},
+                "row_uid": {"S": row_uid},
+                "control_id": {"S": target.control_id},
+                "action": {"S": target.action},
+                "status": {"S": status},
+                "incident_id": {"S": incident_id},
+                "approver": {"S": approver},
+                "resource_type": {"S": target.resource_type},
+                "resource_name": {"S": target.resource_name},
+                "section": {"S": target.section},
+                "severity": {"S": target.severity},
+                "s3_evidence_uri": {"S": evidence_uri},
+            },
+        )
+        return {"row_uid": row_uid, "s3_evidence_uri": evidence_uri}
+
+
+def _deterministic_uid(*parts: str) -> str:
+    material = "|".join(parts)
+    return f"cspmaws-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _safe_path_component(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in (value or "_"))
+    return safe[:120] or "_"
+
+
 def _paginate(
     client: Any, operation_name: str, result_key: str, **kwargs: Any
 ) -> list[dict[str, Any]]:
@@ -71,6 +190,70 @@ def _paginate(
     for page in paginator.paginate(**kwargs):
         items.extend(page.get(result_key, []))
     return items
+
+
+def _parse_env_list(name: str) -> set[str]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return set()
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _account_id(clients: dict[str, Any]) -> str:
+    try:
+        return str(clients["sts"].get_caller_identity()["Account"])
+    except Exception:
+        return ""
+
+
+def _bucket_tags(s3: Any, bucket_name: str) -> dict[str, str]:
+    try:
+        tag_set = s3.get_bucket_tagging(Bucket=bucket_name).get("TagSet", [])
+    except Exception:
+        return {}
+    return {str(tag["Key"]): str(tag["Value"]) for tag in tag_set if "Key" in tag and "Value" in tag}
+
+
+def _sg_tags(group: dict[str, Any]) -> dict[str, str]:
+    return {
+        str(tag["Key"]): str(tag["Value"])
+        for tag in group.get("Tags", [])
+        if isinstance(tag, dict) and "Key" in tag and "Value" in tag
+    }
+
+
+def _is_protected_bucket(s3: Any, bucket_name: str) -> tuple[bool, str]:
+    protected = _parse_env_list("CSPM_AWS_AUTOREMEDIATE_PROTECTED_BUCKETS")
+    if bucket_name in protected:
+        return True, "bucket listed in CSPM_AWS_AUTOREMEDIATE_PROTECTED_BUCKETS"
+    if bucket_name.lower().startswith(DEFAULT_PROTECTED_BUCKET_PREFIXES):
+        return True, "bucket matches protected prefix"
+    tags = _bucket_tags(s3, bucket_name)
+    for key in DEFAULT_PROTECTED_TAG_KEYS:
+        if key in tags and _truthy(tags[key]):
+            return True, f"bucket tag `{key}` marks it protected"
+    return False, ""
+
+
+def _is_protected_security_group(group: dict[str, Any]) -> tuple[bool, str]:
+    group_id = str(group.get("GroupId") or "")
+    group_name = str(group.get("GroupName") or "")
+    protected = _parse_env_list("CSPM_AWS_AUTOREMEDIATE_PROTECTED_SECURITY_GROUPS")
+    if group_id in protected or group_name in protected:
+        return True, "security group listed in CSPM_AWS_AUTOREMEDIATE_PROTECTED_SECURITY_GROUPS"
+    if group_name.lower().startswith(DEFAULT_PROTECTED_SECURITY_GROUP_PREFIXES):
+        return True, "security group matches protected prefix"
+    tags = _sg_tags(group)
+    if _truthy(tags.get(DEFAULT_INTENTIONALLY_OPEN_TAG, "")):
+        return True, f"security group tag `{DEFAULT_INTENTIONALLY_OPEN_TAG}` marks it intentionally open"
+    for key in DEFAULT_PROTECTED_TAG_KEYS:
+        if key in tags and _truthy(tags[key]):
+            return True, f"security group tag `{key}` marks it protected"
+    return False, ""
 
 
 # ---------------------------------------------------------------------------
@@ -731,6 +914,442 @@ def check_4_3_vpc_flow_logs(ec2) -> Finding:
 
 
 # ---------------------------------------------------------------------------
+# Auto-remediation planner / apply
+# ---------------------------------------------------------------------------
+
+
+def _build_bucket_target(
+    finding: Finding,
+    *,
+    bucket_name: str,
+    region: str,
+    account_id: str,
+    action: str,
+    detail: str,
+    parameters: dict[str, Any],
+) -> RemediationTarget:
+    return RemediationTarget(
+        control_id=finding.control_id,
+        title=finding.title,
+        resource_type="s3_bucket",
+        resource_id=bucket_name,
+        resource_name=bucket_name,
+        section=finding.section,
+        severity=finding.severity,
+        region=region,
+        account_id=account_id,
+        action=action,
+        detail=detail,
+        parameters=parameters,
+    )
+
+
+def _build_sg_targets(
+    finding: Finding,
+    *,
+    ec2: Any,
+    region: str,
+    account_id: str,
+    port: int,
+) -> list[tuple[RemediationTarget, str | None]]:
+    targets: list[tuple[RemediationTarget, str | None]] = []
+    for resource in finding.resources:
+        sg_id = resource.split(" ", 1)[0]
+        response = ec2.describe_security_groups(GroupIds=[sg_id])
+        groups = response.get("SecurityGroups", [])
+        if not groups:
+            continue
+        group = groups[0]
+        protected, reason = _is_protected_security_group(group)
+        for perm in group.get("IpPermissions", []):
+            from_port = perm.get("FromPort")
+            to_port = perm.get("ToPort")
+            if from_port is None or to_port is None or not (from_port <= port <= to_port):
+                continue
+            cidrs = [r["CidrIp"] for r in perm.get("IpRanges", []) if r.get("CidrIp") == "0.0.0.0/0"]
+            cidrs.extend(
+                r["CidrIpv6"] for r in perm.get("Ipv6Ranges", []) if r.get("CidrIpv6") == "::/0"
+            )
+            if not cidrs:
+                continue
+            targets.append(
+                (
+                    RemediationTarget(
+                        control_id=finding.control_id,
+                        title=finding.title,
+                        resource_type="security_group_rule",
+                        resource_id=sg_id,
+                        resource_name=str(group.get("GroupName") or sg_id),
+                        section=finding.section,
+                        severity=finding.severity,
+                        region=region,
+                        account_id=account_id,
+                        action="revoke_security_group_ingress",
+                        detail=f"Revoke unrestricted ingress on port {port}",
+                        parameters={
+                            "ip_protocol": perm.get("IpProtocol", "tcp"),
+                            "from_port": from_port,
+                            "to_port": to_port,
+                            "cidrs": cidrs,
+                        },
+                    ),
+                    reason if protected else None,
+                )
+            )
+    return targets
+
+
+def build_remediation_targets(
+    findings: list[Finding],
+    *,
+    clients: dict[str, Any],
+    region: str,
+) -> list[tuple[RemediationTarget, str | None]]:
+    targets: list[tuple[RemediationTarget, str | None]] = []
+    account_id = _account_id(clients)
+    s3 = clients["s3"]
+    ec2 = clients["ec2"]
+
+    for finding in findings:
+        if finding.status != "FAIL":
+            continue
+        if finding.control_id not in SUPPORTED_AUTOREMEDIATE_CONTROLS:
+            continue
+        if finding.control_id == "2.1":
+            for bucket_name in finding.resources:
+                protected, reason = _is_protected_bucket(s3, bucket_name)
+                targets.append(
+                    (
+                        _build_bucket_target(
+                            finding,
+                            bucket_name=bucket_name,
+                            region=region,
+                            account_id=account_id,
+                            action="put_bucket_encryption",
+                            detail="Enable AES256 default bucket encryption",
+                            parameters={
+                                "ServerSideEncryptionConfiguration": {
+                                    "Rules": [
+                                        {
+                                            "ApplyServerSideEncryptionByDefault": {
+                                                "SSEAlgorithm": "AES256"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                        ),
+                        reason if protected else None,
+                    )
+                )
+        elif finding.control_id == "2.3":
+            for bucket_name in finding.resources:
+                protected, reason = _is_protected_bucket(s3, bucket_name)
+                targets.append(
+                    (
+                        _build_bucket_target(
+                            finding,
+                            bucket_name=bucket_name,
+                            region=region,
+                            account_id=account_id,
+                            action="put_public_access_block",
+                            detail="Enable all four S3 public access block settings",
+                            parameters={
+                                "PublicAccessBlockConfiguration": {
+                                    "BlockPublicAcls": True,
+                                    "IgnorePublicAcls": True,
+                                    "BlockPublicPolicy": True,
+                                    "RestrictPublicBuckets": True,
+                                }
+                            },
+                        ),
+                        reason if protected else None,
+                    )
+                )
+        elif finding.control_id == "2.4":
+            for bucket_name in finding.resources:
+                protected, reason = _is_protected_bucket(s3, bucket_name)
+                targets.append(
+                    (
+                        _build_bucket_target(
+                            finding,
+                            bucket_name=bucket_name,
+                            region=region,
+                            account_id=account_id,
+                            action="put_bucket_versioning",
+                            detail="Enable S3 bucket versioning",
+                            parameters={"VersioningConfiguration": {"Status": "Enabled"}},
+                        ),
+                        reason if protected else None,
+                    )
+                )
+        elif finding.control_id == "4.1":
+            targets.extend(
+                _build_sg_targets(
+                    finding,
+                    ec2=ec2,
+                    region=region,
+                    account_id=account_id,
+                    port=22,
+                )
+            )
+        elif finding.control_id == "4.2":
+            targets.extend(
+                _build_sg_targets(
+                    finding,
+                    ec2=ec2,
+                    region=region,
+                    account_id=account_id,
+                    port=3389,
+                )
+            )
+    return targets
+
+
+def _record_for_target(
+    target: RemediationTarget,
+    *,
+    dry_run: bool,
+    status: str,
+    status_detail: str,
+    incident_id: str = "",
+    approver: str = "",
+    audit: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    record = {
+        "schema_mode": "native",
+        "record_type": RECORD_PLAN if dry_run else RECORD_ACTION,
+        "source_skill": SKILL_NAME,
+        "benchmark": BENCHMARK_NAME,
+        "provider": PROVIDER_NAME,
+        "control_id": target.control_id,
+        "title": target.title,
+        "target": {
+            "resource_type": target.resource_type,
+            "resource_id": target.resource_id,
+            "resource_name": target.resource_name,
+            "region": target.region,
+            "account_id": target.account_id,
+        },
+        "action": {
+            "name": target.action,
+            "detail": target.detail,
+            "parameters": target.parameters,
+        },
+        "status": status,
+        "status_detail": status_detail,
+        "dry_run": dry_run,
+    }
+    if not dry_run:
+        record["incident_id"] = incident_id
+        record["approver"] = approver
+    if audit is not None:
+        record["audit"] = audit
+    return record
+
+
+def _apply_target(target: RemediationTarget, clients: dict[str, Any]) -> None:
+    if target.action == "put_bucket_encryption":
+        clients["s3"].put_bucket_encryption(
+            Bucket=target.resource_id,
+            ServerSideEncryptionConfiguration=target.parameters["ServerSideEncryptionConfiguration"],
+        )
+        return
+    if target.action == "put_public_access_block":
+        clients["s3"].put_public_access_block(
+            Bucket=target.resource_id,
+            PublicAccessBlockConfiguration=target.parameters["PublicAccessBlockConfiguration"],
+        )
+        return
+    if target.action == "put_bucket_versioning":
+        clients["s3"].put_bucket_versioning(
+            Bucket=target.resource_id,
+            VersioningConfiguration=target.parameters["VersioningConfiguration"],
+        )
+        return
+    if target.action == "revoke_security_group_ingress":
+        params = target.parameters
+        permission: dict[str, Any] = {
+            "IpProtocol": params["ip_protocol"],
+            "IpRanges": [{"CidrIp": cidr} for cidr in params["cidrs"] if ":" not in cidr],
+            "Ipv6Ranges": [{"CidrIpv6": cidr} for cidr in params["cidrs"] if ":" in cidr],
+        }
+        if params["ip_protocol"] != "-1":
+            permission["FromPort"] = params["from_port"]
+            permission["ToPort"] = params["to_port"]
+        if not permission["IpRanges"]:
+            del permission["IpRanges"]
+        if not permission["Ipv6Ranges"]:
+            del permission["Ipv6Ranges"]
+        clients["ec2"].revoke_security_group_ingress(GroupId=target.resource_id, IpPermissions=[permission])
+        return
+    raise ValueError(f"unsupported remediation action `{target.action}`")
+
+
+def _check_apply_gate() -> tuple[bool, str]:
+    incident_id = os.getenv("CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID", "").strip()
+    approver = os.getenv("CSPM_AWS_AUTOREMEDIATE_APPROVER", "").strip()
+    if not incident_id:
+        return False, "CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID is required for --apply"
+    if not approver:
+        return False, "CSPM_AWS_AUTOREMEDIATE_APPROVER is required for --apply"
+    return True, ""
+
+
+def _resolve_apply_identity() -> tuple[str, str]:
+    return (
+        os.getenv("CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID", "").strip(),
+        os.getenv("CSPM_AWS_AUTOREMEDIATE_APPROVER", "").strip(),
+    )
+
+
+def _confirm_apply(confirm: str | None) -> None:
+    if confirm == CONFIRM_APPLY_PHRASE:
+        return
+    if not sys.stdin.isatty():
+        raise ValueError(
+            f"--apply requires interactive confirmation or --confirm {CONFIRM_APPLY_PHRASE}"
+        )
+    response = input(
+        f"Type {CONFIRM_APPLY_PHRASE} to apply AWS CIS auto-remediation changes: "
+    ).strip()
+    if response != CONFIRM_APPLY_PHRASE:
+        raise ValueError("confirmation declined")
+
+
+def build_remediation_records(
+    findings: list[Finding],
+    *,
+    clients: dict[str, Any],
+    region: str,
+    apply: bool,
+    confirm: str | None = None,
+) -> list[dict[str, Any]]:
+    targets = build_remediation_targets(findings, clients=clients, region=region)
+    if not targets:
+        return []
+
+    incident_id = ""
+    approver = ""
+    audit_writer: DualAuditWriter | None = None
+    if apply:
+        ok, reason = _check_apply_gate()
+        if not ok:
+            raise ValueError(reason)
+        _confirm_apply(confirm)
+        incident_id, approver = _resolve_apply_identity()
+        audit_writer = DualAuditWriter(
+            dynamodb_table=os.environ["CSPM_AWS_AUTOREMEDIATE_AUDIT_DYNAMODB_TABLE"],
+            s3_bucket=os.environ["CSPM_AWS_AUTOREMEDIATE_AUDIT_BUCKET"],
+            kms_key_arn=os.environ["CSPM_AWS_AUTOREMEDIATE_AUDIT_KMS_KEY_ARN"],
+        )
+
+    records: list[dict[str, Any]] = []
+    for target, protected_reason in targets:
+        if protected_reason:
+            records.append(
+                _record_for_target(
+                    target,
+                    dry_run=not apply,
+                    status=STATUS_WOULD_VIOLATE_PROTECTED,
+                    status_detail=protected_reason,
+                    incident_id=incident_id,
+                    approver=approver,
+                )
+            )
+            continue
+
+        if not apply:
+            records.append(
+                _record_for_target(
+                    target,
+                    dry_run=True,
+                    status=STATUS_PLANNED,
+                    status_detail=target.detail,
+                )
+            )
+            continue
+
+        assert audit_writer is not None
+        audit = audit_writer.record(
+            target=target,
+            status="in_progress",
+            detail=f"about to execute {target.action}",
+            incident_id=incident_id,
+            approver=approver,
+        )
+        try:
+            _apply_target(target, clients)
+        except Exception as exc:
+            audit_writer.record(
+                target=target,
+                status=STATUS_FAILURE,
+                detail=str(exc),
+                incident_id=incident_id,
+                approver=approver,
+            )
+            records.append(
+                _record_for_target(
+                    target,
+                    dry_run=False,
+                    status=STATUS_FAILURE,
+                    status_detail=str(exc),
+                    incident_id=incident_id,
+                    approver=approver,
+                    audit=audit,
+                )
+            )
+            continue
+
+        success_audit = audit_writer.record(
+            target=target,
+            status=STATUS_SUCCESS,
+            detail=f"executed {target.action}",
+            incident_id=incident_id,
+            approver=approver,
+        )
+        records.append(
+            _record_for_target(
+                target,
+                dry_run=False,
+                status=STATUS_SUCCESS,
+                status_detail=target.detail,
+                incident_id=incident_id,
+                approver=approver,
+                audit=success_audit,
+            )
+        )
+    return records
+
+
+def print_remediation_summary(records: list[dict[str, Any]]) -> None:
+    if not records:
+        print("\n  No supported failing controls for auto-remediation.")
+        return
+    print("\n  [AUTO-REMEDIATE]")
+    for record in records:
+        target = record["target"]
+        print(f"  {record['control_id']} {target['resource_id']} -> {record['action']['name']}")
+        print(f"         {record['status']}: {record['status_detail']}")
+
+
+def _auto_remediation_exit_code(
+    findings: list[Finding],
+    records: list[dict[str, Any]],
+    *,
+    apply: bool,
+) -> int:
+    critical_high_fails = [
+        f for f in findings if f.status == "FAIL" and f.severity in ("CRITICAL", "HIGH")
+    ]
+    if not records:
+        return 1 if critical_high_fails else 0
+    if apply:
+        failed_records = [r for r in records if r["status"] in {STATUS_FAILURE, STATUS_WOULD_VIOLATE_PROTECTED}]
+        return 1 if failed_records or critical_high_fails else 0
+    return 1 if critical_high_fails else 0
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -772,6 +1391,7 @@ def _get_clients(region: str) -> dict[str, Any]:
         "ct": session.client("cloudtrail"),
         "cw": session.client("cloudwatch"),
         "ec2": session.client("ec2"),
+        "sts": session.client("sts"),
     }
 
 
@@ -791,8 +1411,13 @@ def _run_check(fn, clients: dict) -> Finding:
     return fn(clients["iam"])
 
 
-def run_assessment(region: str = "us-east-1", section: str | None = None) -> list[Finding]:
-    clients = _get_clients(region)
+def run_assessment(
+    region: str = "us-east-1",
+    section: str | None = None,
+    *,
+    clients: dict[str, Any] | None = None,
+) -> list[Finding]:
+    clients = clients or _get_clients(region)
     findings: list[Finding] = []
 
     sections_to_run = {section: SECTIONS[section]} if section and section in SECTIONS else SECTIONS
@@ -867,12 +1492,39 @@ def main():
         default="native",
         help="Structured JSON format for --output json",
     )
+    parser.add_argument(
+        "--auto-remediate",
+        action="store_true",
+        help="Emit remediation plans for supported failing controls (AWS-first slice: 2.1, 2.3, 2.4, 4.1, 4.2).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute supported remediation actions. Requires --auto-remediate, HITL env vars, and confirmation.",
+    )
+    parser.add_argument(
+        "--confirm",
+        help=f"Non-interactive confirmation helper. Must equal {CONFIRM_APPLY_PHRASE} when used with --apply.",
+    )
     args = parser.parse_args()
 
-    findings = run_assessment(region=args.region, section=args.section)
+    if args.apply and not args.auto_remediate:
+        raise SystemExit("--apply requires --auto-remediate")
+
+    clients = _get_clients(args.region)
+    findings = run_assessment(region=args.region, section=args.section, clients=clients)
+    remediation_records: list[dict[str, Any]] = []
+    if args.auto_remediate:
+        remediation_records = build_remediation_records(
+            findings,
+            clients=clients,
+            region=args.region,
+            apply=args.apply,
+            confirm=args.confirm,
+        )
 
     if args.output == "json":
-        rendered = (
+        findings_rendered = (
             findings_to_ocsf(
                 findings,
                 skill_name=SKILL_NAME,
@@ -883,11 +1535,21 @@ def main():
             if args.output_format == "ocsf"
             else findings_to_native(findings)
         )
-        print(json.dumps(rendered, indent=2))
+        payload: Any = findings_rendered
+        if args.auto_remediate:
+            payload = {
+                "findings": findings_rendered,
+                "remediation": remediation_records,
+            }
+        print(json.dumps(payload, indent=2))
     else:
         print_summary(findings)
+        if args.auto_remediate:
+            print_remediation_summary(remediation_records)
 
-    # Exit code: 1 if any CRITICAL/HIGH failures
+    if args.auto_remediate:
+        sys.exit(_auto_remediation_exit_code(findings, remediation_records, apply=args.apply))
+
     critical_high_fails = [
         f for f in findings if f.status == "FAIL" and f.severity in ("CRITICAL", "HIGH")
     ]

--- a/skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py
+++ b/skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py
@@ -40,6 +40,8 @@ assert _SPEC and _SPEC.loader
 _CHECKS = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = _CHECKS
 _SPEC.loader.exec_module(_CHECKS)
+Finding = _CHECKS.Finding
+RemediationTarget = _CHECKS.RemediationTarget
 
 
 class _FakeIamExceptions:
@@ -479,8 +481,10 @@ def _stub_clients() -> dict:
     ec2.describe_security_groups.return_value = {"SecurityGroups": []}
     ec2.describe_vpcs.return_value = {"Vpcs": []}
     ec2.describe_flow_logs.return_value = {"FlowLogs": []}
+    sts = MagicMock()
+    sts.get_caller_identity.return_value = {"Account": "123456789012"}
 
-    return {"iam": iam, "s3": s3, "ct": ct, "cw": cw, "ec2": ec2}
+    return {"iam": iam, "s3": s3, "ct": ct, "cw": cw, "ec2": ec2, "sts": sts}
 
 
 def test_run_assessment_runs_all_sections_with_stubbed_clients(monkeypatch):
@@ -500,7 +504,7 @@ def test_run_assessment_section_filter(monkeypatch):
 def test_get_clients_builds_boto3_session():
     with patch.object(_CHECKS.boto3, "Session") as session:
         clients = _CHECKS._get_clients("us-west-2")
-    assert set(clients.keys()) == {"iam", "s3", "ct", "cw", "ec2"}
+    assert set(clients.keys()) == {"iam", "s3", "ct", "cw", "ec2", "sts"}
     session.assert_called_once_with(region_name="us-west-2")
 
 
@@ -609,3 +613,230 @@ def test_paginate_fallback_when_paginator_unavailable():
     client.list_users = MagicMock(return_value={"Users": [{"UserName": "x"}]})
     items = _CHECKS._paginate(client, "list_users", "Users")
     assert items == [{"UserName": "x"}]
+
+
+def test_build_remediation_targets_for_supported_storage_control():
+    s3 = MagicMock()
+    s3.get_bucket_tagging.side_effect = _client_error("NoSuchTagSet")
+    clients = {"s3": s3, "ec2": MagicMock(), "sts": MagicMock()}
+    clients["sts"].get_caller_identity.return_value = {"Account": "123456789012"}
+
+    findings = [
+        Finding(
+            control_id="2.3",
+            title="S3 public access blocked",
+            section="storage",
+            severity="CRITICAL",
+            status="FAIL",
+            resources=["public-bucket"],
+        )
+    ]
+
+    targets = _CHECKS.build_remediation_targets(findings, clients=clients, region="us-east-1")
+    assert len(targets) == 1
+    target, protected_reason = targets[0]
+    assert protected_reason is None
+    assert target.action == "put_public_access_block"
+    assert target.resource_id == "public-bucket"
+    assert target.account_id == "123456789012"
+
+
+def test_build_remediation_targets_marks_protected_bucket(monkeypatch):
+    monkeypatch.setenv("CSPM_AWS_AUTOREMEDIATE_PROTECTED_BUCKETS", "protected-bucket")
+    s3 = MagicMock()
+    s3.get_bucket_tagging.side_effect = _client_error("NoSuchTagSet")
+    clients = {"s3": s3, "ec2": MagicMock(), "sts": MagicMock()}
+    clients["sts"].get_caller_identity.return_value = {"Account": "123456789012"}
+
+    findings = [
+        Finding(
+            control_id="2.4",
+            title="S3 versioning enabled",
+            section="storage",
+            severity="MEDIUM",
+            status="FAIL",
+            resources=["protected-bucket"],
+        )
+    ]
+
+    targets = _CHECKS.build_remediation_targets(findings, clients=clients, region="us-east-1")
+    assert len(targets) == 1
+    _, protected_reason = targets[0]
+    assert "PROTECTED_BUCKETS" in protected_reason
+
+
+def test_build_remediation_targets_for_open_ssh_rule():
+    ec2 = MagicMock()
+    ec2.describe_security_groups.return_value = {
+        "SecurityGroups": [
+            {
+                "GroupId": "sg-1234",
+                "GroupName": "open-ssh",
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 22,
+                        "ToPort": 22,
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    }
+                ],
+            }
+        ]
+    }
+    clients = {"s3": MagicMock(), "ec2": ec2, "sts": MagicMock()}
+    clients["sts"].get_caller_identity.return_value = {"Account": "123456789012"}
+
+    findings = [
+        Finding(
+            control_id="4.1",
+            title="No unrestricted SSH",
+            section="networking",
+            severity="HIGH",
+            status="FAIL",
+            resources=["sg-1234 (open-ssh)"],
+        )
+    ]
+
+    targets = _CHECKS.build_remediation_targets(findings, clients=clients, region="us-east-1")
+    assert len(targets) == 1
+    target, protected_reason = targets[0]
+    assert protected_reason is None
+    assert target.action == "revoke_security_group_ingress"
+    assert target.parameters["cidrs"] == ["0.0.0.0/0"]
+
+
+def test_build_remediation_records_dry_run_plans_supported_controls():
+    s3 = MagicMock()
+    s3.get_bucket_tagging.side_effect = _client_error("NoSuchTagSet")
+    clients = {"s3": s3, "ec2": MagicMock(), "sts": MagicMock()}
+    clients["sts"].get_caller_identity.return_value = {"Account": "123456789012"}
+    findings = [
+        Finding(
+            control_id="2.1",
+            title="S3 default encryption",
+            section="storage",
+            severity="HIGH",
+            status="FAIL",
+            resources=["unencrypted-bucket"],
+        ),
+        Finding(
+            control_id="3.1",
+            title="CloudTrail multi-region",
+            section="logging",
+            severity="CRITICAL",
+            status="FAIL",
+            resources=["trail-a"],
+        ),
+    ]
+
+    records = _CHECKS.build_remediation_records(
+        findings,
+        clients=clients,
+        region="us-east-1",
+        apply=False,
+    )
+    assert len(records) == 1
+    assert records[0]["record_type"] == "remediation_plan"
+    assert records[0]["control_id"] == "2.1"
+    assert records[0]["status"] == "planned"
+
+
+def test_build_remediation_records_apply_requires_hitl_envs():
+    clients = {"s3": MagicMock(), "ec2": MagicMock(), "sts": MagicMock()}
+    clients["sts"].get_caller_identity.return_value = {"Account": "123456789012"}
+    findings = [
+        Finding(
+            control_id="2.3",
+            title="S3 public access blocked",
+            section="storage",
+            severity="CRITICAL",
+            status="FAIL",
+            resources=["public-bucket"],
+        )
+    ]
+    try:
+        _CHECKS.build_remediation_records(findings, clients=clients, region="us-east-1", apply=True)
+    except ValueError as exc:
+        assert "INCIDENT_ID" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_build_remediation_records_apply_executes_and_audits(monkeypatch):
+    class _FakeAudit:
+        def __init__(self, *args, **kwargs):
+            self.writes = []
+
+        def record(self, *, target, status, detail, incident_id, approver):
+            self.writes.append((target.resource_id, status, incident_id, approver))
+            return {"row_uid": "row-1", "s3_evidence_uri": "s3://bucket/evidence.json"}
+
+    s3 = MagicMock()
+    s3.get_bucket_tagging.side_effect = _client_error("NoSuchTagSet")
+    clients = {"s3": s3, "ec2": MagicMock(), "sts": MagicMock()}
+    clients["sts"].get_caller_identity.return_value = {"Account": "123456789012"}
+    monkeypatch.setenv("CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID", "INC-1")
+    monkeypatch.setenv("CSPM_AWS_AUTOREMEDIATE_APPROVER", "alice@security")
+    monkeypatch.setenv("CSPM_AWS_AUTOREMEDIATE_AUDIT_DYNAMODB_TABLE", "audit-table")
+    monkeypatch.setenv("CSPM_AWS_AUTOREMEDIATE_AUDIT_BUCKET", "audit-bucket")
+    monkeypatch.setenv("CSPM_AWS_AUTOREMEDIATE_AUDIT_KMS_KEY_ARN", "arn:aws:kms:::key/123")
+    monkeypatch.setattr(_CHECKS, "DualAuditWriter", _FakeAudit)
+
+    findings = [
+        Finding(
+            control_id="2.4",
+            title="S3 versioning enabled",
+            section="storage",
+            severity="MEDIUM",
+            status="FAIL",
+            resources=["bucket-a"],
+        )
+    ]
+
+    records = _CHECKS.build_remediation_records(
+        findings,
+        clients=clients,
+        region="us-east-1",
+        apply=True,
+        confirm=_CHECKS.CONFIRM_APPLY_PHRASE,
+    )
+    assert records[0]["record_type"] == "remediation_action"
+    assert records[0]["status"] == "success"
+    assert records[0]["incident_id"] == "INC-1"
+    assert records[0]["approver"] == "alice@security"
+    clients["s3"].put_bucket_versioning.assert_called_once()
+
+
+def test_main_auto_remediate_json_wraps_findings_and_remediation(monkeypatch):
+    clients = _stub_clients()
+    clients["s3"].list_buckets.return_value = {"Buckets": [{"Name": "public-bucket"}]}
+    clients["s3"].get_bucket_encryption.side_effect = _client_error(
+        "ServerSideEncryptionConfigurationNotFoundError"
+    )
+    clients["s3"].get_bucket_logging.return_value = {}
+    clients["s3"].get_public_access_block.side_effect = _client_error("NoSuchPublicAccessBlockConfiguration")
+    clients["s3"].get_bucket_versioning.return_value = {}
+    clients["s3"].get_bucket_tagging = MagicMock(side_effect=_client_error("NoSuchTagSet"))
+    monkeypatch.setattr(_CHECKS, "_get_clients", lambda region: clients)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "checks.py",
+            "--section",
+            "storage",
+            "--output",
+            "json",
+            "--auto-remediate",
+        ],
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        try:
+            _CHECKS.main()
+        except SystemExit:
+            pass
+    payload = json.loads(buf.getvalue())
+    assert "findings" in payload
+    assert "remediation" in payload
+    assert payload["remediation"]


### PR DESCRIPTION
What changed
- added `--auto-remediate` support to `cspm-aws-cis-benchmark` with an AWS-first supported control set: `2.1`, `2.3`, `2.4`, `4.1`, and `4.2`
- kept default benchmark assessment behavior unchanged, but when `--auto-remediate` is set the skill now emits native `remediation_plan` records and, under `--apply`, native `remediation_action` records with dual-audit metadata
- gated `--apply` behind `CSPM_AWS_AUTOREMEDIATE_INCIDENT_ID`, `CSPM_AWS_AUTOREMEDIATE_APPROVER`, audit env vars, and explicit CLI confirmation
- added protected-resource deny-lists for buckets and security groups so break-glass / intentionally-open assets fail closed as `would-violate-protected-resource`
- updated the MCP wrapper safe-mode logic so write-capable `checks.py` skills remain callable in assessment / dry-run mode without `--apply`
- refreshed `SECURITY_BAR.md` and the AWS CSPM skill docs to reflect the new optional write path

Why
Issue #242 asks for auto-remediation on CSPM skills, but landing that across all providers at once would be a risky bundle. This PR ships the first narrow slice where the fixes are low-risk, provider-native, and straightforward to test end to end inside the existing AWS CIS skill.

Scope notes
- this does NOT close #242 by itself
- this PR is AWS only
- CloudTrail bootstrap / alarm creation / IAM-user fixes are still out of scope for this first slice
- MCP remains dry-run/read-only for this skill because the wrapper still blocks `--apply`

Validation
- pytest skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks.py skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py -q
- pytest mcp-server/tests/test_server_unit.py tests/conformance/test_multi_mode_identity.py -q
- pytest mcp-server/tests/test_server.py mcp-server/tests/test_tool_registry.py -q
- ruff check skills/evaluation/cspm-aws-cis-benchmark/src/checks.py skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py mcp-server/src/server.py mcp-server/tests/test_server_unit.py
- python scripts/validate_skill_contract.py
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_skill_integrity.py
- python scripts/generate_security_bar_matrix.py --check
