### PR TITLE
[codex] Harden session remediation identity boundaries

### DIFF
--- a/skills/remediation/remediate-okta-session-kill/SKILL.md
+++ b/skills/remediation/remediate-okta-session-kill/SKILL.md
@@ -14,7 +14,8 @@ description: >-
   response." Do NOT use for Entra / Azure AD, Google Workspace, AWS IAM,
   or GCP sessions — those have their own per-IdP remediation skills. Do
   NOT bypass the deny-list, run with --apply without an explicit
-  human-approved incident window, or edit the audit trail by hand.
+  human-approved incident window, explicit Okta org allow-list, or edit
+  the audit trail by hand.
 license: Apache-2.0
 capability: write-identity
 approval_model: human_required
@@ -102,7 +103,11 @@ The skill refuses to execute unless env var `OKTA_SESSION_KILL_INCIDENT_ID` is s
 
 The intent: a skill invocation that lands in a SIEM alert or a naive agent loop STILL requires an operator to register an incident before writes happen. The gate sits outside the agent loop.
 
-### 4. Dual audit — before and after each API call
+### 4. `--apply` requires an explicit org boundary
+
+The current `OKTA_ORG_URL` must be present in `OKTA_SESSION_KILL_ALLOWED_ORG_URLS` before any write runs. This keeps the handler from acting against whichever Okta tenant ambient credentials happen to point at. The boundary is invocation-scoped, not target-scoped: one run talks to one Okta org.
+
+### 5. Dual audit — before and after each API call
 
 For every containment action (session revoke, token revoke, password expire) the skill writes:
 
@@ -111,7 +116,7 @@ For every containment action (session revoke, token revoke, password expire) the
 
 If either write fails, the skill raises BEFORE the Okta API call. No action without an audit trail.
 
-### 5. Okta API token is fetched, not hardcoded
+### 6. Okta API token is fetched, not hardcoded
 
 `OKTA_API_TOKEN_SECRETSMANAGER_ARN` points at an AWS Secrets Manager secret. The skill calls `secretsmanager:GetSecretValue` at invocation time and never persists the token to disk or stderr.
 
@@ -156,6 +161,7 @@ cat finding.ocsf.jsonl | python src/handler.py
 
 # Apply — requires declared incident window
 export OKTA_ORG_URL=https://example.okta.com
+export OKTA_SESSION_KILL_ALLOWED_ORG_URLS=https://example.okta.com
 export OKTA_API_TOKEN_SECRETSMANAGER_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:okta-api-token
 export OKTA_SESSION_KILL_INCIDENT_ID=inc-2026-04-18-001
 export OKTA_SESSION_KILL_APPROVER=alice@example.com
@@ -172,6 +178,7 @@ cat finding.ocsf.jsonl | python src/handler.py --apply
 - To bypass the deny-list of protected principals
 - As a generic "log out user" button for ops workflows — this is an **incident response** skill with dual audit
 - Without `OKTA_SESSION_KILL_INCIDENT_ID` set under `--apply`
+- Without `OKTA_SESSION_KILL_ALLOWED_ORG_URLS` explicitly binding the invocation to the intended Okta org
 
 ## Closed-loop verification
 
@@ -185,7 +192,7 @@ The drift-detection plumbing is tracked in #257. This skill only ensures the aud
 ## Tests
 
 - Dry-run emits a plan without any Okta HTTP call
-- Apply requires `OKTA_SESSION_KILL_INCIDENT_ID` + approver — fails closed if either is missing
+- Apply requires `OKTA_SESSION_KILL_INCIDENT_ID` + approver + org allow-list — fails closed if any are missing
 - Deny-list rejects admin / service-account / break-glass targets before any Okta API call
 - Source-skill mismatch (finding from a non-Okta detector) is skipped with `stderr` warning
 - Audit write precedes the Okta API call in the recorded order

