### PR TITLE
[codex] Harden remediation target boundaries

### DIFF
--- a/skills/remediation/remediate-aws-sg-revoke/SKILL.md
+++ b/skills/remediation/remediate-aws-sg-revoke/SKILL.md
@@ -9,7 +9,8 @@ description: >-
   Every action is dry-run by default, deny-listed against `default*` SG
   names, any SG carrying the `intentionally-open` tag, and any sg id in
   AWS_SG_REVOKE_PROTECTED_IDS. Apply requires AWS_SG_REVOKE_INCIDENT_ID +
-  AWS_SG_REVOKE_APPROVER. Dual audit (DynamoDB + KMS-encrypted S3). Reverify
+  AWS_SG_REVOKE_APPROVER plus an explicit allowed-account binding via
+  AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS. Dual audit (DynamoDB + KMS-encrypted S3). Reverify
   re-reads the SG via DescribeSecurityGroups and emits VERIFIED if no
   offending IpPermissions remain, DRIFT (+ paired OCSF Detection Finding
   via the shared remediation_verifier contract) if the rule came back,
@@ -88,6 +89,7 @@ OCSF 1.8 Detection Finding (class 2004) from `detect-aws-open-security-group`. R
 | Intentionally-open tag | SGs tagged `intentionally-open` (e.g. ALB on 443) refuse revoke; tag value is logged in the audit row |
 | Operator allowlist | `AWS_SG_REVOKE_PROTECTED_IDS` env var (comma-separated sg ids) refuses revoke |
 | Apply gate | `--apply` requires `AWS_SG_REVOKE_INCIDENT_ID` + `AWS_SG_REVOKE_APPROVER` set out-of-band |
+| Account boundary | `--apply` also requires `AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS`, and the finding's `account.uid` must match both that allow-list and the caller's current STS account |
 | Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER the revoke; failure paths still write the failure audit row |
 | Re-verify | Re-reads the SG via `DescribeSecurityGroups`; emits VERIFIED if no offending permissions, DRIFT (+ paired OCSF finding) if re-added, UNREACHABLE if API throws — never silently downgrades |
 
@@ -102,6 +104,7 @@ export AWS_REGION=us-east-1
 export AWS_PROFILE=incident-response
 export AWS_SG_REVOKE_INCIDENT_ID=INC-2026-04-19-005
 export AWS_SG_REVOKE_APPROVER=alice@security
+export AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS=111122223333
 export AWS_SG_REVOKE_AUDIT_DYNAMODB_TABLE=aws-sg-revoke-audit
 export AWS_SG_REVOKE_AUDIT_BUCKET=acme-aws-sg-audit
 export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
@@ -135,7 +138,7 @@ The execution role needs:
 
 - Deleting the SG entirely
 - Tag-based discovery of SGs to revoke (this skill is finding-driven)
