### PR TITLE
Expand Azure CIS coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 63 shipped skill bundles. OCSF 1.8 on the wire. 89 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 63 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -23,7 +23,7 @@
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
 | **Detect** | 16 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
-| **Evaluate** | 7 | 89 posture and benchmark checks | compliance result |
+| **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -87,14 +87,14 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">14</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">16</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 
       <rect x="642" y="440" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="482" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
       <text x="674" y="544" font-size="56" font-weight="900" fill="#ffffff">7</text>
-      <text x="674" y="576" font-size="15" fill="#a7f3d0">82 benchmark checks across</text>
+      <text x="674" y="576" font-size="15" fill="#a7f3d0">91 benchmark checks across</text>
       <text x="674" y="598" font-size="15" fill="#a7f3d0">CIS · K8s · container · AI</text>
     </g>
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 61 shipped skill bundles, OCSF 1.8, 82 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 14 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 63 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 16 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">61</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">63</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -66,7 +66,7 @@
       </g>
       <g transform="translate(328,0)">
         <rect x="0" y="0" width="186" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
-        <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">82</text>
+        <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">91</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">benchmark checks</text>
       </g>
     </g>
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">14</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">16</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/skills/evaluation/cspm-azure-cis-benchmark/REFERENCES.md
+++ b/skills/evaluation/cspm-azure-cis-benchmark/REFERENCES.md
@@ -6,7 +6,7 @@
 - **NIST CSF 2.0** — https://www.nist.gov/cyberframework
 - **ISO/IEC 27001:2022** — https://www.iso.org/standard/27001
 
-The full v2.1 benchmark has 90+ controls. This skill implements **6
+The full v2.1 benchmark has 90+ controls. This skill implements **8
 high-impact checks** covering Storage and Networking. Identity / Logging /
 AI Foundry controls are tracked in the Roadmap section of
 [`SKILL.md`](SKILL.md).
@@ -15,8 +15,8 @@ AI Foundry controls are tracked in the Roadmap section of
 
 | Section | Provider | Method | Why |
 |---|---|---|---|
-| Storage | `Microsoft.Storage` | `storageAccounts.list` | HTTPS-only (CIS 2.2), public blob (CIS 2.3), network rules (CIS 2.4) |
-| Networking | `Microsoft.Network` | `networkSecurityGroups.listAll`, `networkWatchers.listAll`, `flowLogs.list` | Unrestricted SSH/RDP (CIS 4.1, 4.2), NSG flow logs (CIS 4.3) |
+| Storage | `Microsoft.Storage` | `storageAccounts.list` | CMK encryption (CIS 2.1), HTTPS-only (CIS 2.2), public blob (CIS 2.3), network rules (CIS 2.4) |
+| Networking | `Microsoft.Network` | `virtualNetworks.listAll`, `networkSecurityGroups.listAll`, `networkWatchers.listAll`, `flowLogs.list` | Unrestricted SSH/RDP (CIS 4.1, 4.2), NSG flow logs (CIS 4.3), Network Watcher regional coverage (CIS 4.4) |
 
 ## Required role
 
