### PR TITLE
[codex] Harden Entra remediation tenant boundary

### DIFF
--- a/skills/remediation/remediate-entra-credential-revoke/SKILL.md
+++ b/skills/remediation/remediate-entra-credential-revoke/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   detect-entra-role-grant-escalation (T1098.003) via Microsoft Graph v1.0.
   Every action is dry-run by default, deny-listed against tenant-bootstrap
   and break-glass principals (display-name prefix + ENTRA_PROTECTED_OBJECT_IDS
-  env list), gated behind an incident ID plus approver for --apply, and
+  env list), gated behind an incident ID plus approver for --apply, bound to
+  an explicit tenant allow-list via ENTRA_REVOKE_ALLOWED_TENANT_IDS, and
   dual-audited (DynamoDB + KMS-encrypted S3). Re-verify confirms the SP is
   still disabled and emits a paired OCSF Detection Finding via the shared
   remediation_verifier contract on DRIFT (the SP was re-enabled). Use when
@@ -105,6 +106,7 @@ JSONL records on stdout:
 | Protected-objectId deny-list | comma-separated `ENTRA_PROTECTED_OBJECT_IDS` env var — match by exact objectId (use this for tenant-specific bootstrap SPs that don't follow the prefix convention) |
 | Target-type filter | only `ServicePrincipal` and `Application` accepted; other Graph types are out of scope |
 | Apply gate | `--apply` requires `ENTRA_REVOKE_INCIDENT_ID` + `ENTRA_REVOKE_APPROVER` env vars set out-of-band |
+| Tenant boundary | `--apply` also requires `AZURE_TENANT_ID` and `ENTRA_REVOKE_ALLOWED_TENANT_IDS`; the active tenant must be listed explicitly before Graph writes proceed |
 | Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each Graph call; failure paths still write the failure audit row |
 | Re-verify | Reads the SP via `GET /servicePrincipals/{id}`; emits VERIFIED if `accountEnabled=false`, DRIFT (+ paired OCSF finding) if re-enabled, UNREACHABLE if Graph throws — never silently downgrades |
 
@@ -120,6 +122,7 @@ export AZURE_CLIENT_ID=...
 export AZURE_CLIENT_SECRET=...
 export ENTRA_REVOKE_INCIDENT_ID=INC-2026-04-19-003
 export ENTRA_REVOKE_APPROVER=alice@security
+export ENTRA_REVOKE_ALLOWED_TENANT_IDS=...
 export ENTRA_REVOKE_AUDIT_DYNAMODB_TABLE=entra-revoke-audit
 export ENTRA_REVOKE_AUDIT_BUCKET=acme-entra-audit
 export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...

--- a/skills/remediation/remediate-entra-credential-revoke/src/handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/src/handler.py
@@ -539,11 +539,24 @@ def is_protected_target(target: Target, *, name_prefixes: Iterable[str], object_
 def check_apply_gate() -> tuple[bool, str]:
     incident_id = os.getenv("ENTRA_REVOKE_INCIDENT_ID", "").strip()
     approver = os.getenv("ENTRA_REVOKE_APPROVER", "").strip()
+    tenant_id = os.getenv("AZURE_TENANT_ID", "").strip()
     if not incident_id:
         return False, "ENTRA_REVOKE_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "ENTRA_REVOKE_APPROVER is required for --apply"
+    if not tenant_id:
+        return False, "AZURE_TENANT_ID is required for --apply"
+    allowed_tenants = load_allowed_tenant_ids()
+    if not allowed_tenants:
+        return False, "ENTRA_REVOKE_ALLOWED_TENANT_IDS is required for --apply"
+    if tenant_id not in allowed_tenants:
+        return False, f"AZURE_TENANT_ID `{tenant_id}` is not listed in ENTRA_REVOKE_ALLOWED_TENANT_IDS"
     return True, ""
+
+
+def load_allowed_tenant_ids() -> tuple[str, ...]:
+    raw = os.getenv("ENTRA_REVOKE_ALLOWED_TENANT_IDS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
 
 
 def _disable_endpoint(resolved: ResolvedServicePrincipal) -> str:
@@ -910,9 +923,20 @@ def run(
     object_ids: Iterable[str] = (),
     incident_id: str = "",
     approver: str = "",
+    tenant_id: str = "",
+    allowed_tenant_ids: Iterable[str] = (),
 ) -> Iterator[dict[str, Any]]:
     name_prefixes = tuple(name_prefixes)
     object_ids = tuple(object_ids)
+    allowed_tenant_ids = tuple(allowed_tenant_ids)
+
+    if apply:
+        if not tenant_id:
+            raise ValueError("tenant_id is required under --apply")
+        if tenant_id not in allowed_tenant_ids:
+            raise ValueError(
+                f"tenant_id `{tenant_id}` is not listed in ENTRA_REVOKE_ALLOWED_TENANT_IDS"
+            )
 
     for target, event in parse_targets(events):
         if target is None:
@@ -1038,6 +1062,8 @@ def main(argv: list[str] | None = None) -> int:
             object_ids=load_protected_object_ids(),
             incident_id=incident_id,
             approver=approver,
+            tenant_id=os.environ.get("AZURE_TENANT_ID", "").strip(),
+            allowed_tenant_ids=load_allowed_tenant_ids(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
@@ -207,12 +207,20 @@ def test_regular_target_passes_protected_check():
 def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.delenv("ENTRA_REVOKE_INCIDENT_ID", raising=False)
     monkeypatch.delenv("ENTRA_REVOKE_APPROVER", raising=False)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("ENTRA_REVOKE_ALLOWED_TENANT_IDS", raising=False)
     ok, reason = check_apply_gate()
     assert ok is False and "INCIDENT_ID" in reason
     monkeypatch.setenv("ENTRA_REVOKE_INCIDENT_ID", "INC-1")
     ok, reason = check_apply_gate()
     assert ok is False and "APPROVER" in reason
     monkeypatch.setenv("ENTRA_REVOKE_APPROVER", "alice")
+    ok, reason = check_apply_gate()
+    assert ok is False and "AZURE_TENANT_ID" in reason
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant-a")
+    ok, reason = check_apply_gate()
+    assert ok is False and "ALLOWED_TENANT_IDS" in reason
+    monkeypatch.setenv("ENTRA_REVOKE_ALLOWED_TENANT_IDS", "tenant-a")
     ok, _ = check_apply_gate()
     assert ok is True
 
@@ -297,6 +305,8 @@ def test_run_skips_protected_object_id_in_apply():
             object_ids=("bootstrap-sp-id",),
             incident_id="INC-1",
             approver="alice",
+            tenant_id="tenant-a",
+            allowed_tenant_ids=("tenant-a",),
         )
     )
     assert records[0]["status"] == STATUS_SKIPPED_PROTECTED
@@ -324,6 +334,8 @@ def test_run_apply_disables_and_emits_triage_with_dual_audit():
             audit=audit,
             incident_id="INC-1",
             approver="alice@security",
+            tenant_id="tenant-a",
+            allowed_tenant_ids=("tenant-a",),
         )
     )
     rec = records[0]