-- Cross-account auto-revoke (operators run the skill under the right account context, or the runner does)
+- Cross-account auto-revoke (the skill now fails closed unless the target account is named explicitly and matches the caller's current STS account)
 - Posture-at-rest scanning (use `cspm-aws-cis-benchmark`)
 
 ## See also

--- a/skills/remediation/remediate-aws-sg-revoke/src/handler.py
+++ b/skills/remediation/remediate-aws-sg-revoke/src/handler.py
@@ -80,6 +80,7 @@ STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
 STATUS_SKIPPED_PROTECTED = "skipped_protected_sg"
 STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-sg"
 STATUS_SKIPPED_NO_SG = "skipped_no_sg_pointer"
+STATUS_SKIPPED_ACCOUNT_BOUNDARY = "skipped_account_boundary"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -384,7 +385,22 @@ def check_apply_gate() -> tuple[bool, str]:
         return False, "AWS_SG_REVOKE_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "AWS_SG_REVOKE_APPROVER is required for --apply"
+    if not load_allowed_account_ids():
+        return False, "AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS is required for --apply"
     return True, ""
+
+
+def load_allowed_account_ids() -> tuple[str, ...]:
+    raw = os.getenv("AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _resolve_current_account_id(*, profile: str = "", region: str = "") -> str:
+    import boto3
+
+    session = boto3.Session(profile_name=profile or None)
+    client = session.client("sts", region_name=region or None)
+    return str(client.get_caller_identity()["Account"])
 
 
 def _revoke_endpoint(target: Target) -> str:
@@ -649,9 +665,12 @@ def run(
     intentionally_open_tag: str = DEFAULT_INTENTIONALLY_OPEN_TAG,
     incident_id: str = "",
     approver: str = "",
+    allowed_account_ids: Iterable[str] = (),
+    current_account_id: str = "",
 ) -> Iterator[dict[str, Any]]:
     name_prefixes = tuple(name_prefixes)
     sg_ids = tuple(sg_ids)
+    allowed_account_ids = tuple(allowed_account_ids)
 
     for target, event in parse_targets(events):
         if target is None:
@@ -666,6 +685,30 @@ def run(
                 dry_run=dry_run,
             )
             continue
+
+        if apply:
+            if target.account_uid and allowed_account_ids and target.account_uid not in allowed_account_ids:
+                yield _skip_record(
+                    target,
+                    status=STATUS_SKIPPED_ACCOUNT_BOUNDARY,
+                    detail=(
+                        f"target account `{target.account_uid}` is not listed in "
+                        "AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS"
+                    ),
+                    dry_run=False,
+                )
+                continue
+            if current_account_id and target.account_uid and target.account_uid != current_account_id:
+                yield _skip_record(
+                    target,
+                    status=STATUS_SKIPPED_ACCOUNT_BOUNDARY,
+                    detail=(
+                        f"target account `{target.account_uid}` does not match current AWS account "
+                        f"`{current_account_id}`"
+                    ),
+                    dry_run=False,
+                )
+                continue
 
         # Live tag check requires a describe call. We do it once per target.
         sg_describe: dict[str, Any] | None = None
@@ -744,6 +787,14 @@ def main(argv: list[str] | None = None) -> int:
             if not ok:
                 print(reason, file=sys.stderr)
                 return 2
+            try:
+                current_account_id = _resolve_current_account_id(
+                    profile=os.environ.get("AWS_PROFILE", ""),
+                    region=os.environ.get("AWS_REGION", ""),
+                )
+            except Exception as exc:
+                print(f"failed to resolve current AWS account for --apply: {exc}", file=sys.stderr)
+                return 2
             incident_id = os.environ["AWS_SG_REVOKE_INCIDENT_ID"].strip()
             approver = os.environ["AWS_SG_REVOKE_APPROVER"].strip()
             audit = DualAuditWriter(
@@ -751,12 +802,16 @@ def main(argv: list[str] | None = None) -> int:
                 s3_bucket=os.environ["AWS_SG_REVOKE_AUDIT_BUCKET"],
                 kms_key_arn=os.environ["KMS_KEY_ARN"],
             )
+        else:
+            current_account_id = ""
 
         for record in run(
             load_jsonl(in_stream), ec2_client=ec2_client,
             apply=args.apply, reverify=args.reverify, audit=audit,
             sg_ids=load_protected_sg_ids(),
             incident_id=incident_id, approver=approver,
+            allowed_account_ids=load_allowed_account_ids(),
+            current_account_id=current_account_id,
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py
@@ -15,6 +15,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_FAILURE,
     STATUS_IN_PROGRESS,
     STATUS_PLANNED,
+    STATUS_SKIPPED_ACCOUNT_BOUNDARY,
     STATUS_SKIPPED_NO_SG,
     STATUS_SKIPPED_PROTECTED,
     STATUS_SUCCESS,
@@ -142,12 +143,16 @@ def test_intentionally_open_tag_default():
 def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.delenv("AWS_SG_REVOKE_INCIDENT_ID", raising=False)
     monkeypatch.delenv("AWS_SG_REVOKE_APPROVER", raising=False)
+    monkeypatch.delenv("AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS", raising=False)
     ok, _ = check_apply_gate()
     assert ok is False
     monkeypatch.setenv("AWS_SG_REVOKE_INCIDENT_ID", "INC-1")
     ok, _ = check_apply_gate()
     assert ok is False
     monkeypatch.setenv("AWS_SG_REVOKE_APPROVER", "alice")
+    ok, _ = check_apply_gate()
+    assert ok is False
+    monkeypatch.setenv("AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS", "111122223333")
     ok, _ = check_apply_gate()
     assert ok is True
 
@@ -256,7 +261,9 @@ def test_run_skips_intentionally_open_tagged_sg_in_apply():
     audit = _FakeAudit()
     ec2 = _FakeEC2(sgs={"sg-rogue": {"GroupId": "sg-rogue", "Tags": [{"Key": "intentionally-open", "Value": "yes"}], "IpPermissions": []}})
     records = list(run([_finding()], ec2_client=ec2, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice"))
+                       incident_id="INC-1", approver="alice",
+                       allowed_account_ids=("111122223333",),
+                       current_account_id="111122223333"))
     assert records[0]["status"] == STATUS_SKIPPED_PROTECTED
     assert ec2.revokes == []
     assert audit.writes == []
@@ -277,7 +284,9 @@ def test_run_apply_revokes_with_dual_audit():
         "IpPermissions": [{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22,
                            "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]}})
     records = list(run([_finding()], ec2_client=ec2, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice@security"))
+                       incident_id="INC-1", approver="alice@security",
+                       allowed_account_ids=("111122223333",),
+                       current_account_id="111122223333"))
     rec = records[0]
     assert rec["status"] == STATUS_SUCCESS
     assert rec["dry_run"] is False
@@ -308,6 +317,8 @@ def test_run_apply_revokes_all_protocol_permission_with_exact_shape():
             audit=audit,
             incident_id="INC-1",
             approver="alice@security",
+            allowed_account_ids=("111122223333",),
+            current_account_id="111122223333",
         )
     )
     assert records[0]["status"] == STATUS_SUCCESS
@@ -318,7 +329,9 @@ def test_run_apply_writes_failure_audit_when_revoke_throws():
     audit = _FakeAudit()
     ec2 = _FakeEC2(raise_on_revoke=True)
     records = list(run([_finding()], ec2_client=ec2, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice"))
+                       incident_id="INC-1", approver="alice",
+                       allowed_account_ids=("111122223333",),
+                       current_account_id="111122223333"))
     assert records[0]["status"] == STATUS_FAILURE
     assert len(audit.writes) == 2
     assert audit.writes[1]["status"] == STATUS_FAILURE
@@ -327,7 +340,20 @@ def test_run_apply_writes_failure_audit_when_revoke_throws():
 def test_run_apply_requires_audit_writer():
     import pytest
     with pytest.raises(ValueError, match="audit writer is required"):
-        list(run([_finding()], ec2_client=_FakeEC2(), apply=True, audit=None))
+        list(run([_finding()], ec2_client=_FakeEC2(), apply=True, audit=None,
+                 allowed_account_ids=("111122223333",), current_account_id="111122223333"))
+
+
+def test_run_apply_skips_wrong_account_boundary():
+    audit = _FakeAudit()
+    ec2 = _FakeEC2()
+    records = list(run([_finding()], ec2_client=ec2, apply=True, audit=audit,
+                       incident_id="INC-1", approver="alice",
+                       allowed_account_ids=("444455556666",),
+                       current_account_id="111122223333"))
+    assert records[0]["status"] == STATUS_SKIPPED_ACCOUNT_BOUNDARY
+    assert ec2.revokes == []
+    assert audit.writes == []
 
 
 # ---------- run: re-verify ----------

--- a/skills/remediation/remediate-azure-nsg-revoke/SKILL.md
+++ b/skills/remediation/remediate-azure-nsg-revoke/SKILL.md
@@ -15,7 +15,9 @@ description: >-
   deny-listed against `default*`/`Default*` rule names, NSG names ending
   `-protected`, the parent NSG's `intentionally-open` tag, and any
   rule-fully-qualified-id in AZURE_NSG_REVOKE_DENY_RULE_IDS. Apply
-  requires AZURE_NSG_REVOKE_INCIDENT_ID + AZURE_NSG_REVOKE_APPROVER.
+  requires AZURE_NSG_REVOKE_INCIDENT_ID + AZURE_NSG_REVOKE_APPROVER
+  plus an explicit allowed-subscription binding via
+  AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS.
   Dual audit (DynamoDB + KMS-encrypted S3). Reverify re-reads the rule
   via `security_rules.get()` and emits VERIFIED if the rule is gone (or
   patched to Deny), DRIFT (+ paired OCSF Detection Finding via the
@@ -103,6 +105,7 @@ OCSF 1.8 Detection Finding (class 2004) from `detect-azure-open-nsg`. Required o
 | Intentionally-open tag | NSGs tagged `intentionally-open` refuse revoke; tag value is logged in the audit row |
 | Operator allowlist | `AZURE_NSG_REVOKE_DENY_RULE_IDS` env var (comma-separated rule ids) refuses revoke |
 | Apply gate | `--apply` requires `AZURE_NSG_REVOKE_INCIDENT_ID` + `AZURE_NSG_REVOKE_APPROVER` set out-of-band |
+| Subscription boundary | `--apply` also requires `AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS`, and the parsed subscription from `target.uid` must be listed there |
 | Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER the action; failure paths still write the failure audit row |
 | Re-verify | Re-reads the rule via `security_rules.get()`; emits VERIFIED if the rule is absent or patched to Deny, DRIFT (+ paired OCSF finding) if it re-appears as Allow, UNREACHABLE if the Azure API throws — never silently downgrades |
 
@@ -115,6 +118,7 @@ python skills/remediation/remediate-azure-nsg-revoke/src/handler.py findings.ocs
 # Apply (after out-of-band approval)
 export AZURE_NSG_REVOKE_INCIDENT_ID=INC-2026-04-20-001
 export AZURE_NSG_REVOKE_APPROVER=alice@security
+export AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS=00000000-0000-0000-0000-000000000001
 export AZURE_NSG_REVOKE_AUDIT_DYNAMODB_TABLE=azure-nsg-revoke-audit
 export AZURE_NSG_REVOKE_AUDIT_BUCKET=acme-azure-nsg-audit
 export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
@@ -142,7 +146,7 @@ The dual-audit sink also needs the same AWS DynamoDB + S3 + KMS permissions used
 
 - Deleting the NSG entirely
 - Tag-based discovery of NSG rules to revoke (this skill is finding-driven)
-- Cross-subscription auto-revoke (operators run the skill under the right credential context, or the runner does)
+- Cross-subscription auto-revoke (the skill now fails closed unless the target subscription is named explicitly in `AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS`)
 - Posture-at-rest scanning (use `cspm-azure-cis-benchmark`)
 
 ## See also

--- a/skills/remediation/remediate-azure-nsg-revoke/src/handler.py
+++ b/skills/remediation/remediate-azure-nsg-revoke/src/handler.py
@@ -89,6 +89,7 @@ STATUS_SKIPPED_PROTECTED = "skipped_protected_rule"
 STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-rule"
 STATUS_SKIPPED_NO_RULE = "skipped_no_rule_pointer"
 STATUS_SKIPPED_BAD_RULE_ID = "skipped_unparseable_rule_id"
+STATUS_SKIPPED_SUBSCRIPTION_BOUNDARY = "skipped_subscription_boundary"
 
 # Format: /subscriptions/<sub>/resourceGroups/<rg>/providers/
 #         Microsoft.Network/networkSecurityGroups/<nsg>/securityRules/<rule>
@@ -518,7 +519,14 @@ def check_apply_gate() -> tuple[bool, str]:
         return False, "AZURE_NSG_REVOKE_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "AZURE_NSG_REVOKE_APPROVER is required for --apply"
+    if not load_allowed_subscription_ids():
+        return False, "AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS is required for --apply"
     return True, ""
+
+
+def load_allowed_subscription_ids() -> tuple[str, ...]:
+    raw = os.getenv("AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
 
 
 def _delete_endpoint(target: Target) -> str:
@@ -814,12 +822,14 @@ def run(
     incident_id: str = "",
     approver: str = "",
     mode: str = MODE_DELETE,
+    allowed_subscription_ids: Iterable[str] = (),
 ) -> Iterator[dict[str, Any]]:
     if mode not in SUPPORTED_MODES:
         raise ValueError(f"unsupported mode `{mode}`; choose one of {sorted(SUPPORTED_MODES)}")
     rule_name_prefixes = tuple(rule_name_prefixes)
     nsg_name_suffixes = tuple(nsg_name_suffixes)
     rule_ids = tuple(rule_ids)
+    allowed_subscription_ids = tuple(allowed_subscription_ids)
 
     for target, event in parse_targets(events):
         if target is None:
@@ -843,6 +853,19 @@ def run(
                     "security rule resource id"
                 ),
                 dry_run=dry_run, mode=mode,
+            )
+            continue
+
+        if apply and target.subscription_id not in allowed_subscription_ids:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_SUBSCRIPTION_BOUNDARY,
+                detail=(
+                    f"target subscription `{target.subscription_id}` is not listed in "
+                    "AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS"
+                ),
+                dry_run=False,
+                mode=mode,
             )
             continue
 
@@ -948,6 +971,7 @@ def main(argv: list[str] | None = None) -> int:
             apply=args.apply, reverify=args.reverify, audit=audit,
             rule_ids=load_protected_rule_ids(),
             incident_id=incident_id, approver=approver, mode=args.mode,
+            allowed_subscription_ids=load_allowed_subscription_ids(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-azure-nsg-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-azure-nsg-revoke/tests/test_handler.py
@@ -20,6 +20,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_PLANNED,
     STATUS_SKIPPED_NO_RULE,
     STATUS_SKIPPED_PROTECTED,
+    STATUS_SKIPPED_SUBSCRIPTION_BOUNDARY,
     STATUS_SUCCESS,
     STATUS_WOULD_VIOLATE_PROTECTED,
     AzureNetworkClient,
@@ -165,12 +166,16 @@ def test_intentionally_open_tag_default():
 def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.delenv("AZURE_NSG_REVOKE_INCIDENT_ID", raising=False)
     monkeypatch.delenv("AZURE_NSG_REVOKE_APPROVER", raising=False)
+    monkeypatch.delenv("AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS", raising=False)
     ok, _ = check_apply_gate()
     assert ok is False
     monkeypatch.setenv("AZURE_NSG_REVOKE_INCIDENT_ID", "INC-1")
     ok, _ = check_apply_gate()
     assert ok is False
     monkeypatch.setenv("AZURE_NSG_REVOKE_APPROVER", "alice")
+    ok, _ = check_apply_gate()
+    assert ok is False
+    monkeypatch.setenv("AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS", SUB)
     ok, _ = check_apply_gate()
     assert ok is True
 
@@ -353,7 +358,8 @@ def test_run_skips_intentionally_open_tagged_nsg_in_apply():
         nsgs={f"{SUB}|{RG}|{NSG}": {"name": NSG, "tags": {"intentionally-open": "yes"}}},
     )
     records = list(run([_finding()], network_client=nc, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice"))
+                       incident_id="INC-1", approver="alice",
+                       allowed_subscription_ids=(SUB,)))
     assert records[0]["status"] == STATUS_SKIPPED_PROTECTED
     assert nc.deletes == []
     assert nc.patches == []
@@ -379,7 +385,8 @@ def test_run_apply_delete_with_dual_audit():
         nsgs={f"{SUB}|{RG}|{NSG}": {"name": NSG, "tags": {}}},
     )
     records = list(run([_finding()], network_client=nc, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice@security"))
+                       incident_id="INC-1", approver="alice@security",
+                       allowed_subscription_ids=(SUB,)))
     rec = records[0]
     assert rec["status"] == STATUS_SUCCESS
     assert rec["dry_run"] is False
@@ -396,7 +403,8 @@ def test_run_apply_delete_writes_failure_audit_when_delete_throws():
     nc = _FakeNetworkClient(raise_on_delete=True,
                             nsgs={f"{SUB}|{RG}|{NSG}": {"name": NSG, "tags": {}}})
     records = list(run([_finding()], network_client=nc, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice"))
+                       incident_id="INC-1", approver="alice",
+                       allowed_subscription_ids=(SUB,)))
     assert records[0]["status"] == STATUS_FAILURE
     assert len(audit.writes) == 2
     assert audit.writes[1]["status"] == STATUS_FAILURE
@@ -405,7 +413,8 @@ def test_run_apply_delete_writes_failure_audit_when_delete_throws():
 def test_run_apply_requires_audit_writer():
     import pytest
     with pytest.raises(ValueError, match="audit writer is required"):
-        list(run([_finding()], network_client=_FakeNetworkClient(), apply=True, audit=None))
+        list(run([_finding()], network_client=_FakeNetworkClient(), apply=True, audit=None,
+                 allowed_subscription_ids=(SUB,)))
 
 
 # ---------- run: apply (patch mode) ----------
@@ -421,7 +430,8 @@ def test_run_apply_patch_to_deny():
         nsgs={f"{SUB}|{RG}|{NSG}": {"name": NSG, "tags": {}}},
     )
     records = list(run([_finding()], network_client=nc, apply=True, audit=audit,
-                       incident_id="INC-1", approver="alice", mode=MODE_PATCH))
+                       incident_id="INC-1", approver="alice", mode=MODE_PATCH,
+                       allowed_subscription_ids=(SUB,)))
     rec = records[0]
     assert rec["status"] == STATUS_SUCCESS
     assert rec["mode"] == "patch"
