### PR TITLE
Expand AWS CIS coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 61 shipped skill bundles. OCSF 1.8 on the wire. 82 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 61 shipped skill bundles. OCSF 1.8 on the wire. 86 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -23,7 +23,7 @@
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
 | **Detect** | 14 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
-| **Evaluate** | 7 | 82 posture and benchmark checks | compliance result |
+| **Evaluate** | 7 | 86 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |

--- a/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-aws-cis-benchmark/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: cspm-aws-cis-benchmark
 description: >-
-  Assess AWS accounts against CIS AWS Foundations Benchmark v3.0. Runs 18 automated
-  read-only checks across IAM, Storage, Logging, and Networking. Produces per-control
+  Assess AWS accounts against CIS AWS Foundations Benchmark v3.0. Runs 22 automated
+  read-only checks across IAM, Storage, Logging, Networking, and security services. Produces per-control
   pass/fail results with remediation commands. Optional `--auto-remediate` support
   adds dry-run-first plans for a narrow AWS-first control set (S3 encryption, S3 public
   access block, S3 versioning, unrestricted SSH/RDP SG rules), with `--apply` gated by
@@ -46,7 +46,7 @@ metadata:
 # CSPM — AWS CIS Foundations Benchmark v3.0
 
 Automated assessment of AWS accounts against the CIS AWS Foundations Benchmark v3.0.
-18 checks across 4 domains, each mapped to NIST CSF 2.0, ISO 27001:2022, and SOC 2.
+22 checks across 5 domains, each mapped to NIST CSF 2.0, ISO 27001:2022, and SOC 2.
 
 ## Use when
 
@@ -71,16 +71,18 @@ flowchart TD
     subgraph AWS["AWS Account"]
         IAM["IAM<br/>7 checks"]
         S3["S3 Storage<br/>4 checks"]
-        CT["CloudTrail<br/>4 checks"]
+        CT["CloudTrail<br/>6 checks"]
         VPC["VPC/Network<br/>3 checks"]
+        SEC["Security Services<br/>2 checks"]
     end
 
-    CHK["checks.py<br/>18 CIS v3.0 controls<br/>dry-run auto-remediate for supported failures"]
+    CHK["checks.py<br/>22 CIS v3.0 controls<br/>dry-run auto-remediate for supported failures"]
 
     IAM --> CHK
     S3 --> CHK
     CT --> CHK
     VPC --> CHK
+    SEC --> CHK
 
     CHK --> JSON["JSON<br/>findings or findings+plans"]
     CHK --> CON["Console<br/>pass/fail + remediation plan"]
@@ -106,7 +108,7 @@ flowchart TD
 
 ## Controls — CIS AWS Foundations v3.0 (key controls)
 
-> The full CIS AWS Foundations Benchmark v3.0 has 60+ controls. This skill automates the 18 most impactful checks — the ones most frequently flagged in audits and with the highest blast radius if misconfigured.
+> The full CIS AWS Foundations Benchmark v3.0 has 60+ controls. This skill automates 22 high-signal checks — the ones most frequently flagged in audits and with the highest blast radius if misconfigured.
 
 ### Section 1 — IAM (7 checks)
 
@@ -129,7 +131,7 @@ flowchart TD
 | 2.3 | S3 public access blocked | CRITICAL | PR.AC-3 | A.8.3 |
 | 2.4 | S3 versioning enabled | MEDIUM | PR.DS-1 | A.8.13 |
 
-### Section 3 — Logging (4 checks)
+### Section 3 — Logging (6 checks)
 
 | # | CIS Control | Severity | NIST CSF 2.0 | ISO 27001 |
 |---|------------|----------|--------------|-----------|
@@ -137,6 +139,8 @@ flowchart TD
 | 3.2 | CloudTrail log validation | HIGH | PR.DS-6 | A.8.15 |
 | 3.3 | CloudTrail S3 not public | CRITICAL | PR.AC-3 | A.8.3 |
 | 3.4 | CloudWatch alarms configured | MEDIUM | DE.CM-1 | A.8.16 |
+| 3.5 | CloudTrail KMS encryption | MEDIUM | PR.DS-1 | A.8.24 |
+| 3.6 | CloudTrail data events | MEDIUM | DE.CM-1 | A.8.15 |
 
 ### Section 4 — Networking (3 checks)
 
