### PR TITLE
Add GCP audit log disable detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 63 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 64 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**63 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**64 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 16 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 17 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 63 shipped skills.**
+**Total: 64 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -60,6 +60,7 @@ is the row you can take to your auditor.
 | `detect-credential-stuffing-okta` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-entra-credential-addition` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-entra-role-grant-escalation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-gcp-audit-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-open-firewall` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -93,7 +94,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_63 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_64 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 16 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 17 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,17 +4,17 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **63**
+- Total shipped skills in registry: **64**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **42** | — |
-| MITRE ATT&CK | v14 | **39** | 100% mapped coverage |
+| OCSF | 1.8.0 | **43** | — |
+| MITRE ATT&CK | v14 | **40** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
-| CIS GCP Foundations | v3.0 | **4** | — |
+| CIS GCP Foundations | v3.0 | **5** | — |
 | CIS Azure Foundations | v2.1 | **5** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
@@ -36,7 +36,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **42**
+Shipped skills mapped: **43**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -48,6 +48,7 @@ Shipped skills mapped: **42**
 | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta) | detection | okta | identities, authentication, sessions |
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
+| [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
@@ -90,7 +91,7 @@ Shipped skills mapped: **42**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **39**
+Shipped skills mapped: **40**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -101,6 +102,7 @@ Shipped skills mapped: **39**
 | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta) | detection | okta | identities, authentication, sessions |
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
+| [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
@@ -171,10 +173,11 @@ Shipped skills mapped: **4**
 
 - Registry id: `cis-gcp-v3`
 
-Shipped skills mapped: **4**
+Shipped skills mapped: **5**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
+| [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`cspm-gcp-cis-benchmark`](../skills/evaluation/cspm-gcp-cis-benchmark) | evaluation | gcp | identities, storage, logging, network |
 | [`iam-departures-gcp`](../skills/remediation/iam-departures-gcp) | remediation | gcp | identities, access, audit, hr-events |

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -842,6 +842,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-gcp-audit-logs-disabled",
+      "layer": "detection",
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "audit-logs",
+        "logging-sinks",
+        "log-streams"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "ocsf-1.8",
+        "cis-gcp-v3"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-okta-mfa-fatigue",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">16</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">17</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 63 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 16 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 64 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 17 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">63</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">64</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">16</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">17</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/skills/detection/detect-gcp-audit-logs-disabled/REFERENCES.md
+++ b/skills/detection/detect-gcp-audit-logs-disabled/REFERENCES.md
@@ -1,0 +1,12 @@
+# References — detect-gcp-audit-logs-disabled
+
+- Google Cloud Logging `sinks.delete` method:
+  https://cloud.google.com/logging/docs/reference/v2/rest/v2/sinks/delete
+- Google Cloud Logging audit logging methods:
+  https://cloud.google.com/logging/docs/audit-logging
+- Google Cloud Audit Logs overview:
+  https://cloud.google.com/logging/docs/audit
+- MITRE ATT&CK T1562.001 — Disable or Modify Tools:
+  https://attack.mitre.org/techniques/T1562/001/
+- Upstream ingester:
+  [`../../ingestion/ingest-gcp-audit-ocsf/`](../../ingestion/ingest-gcp-audit-ocsf/)

--- a/skills/detection/detect-gcp-audit-logs-disabled/SKILL.md
+++ b/skills/detection/detect-gcp-audit-logs-disabled/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: detect-gcp-audit-logs-disabled
+description: >-
+  Detect successful GCP Cloud Logging `DeleteSink` and `DeleteLog` API calls
+  from OCSF 1.8 API Activity records emitted by ingest-gcp-audit-ocsf. Emits
+  an OCSF 1.8 Detection Finding (class 2004) tagged with MITRE ATT&CK
+  T1562.001 (Disable or Modify Tools) when a log sink or log stream is
+  explicitly deleted. Use when the user mentions "GCP audit logs disabled,"
+  "logging sink deleted," "DeleteLog," or "defense evasion in GCP logging."
+  Do NOT use as a posture-at-rest check, to infer IAM auditConfig changes, or
+  to claim every possible GCP logging impairment path. This first slice only
+  covers successful `DeleteSink` and `DeleteLog` events.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No GCP
+  SDK; pairs with ingest-gcp-audit-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-gcp-audit-logs-disabled
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - CIS GCP Foundations
+  cloud: gcp
+  capability: read-only
+---
+
+# detect-gcp-audit-logs-disabled
+
+Streaming detector for explicit GCP Cloud Logging impairment operations. This is
+the next concrete slice under issue `#253`: it adds a tested GCP defense-evasion
+detector instead of broadening ATT&CK claims without shipped code.
+
+## Use when
+
+- You stream GCP audit logs through `ingest-gcp-audit-ocsf` and want near-real-time defense-evasion findings
+- You want to catch explicit deletion of logging sinks or log streams
+- You are closing ATT&CK T1562.001 coverage with a read-only GCP detector
+
+## Do NOT use
+
+- As a posture-at-rest logging check; use [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/)
+- To infer IAM `auditConfigs` changes or sink-filter weakening; the shipped ingester does not preserve those request bodies
+- To claim every possible GCP logging impairment path; this first slice is only `DeleteSink` and `DeleteLog`
+
+## Rule
+
+A finding fires on every successful Cloud Logging event from `ingest-gcp-audit-ocsf` where:
+
+1. `api.operation` is `google.logging.v2.ConfigServiceV2.DeleteSink` or `google.logging.v2.LoggingServiceV2.DeleteLog`
+2. `status_id == 1`
+3. `resources[]` resolves a sink or log target name
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0005` (Defense Evasion)
+- `finding_info.attacks[].technique_uid = T1562.001` (Disable or Modify Tools)
+- `observables[]` including `target.name`, `target.type`, `account.uid`, `actor.name`, and `api.operation`
+
+The native projection (`--output-format native`) keeps the target and actor/account context in a flatter shape.
+
+## Run
+
+```bash
+# GCP audit logs -> ingest -> detect (default OCSF output)
+python skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-gcp-audit-logs-disabled/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-gcp-audit-logs-disabled/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-gcp-audit-ocsf`](../../ingestion/ingest-gcp-audit-ocsf/) — upstream ingester
+- [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/) — posture-at-rest logging coverage
+- [`detect-cloudtrail-disabled`](../detect-cloudtrail-disabled/) — sibling AWS logging impairment detector

--- a/skills/detection/detect-gcp-audit-logs-disabled/src/detect.py
+++ b/skills/detection/detect-gcp-audit-logs-disabled/src/detect.py
@@ -1,0 +1,318 @@
+"""Detect GCP logging surfaces being explicitly disabled or deleted.
+
+Reads OCSF 1.8 API Activity (class 6003) records emitted by
+`ingest-gcp-audit-ocsf` from stdin or a file. Fires on successful
+Cloud Logging `DeleteSink` and `DeleteLog` calls and emits an OCSF 1.8
+Detection Finding (class 2004) tagged with MITRE ATT&CK T1562.001
+(Impair Defenses / Disable or Modify Tools).
+
+This first slice is intentionally narrow and high-confidence:
+1. event.api.operation in {
+     "google.logging.v2.ConfigServiceV2.DeleteSink",
+     "google.logging.v2.LoggingServiceV2.DeleteLog",
+   }
+2. event.status_id == 1 (success)
+3. the target sink/log name resolves from `resources[]`
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-gcp-audit-logs-disabled"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0005"
+TACTIC_NAME = "Defense Evasion"
+TECHNIQUE_UID = "T1562.001"
+TECHNIQUE_NAME = "Disable or Modify Tools"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-gcp-audit-ocsf"})
+DISABLING_OPERATIONS = frozenset(
+    {
+        "google.logging.v2.ConfigServiceV2.DeleteSink",
+        "google.logging.v2.LoggingServiceV2.DeleteLog",
+    }
+)
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _service_name(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    service = api.get("service") or {}
+    return str(service.get("name") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _actor(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _target(event: dict[str, Any], operation: str) -> tuple[str, str]:
+    target_type = "log_sink" if operation.endswith("DeleteSink") else "log_stream"
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        name = str(resource.get("name") or "")
+        if not name:
+            continue
+        if operation.endswith("DeleteSink") and "/sinks/" in name:
+            return name.rsplit("/", 1)[-1], target_type
+        if operation.endswith("DeleteLog") and "/logs/" in name:
+            return name.rsplit("/", 1)[-1], target_type
+    return "", target_type
+
+
+def _finding_uid(event_uid: str, operation: str, target_name: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{operation}|{target_name}|{time_ms}"
+    return f"gald-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(
+    *,
+    event: dict[str, Any],
+    operation: str,
+    target_name: str,
+    target_type: str,
+) -> dict[str, Any]:
+    time_ms = int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+    event_uid = str((event.get("metadata") or {}).get("uid") or "")
+    finding_uid = _finding_uid(event_uid, operation, target_name, time_ms)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "gcp-audit-logs-disabled",
+        "api_operation": operation,
+        "service_name": _service_name(event),
+        "target_name": target_name,
+        "target_type": target_type,
+        "actor_name": _actor(event),
+        "account_uid": _account(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Actor `{native['actor_name'] or 'unknown'}` successfully called "
+        f"`{native['api_operation']}` against GCP logging target "
+        f"`{native['target_name'] or '<unknown>'}` in account "
+        f"`{native['account_uid']}`. Source IP: {native['src_ip'] or '<unknown>'}."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "GCP"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": native["api_operation"]},
+        {"name": "service.name", "type": "Other", "value": native["service_name"] or "logging.googleapis.com"},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.type", "type": "Other", "value": native["target_type"]},
+        {"name": "target.uid", "type": "Other", "value": native["target_name"]},
+        {"name": "target.name", "type": "Other", "value": native["target_name"]},
+        {"name": "account.uid", "type": "Other", "value": native["account_uid"]},
+    ]
+    if native["region"]:
+        observables.append({"name": "region", "type": "Other", "value": native["region"]})
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["gcp", "logging", "defense-evasion"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": f"GCP logging disabled via {native['api_operation'].rsplit('.', 1)[-1]}",
+            "desc": description,
+            "types": ["gcp-audit-logs-disabled"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "target_name": native["target_name"],
+            "target_type": native["target_type"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-gcp-audit producer `{producer}`",
+            )
+            continue
+        operation = _api_operation(event)
+        if operation not in DISABLING_OPERATIONS:
+            continue
+        if not _is_success(event):
+            continue
+        target_name, target_type = _target(event, operation)
+        if not target_name:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_target",
+                message=f"{operation} event missing logging target; skipping",
+            )
+            continue
+        native = _build_native_finding(
+            event=event,
+            operation=operation,
+            target_name=target_name,
+            target_type=target_type,
+        )
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect successful GCP Cloud Logging DeleteSink and DeleteLog operations."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(OUTPUT_FORMATS),
+        default="ocsf",
+        help="Emit OCSF Detection Finding (default) or native projection.",
+    )
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    try:
+        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+            out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-gcp-audit-logs-disabled/tests/test_detect.py
+++ b/skills/detection/detect-gcp-audit-logs-disabled/tests/test_detect.py
@@ -1,0 +1,125 @@
+"""Tests for detect-gcp-audit-logs-disabled."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_gcp_audit_logs_disabled_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ACCEPTED_PRODUCERS = MODULE.ACCEPTED_PRODUCERS
+DISABLING_OPERATIONS = MODULE.DISABLING_OPERATIONS
+TECHNIQUE_UID = MODULE.TECHNIQUE_UID
+detect = MODULE.detect
+
+
+def _gcp_event(
+    *,
+    operation: str = "google.logging.v2.ConfigServiceV2.DeleteSink",
+    success: bool = True,
+    target_name: str = "audit-export",
+    actor: str = "alice@example.com",
+    account_uid: str = "p-1",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-gcp-audit-ocsf",
+) -> dict:
+    resource_path = (
+        f"projects/{account_uid}/sinks/{target_name}"
+        if operation.endswith("DeleteSink")
+        else f"projects/{account_uid}/logs/{target_name}"
+    )
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1700000000000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "actor": {"user": {"name": actor}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation, "service": {"name": "logging.googleapis.com"}},
+        "cloud": {"provider": "GCP", "account": {"uid": account_uid}, "region": "global"},
+        "resources": [{"name": resource_path, "type": "logging_resource"}] if target_name else [],
+    }
+
+
+def test_accepted_producer_is_gcp_audit():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-gcp-audit-ocsf"})
+
+
+def test_disabling_operations_are_delete_sink_and_delete_log():
+    assert DISABLING_OPERATIONS == frozenset(
+        {
+            "google.logging.v2.ConfigServiceV2.DeleteSink",
+            "google.logging.v2.LoggingServiceV2.DeleteLog",
+        }
+    )
+
+
+def test_fires_on_delete_sink():
+    findings = list(detect([_gcp_event(operation="google.logging.v2.ConfigServiceV2.DeleteSink")]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    assert finding["finding_info"]["attacks"][0]["technique_uid"] == TECHNIQUE_UID
+    assert any(obs["name"] == "target.name" and obs["value"] == "audit-export" for obs in finding["observables"])
+
+
+def test_fires_on_delete_log():
+    findings = list(detect([_gcp_event(operation="google.logging.v2.LoggingServiceV2.DeleteLog", target_name="cloudaudit.googleapis.com%2Factivity")]))
+    assert len(findings) == 1
+    assert any(obs["name"] == "api.operation" and obs["value"] == "google.logging.v2.LoggingServiceV2.DeleteLog" for obs in findings[0]["observables"])
+
+
+def test_native_output_contains_target_identity():
+    findings = list(
+        detect(
+            [_gcp_event(operation="google.logging.v2.ConfigServiceV2.DeleteSink", target_name="audit-export")],
+            output_format="native",
+        )
+    )
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["target_name"] == "audit-export"
+    assert finding["target_type"] == "log_sink"
+
+
+def test_skips_failed_event():
+    assert list(detect([_gcp_event(success=False)])) == []
+
+
+def test_skips_unrelated_operation():
+    assert list(detect([_gcp_event(operation="google.logging.v2.ConfigServiceV2.CreateSink")])) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_gcp_event(producer="ingest-cloudtrail-ocsf")]))
+    assert findings == []
+    assert "non-gcp-audit producer" in capsys.readouterr().err
+
+
+def test_skips_missing_target(capsys):
+    findings = list(detect([_gcp_event(target_name="")]))
+    assert findings == []
+    assert "missing logging target" in capsys.readouterr().err
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_gcp_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    event = _gcp_event()
+    first = list(detect([event]))[0]["finding_info"]["uid"]
+    second = list(detect([event]))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("gald-")


### PR DESCRIPTION
What changed

added a new read-only detection skill, `detect-gcp-audit-logs-disabled`, for successful GCP Cloud Logging `DeleteSink` and `DeleteLog` operations from `ingest-gcp-audit-ocsf`
kept the rule intentionally narrow and high-confidence; it does not over-claim generic IAM `auditConfigs` drift that the current ingester does not preserve
added unit tests for positive hits, negative cases, native output, deterministic finding ids, and malformed/missing logging target context
updated `docs/framework-coverage.json`, regenerated `docs/FRAMEWORK_COVERAGE.md`, refreshed `SECURITY_BAR.md`, and aligned README / visuals to the branch state (`64` skills, `17` detect, `91` benchmark checks)

Why

`#253` is the ATT&CK umbrella, and the repo needed the next real cross-cloud defense-evasion slice after AWS. This PR adds a shipped GCP detector for explicit logging impairment instead of expanding ATT&CK claims in docs only.

Scope

This first slice intentionally covers only:

successful `google.logging.v2.ConfigServiceV2.DeleteSink`
successful `google.logging.v2.LoggingServiceV2.DeleteLog`

It does not claim every GCP logging impairment path yet. IAM `auditConfigs` edits, exclusion-filter abuse, and broader sink weakening remain separate follow-on work.

Validation

`pytest skills/detection/detect-gcp-audit-logs-disabled/tests/test_detect.py -q`
`ruff check skills/detection/detect-gcp-audit-logs-disabled/src/detect.py skills/detection/detect-gcp-audit-logs-disabled/tests/test_detect.py`
`python scripts/generate_framework_coverage_doc.py`
`python scripts/generate_security_bar_matrix.py`
`python scripts/validate_skill_contract.py`
`python scripts/validate_skill_integrity.py`
`python scripts/validate_framework_coverage.py`
`xmllint --noout docs/images/hero-banner.svg docs/images/architecture-layers.svg`

Part of #253