@@ -432,6 +442,18 @@ def test_run_apply_patch_to_deny():
     assert params["access"] == "Allow"  # the existing value, before flip
     # The fake then writes Deny back to the in-memory store
     assert nc.rules[f"{SUB}|{RG}|{NSG}|{RULE}"]["access"] == "Deny"
+
+
+def test_run_apply_skips_wrong_subscription_boundary():
+    audit = _FakeAudit()
+    nc = _FakeNetworkClient()
+    records = list(run([_finding()], network_client=nc, apply=True, audit=audit,
+                       incident_id="INC-1", approver="alice",
+                       allowed_subscription_ids=("00000000-0000-0000-0000-000000000099",)))
+    assert records[0]["status"] == STATUS_SKIPPED_SUBSCRIPTION_BOUNDARY
+    assert nc.deletes == []
+    assert nc.patches == []
+    assert audit.writes == []
 
 
 # ---------- run: re-verify ----------

--- a/skills/remediation/remediate-gcp-firewall-revoke/SKILL.md
+++ b/skills/remediation/remediate-gcp-firewall-revoke/SKILL.md
@@ -11,7 +11,9 @@ description: >-
   is dry-run by default, deny-listed against rule names matching
   `default-*`, rules whose `description` contains `intentionally-open`,
   and any rule name in GCP_FIREWALL_REVOKE_DENY_RULE_NAMES. Apply