@@ -358,6 +370,8 @@ def test_run_apply_writes_failure_audit_when_disable_throws():
             audit=audit,
             incident_id="INC-1",
             approver="alice",
+            tenant_id="tenant-a",
+            allowed_tenant_ids=("tenant-a",),
         )
     )
     rec = records[0]
@@ -380,6 +394,8 @@ def test_run_apply_disable_succeeds_even_if_triage_fails():
             audit=audit,
             incident_id="INC-1",
             approver="alice",
+            tenant_id="tenant-a",
+            allowed_tenant_ids=("tenant-a",),
         )
     )
     rec = records[0]
@@ -408,6 +424,8 @@ def test_run_apply_application_target_resolves_backing_service_principal():
             audit=audit,
             incident_id="INC-1",
             approver="alice@security",
+            tenant_id="tenant-a",
+            allowed_tenant_ids=("tenant-a",),
         )
     )
     rec = records[0]
@@ -420,7 +438,34 @@ def test_run_apply_application_target_resolves_backing_service_principal():
 def test_run_apply_requires_audit_writer():
     import pytest
     with pytest.raises(ValueError, match="audit writer is required"):
-        list(run([_finding()], graph_client=_FakeGraph(), apply=True, audit=None))
+        list(
+            run(
+                [_finding()],
+                graph_client=_FakeGraph(),
+                apply=True,
+                audit=None,
+                tenant_id="tenant-a",
+                allowed_tenant_ids=("tenant-a",),
+            )
+        )
+
+
+def test_run_apply_rejects_wrong_tenant_boundary():
+    import pytest
+
+    with pytest.raises(ValueError, match="ALLOWED_TENANT_IDS"):
+        list(
+            run(
+                [_finding()],
+                graph_client=_FakeGraph(),
+                apply=True,
+                audit=_FakeAudit(),
+                incident_id="INC-1",
+                approver="alice",
+                tenant_id="tenant-a",
+                allowed_tenant_ids=("tenant-b",),
+            )
+        )
 
 
 # ----------------- run: re-verify -----------------


### PR DESCRIPTION
What changed

added an explicit tenant-boundary gate to `remediate-entra-credential-revoke --apply`
required `AZURE_TENANT_ID` and `ENTRA_REVOKE_ALLOWED_TENANT_IDS` to be present and to match before any Microsoft Graph write proceeds
updated the skill docs/example env block so the runtime boundary matches the documented guardrails
added regression tests for missing tenant envs, wrong-tenant rejection, and the existing apply paths

Why

The Entra revoker already required incident, approver, and dual-audit env vars, but it still trusted whichever tenant `AZURE_TENANT_ID` happened to point at. For a write-capable identity remediator, that is too much ambient trust.

This PR makes the tenant boundary explicit and fail-closed.

Validation

pytest skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py -q
ruff check skills/remediation/remediate-entra-credential-revoke/src/handler.py skills/remediation/remediate-entra-credential-revoke/tests/test_handler.py
python scripts/validate_skill_contract.py
python scripts/validate_safe_skill_bar.py
python scripts/validate_skill_integrity.py
