### PR TITLE
Add CloudTrail disable detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 ![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 62 shipped skill bundles. OCSF 1.8 on the wire. 86 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
-=======
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 61 shipped skill bundles. OCSF 1.8 on the wire. 86 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
->>>>>>> origin/main
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -26,13 +22,8 @@
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-<<<<<<< HEAD
 | **Detect** | 15 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 86 posture and benchmark checks | compliance result |
-=======
-| **Detect** | 14 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
-| **Evaluate** | 7 | 86 posture and benchmark checks | compliance result |
->>>>>>> origin/main
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 61 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 62 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**61 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**62 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 14 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 15 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 61 shipped skills.**
+**Total: 62 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -54,6 +54,7 @@ is the row you can take to your auditor.
 | `iam-departures-reconciler` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `detect-aws-open-security-group` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-open-nsg` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-cloudtrail-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-container-escape-k8s` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-credential-stuffing-okta` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-entra-credential-addition` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -91,7 +92,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_61 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_62 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 14 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 15 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,16 +4,16 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **61**
+- Total shipped skills in registry: **62**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **40** | — |
-| MITRE ATT&CK | v14 | **38** | 100% mapped coverage |
+| OCSF | 1.8.0 | **41** | — |
+| MITRE ATT&CK | v14 | **39** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
-| CIS AWS Foundations | v3.0 | **3** | — |
+| CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **4** | — |
 | CIS Azure Foundations | v2.1 | **5** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
@@ -36,12 +36,13 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **40**
+Shipped skills mapped: **41**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
+| [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled) | detection | aws | cloudtrail, audit-trails, logging |
 | [`detect-container-escape-k8s`](../skills/detection/detect-container-escape-k8s) | detection | kubernetes | clusters, containers, runtime |
 | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta) | detection | okta | identities, authentication, sessions |
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
@@ -88,12 +89,13 @@ Shipped skills mapped: **40**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **38**
+Shipped skills mapped: **39**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
+| [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled) | detection | aws | cloudtrail, audit-trails, logging |
 | [`detect-container-escape-k8s`](../skills/detection/detect-container-escape-k8s) | detection | kubernetes | clusters, containers, runtime |
 | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta) | detection | okta | identities, authentication, sessions |
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
@@ -155,11 +157,12 @@ Shipped skills mapped: **8**
 
 - Registry id: `cis-aws-v3`
 