-  requires GCP_FIREWALL_REVOKE_INCIDENT_ID + GCP_FIREWALL_REVOKE_APPROVER.
+  requires GCP_FIREWALL_REVOKE_INCIDENT_ID + GCP_FIREWALL_REVOKE_APPROVER
+  plus an explicit allowed-project binding via
+  GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS.
   Dual audit (DynamoDB + KMS-encrypted S3, same shared infra as the AWS
   pair, with `provider: "gcp"`). Reverify re-reads the rule via
   `firewalls.get` and emits VERIFIED if the rule is gone or remains
@@ -101,6 +103,7 @@ OCSF 1.8 Detection Finding (class 2004) from `detect-gcp-open-firewall`. Require
 | Intentionally-open description | rules whose `description` contains `intentionally-open` refuse revoke; description is logged in the audit row |
 | Operator allowlist | `GCP_FIREWALL_REVOKE_DENY_RULE_NAMES` env var (comma-separated rule names) refuses revoke |
 | Apply gate | `--apply` requires `GCP_FIREWALL_REVOKE_INCIDENT_ID` + `GCP_FIREWALL_REVOKE_APPROVER` set out-of-band |
+| Project boundary | `--apply` also requires `GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS`, and the finding's `account.uid` project must be listed there |
 | Mode gate | `--mode patch` (default, sets `disabled: true`) is non-destructive; `--mode delete` is opt-in and dual-logged |
 | Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER the patch/delete; failure paths still write the failure audit row |
 | Re-verify | Re-reads the rule via `firewalls.get`; emits VERIFIED if absent or `disabled: true`, DRIFT (+ paired OCSF finding) if re-enabled or re-created, UNREACHABLE if API throws — never silently downgrades |