--- a/skills/remediation/remediate-okta-session-kill/src/handler.py
+++ b/skills/remediation/remediate-okta-session-kill/src/handler.py
@@ -9,6 +9,7 @@ Guardrails enforced in code:
 - source-skill check rejects findings from any non-Okta producer
 - deny-list of protected principals (admin / service-account / break-glass)
 - --apply requires OKTA_SESSION_KILL_INCIDENT_ID + OKTA_SESSION_KILL_APPROVER
+- --apply requires OKTA_ORG_URL to be explicitly allow-listed for this run
 - dual-audit write (DynamoDB + S3) BEFORE and AFTER each Okta API call
 - Okta API token pulled from AWS Secrets Manager at invocation time
 
@@ -80,6 +81,7 @@ STATUS_SUCCESS = "success"
 STATUS_FAILURE = "failure"
 STATUS_SKIPPED_DENY_LIST = "skipped_deny_list"
 STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
+STATUS_SKIPPED_ORG_BOUNDARY = "skipped_org_boundary"
 
 
 # -- Data classes ------------------------------------------------------------
@@ -385,14 +387,41 @@ def is_protected(target: Target, deny_patterns: tuple[str, ...]) -> tuple[bool, 
     return False, None
 
 
+def _normalize_org_url(raw: str) -> str:
+    value = raw.strip().rstrip("/")
+    return value.lower()
+
+
+def load_allowed_org_urls() -> tuple[str, ...]:
+    raw = os.environ.get("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", "").strip()
+    if not raw:
+        return ()
+    return tuple(
+        normalized
+        for normalized in (_normalize_org_url(part) for part in raw.split(","))
+        if normalized
+    )
+
+
 def check_apply_gate() -> tuple[bool, str]:
     """Return (ok, reason). Both env vars must be set before any Okta write."""
     incident_id = os.environ.get("OKTA_SESSION_KILL_INCIDENT_ID", "").strip()
     approver = os.environ.get("OKTA_SESSION_KILL_APPROVER", "").strip()
+    org_url = _normalize_org_url(os.environ.get("OKTA_ORG_URL", ""))
+    allowed_org_urls = load_allowed_org_urls()
     if not incident_id:
         return False, "OKTA_SESSION_KILL_INCIDENT_ID must be set before --apply"
     if not approver:
         return False, "OKTA_SESSION_KILL_APPROVER must be set before --apply"
+    if not org_url:
+        return False, "OKTA_ORG_URL must be set before --apply"
+    if not allowed_org_urls:
+        return False, "OKTA_SESSION_KILL_ALLOWED_ORG_URLS must be set before --apply"
+    if org_url not in allowed_org_urls:
+        return (
+            False,
+            "OKTA_ORG_URL must be included in OKTA_SESSION_KILL_ALLOWED_ORG_URLS before --apply",
+        )
     return True, ""
 
 
@@ -574,10 +603,16 @@ def run(
     deny_patterns: tuple[str, ...] | None = None,
     incident_id: str = "",
     approver: str = "",
+    org_url: str = "",
+    allowed_org_urls: tuple[str, ...] | None = None,
     now_ms: int | None = None,
     reverify: bool = False,
 ) -> Iterator[dict[str, Any]]:
     deny_patterns = deny_patterns if deny_patterns is not None else load_deny_patterns()
+    normalized_org_url = _normalize_org_url(org_url)
+    resolved_allowed_org_urls = (
+        allowed_org_urls if allowed_org_urls is not None else load_allowed_org_urls()
+    )
     for target, skip_reason in parse_targets(events):
         if target is None:
             continue
@@ -628,6 +663,14 @@ def run(
         if okta_client is None or audit is None:
             raise RuntimeError(
                 "apply=True requires both okta_client and audit to be provided"
+            )
+        if not normalized_org_url:
+            raise RuntimeError("apply=True requires org_url to be provided")
+        if not resolved_allowed_org_urls:
+            raise RuntimeError("apply=True requires allowed_org_urls to be provided")
+        if normalized_org_url not in resolved_allowed_org_urls:
+            raise RuntimeError(
+                "OKTA_ORG_URL is outside OKTA_SESSION_KILL_ALLOWED_ORG_URLS; refusing apply"
             )
         results, audit_refs = apply_actions(
             target,
@@ -823,6 +866,8 @@ def main(argv: list[str] | None = None) -> int:
             audit=audit,
             incident_id=incident_id,
             approver=approver,
+            org_url=os.environ.get("OKTA_ORG_URL", ""),
+            allowed_org_urls=load_allowed_org_urls(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-okta-session-kill/tests/test_handler.py
+++ b/skills/remediation/remediate-okta-session-kill/tests/test_handler.py
@@ -296,6 +296,8 @@ class TestApplyGate:
     def test_missing_incident_id_fails_closed(self, monkeypatch):
         monkeypatch.delenv("OKTA_SESSION_KILL_INCIDENT_ID", raising=False)
         monkeypatch.setenv("OKTA_SESSION_KILL_APPROVER", "alice")
+        monkeypatch.setenv("OKTA_ORG_URL", "https://example.okta.com")
+        monkeypatch.setenv("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", "https://example.okta.com")
         ok, reason = check_apply_gate()
         assert ok is False
         assert "INCIDENT_ID" in reason
@@ -303,13 +305,35 @@ class TestApplyGate:
     def test_missing_approver_fails_closed(self, monkeypatch):
         monkeypatch.setenv("OKTA_SESSION_KILL_INCIDENT_ID", "inc-1")
         monkeypatch.delenv("OKTA_SESSION_KILL_APPROVER", raising=False)
+        monkeypatch.setenv("OKTA_ORG_URL", "https://example.okta.com")
+        monkeypatch.setenv("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", "https://example.okta.com")
         ok, reason = check_apply_gate()
         assert ok is False
         assert "APPROVER" in reason
 
+    def test_missing_allowed_org_urls_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("OKTA_SESSION_KILL_INCIDENT_ID", "inc-1")
+        monkeypatch.setenv("OKTA_SESSION_KILL_APPROVER", "alice@example.com")
+        monkeypatch.setenv("OKTA_ORG_URL", "https://example.okta.com")
+        monkeypatch.delenv("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", raising=False)
+        ok, reason = check_apply_gate()
+        assert ok is False
+        assert "ALLOWED_ORG_URLS" in reason
+
+    def test_org_url_outside_allow_list_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("OKTA_SESSION_KILL_INCIDENT_ID", "inc-1")
+        monkeypatch.setenv("OKTA_SESSION_KILL_APPROVER", "alice@example.com")
+        monkeypatch.setenv("OKTA_ORG_URL", "https://prod.okta.com")
+        monkeypatch.setenv("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", "https://sandbox.okta.com")
+        ok, reason = check_apply_gate()
+        assert ok is False
+        assert "ALLOWED_ORG_URLS" in reason
+
     def test_both_set_passes(self, monkeypatch):
         monkeypatch.setenv("OKTA_SESSION_KILL_INCIDENT_ID", "inc-1")
         monkeypatch.setenv("OKTA_SESSION_KILL_APPROVER", "alice@example.com")
+        monkeypatch.setenv("OKTA_ORG_URL", "https://example.okta.com")
+        monkeypatch.setenv("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", "https://example.okta.com")
         ok, reason = check_apply_gate()
         assert ok is True
         assert reason == ""
@@ -317,6 +341,8 @@ class TestApplyGate:
     def test_main_returns_2_when_apply_gate_blocks(self, monkeypatch, tmp_path, capsys):
         monkeypatch.delenv("OKTA_SESSION_KILL_INCIDENT_ID", raising=False)
         monkeypatch.delenv("OKTA_SESSION_KILL_APPROVER", raising=False)
+        monkeypatch.setenv("OKTA_ORG_URL", "https://example.okta.com")
+        monkeypatch.setenv("OKTA_SESSION_KILL_ALLOWED_ORG_URLS", "https://example.okta.com")
         finding_path = tmp_path / "f.jsonl"
         finding_path.write_text("{}\n")
         rc = main([str(finding_path), "--apply"])
@@ -431,6 +457,8 @@ class TestApplyEndToEnd:
                 audit=fake_audit,
                 incident_id="inc-2026-04-18-001",
                 approver="alice@example.com",
+                org_url="https://example.okta.com",
+                allowed_org_urls=("https://example.okta.com",),
                 now_ms=1776046500000,
             )
         )
@@ -465,6 +493,23 @@ class TestApplyEndToEnd:
                     audit=None,
                     incident_id="inc-1",
                     approver="alice",
+                    org_url="https://example.okta.com",
+                    allowed_org_urls=("https://example.okta.com",),
+                )
+            )
+
+    def test_apply_rejects_wrong_org_boundary(self):
+        with pytest.raises(RuntimeError, match="ALLOWED_ORG_URLS"):
+            list(
+                run(
+                    [_finding()],
+                    apply=True,
+                    okta_client=_FakeOkta(),
+                    audit=_FakeAudit(),
+                    incident_id="inc-1",
+                    approver="alice",
+                    org_url="https://prod.okta.com",
+                    allowed_org_urls=("https://sandbox.okta.com",),
                 )
             )
 