@@ -145,6 +149,13 @@ flowchart TD
 | 4.1 | No unrestricted SSH (0.0.0.0/0:22) | HIGH | PR.AC-5 | A.8.20 |
 | 4.2 | No unrestricted RDP (0.0.0.0/0:3389) | HIGH | PR.AC-5 | A.8.20 |
 | 4.3 | VPC flow logs enabled | MEDIUM | DE.CM-1 | A.8.16 |
+
+### Section 6 — Security Services (2 checks)
+
+| # | CIS Control | Severity | NIST CSF 2.0 | ISO 27001 |
+|---|------------|----------|--------------|-----------|
+| 6.1 | GuardDuty enabled | MEDIUM | DE.CM-1 | A.8.16 |
+| 6.2 | Security Hub enabled | MEDIUM | DE.CM-1 | A.8.16 |
 
 ## Usage
 
@@ -157,6 +168,7 @@ python src/checks.py --section iam
 python src/checks.py --section storage
 python src/checks.py --section logging
 python src/checks.py --section networking
+python src/checks.py --section security-services
 
 # Output JSON for SIEM/warehouse ingestion
 python src/checks.py --output json --output-format ocsf > cis-aws-results.json

--- a/skills/evaluation/cspm-aws-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-aws-cis-benchmark/src/checks.py
@@ -1,7 +1,7 @@
 """
 CIS AWS Foundations Benchmark v3.0 — Automated Assessment
 
-18 checks across IAM, Storage, Logging, and Networking.
+22 checks across IAM, Storage, Logging, Networking, and Security Services.
 Read-only: requires SecurityAudit managed policy.
 
 Frameworks:
@@ -823,6 +823,110 @@ def check_3_4_cloudwatch_alarms(cw) -> Finding:
         )
 
 
+def check_3_5_cloudtrail_kms_encryption(ct) -> Finding:
+    """CIS 3.5 — CloudTrail trails encrypted with KMS."""
+    try:
+        trails = ct.describe_trails()["trailList"]
+        if not trails:
+            return Finding(
+                control_id="3.5",
+                title="CloudTrail KMS encryption",
+                section="logging",
+                severity="MEDIUM",
+                status="FAIL",
+                detail="No CloudTrail trails found",
+                nist_csf="PR.DS-1",
+                iso_27001="A.8.24",
+            )
+        no_kms = [t["Name"] for t in trails if not t.get("KmsKeyId")]
+        return Finding(
+            control_id="3.5",
+            title="CloudTrail KMS encryption",
+            section="logging",
+            severity="MEDIUM",
+            status="FAIL" if no_kms else "PASS",
+            detail=f"{len(no_kms)} trails without KMS encryption"
+            if no_kms
+            else "All trails use KMS encryption",
+            nist_csf="PR.DS-1",
+            iso_27001="A.8.24",
+            resources=no_kms,
+        )
+    except ClientError as e:
+        return Finding(
+            control_id="3.5",
+            title="CloudTrail KMS encryption",
+            section="logging",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-1",
+            iso_27001="A.8.24",
+        )
+
+
+def _trail_has_data_events(selectors: dict[str, Any]) -> bool:
+    for selector in selectors.get("EventSelectors", []) or []:
+        if selector.get("DataResources"):
+            return True
+    for selector in selectors.get("AdvancedEventSelectors", []) or []:
+        field_selectors = selector.get("FieldSelectors", []) or []
+        for field_selector in field_selectors:
+            if field_selector.get("Field") != "eventCategory":
+                continue
+            values = field_selector.get("Equals") or []
+            if any(str(value) == "Data" for value in values):
+                return True
+    return False
+
+
+def check_3_6_cloudtrail_data_events(ct) -> Finding:
+    """CIS 3.6 — CloudTrail data events enabled."""
+    try:
+        trails = ct.describe_trails()["trailList"]
+        if not trails:
+            return Finding(
+                control_id="3.6",
+                title="CloudTrail data events",
+                section="logging",
+                severity="MEDIUM",
+                status="FAIL",
+                detail="No CloudTrail trails found",
+                nist_csf="DE.CM-1",
+                iso_27001="A.8.15",
+            )
+        missing = []
+        for trail in trails:
+            trail_name = str(trail.get("Name") or "")
+            selectors = ct.get_event_selectors(TrailName=trail_name)
+            if not _trail_has_data_events(selectors):
+                missing.append(trail_name)
+        return Finding(
+            control_id="3.6",
+            title="CloudTrail data events",
+            section="logging",
+            severity="MEDIUM",
+            status="FAIL" if missing else "PASS",
+            detail=f"{len(missing)} trails without data events"
+            if missing
+            else "All trails record data events",
+            nist_csf="DE.CM-1",
+            iso_27001="A.8.15",
+            resources=missing,
+        )
+    except ClientError as e:
+        return Finding(
+            control_id="3.6",
+            title="CloudTrail data events",
+            section="logging",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.CM-1",
+            iso_27001="A.8.15",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Section 4 — Networking
 # ---------------------------------------------------------------------------
@@ -905,6 +1009,82 @@ def check_4_3_vpc_flow_logs(ec2) -> Finding:
             control_id="4.3",
             title="VPC flow logs enabled",
             section="networking",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.CM-1",
+            iso_27001="A.8.16",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Security Services
+# ---------------------------------------------------------------------------
+
+
+def check_6_1_guardduty_enabled(gd) -> Finding:
+    """CIS 6.1 — GuardDuty enabled."""
+    try:
+        detectors = gd.list_detectors().get("DetectorIds", [])
+        return Finding(
+            control_id="6.1",
+            title="GuardDuty enabled",
+            section="security-services",
+            severity="MEDIUM",
+            status="PASS" if detectors else "FAIL",
+            detail=f"{len(detectors)} GuardDuty detector(s) enabled"
+            if detectors
+            else "GuardDuty is not enabled",
+            nist_csf="DE.CM-1",
+            iso_27001="A.8.16",
+            resources=list(detectors),
+        )
+    except ClientError as e:
+        return Finding(
+            control_id="6.1",
+            title="GuardDuty enabled",
+            section="security-services",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.CM-1",
+            iso_27001="A.8.16",
+        )
+
+
+def check_6_2_securityhub_enabled(sh) -> Finding:
+    """CIS 6.2 — Security Hub enabled."""
+    try:
+        hub = sh.describe_hub()
+        hub_arn = str(hub.get("HubArn") or "")
+        return Finding(
+            control_id="6.2",
+            title="Security Hub enabled",
+            section="security-services",
+            severity="MEDIUM",
+            status="PASS" if hub_arn else "FAIL",
+            detail="Security Hub is enabled" if hub_arn else "Security Hub is not enabled",
+            nist_csf="DE.CM-1",
+            iso_27001="A.8.16",
+            resources=[hub_arn] if hub_arn else [],
+        )
+    except ClientError as e:
+        code = str(e.response.get("Error", {}).get("Code") or "")
+        if code in {"InvalidAccessException", "ResourceNotFoundException"}:
+            return Finding(
+                control_id="6.2",
+                title="Security Hub enabled",
+                section="security-services",
+                severity="MEDIUM",
+                status="FAIL",
+                detail="Security Hub is not enabled",
+                nist_csf="DE.CM-1",
+                iso_27001="A.8.16",
+            )
+        return Finding(
+            control_id="6.2",
+            title="Security Hub enabled",
+            section="security-services",
             severity="MEDIUM",
             status="ERROR",
             detail=str(e),
@@ -1396,11 +1576,17 @@ SECTIONS: dict[str, list] = {
         check_3_2_cloudtrail_validation,
         check_3_3_cloudtrail_s3_not_public,
         check_3_4_cloudwatch_alarms,
+        check_3_5_cloudtrail_kms_encryption,
+        check_3_6_cloudtrail_data_events,
     ],
     "networking": [
         check_4_1_no_unrestricted_ssh,
         check_4_2_no_unrestricted_rdp,
         check_4_3_vpc_flow_logs,
+    ],
+    "security-services": [
+        check_6_1_guardduty_enabled,
+        check_6_2_securityhub_enabled,
     ],
 }
 
@@ -1413,6 +1599,8 @@ def _get_clients(region: str) -> dict[str, Any]:
         "ct": session.client("cloudtrail"),
         "cw": session.client("cloudwatch"),
         "ec2": session.client("ec2"),
+        "gd": session.client("guardduty"),
+        "sh": session.client("securityhub"),
         "sts": session.client("sts"),
     }
 
@@ -1430,6 +1618,10 @@ def _run_check(fn, clients: dict) -> Finding:
         return fn(clients["ct"] if "cloudtrail" in name else clients["cw"])
     if name.startswith("check_4"):
         return fn(clients["ec2"])
+    if "guardduty" in name:
+        return fn(clients["gd"])
+    if "securityhub" in name:
+        return fn(clients["sh"])
     return fn(clients["iam"])
 
 

--- a/skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py
+++ b/skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py
@@ -8,6 +8,10 @@ Targets the uncovered paths in src/checks.py:
     - check_3_2_cloudtrail_validation (log file validation)
     - check_3_3_cloudtrail_s3_not_public (trail bucket public-access block)
     - check_3_4_cloudwatch_alarms (empty / populated)
+    - check_3_5_cloudtrail_kms_encryption
+    - check_3_6_cloudtrail_data_events
+    - check_6_1_guardduty_enabled
+    - check_6_2_securityhub_enabled
     - _check_unrestricted_port (IPv6 path, cross-port range)
     - check_4_3_vpc_flow_logs (VPC w/ and w/o flow logs)
     - run_assessment (section filter + full run routing)
@@ -357,6 +361,57 @@ def test_3_4_cloudwatch_alarms_client_error():
     assert f.status == "ERROR"
 
 
+def test_3_5_cloudtrail_kms_encryption_detects_missing_kms():
+    ct = MagicMock()
+    ct.describe_trails.return_value = {
+        "trailList": [
+            {"Name": "bad"},
+            {"Name": "good", "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/abc"},
+        ]
+    }
+    f = _CHECKS.check_3_5_cloudtrail_kms_encryption(ct)
+    assert f.status == "FAIL"
+    assert f.resources == ["bad"]
+
+
+def test_3_5_cloudtrail_kms_encryption_client_error():
+    ct = MagicMock()
+    ct.describe_trails.side_effect = _client_error("AccessDenied")
+    f = _CHECKS.check_3_5_cloudtrail_kms_encryption(ct)
+    assert f.status == "ERROR"
+
+
+def test_3_6_cloudtrail_data_events_detects_missing_selectors():
+    ct = MagicMock()
+    ct.describe_trails.return_value = {"trailList": [{"Name": "trail-a"}, {"Name": "trail-b"}]}
+    ct.get_event_selectors.side_effect = [
+        {"EventSelectors": [{"DataResources": [{"Type": "AWS::S3::Object", "Values": ["arn:aws:s3:::"]}]}]},
+        {"EventSelectors": []},
+    ]
+    f = _CHECKS.check_3_6_cloudtrail_data_events(ct)
+    assert f.status == "FAIL"
+    assert f.resources == ["trail-b"]
+
+
+def test_3_6_cloudtrail_data_events_accepts_advanced_event_selectors():
+    ct = MagicMock()
+    ct.describe_trails.return_value = {"trailList": [{"Name": "trail-a"}]}
+    ct.get_event_selectors.return_value = {
+        "AdvancedEventSelectors": [
+            {"FieldSelectors": [{"Field": "eventCategory", "Equals": ["Data"]}]}
+        ]
+    }
+    f = _CHECKS.check_3_6_cloudtrail_data_events(ct)
+    assert f.status == "PASS"
+
+
+def test_3_6_cloudtrail_data_events_client_error():
+    ct = MagicMock()
+    ct.describe_trails.side_effect = _client_error("AccessDenied")
+    f = _CHECKS.check_3_6_cloudtrail_data_events(ct)
+    assert f.status == "ERROR"
+
+
 # ---------------------------------------------------------------------------
 # Section 4 — Networking
 # ---------------------------------------------------------------------------
@@ -440,6 +495,39 @@ def test_4_3_vpc_flow_logs_client_error():
 
 
 # ---------------------------------------------------------------------------
+# Section 6 — Security Services
+# ---------------------------------------------------------------------------
+
+
+def test_6_1_guardduty_enabled_passes_when_detector_present():
+    gd = MagicMock()
+    gd.list_detectors.return_value = {"DetectorIds": ["12abc34d567e8fa901bc2d34e56789f0"]}
+    f = _CHECKS.check_6_1_guardduty_enabled(gd)
+    assert f.status == "PASS"
+
+
+def test_6_1_guardduty_enabled_fails_when_missing():
+    gd = MagicMock()
+    gd.list_detectors.return_value = {"DetectorIds": []}
+    f = _CHECKS.check_6_1_guardduty_enabled(gd)
+    assert f.status == "FAIL"
+
+
+def test_6_2_securityhub_enabled_handles_missing_hub_as_fail():
+    sh = MagicMock()
+    sh.describe_hub.side_effect = _client_error("InvalidAccessException")
+    f = _CHECKS.check_6_2_securityhub_enabled(sh)
+    assert f.status == "FAIL"
+
+
+def test_6_2_securityhub_enabled_passes_when_hub_exists():
+    sh = MagicMock()
+    sh.describe_hub.return_value = {"HubArn": "arn:aws:securityhub:us-east-1:123456789012:hub/default"}
+    f = _CHECKS.check_6_2_securityhub_enabled(sh)
+    assert f.status == "PASS"
+
+
+# ---------------------------------------------------------------------------
 # Runner / CLI / helpers
 # ---------------------------------------------------------------------------
 
@@ -481,18 +569,22 @@ def _stub_clients() -> dict:
     ec2.describe_security_groups.return_value = {"SecurityGroups": []}
     ec2.describe_vpcs.return_value = {"Vpcs": []}
     ec2.describe_flow_logs.return_value = {"FlowLogs": []}
+    gd = MagicMock()
+    gd.list_detectors.return_value = {"DetectorIds": ["det-1"]}
+    sh = MagicMock()
+    sh.describe_hub.return_value = {"HubArn": "arn:aws:securityhub:us-east-1:123456789012:hub/default"}
     sts = MagicMock()
     sts.get_caller_identity.return_value = {"Account": "123456789012"}
 
-    return {"iam": iam, "s3": s3, "ct": ct, "cw": cw, "ec2": ec2, "sts": sts}
+    return {"iam": iam, "s3": s3, "ct": ct, "cw": cw, "ec2": ec2, "gd": gd, "sh": sh, "sts": sts}
 
 
 def test_run_assessment_runs_all_sections_with_stubbed_clients(monkeypatch):
     monkeypatch.setattr(_CHECKS, "_get_clients", lambda region: _stub_clients())
     findings = _CHECKS.run_assessment(region="us-east-1")
-    # 18 checks defined across 4 sections
+    # 22 checks defined across 5 sections
     assert len(findings) == sum(len(v) for v in _CHECKS.SECTIONS.values())
-    assert {f.section for f in findings} == {"iam", "storage", "logging", "networking"}
+    assert {f.section for f in findings} == {"iam", "storage", "logging", "networking", "security-services"}
 
 
 def test_run_assessment_section_filter(monkeypatch):
@@ -504,7 +596,7 @@ def test_run_assessment_section_filter(monkeypatch):
 def test_get_clients_builds_boto3_session():
     with patch.object(_CHECKS.boto3, "Session") as session:
         clients = _CHECKS._get_clients("us-west-2")
-    assert set(clients.keys()) == {"iam", "s3", "ct", "cw", "ec2", "sts"}
+    assert set(clients.keys()) == {"iam", "s3", "ct", "cw", "ec2", "gd", "sh", "sts"}
     session.assert_called_once_with(region_name="us-west-2")
 
 
@@ -523,6 +615,12 @@ def test_run_check_routes_by_function_name():
     # ec2 routing
     f = _CHECKS._run_check(_CHECKS.check_4_3_vpc_flow_logs, clients)
     assert f.control_id == "4.3"
+    # guardduty routing
+    f = _CHECKS._run_check(_CHECKS.check_6_1_guardduty_enabled, clients)
+    assert f.control_id == "6.1"
+    # securityhub routing
+    f = _CHECKS._run_check(_CHECKS.check_6_2_securityhub_enabled, clients)
+    assert f.control_id == "6.2"
 
 
 def test_severity_color_and_status_symbol_cover_all_keys():


### PR DESCRIPTION
What changed

- expanded `cspm-aws-cis-benchmark` from 18 to 22 shipped AWS CIS checks
- added four new AWS controls:
  - `3.5` CloudTrail KMS encryption
  - `3.6` CloudTrail data events
  - `6.1` GuardDuty enabled
  - `6.2` Security Hub enabled
- wired the new GuardDuty and Security Hub clients into the benchmark runner
- updated the AWS CIS skill docs and README benchmark-check counts to match the new shipped surface

Why

Issue #254 is an umbrella. The clean first slice is to deepen the existing AWS benchmark skill with high-signal read-only controls before broadening auto-remediation or opening new platform branches.

Scope

This PR is coverage-only. It does not expand `--auto-remediate`; the existing guarded apply path stays limited to the AWS-first supported controls already shipped.

Validation

- `pytest skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks.py skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py -q`
- `ruff check skills/evaluation/cspm-aws-cis-benchmark/src/checks.py skills/evaluation/cspm-aws-cis-benchmark/tests/test_checks_extra.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_framework_coverage.py`

Part of #254