@@ -115,6 +118,7 @@ python skills/remediation/remediate-gcp-firewall-revoke/src/handler.py findings.
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
 export GCP_FIREWALL_REVOKE_INCIDENT_ID=INC-2026-04-19-006
 export GCP_FIREWALL_REVOKE_APPROVER=alice@security
+export GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS=my-prod-project
 export GCP_FIREWALL_REVOKE_AUDIT_DYNAMODB_TABLE=gcp-firewall-revoke-audit
 export GCP_FIREWALL_REVOKE_AUDIT_BUCKET=acme-gcp-firewall-audit
 export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
@@ -145,7 +149,7 @@ recommended path.
 
 - Deleting all firewall rules in a project (one-rule-at-a-time, finding-driven)
 - Tag-based discovery of rules to revoke (this skill is finding-driven)
-- Cross-project auto-revoke (operators run the skill under the right project credentials, or the runner does)
+- Cross-project auto-revoke (the skill now fails closed unless the target project is named explicitly in `GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS`)
 - Posture-at-rest scanning (use `cspm-gcp-cis-benchmark`)
 
 ## See also

--- a/skills/remediation/remediate-gcp-firewall-revoke/src/handler.py
+++ b/skills/remediation/remediate-gcp-firewall-revoke/src/handler.py
@@ -85,6 +85,7 @@ STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
 STATUS_SKIPPED_PROTECTED = "skipped_protected_firewall"
 STATUS_WOULD_VIOLATE_PROTECTED = "would-violate-protected-firewall"
 STATUS_SKIPPED_NO_TARGET = "skipped_no_firewall_pointer"