@@ -483,6 +528,8 @@ class TestApplyEndToEnd:
                 audit=fake_audit,
                 incident_id="inc-1",
                 approver="alice",
+                org_url="https://example.okta.com",
+                allowed_org_urls=("https://example.okta.com",),
             )
         )
         assert len(records) == 2

--- a/skills/remediation/remediate-workspace-session-kill/SKILL.md
+++ b/skills/remediation/remediate-workspace-session-kill/SKILL.md
@@ -11,7 +11,8 @@ description: >-
   dry-run by default, deny-listed against admin / service-account /
   break-glass / @google.com principals (extensible via
   WORKSPACE_SESSION_KILL_DENY_LIST_FILE), gated behind an incident ID plus
-  approver for --apply, and dual-audited (DynamoDB + KMS-encrypted S3).
+  approver plus an explicit allowed-domain boundary for --apply, and
+  dual-audited (DynamoDB + KMS-encrypted S3).
   Re-verify reads the Admin SDK Reports API for any login_success since
   remediation; emits VERIFIED if absent, DRIFT (+ paired OCSF Detection
   Finding via the shared remediation_verifier contract) if the attacker
@@ -101,6 +102,7 @@ JSONL records on stdout:
 | Source check | `ACCEPTED_PRODUCERS = {"detect-google-workspace-suspicious-login"}` |
 | Protected-principal deny-list | `@google.com`, `admin`, `administrator`, `service-account`, `svc-`, `break-glass`, `emergency`, `root` (substring match on `user_uid + " " + user_name`); extensible via `WORKSPACE_SESSION_KILL_DENY_LIST_FILE` JSON array |
 | Apply gate | `--apply` requires `WORKSPACE_SESSION_KILL_INCIDENT_ID` + `WORKSPACE_SESSION_KILL_APPROVER` env vars set out-of-band |