-Shipped skills mapped: **3**
+Shipped skills mapped: **4**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
+| [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled) | detection | aws | cloudtrail, audit-trails, logging |
 | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark) | evaluation | aws | identities, storage, logging, network |
 | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke) | remediation | aws | security-groups, ingress-rules, audit |
 

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -746,6 +746,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-cloudtrail-disabled",
+      "layer": "detection",
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "cloudtrail",
+        "audit-trails",
+        "logging"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "ocsf-1.8",
+        "cis-aws-v3"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-azure-open-nsg",
       "layer": "detection",
       "providers": [

--- a/skills/detection/detect-cloudtrail-disabled/REFERENCES.md
+++ b/skills/detection/detect-cloudtrail-disabled/REFERENCES.md
@@ -1,0 +1,10 @@
+# References — detect-cloudtrail-disabled
+
+- AWS CloudTrail API Reference — `StopLogging`:
+  https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_StopLogging.html
+- AWS CloudTrail API Reference — `DeleteTrail`:
+  https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_DeleteTrail.html
+- MITRE ATT&CK T1562.001 — Disable or Modify Tools:
+  https://attack.mitre.org/techniques/T1562/001/
+- Upstream ingester:
+  [`../../ingestion/ingest-cloudtrail-ocsf/`](../../ingestion/ingest-cloudtrail-ocsf/)

--- a/skills/detection/detect-cloudtrail-disabled/SKILL.md
+++ b/skills/detection/detect-cloudtrail-disabled/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: detect-cloudtrail-disabled
+description: >-
+  Detect successful AWS CloudTrail `StopLogging` and `DeleteTrail` API calls
+  from OCSF 1.8 API Activity records emitted by ingest-cloudtrail-ocsf. Emits
+  an OCSF 1.8 Detection Finding (class 2004) tagged with MITRE ATT&CK
+  T1562.001 (Disable or Modify Tools) when a trail is explicitly stopped or
+  deleted. Use when the user mentions "CloudTrail disabled," "trail
+  deletion," "defense evasion in AWS logging," or "T1562.001 CloudTrail."
+  Do NOT use as a posture-at-rest check (use the CSPM AWS CIS skill), for GCP
+  or Azure audit logging changes, or to infer every possible logging
+  impairment path. This first slice only covers successful `StopLogging` and
+  `DeleteTrail` events.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No AWS
+  SDK; pairs with ingest-cloudtrail-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-cloudtrail-disabled
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - CIS AWS Foundations
+  cloud: aws
+  capability: read-only
+---
+
+# detect-cloudtrail-disabled
+
+Streaming detector for successful CloudTrail disable/delete operations in AWS. This is the first concrete slice under issue `#253`: it keeps the rule narrow and high-confidence instead of over-claiming every possible logging impairment path.
+
+## Use when
+
+- You stream CloudTrail through `ingest-cloudtrail-ocsf` and want near-real-time defense-evasion findings
+- You want to catch explicit trail shutdown or deletion events the moment they happen
+- You are closing ATT&CK T1562.001 coverage with a read-only detector
+
+## Do NOT use
+
+- As a posture-at-rest logging check; use [`cspm-aws-cis-benchmark`](../../evaluation/cspm-aws-cis-benchmark/)
+- For GCP or Azure audit-log disablement; those are separate detectors
+- To infer missing trails, missing data events, or KMS drift; those belong in CSPM and follow-on detectors
+
+## Rule
+
+A finding fires on every successful CloudTrail event from `ingest-cloudtrail-ocsf` where:
+
+1. `api.operation` is `StopLogging` or `DeleteTrail`
+2. `status_id == 1`
+3. request parameters resolve a trail name or trail ARN
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0005` (Defense Evasion)
+- `finding_info.attacks[].technique_uid = T1562.001` (Disable or Modify Tools)
+- `observables[]` including `target.name`, `trail.arn` when present, `account.uid`, `region`, `actor.name`, and `api.operation`
+
+The native projection (`--output-format native`) keeps the trail identity and actor/account context in a flatter shape.
+
+## Run
+
+```bash
+# CloudTrail -> ingest -> detect (default OCSF output)
+python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-cloudtrail-disabled/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-cloudtrail-disabled/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-cloudtrail-ocsf`](../../ingestion/ingest-cloudtrail-ocsf/) — upstream ingester
+- [`cspm-aws-cis-benchmark`](../../evaluation/cspm-aws-cis-benchmark/) — posture-at-rest logging coverage
+- [`detect-aws-open-security-group`](../detect-aws-open-security-group/) — sibling AWS CloudTrail detector

--- a/skills/detection/detect-cloudtrail-disabled/src/detect.py
+++ b/skills/detection/detect-cloudtrail-disabled/src/detect.py
@@ -1,0 +1,332 @@
+"""Detect CloudTrail logging being disabled or deleted in AWS.
+
+Reads OCSF 1.8 API Activity (class 6003) records emitted by
+`ingest-cloudtrail-ocsf` from stdin or a file. Fires on successful
+`StopLogging` and `DeleteTrail` calls and emits an OCSF 1.8 Detection
+Finding (class 2004) tagged with MITRE ATT&CK T1562.001 (Impair Defenses).
+
+Rule:
+1. event.api.operation in {"StopLogging", "DeleteTrail"}
+2. event.status_id == 1 (success)
+3. requestParameters resolves a trail name or ARN
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-cloudtrail-disabled"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0005"
+TACTIC_NAME = "Defense Evasion"
+TECHNIQUE_UID = "T1562.001"
+TECHNIQUE_NAME = "Disable or Modify Tools"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-cloudtrail-ocsf"})
+DISABLING_OPERATIONS = frozenset({"StopLogging", "DeleteTrail"})
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _request_parameters(event: dict[str, Any]) -> dict[str, Any]:
+    unmapped = event.get("unmapped") or {}
+    cloudtrail = unmapped.get("cloudtrail") if isinstance(unmapped, dict) else None
+    if isinstance(cloudtrail, dict):
+        params = cloudtrail.get("request_parameters") or cloudtrail.get("requestParameters")
+        if isinstance(params, dict):
+            return params
+    api = event.get("api") or {}
+    request = api.get("request") or {}
+    data = request.get("data") if isinstance(request, dict) else None
+    if isinstance(data, dict):
+        params = data.get("requestParameters") or data
+        if isinstance(params, dict):
+            return params
+    return {}
+
+
+def _trail_identifier(event: dict[str, Any], params: dict[str, Any]) -> tuple[str, str]:
+    trail_name = str(
+        params.get("name")
+        or params.get("trailName")
+        or params.get("trail")
+        or ""
+    )
+    trail_arn = str(params.get("trailARN") or params.get("trailArn") or "")
+    if trail_name or trail_arn:
+        return trail_name, trail_arn
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        resource_type = str(resource.get("type") or "")
+        resource_name = str(resource.get("name") or "")
+        if resource_type.lower() in {"name", "trailname", "trail"} and resource_name:
+            trail_name = trail_name or resource_name
+        if resource_type.lower() in {"trailarn", "arn"} and resource_name:
+            trail_arn = trail_arn or resource_name
+    return trail_name, trail_arn
+
+
+def _actor(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _finding_uid(event_uid: str, operation: str, trail_identity: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{operation}|{trail_identity}|{time_ms}"
+    return f"ctd-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(
+    *,
+    event: dict[str, Any],
+    operation: str,
+    trail_name: str,
+    trail_arn: str,
+) -> dict[str, Any]:
+    time_ms = int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+    event_uid = str((event.get("metadata") or {}).get("uid") or "")
+    trail_identity = trail_arn or trail_name
+    finding_uid = _finding_uid(event_uid, operation, trail_identity, time_ms)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "cloudtrail-disabled",
+        "api_operation": operation,
+        "trail_name": trail_name,
+        "trail_arn": trail_arn,
+        "actor_name": _actor(event),
+        "account_uid": _account(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    trail_label = native["trail_name"] or native["trail_arn"] or "<unknown>"
+    description = (
+        f"Actor `{native['actor_name'] or 'unknown'}` successfully called "
+        f"`{native['api_operation']}` against CloudTrail `{trail_label}` in account "
+        f"`{native['account_uid']}` ({native['region']}). Source IP: "
+        f"{native['src_ip'] or '<unknown>'}."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "AWS"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": native["api_operation"]},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.type", "type": "Other", "value": "CloudTrailTrail"},
+        {"name": "account.uid", "type": "Other", "value": native["account_uid"]},
+        {"name": "region", "type": "Other", "value": native["region"]},
+    ]
+    if native["trail_name"]:
+        observables.append({"name": "target.name", "type": "Other", "value": native["trail_name"]})
+        observables.append({"name": "target.uid", "type": "Other", "value": native["trail_name"]})
+    if native["trail_arn"]:
+        observables.append({"name": "trail.arn", "type": "Other", "value": native["trail_arn"]})
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["aws", "cloudtrail", "defense-evasion"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": f"CloudTrail disabled via {native['api_operation']}",
+            "desc": description,
+            "types": ["cloudtrail-disabled"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "trail_name": native["trail_name"],
+            "trail_arn": native["trail_arn"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-cloudtrail producer `{producer}`",
+            )
+            continue
+        operation = _api_operation(event)
+        if operation not in DISABLING_OPERATIONS:
+            continue
+        if not _is_success(event):
+            continue
+
+        params = _request_parameters(event)
+        trail_name, trail_arn = _trail_identifier(event, params)
+        if not trail_name and not trail_arn:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_trail_pointer",
+                message=f"{operation} event missing trail identifier; skipping",
+            )
+            continue
+
+        native = _build_native_finding(
+            event=event,
+            operation=operation,
+            trail_name=trail_name,
+            trail_arn=trail_arn,
+        )
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect successful StopLogging and DeleteTrail operations in AWS CloudTrail."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(OUTPUT_FORMATS),
+        default="ocsf",
+        help="Emit OCSF Detection Finding (default) or native projection.",
+    )
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    try:
+        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+            out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-cloudtrail-disabled/tests/test_detect.py
+++ b/skills/detection/detect-cloudtrail-disabled/tests/test_detect.py
@@ -1,0 +1,121 @@
+"""Tests for detect-cloudtrail-disabled."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from detect import (  # type: ignore[import-not-found]
+    ACCEPTED_PRODUCERS,
+    DISABLING_OPERATIONS,
+    TECHNIQUE_UID,
+    detect,
+)
+
+
+def _ct_event(
+    *,
+    operation: str = "StopLogging",
+    success: bool = True,
+    trail_name: str = "org-trail",
+    trail_arn: str = "",
+    actor: str = "alice",
+    account_uid: str = "111122223333",
+    region: str = "us-east-1",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-cloudtrail-ocsf",
+) -> dict:
+    params: dict[str, str] = {}
+    if trail_name:
+        params["name"] = trail_name
+    if trail_arn:
+        params["trailARN"] = trail_arn
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1700000000000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "actor": {"user": {"name": actor}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation},
+        "cloud": {"provider": "AWS", "account": {"uid": account_uid}, "region": region},
+        "unmapped": {"cloudtrail": {"request_parameters": params}},
+        "resources": [{"name": trail_name, "type": "name"}] if trail_name else [],
+    }
+
+
+def test_accepted_producer_is_cloudtrail():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-cloudtrail-ocsf"})
+
+
+def test_disabling_operations_are_stop_and_delete():
+    assert DISABLING_OPERATIONS == frozenset({"StopLogging", "DeleteTrail"})
+
+
+def test_fires_on_stop_logging():
+    findings = list(detect([_ct_event(operation="StopLogging")]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    assert finding["finding_info"]["attacks"][0]["technique_uid"] == TECHNIQUE_UID
+    assert finding["finding_info"]["title"] == "CloudTrail disabled via StopLogging"
+    assert any(obs["name"] == "target.name" and obs["value"] == "org-trail" for obs in finding["observables"])
+
+
+def test_fires_on_delete_trail():
+    findings = list(detect([_ct_event(operation="DeleteTrail")]))
+    assert len(findings) == 1
+    assert any(obs["name"] == "api.operation" and obs["value"] == "DeleteTrail" for obs in findings[0]["observables"])
+
+
+def test_native_output_contains_trail_identity():
+    findings = list(
+        detect(
+            [_ct_event(operation="StopLogging", trail_name="org-trail", trail_arn="arn:aws:cloudtrail:us-east-1:111122223333:trail/org-trail")],
+            output_format="native",
+        )
+    )
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["trail_name"] == "org-trail"
+    assert finding["trail_arn"].endswith(":trail/org-trail")
+
+
+def test_skips_failed_event():
+    assert list(detect([_ct_event(success=False)])) == []
+
+
+def test_skips_unrelated_operation():
+    assert list(detect([_ct_event(operation="DescribeTrails")])) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_ct_event(producer="ingest-okta-system-log-ocsf")]))
+    assert findings == []
+    assert "non-cloudtrail producer" in capsys.readouterr().err
+
+
+def test_skips_missing_trail_identifier(capsys):
+    findings = list(detect([_ct_event(trail_name="", trail_arn="")]))
+    assert findings == []
+    assert "missing trail identifier" in capsys.readouterr().err
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_ct_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    event = _ct_event()
+    first = list(detect([event]))[0]["finding_info"]["uid"]
+    second = list(detect([event]))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("ctd-")


### PR DESCRIPTION
What changed

- added a new read-only detection skill, `detect-cloudtrail-disabled`, for successful AWS CloudTrail `StopLogging` and `DeleteTrail` events from `ingest-cloudtrail-ocsf`
- added unit tests for positive hits, negative cases, output formats, deterministic finding ids, and malformed/missing trail context
- updated `docs/framework-coverage.json`, regenerated `docs/FRAMEWORK_COVERAGE.md`, and refreshed repo counts in `README.md` and `docs/ARCHITECTURE.md`

Why

Issue #253 is an umbrella, and the fastest honest first slice is a narrow P0 defense-evasion detector built on a shipped ingester. This PR adds one concrete ATT&CK-aligned detector instead of broadening coverage claims without shipped code.

Scope

This first slice intentionally covers only:
- successful `StopLogging`
- successful `DeleteTrail`

It does not claim every CloudTrail impairment path yet. Multi-region drift, KMS drift, and other logging-control changes remain separate follow-on work.

Validation

- `pytest skills/detection/detect-cloudtrail-disabled/tests/test_detect.py -q`
- `ruff check skills/detection/detect-cloudtrail-disabled/src/detect.py skills/detection/detect-cloudtrail-disabled/tests/test_detect.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/generate_framework_coverage_doc.py --check`

Part of #253