+STATUS_SKIPPED_PROJECT_BOUNDARY = "skipped_project_boundary"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -356,7 +357,14 @@ def check_apply_gate() -> tuple[bool, str]:
         return False, "GCP_FIREWALL_REVOKE_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "GCP_FIREWALL_REVOKE_APPROVER is required for --apply"
+    if not load_allowed_project_ids():
+        return False, "GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS is required for --apply"
     return True, ""
+
+
+def load_allowed_project_ids() -> tuple[str, ...]:
+    raw = os.getenv("GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
 
 
 def _action_endpoint(target: Target, mode: str) -> str:
@@ -598,12 +606,14 @@ def run(
     incident_id: str = "",
     approver: str = "",
     mode: str = MODE_PATCH,
+    allowed_project_ids: Iterable[str] = (),
 ) -> Iterator[dict[str, Any]]:
     if mode not in SUPPORTED_MODES:
         raise ValueError(f"unsupported mode `{mode}`; expected one of {sorted(SUPPORTED_MODES)}")
 
     name_prefixes = tuple(name_prefixes)
     rule_names = tuple(rule_names)
+    allowed_project_ids = tuple(allowed_project_ids)
 
     for target, event in parse_targets(events):
         if target is None:
@@ -616,6 +626,19 @@ def run(
                 target, status=STATUS_SKIPPED_NO_TARGET,
                 detail="finding did not carry a target.uid (rule name) and account.uid (project) observable",
                 dry_run=dry_run, mode=mode,
+            )
+            continue
+
+        if apply and target.project_id not in allowed_project_ids:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_PROJECT_BOUNDARY,
+                detail=(
+                    f"target project `{target.project_id}` is not listed in "
+                    "GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS"
+                ),
+                dry_run=False,
+                mode=mode,
             )
             continue
 