+| Tenant boundary | `--apply` requires `WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS`; target `user.uid` domain must be in the allow-list, and the delegated admin email must belong to one of those domains when provided |
 | Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER each Admin SDK call; failure paths still write the failure audit row |
 | Re-verify | Reads Admin SDK Reports API for any `login_success` since `remediated_at`; emits VERIFIED if 0, DRIFT (+ paired OCSF finding) if any, UNREACHABLE if API throws — never silently downgrades |
 
@@ -112,6 +114,7 @@ python skills/remediation/remediate-workspace-session-kill/src/handler.py findin
 
 # Apply (after out-of-band approval)
 export WORKSPACE_DELEGATED_ADMIN_EMAIL=admin@yourdomain.com
+export WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS=yourdomain.com
 export WORKSPACE_SA_KEY_JSON='{...}'  # JSON-encoded service-account key (fetch from secrets manager)
 export WORKSPACE_SESSION_KILL_INCIDENT_ID=INC-2026-04-19-004
 export WORKSPACE_SESSION_KILL_APPROVER=alice@security
@@ -133,7 +136,7 @@ python skills/remediation/remediate-workspace-session-kill/src/handler.py findin
 ## Do NOT use
 
 - For Okta, Entra, AWS IAM, or GCP IAM sessions — those have their own per-IdP remediation skills