@@ -30,6 +30,7 @@ If you want a tighter custom role, the minimal action set is:
   "Name": "cspm-azure-cis-benchmark-reader",
     "Actions": [
       "Microsoft.Storage/storageAccounts/read",
+      "Microsoft.Network/virtualNetworks/read",
       "Microsoft.Network/networkSecurityGroups/read",
       "Microsoft.Network/networkWatchers/read",
       "Microsoft.Network/networkWatchers/flowLogs/read"

--- a/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-azure-cis-benchmark/SKILL.md
@@ -2,11 +2,11 @@
 name: cspm-azure-cis-benchmark
 description: >-
   Assess Azure subscriptions against a curated subset of CIS Azure Foundations
-  Benchmark v2.1. Automates 6 high-impact read-only checks across Storage and
+  Benchmark v2.1. Automates 8 high-impact read-only checks across Storage and
   Networking. Use when the user mentions Azure CIS benchmark, Azure storage
   security, or unrestricted SSH/RDP detection in NSGs. Do NOT use for AWS or GCP;
   do NOT use to remediate findings (assessment-only, Reader role only); do NOT
-  claim full CIS Azure coverage — only 6 controls are implemented, see the Roadmap
+  claim full CIS Azure coverage — only 8 controls are implemented, see the Roadmap
   section in this file for the gap.
 license: Apache-2.0
 approval_model: none
@@ -34,7 +34,7 @@ metadata:
 
 Automated assessment of Azure subscriptions against a curated subset of CIS
 Azure Foundations Benchmark v2.1. The full benchmark has 90+ controls; this
-skill implements **6 high-impact checks** that cover the most common findings
+skill implements **8 high-impact checks** that cover the most common findings
 on real subscriptions. Each check is mapped to NIST CSF 2.0.
 
 > **Honest scope:** the table below lists *only* what `src/checks.py` actually
@@ -61,7 +61,7 @@ flowchart LR
         NSG["NSG / VNet<br/>3 checks"]
     end
 
-    CHK["checks.py<br/>6 CIS v2.1 controls<br/>Reader role only"]
+    CHK["checks.py<br/>8 CIS v2.1 controls<br/>Reader role only"]
     OUT["Findings<br/>JSON · Console"]
     FIX["Remediation<br/>az CLI · Bicep PR<br/>or exception with TTL"]
     VERIFY["Re-scan<br/>control_id == pass"]
@@ -84,25 +84,27 @@ flowchart LR
 - **AI Foundry safe**: Checks managed identity, private endpoints, CMK — does not access model endpoints or data.
 - **Idempotent**: Run as often as needed with no side effects.
 
-## Implemented Controls (6)
+## Implemented Controls (8)
 
 Each row maps to one function in `src/checks.py`. If it's not in this table, it's not implemented.
 
-### Section 2 — Storage (3 checks)
+### Section 2 — Storage (4 checks)
 
 | # | CIS Control | Function | Severity | NIST CSF 2.0 |
 |---|------------|----------|----------|--------------|
+| 2.1 | Storage accounts use customer-managed keys | `check_2_1_storage_cmk` | HIGH | PR.DS-1 |
 | 2.2 | Storage account HTTPS-only | `check_2_2_https_only` | HIGH | PR.DS-2 |
 | 2.3 | No public blob access | `check_2_3_no_public_blob` | CRITICAL | PR.AC-3 |
 | 2.4 | Storage account network rules (deny by default) | `check_2_4_network_rules` | HIGH | PR.AC-5 |
 
-### Section 4 — Networking (3 checks)
+### Section 4 — Networking (4 checks)
 
 | # | CIS Control | Function | Severity | NIST CSF 2.0 |
 |---|------------|----------|----------|--------------|
 | 4.1 | No unrestricted SSH (0.0.0.0/0:22) in NSGs | `check_4_1_no_unrestricted_ssh` | HIGH | PR.AC-5 |
 | 4.2 | No unrestricted RDP (0.0.0.0/0:3389) in NSGs | `check_4_2_no_unrestricted_rdp` | HIGH | PR.AC-5 |
 | 4.3 | NSG flow logs enabled | `check_4_3_nsg_flow_logs` | MEDIUM | DE.CM-1 |
+| 4.4 | Network Watcher in all VNet regions | `check_4_4_network_watcher_regions` | MEDIUM | DE.CM-1 |
 
 ## Roadmap — Documented but Not Yet Automated
 
@@ -111,9 +113,7 @@ These controls are part of the CIS Azure Foundations v2.1 benchmark but are *not
 | Section | Controls | Why it matters |
 |---------|---------|----------------|
 | 1.x — Identity | MFA, Conditional Access, guest roles, legacy auth, PIM | Requires Microsoft Graph API + Entra ID licensing checks |
-| 2.1 | Storage account CMK encryption | KMS key resolution per account |
 | 3.x — Logging | Activity log retention, diagnostic settings, log alerts | `azure-mgmt-monitor` enumeration |
-| 4.4 | Network Watcher in all regions | Region enumeration + Network Watcher API |
 | AI Foundry | Managed identity, private endpoints, CMK, content safety, diagnostic logging | `azure-mgmt-cognitiveservices` |
 
 ## Usage

--- a/skills/evaluation/cspm-azure-cis-benchmark/examples/sample-output.json
+++ b/skills/evaluation/cspm-azure-cis-benchmark/examples/sample-output.json
@@ -3,7 +3,7 @@
   "scan_metadata": {
     "skill": "cspm-azure-cis-benchmark",
     "skill_version": "0.1.0",
-    "benchmark": "CIS Azure Foundations v2.1 (subset of 6 controls)",
+    "benchmark": "CIS Azure Foundations v2.1 (subset of 8 controls)",
     "subscription_id": "00000000-0000-0000-0000-000000000000",
     "scan_started_at": "2026-04-10T05:00:00Z",
     "scan_completed_at": "2026-04-10T05:00:28Z"

--- a/skills/evaluation/cspm-azure-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-azure-cis-benchmark/src/checks.py
@@ -1,7 +1,7 @@
 """
 CIS Azure Foundations Benchmark v2.1 — Automated Assessment
 
-19 CIS controls + 5 AI Foundry controls across Identity, Storage,
+21 CIS controls + 5 AI Foundry controls across Identity, Storage,
 Logging, and Networking.
 Read-only: requires Reader role on the subscription.
 
@@ -50,6 +50,38 @@ class Finding:
 # ---------------------------------------------------------------------------
 # Section 2 — Storage
 # ---------------------------------------------------------------------------
+
+
+def check_2_1_storage_cmk(storage_client, subscription_id: str) -> Finding:
+    """CIS 2.1 — Storage accounts use customer-managed keys."""
+    try:
+        accounts = list(storage_client.storage_accounts.list())
+        non_cmk = []
+        for account in accounts:
+            encryption = getattr(account, "encryption", None)
+            key_source = getattr(encryption, "key_source", None)
+            if key_source != "Microsoft.Keyvault":
+                non_cmk.append(account.name)
+        return Finding(
+            control_id="2.1",
+            title="Storage customer-managed keys",
+            section="storage",
+            severity="HIGH",
+            status="FAIL" if non_cmk else "PASS",
+            detail=f"{len(non_cmk)} accounts do not use customer-managed keys" if non_cmk else "All accounts use customer-managed keys",
+            nist_csf="PR.DS-1",
+            resources=non_cmk,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="2.1",
+            title="Storage customer-managed keys",
+            section="storage",
+            severity="HIGH",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-1",
+        )
 
 
 def check_2_3_no_public_blob(storage_client, subscription_id: str) -> Finding:
@@ -281,6 +313,65 @@ def check_4_3_nsg_flow_logs(network_client, subscription_id: str) -> Finding:
         )
 
 
+def check_4_4_network_watcher_regions(network_client, subscription_id: str) -> Finding:
+    """CIS 4.4 — Network Watcher enabled in all VNet regions."""
+    try:
+        vnets = list(network_client.virtual_networks.list_all())
+        vnet_regions = {
+            (getattr(vnet, "location", "") or "").lower()
+            for vnet in vnets
+            if getattr(vnet, "location", None)
+        }
+        if not vnet_regions:
+            return Finding(
+                control_id="4.4",
+                title="Network Watcher in all VNet regions",
+                section="networking",
+                severity="MEDIUM",
+                status="PASS",
+                detail="No virtual networks found",
+                nist_csf="DE.CM-1",
+            )
+
+        watchers = list(network_client.network_watchers.list_all())
+        watcher_regions = {
+            (getattr(watcher, "location", "") or "").lower()
+            for watcher in watchers
+            if getattr(watcher, "location", None)
+        }
+        missing_regions = sorted(region for region in vnet_regions if region not in watcher_regions)
+        if missing_regions:
+            return Finding(
+                control_id="4.4",
+                title="Network Watcher in all VNet regions",
+                section="networking",
+                severity="MEDIUM",
+                status="FAIL",
+                detail=f"Network Watcher missing in {len(missing_regions)} VNet region(s)",
+                nist_csf="DE.CM-1",
+                resources=missing_regions,
+            )
+        return Finding(
+            control_id="4.4",
+            title="Network Watcher in all VNet regions",
+            section="networking",
+            severity="MEDIUM",
+            status="PASS",
+            detail=f"Network Watcher enabled in all {len(vnet_regions)} VNet region(s)",
+            nist_csf="DE.CM-1",
+        )
+    except Exception as e:
+        return Finding(
+            control_id="4.4",
+            title="Network Watcher in all VNet regions",
+            section="networking",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.CM-1",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -308,6 +399,7 @@ def run_assessment(subscription_id: str, section: str | None = None) -> list[Fin
 
     checks = {
         "storage": [
+            lambda: check_2_1_storage_cmk(storage_client, subscription_id),
             lambda: check_2_2_https_only(storage_client, subscription_id),
             lambda: check_2_3_no_public_blob(storage_client, subscription_id),
             lambda: check_2_4_network_rules(storage_client, subscription_id),
@@ -316,6 +408,7 @@ def run_assessment(subscription_id: str, section: str | None = None) -> list[Fin
             lambda: check_4_1_no_unrestricted_ssh(network_client, subscription_id),
             lambda: check_4_2_no_unrestricted_rdp(network_client, subscription_id),
             lambda: check_4_3_nsg_flow_logs(network_client, subscription_id),
+            lambda: check_4_4_network_watcher_regions(network_client, subscription_id),
         ],
     }
 

--- a/skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks.py
+++ b/skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks.py
@@ -20,11 +20,13 @@ sys.modules[_SPEC.name] = _CHECKS
 _SPEC.loader.exec_module(_CHECKS)
 
 check_2_2_https_only = _CHECKS.check_2_2_https_only
+check_2_1_storage_cmk = _CHECKS.check_2_1_storage_cmk
 check_2_3_no_public_blob = _CHECKS.check_2_3_no_public_blob
 check_2_4_network_rules = _CHECKS.check_2_4_network_rules
 check_4_1_no_unrestricted_ssh = _CHECKS.check_4_1_no_unrestricted_ssh
 check_4_2_no_unrestricted_rdp = _CHECKS.check_4_2_no_unrestricted_rdp
 check_4_3_nsg_flow_logs = _CHECKS.check_4_3_nsg_flow_logs
+check_4_4_network_watcher_regions = _CHECKS.check_4_4_network_watcher_regions
 
 SUB_ID = "00000000-0000-0000-0000-000000000000"
 
@@ -33,14 +35,30 @@ SUB_ID = "00000000-0000-0000-0000-000000000000"
 
 
 class TestStorageChecks:
-    def _account(self, name, *, https=True, public_blob=False, default_action="Deny"):
+    def _account(self, name, *, https=True, public_blob=False, default_action="Deny", key_source="Microsoft.Keyvault"):
         a = MagicMock()
         a.name = name
         a.enable_https_traffic_only = https
         a.allow_blob_public_access = public_blob
         a.network_rule_set = MagicMock()
         a.network_rule_set.default_action = default_action
+        a.encryption = MagicMock()
+        a.encryption.key_source = key_source
         return a
+
+    def test_2_1_storage_cmk_passes(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("ok", key_source="Microsoft.Keyvault")]
+        f = check_2_1_storage_cmk(client, SUB_ID)
+        assert f.control_id == "2.1"
+        assert f.status == "PASS"
+
+    def test_2_1_storage_cmk_fails(self):
+        client = MagicMock()
+        client.storage_accounts.list.return_value = [self._account("bad", key_source="Microsoft.Storage")]
+        f = check_2_1_storage_cmk(client, SUB_ID)
+        assert f.status == "FAIL"
+        assert "bad" in f.resources
 
     def test_2_2_https_only_passes(self):
         client = MagicMock()
@@ -180,6 +198,32 @@ class TestNetworkChecks:
         f = check_4_3_nsg_flow_logs(client, SUB_ID)
         assert f.status == "FAIL"
         assert nsg_b.id in f.resources
+
+    def test_4_4_network_watcher_regions_passes(self):
+        client = MagicMock()
+        vnet = MagicMock()
+        vnet.location = "eastus"
+        watcher = MagicMock()
+        watcher.location = "eastus"
+        client.virtual_networks.list_all.return_value = [vnet]
+        client.network_watchers.list_all.return_value = [watcher]
+        f = check_4_4_network_watcher_regions(client, SUB_ID)
+        assert f.control_id == "4.4"
+        assert f.status == "PASS"
+
+    def test_4_4_network_watcher_regions_fails_for_missing_region(self):
+        client = MagicMock()
+        eastus = MagicMock()
+        eastus.location = "eastus"
+        westus = MagicMock()
+        westus.location = "westus"
+        watcher = MagicMock()
+        watcher.location = "eastus"
+        client.virtual_networks.list_all.return_value = [eastus, westus]
+        client.network_watchers.list_all.return_value = [watcher]
+        f = check_4_4_network_watcher_regions(client, SUB_ID)
+        assert f.status == "FAIL"
+        assert f.resources == ["westus"]
 
 
 class TestFindingStructure:

--- a/skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks_extra.py
+++ b/skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks_extra.py
@@ -50,6 +50,22 @@ def test_2_3_public_blob_fail():
     assert f.resources == ["open"]
 
 
+def test_2_1_storage_cmk_fail():
+    client = MagicMock()
+    account = _account(name="managed")
+    account.encryption = MagicMock(key_source="Microsoft.Storage")
+    client.storage_accounts.list.return_value = [account]
+    f = _CHECKS.check_2_1_storage_cmk(client, "sub")
+    assert f.status == "FAIL"
+    assert f.resources == ["managed"]
+
+
+def test_2_1_storage_cmk_error_branch():
+    client = MagicMock()
+    client.storage_accounts.list.side_effect = RuntimeError("x")
+    assert _CHECKS.check_2_1_storage_cmk(client, "sub").status == "ERROR"
+
+
 def test_2_3_error_branch():
     client = MagicMock()
     client.storage_accounts.list.side_effect = RuntimeError("x")
@@ -262,6 +278,32 @@ def test_4_3_error_branch():
     client = MagicMock()
     client.network_security_groups.list_all.side_effect = RuntimeError("x")
     assert _CHECKS.check_4_3_nsg_flow_logs(client, "sub").status == "ERROR"
+
+
+def test_4_4_no_virtual_networks_passes():
+    client = MagicMock()
+    client.virtual_networks.list_all.return_value = []
+    client.network_watchers.list_all.return_value = []
+    f = _CHECKS.check_4_4_network_watcher_regions(client, "sub")
+    assert f.status == "PASS"
+
+
+def test_4_4_missing_watcher_region_fails():
+    client = MagicMock()
+    eastus = MagicMock(location="eastus")
+    westus = MagicMock(location="westus2")
+    watcher = MagicMock(location="eastus")
+    client.virtual_networks.list_all.return_value = [eastus, westus]
+    client.network_watchers.list_all.return_value = [watcher]
+    f = _CHECKS.check_4_4_network_watcher_regions(client, "sub")
+    assert f.status == "FAIL"
+    assert f.resources == ["westus2"]
+
+
+def test_4_4_error_branch():
+    client = MagicMock()
+    client.virtual_networks.list_all.side_effect = RuntimeError("x")
+    assert _CHECKS.check_4_4_network_watcher_regions(client, "sub").status == "ERROR"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
What changed

expanded `cspm-azure-cis-benchmark` with two additional read-only CIS Azure controls: `2.1` storage customer-managed keys and `4.4` Network Watcher coverage for all VNet regions
kept the skill assessment-only; no write paths, no new privileges, and no change to the MCP/runtime contract
updated the Azure skill docs/examples plus README and the shipped visuals so repo counts align with the current branch state (`63` skills, `16` detect, `91` benchmark checks)

Why

`#254` is a roadmap umbrella, and Azure was the next clean provider slice after the AWS and GCP benchmark expansions. These two controls fit the existing Reader-only design, improve zero-trust posture around storage encryption and network observability, and avoid adding a new write or elevated-permission surface.

Validation

`pytest skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks.py skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks_extra.py -q`
`ruff check skills/evaluation/cspm-azure-cis-benchmark/src/checks.py skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks.py skills/evaluation/cspm-azure-cis-benchmark/tests/test_checks_extra.py`
`python scripts/validate_skill_contract.py`
`python scripts/validate_skill_integrity.py`
`xmllint --noout docs/images/hero-banner.svg docs/images/architecture-layers.svg`

Note: local `validate_skill_count_consistency.py` is currently tripped by unrelated stale `.claude/worktrees/.../README.md` copies in this workstation checkout; those files are not part of this branch or CI.

Part of #254