@@ -712,6 +735,7 @@ def main(argv: list[str] | None = None) -> int:
             apply=args.apply, reverify=args.reverify, audit=audit,
             rule_names=load_protected_rule_names(),
             incident_id=incident_id, approver=approver, mode=args.mode,
+            allowed_project_ids=load_allowed_project_ids(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-gcp-firewall-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-gcp-firewall-revoke/tests/test_handler.py
@@ -19,6 +19,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_IN_PROGRESS,
     STATUS_PLANNED,
     STATUS_SKIPPED_NO_TARGET,
+    STATUS_SKIPPED_PROJECT_BOUNDARY,
     STATUS_SKIPPED_PROTECTED,
     STATUS_SUCCESS,
     STATUS_WOULD_VIOLATE_PROTECTED,
@@ -133,12 +134,16 @@ def test_intentionally_open_description_marker_default():
 def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.delenv("GCP_FIREWALL_REVOKE_INCIDENT_ID", raising=False)
     monkeypatch.delenv("GCP_FIREWALL_REVOKE_APPROVER", raising=False)
+    monkeypatch.delenv("GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS", raising=False)
     ok, _ = check_apply_gate()
     assert ok is False
     monkeypatch.setenv("GCP_FIREWALL_REVOKE_INCIDENT_ID", "INC-1")
     ok, _ = check_apply_gate()
     assert ok is False
     monkeypatch.setenv("GCP_FIREWALL_REVOKE_APPROVER", "alice")
+    ok, _ = check_apply_gate()
+    assert ok is False
+    monkeypatch.setenv("GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS", "p-1")
     ok, _ = check_apply_gate()
     assert ok is True
 
@@ -276,7 +281,8 @@ def test_run_skips_intentionally_open_described_rule_in_apply():
     )
     records = list(
         run([_finding()], compute_client=compute, apply=True, audit=audit,
-            incident_id="INC-1", approver="alice")
+            incident_id="INC-1", approver="alice",
+            allowed_project_ids=("p-1",))
     )
     assert records[0]["status"] == STATUS_SKIPPED_PROTECTED
     assert compute.patches == []
@@ -298,7 +304,8 @@ def test_run_skips_via_env_protected_rule_name():
 def test_run_apply_requires_audit_writer():
     import pytest
     with pytest.raises(ValueError, match="audit writer is required"):