-- To bypass the deny-list, run with `--apply` without an explicit human-approved incident window, or edit the audit trail by hand
+- To bypass the deny-list, run with `--apply` without an explicit human-approved incident window and allowed-domain boundary, or edit the audit trail by hand
 - For full HR-departure offboarding (delete user across all systems) — that is shaped by the IAM-departures workflow
 
 ## Non-goals

--- a/skills/remediation/remediate-workspace-session-kill/src/handler.py
+++ b/skills/remediation/remediate-workspace-session-kill/src/handler.py
@@ -33,6 +33,8 @@ Guardrails enforced in code:
   root, plus an extensible WORKSPACE_SESSION_KILL_DENY_LIST_FILE
 - --apply requires WORKSPACE_SESSION_KILL_INCIDENT_ID +
   WORKSPACE_SESSION_KILL_APPROVER
+- --apply requires explicit target-domain allow-listing via
+  WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS
 - dual audit BEFORE and AFTER each Admin SDK call
 - failure paths still write the failure audit row
 
@@ -104,6 +106,7 @@ STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
 STATUS_SKIPPED_DENY_LIST = "skipped_deny_list"
 STATUS_WOULD_VIOLATE_DENY_LIST = "would-violate-deny-list"
 STATUS_SKIPPED_NO_USER = "skipped_no_user_pointer"