-        list(run([_finding()], compute_client=_FakeCompute(), apply=True, audit=None))
+        list(run([_finding()], compute_client=_FakeCompute(), apply=True, audit=None,
+                 allowed_project_ids=("p-1",)))
 
 
 def test_check_apply_gate_rejects_missing_envs(monkeypatch):
@@ -323,7 +330,8 @@ def test_run_apply_patches_with_dual_audit():
     )
     records = list(
         run([_finding()], compute_client=compute, apply=True, audit=audit,
-            incident_id="INC-1", approver="alice@security")
+            incident_id="INC-1", approver="alice@security",
+            allowed_project_ids=("p-1",))
     )
     rec = records[0]
     assert rec["status"] == STATUS_SUCCESS
@@ -347,7 +355,8 @@ def test_run_apply_delete_mode_calls_delete():
     )
     records = list(
         run([_finding()], compute_client=compute, apply=True, audit=audit,
-            incident_id="INC-1", approver="alice", mode=MODE_DELETE)
+            incident_id="INC-1", approver="alice", mode=MODE_DELETE,
+            allowed_project_ids=("p-1",))
     )
     assert records[0]["status"] == STATUS_SUCCESS
     assert compute.deletes == [("p-1", "allow-ssh-world")]
@@ -359,7 +368,8 @@ def test_run_apply_writes_failure_audit_when_patch_throws():
     compute = _FakeCompute(raise_on_patch=True)
     records = list(
         run([_finding()], compute_client=compute, apply=True, audit=audit,
-            incident_id="INC-1", approver="alice")
+            incident_id="INC-1", approver="alice",
+            allowed_project_ids=("p-1",))
     )
     assert records[0]["status"] == STATUS_FAILURE
     assert len(audit.writes) == 2
@@ -370,6 +380,20 @@ def test_run_unsupported_mode_raises():
     import pytest
     with pytest.raises(ValueError, match="unsupported mode"):
         list(run([_finding()], compute_client=_FakeCompute(), mode="purge"))
+
+
+def test_run_apply_skips_wrong_project_boundary():
+    audit = _FakeAudit()
+    compute = _FakeCompute()
+    records = list(
+        run([_finding()], compute_client=compute, apply=True, audit=audit,
+            incident_id="INC-1", approver="alice",
+            allowed_project_ids=("p-2",))
+    )
+    assert records[0]["status"] == STATUS_SKIPPED_PROJECT_BOUNDARY
+    assert compute.patches == []
+    assert compute.deletes == []
+    assert audit.writes == []
 
 
 # ---------- run: re-verify ----------


### PR DESCRIPTION
What changed

added explicit apply-time target-boundary gates to the three network remediators:
- `remediate-aws-sg-revoke` now requires `AWS_SG_REVOKE_ALLOWED_ACCOUNT_IDS`
- `remediate-azure-nsg-revoke` now requires `AZURE_NSG_REVOKE_ALLOWED_SUBSCRIPTION_IDS`
- `remediate-gcp-firewall-revoke` now requires `GCP_FIREWALL_REVOKE_ALLOWED_PROJECT_IDS`

for AWS, `--apply` now also cross-checks the finding's `account.uid` against the caller's current STS account before any revoke is attempted
updated SKILL docs and examples for all three skills to reflect the new zero-trust boundary requirement
added regression tests for missing allow-lists, wrong-boundary skips, and the existing happy paths

Why

These write-capable remediators were incident-gated and deny-list-protected, but they still trusted ambient cloud context too much. An operator could run `--apply` with the wrong credential context or against mixed-target findings without an explicit account/subscription/project assertion.

This PR makes the remote write boundary explicit and fail-closed.

Validation

pytest skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py -q
pytest skills/remediation/remediate-azure-nsg-revoke/tests/test_handler.py -q
pytest skills/remediation/remediate-gcp-firewall-revoke/tests/test_handler.py -q
ruff check skills/remediation/remediate-aws-sg-revoke/src/handler.py skills/remediation/remediate-aws-sg-revoke/tests/test_handler.py skills/remediation/remediate-azure-nsg-revoke/src/handler.py skills/remediation/remediate-azure-nsg-revoke/tests/test_handler.py skills/remediation/remediate-gcp-firewall-revoke/src/handler.py skills/remediation/remediate-gcp-firewall-revoke/tests/test_handler.py
python scripts/validate_skill_contract.py
python scripts/validate_safe_skill_bar.py
python scripts/validate_skill_integrity.py