+STATUS_SKIPPED_DOMAIN_BOUNDARY = "skipped_domain_boundary"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -378,13 +381,41 @@ def is_protected(target: Target, deny_patterns: tuple[str, ...]) -> tuple[bool, 
     return False, None
 
 
+def _email_domain(value: str) -> str:
+    candidate = value.strip().lower()
+    if "@" not in candidate:
+        return ""
+    return candidate.rsplit("@", 1)[1]
+
+
+def load_allowed_domains() -> tuple[str, ...]:
+    raw = os.getenv("WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS", "").strip()
+    if not raw:
+        return ()
+    return tuple(
+        domain
+        for domain in (part.strip().lower() for part in raw.split(","))
+        if domain
+    )
+
+
 def check_apply_gate() -> tuple[bool, str]:
     incident_id = os.getenv("WORKSPACE_SESSION_KILL_INCIDENT_ID", "").strip()
     approver = os.getenv("WORKSPACE_SESSION_KILL_APPROVER", "").strip()
+    delegated_admin = os.getenv("WORKSPACE_DELEGATED_ADMIN_EMAIL", "").strip()
+    delegated_admin_domain = _email_domain(delegated_admin)
+    allowed_domains = load_allowed_domains()
     if not incident_id:
         return False, "WORKSPACE_SESSION_KILL_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "WORKSPACE_SESSION_KILL_APPROVER is required for --apply"
+    if not allowed_domains:
+        return False, "WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS is required for --apply"
+    if delegated_admin and delegated_admin_domain not in allowed_domains:
+        return (
+            False,
+            "WORKSPACE_DELEGATED_ADMIN_EMAIL must belong to WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS",
+        )
     return True, ""
 
 
@@ -596,9 +627,13 @@ def run(
     deny_patterns: tuple[str, ...] | None = None,
     incident_id: str = "",
     approver: str = "",
+    allowed_domains: tuple[str, ...] | None = None,
     now_ms: int | None = None,
 ) -> Iterator[dict[str, Any]]:
     deny_patterns = deny_patterns if deny_patterns is not None else load_deny_patterns()
+    resolved_allowed_domains = (
+        allowed_domains if allowed_domains is not None else load_allowed_domains()
+    )
     for target, event in parse_targets(events):
         if target is None:
             continue
@@ -650,6 +685,19 @@ def run(
 
         if workspace_client is None or audit is None:
             raise RuntimeError("apply=True requires both workspace_client and audit to be provided")
+        if not resolved_allowed_domains:
+            raise RuntimeError("apply=True requires allowed_domains to be provided")
+        user_domain = _email_domain(target.user_uid)
+        if not user_domain or user_domain not in resolved_allowed_domains:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_DOMAIN_BOUNDARY,
+                detail=(
+                    "target user domain is outside WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS"
+                ),
+                dry_run=False,
+            )
+            continue
         yield apply_actions(
             target, workspace_client=workspace_client, audit=audit,
             incident_id=incident_id, approver=approver,
@@ -711,7 +759,10 @@ def main(argv: list[str] | None = None) -> int:
             load_jsonl(in_stream),
             workspace_client=workspace_client,
             apply=args.apply, reverify=args.reverify,
-            audit=audit, incident_id=incident_id, approver=approver,
+            audit=audit,
+            incident_id=incident_id,
+            approver=approver,
+            allowed_domains=load_allowed_domains(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-workspace-session-kill/tests/test_handler.py
+++ b/skills/remediation/remediate-workspace-session-kill/tests/test_handler.py
@@ -16,6 +16,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_IN_PROGRESS,
     STATUS_PLANNED,
     STATUS_SKIPPED_DENY_LIST,
+    STATUS_SKIPPED_DOMAIN_BOUNDARY,
     STATUS_SKIPPED_NO_USER,
     STATUS_SUCCESS,
     STATUS_WOULD_VIOLATE_DENY_LIST,
@@ -116,6 +117,7 @@ def test_default_deny_patterns_cover_protected_principal_classes():
 def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.delenv("WORKSPACE_SESSION_KILL_INCIDENT_ID", raising=False)
     monkeypatch.delenv("WORKSPACE_SESSION_KILL_APPROVER", raising=False)
+    monkeypatch.setenv("WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS", "example.com")
     ok, reason = check_apply_gate()
     assert ok is False and "INCIDENT_ID" in reason
     monkeypatch.setenv("WORKSPACE_SESSION_KILL_INCIDENT_ID", "INC-1")
@@ -124,6 +126,25 @@ def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.setenv("WORKSPACE_SESSION_KILL_APPROVER", "alice")
     ok, _ = check_apply_gate()
     assert ok is True
+
+
+def test_check_apply_gate_requires_allowed_domains(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_SESSION_KILL_INCIDENT_ID", "INC-1")
+    monkeypatch.setenv("WORKSPACE_SESSION_KILL_APPROVER", "alice")
+    monkeypatch.delenv("WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS", raising=False)
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "ALLOWED_DOMAINS" in reason
+
+
+def test_check_apply_gate_rejects_admin_email_outside_allowed_domains(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_SESSION_KILL_INCIDENT_ID", "INC-1")
+    monkeypatch.setenv("WORKSPACE_SESSION_KILL_APPROVER", "alice")
+    monkeypatch.setenv("WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS", "example.com")
+    monkeypatch.setenv("WORKSPACE_DELEGATED_ADMIN_EMAIL", "admin@other.com")
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "DELEGATED_ADMIN_EMAIL" in reason
 
 
 # ---------- deny-list ----------
@@ -228,6 +249,7 @@ def test_run_skips_protected_principal_apply():
             [_finding(user_name="break-glass-oncall@example.com")],
             workspace_client=ws, apply=True, audit=audit,
             incident_id="INC-1", approver="alice",
+            allowed_domains=("example.com",),
         )
     )
     assert records[0]["status"] == STATUS_SKIPPED_DENY_LIST
@@ -243,7 +265,8 @@ def test_run_apply_runs_both_steps_with_dual_audit():
     ws = _FakeWorkspace()
     records = list(
         run([_finding()], workspace_client=ws, apply=True, audit=audit,
-            incident_id="INC-1", approver="alice@security")
+            incident_id="INC-1", approver="alice@security",
+            allowed_domains=("example.com",))
     )
     rec = records[0]
     assert rec["status"] == STATUS_SUCCESS
@@ -272,7 +295,8 @@ def test_run_apply_marks_failure_when_step_throws():
     ws = _FakeWorkspace(fail_on="sign_out")
     records = list(
         run([_finding()], workspace_client=ws, apply=True, audit=audit,
-            incident_id="INC-1", approver="alice")
+            incident_id="INC-1", approver="alice",
+            allowed_domains=("example.com",))
     )
     rec = records[0]
     assert rec["status"] == STATUS_FAILURE
@@ -286,9 +310,44 @@ def test_run_apply_marks_failure_when_step_throws():
 def test_run_apply_requires_both_clients():
     import pytest
     with pytest.raises(RuntimeError, match="apply=True requires"):
-        list(run([_finding()], workspace_client=_FakeWorkspace(), apply=True, audit=None))
+        list(
+            run(
+                [_finding()],
+                workspace_client=_FakeWorkspace(),
+                apply=True,
+                audit=None,
+                allowed_domains=("example.com",),
+            )
+        )
     with pytest.raises(RuntimeError, match="apply=True requires"):
-        list(run([_finding()], workspace_client=None, apply=True, audit=_FakeAudit()))
+        list(
+            run(
+                [_finding()],
+                workspace_client=None,
+                apply=True,
+                audit=_FakeAudit(),
+                allowed_domains=("example.com",),
+            )
+        )
+
+
+def test_run_apply_skips_wrong_domain_boundary():
+    audit = _FakeAudit()
+    ws = _FakeWorkspace()
+    records = list(
+        run(
+            [_finding(user_uid="alice@other.com")],
+            workspace_client=ws,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice",
+            allowed_domains=("example.com",),
+        )
+    )
+    assert records[0]["status"] == STATUS_SKIPPED_DOMAIN_BOUNDARY
+    assert ws.calls == []
+    assert audit.writes == []
 
 
 # ---------- run: re-verify ----------


### PR DESCRIPTION
What changed

- hardened `remediate-okta-session-kill` so `--apply` now requires `OKTA_ORG_URL` to be explicitly included in `OKTA_SESSION_KILL_ALLOWED_ORG_URLS`
- hardened `remediate-workspace-session-kill` so `--apply` now requires `WORKSPACE_SESSION_KILL_ALLOWED_DOMAINS`, and target users outside that allow-list are skipped without any Admin SDK call
- updated both skills' tests and SKILL docs so the new identity-boundary contract is explicit and enforced in CI

Why

The incident/HITL gates were already there, but the IdP write paths still trusted ambient tenant context too much. That leaves too much room for accidental cross-org or cross-domain action if the wrong credentials are loaded. This PR adds the same explicit target-boundary binding we already added to the cloud remediation skills.

Impact

- Okta apply runs are now pinned to one explicitly approved org URL per invocation
- Workspace apply runs are now pinned to explicitly approved domains, including the delegated admin identity when present
- dry-run and reverify behavior stay unchanged

Validation

- `pytest skills/remediation/remediate-okta-session-kill/tests/test_handler.py -q`
- `pytest skills/remediation/remediate-workspace-session-kill/tests/test_handler.py -q`
- `ruff check skills/remediation/remediate-okta-session-kill/src/handler.py skills/remediation/remediate-okta-session-kill/tests/test_handler.py skills/remediation/remediate-workspace-session-kill/src/handler.py skills/remediation/remediate-workspace-session-kill/tests/test_handler.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_safe_skill_bar.py`
- `python scripts/validate_skill_integrity.py`
