### PR TITLE
Add Azure activity log disable detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 64 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 65 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**64 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**65 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 17 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 18 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 64 shipped skills.**
+**Total: 65 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -54,6 +54,7 @@ is the row you can take to your auditor.
 | `iam-departures-reconciler` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `detect-agent-credential-leak-mcp` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-open-security-group` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-azure-activity-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-open-nsg` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-cloudtrail-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-container-escape-k8s` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -94,7 +95,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_64 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_65 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 17 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 18 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,18 +4,18 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.4.0`
 - Registry updated: `2026-04-17`
-- Total shipped skills in registry: **64**
+- Total shipped skills in registry: **65**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **43** | — |
-| MITRE ATT&CK | v14 | **40** | 100% mapped coverage |
+| OCSF | 1.8.0 | **44** | — |
+| MITRE ATT&CK | v14 | **41** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
-| CIS Azure Foundations | v2.1 | **5** | — |
+| CIS Azure Foundations | v2.1 | **6** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
 | CIS Controls | v8 | **2** | — |
@@ -36,12 +36,13 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **43**
+Shipped skills mapped: **44**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-agent-credential-leak-mcp`](../skills/detection/detect-agent-credential-leak-mcp) | detection | mcp, multi | agent-tools, tool-results, credentials |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
+| [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
 | [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled) | detection | aws | cloudtrail, audit-trails, logging |
 | [`detect-container-escape-k8s`](../skills/detection/detect-container-escape-k8s) | detection | kubernetes | clusters, containers, runtime |
@@ -91,11 +92,12 @@ Shipped skills mapped: **43**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **40**
+Shipped skills mapped: **41**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
+| [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
 | [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled) | detection | aws | cloudtrail, audit-trails, logging |
 | [`detect-container-escape-k8s`](../skills/detection/detect-container-escape-k8s) | detection | kubernetes | clusters, containers, runtime |
@@ -187,10 +189,11 @@ Shipped skills mapped: **5**
 
 - Registry id: `cis-azure-v2.1`
 
-Shipped skills mapped: **5**
+Shipped skills mapped: **6**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
+| [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
 | [`cspm-azure-cis-benchmark`](../skills/evaluation/cspm-azure-cis-benchmark) | evaluation | azure | identities, storage, logging, network |
 | [`iam-departures-azure-entra`](../skills/remediation/iam-departures-azure-entra) | remediation | azure | identities, access, audit, hr-events |

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -1039,6 +1039,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-azure-activity-logs-disabled",
+      "layer": "detection",
+      "providers": [
+        "azure"
+      ],
+      "asset_classes": [
+        "activity-logs",
+        "diagnostic-settings",
+        "logging"
+      ],
+      "frameworks": [
+        "mitre-attack-v14",
+        "ocsf-1.8",
+        "cis-azure-v2.1"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-container-escape-k8s",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">17</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">18</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 64 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 17 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 65 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 18 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">64</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">65</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">17</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">18</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/skills/detection/detect-azure-activity-logs-disabled/REFERENCES.md
+++ b/skills/detection/detect-azure-activity-logs-disabled/REFERENCES.md
@@ -1,0 +1,12 @@
+# References — detect-azure-activity-logs-disabled
+
+- Azure Monitor diagnostic settings:
+  https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/create-diagnostic-settings
+- Azure Monitor Activity Log:
+  https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log
+- Azure Monitor Diagnostic Settings delete REST API:
+  https://learn.microsoft.com/en-us/rest/api/monitor/diagnostic-settings/delete?view=rest-monitor-2021-05-01-preview
+- MITRE ATT&CK T1562.001 — Disable or Modify Tools:
+  https://attack.mitre.org/techniques/T1562/001/
+- Upstream ingester:
+  [`../../ingestion/ingest-azure-activity-ocsf/`](../../ingestion/ingest-azure-activity-ocsf/)

--- a/skills/detection/detect-azure-activity-logs-disabled/SKILL.md
+++ b/skills/detection/detect-azure-activity-logs-disabled/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: detect-azure-activity-logs-disabled
+description: >-
+  Detect successful Azure `Microsoft.Insights/diagnosticSettings/delete`
+  operations from OCSF 1.8 API Activity records emitted by
+  ingest-azure-activity-ocsf. Emits an OCSF 1.8 Detection Finding
+  (class 2004) tagged with MITRE ATT&CK T1562.001 (Disable or Modify Tools)
+  when a diagnostic setting is explicitly deleted. Use when the user mentions
+  "Azure activity logs disabled," "diagnostic settings deleted," or "defense
+  evasion in Azure logging." Do NOT use as a posture-at-rest check, to infer
+  every logging impairment path, or for metric/resource-log pipelines outside
+  the Azure Activity Log surface. This first slice only covers successful
+  diagnostic-settings delete events.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No
+  Azure SDK; pairs with ingest-azure-activity-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-azure-activity-logs-disabled
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - CIS Azure Foundations
+  cloud: azure
+  capability: read-only
+---
+
+# detect-azure-activity-logs-disabled
+
+Streaming detector for explicit Azure diagnostic-settings deletion events. This is
+the Azure defense-evasion counterpart to the AWS and GCP logging-impaired
+detectors under issue `#253`.
+
+## Use when
+
+- You stream Azure Activity Logs through `ingest-azure-activity-ocsf` and want near-real-time defense-evasion findings
+- You want to catch explicit deletion of Azure diagnostic settings
+- You are closing ATT&CK T1562.001 coverage with a read-only Azure detector
+
+## Do NOT use
+
+- As a posture-at-rest logging check; use Azure benchmark/evidence skills
+- To infer every Azure logging impairment path; this first slice does not claim workspace unlink, policy drift, or destination weakening
+- For Azure resource logs or metrics ingestion paths outside Activity Log
+
+## Rule
+
+A finding fires on every successful Azure Activity event from `ingest-azure-activity-ocsf` where:
+
+1. `api.operation` case-insensitively equals `Microsoft.Insights/diagnosticSettings/delete`
+2. `status_id == 1`
+3. `resources[]` resolves a diagnostic setting resource id
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0005` (Defense Evasion)
+- `finding_info.attacks[].technique_uid = T1562.001` (Disable or Modify Tools)
+- `observables[]` including `target.uid`, `target.name`, `account.uid`, `actor.name`, and `api.operation`
+
+The native projection (`--output-format native`) keeps the target resource id and actor/account context in a flatter shape.
+
+## Run
+
+```bash
+# Azure Activity -> ingest -> detect (default OCSF output)
+python skills/ingestion/ingest-azure-activity-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-azure-activity-logs-disabled/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-azure-activity-logs-disabled/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-azure-activity-ocsf`](../../ingestion/ingest-azure-activity-ocsf/) — upstream ingester
+- [`detect-cloudtrail-disabled`](../detect-cloudtrail-disabled/) — sibling AWS logging impairment detector
+- [`detect-gcp-audit-logs-disabled`](../detect-gcp-audit-logs-disabled/) — sibling GCP logging impairment detector

--- a/skills/detection/detect-azure-activity-logs-disabled/src/detect.py
+++ b/skills/detection/detect-azure-activity-logs-disabled/src/detect.py
@@ -1,0 +1,293 @@
+"""Detect Azure diagnostic settings being explicitly deleted.
+
+Reads OCSF 1.8 API Activity (class 6003) records emitted by
+`ingest-azure-activity-ocsf` from stdin or a file. Fires on successful
+`Microsoft.Insights/diagnosticSettings/delete` operations and emits an OCSF
+1.8 Detection Finding (class 2004) tagged with MITRE ATT&CK T1562.001
+(Disable or Modify Tools).
+
+This first slice is intentionally narrow and high-confidence:
+1. event.api.operation case-insensitively equals
+   `Microsoft.Insights/diagnosticSettings/delete`
+2. event.status_id == 1 (success)
+3. the target diagnostic setting resource id resolves from `resources[]`
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-azure-activity-logs-disabled"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0005"
+TACTIC_NAME = "Defense Evasion"
+TECHNIQUE_UID = "T1562.001"
+TECHNIQUE_NAME = "Disable or Modify Tools"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-azure-activity-ocsf"})
+DIAGNOSTIC_DELETE_OPERATION = "microsoft.insights/diagnosticsettings/delete"
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _normalized_operation(event: dict[str, Any]) -> str:
+    return _api_operation(event).strip().lower()
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _actor(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _resource_id(event: dict[str, Any]) -> str:
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        name = str(resource.get("name") or resource.get("uid") or "")
+        if name:
+            return name
+    return ""
+
+
+def _setting_name(resource_id: str) -> str:
+    if not resource_id:
+        return ""
+    return resource_id.rstrip("/").split("/")[-1]
+
+
+def _finding_uid(event_uid: str, resource_id: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{resource_id}|{time_ms}"
+    return f"aad-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(*, event: dict[str, Any], resource_id: str, setting_name: str) -> dict[str, Any]:
+    time_ms = int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+    event_uid = str((event.get("metadata") or {}).get("uid") or "")
+    finding_uid = _finding_uid(event_uid, resource_id, time_ms)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "azure-activity-logs-disabled",
+        "api_operation": _api_operation(event),
+        "resource_id": resource_id,
+        "setting_name": setting_name,
+        "actor_name": _actor(event),
+        "account_uid": _account(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Actor `{native['actor_name'] or 'unknown'}` successfully called "
+        f"`{native['api_operation']}` against Azure diagnostic setting "
+        f"`{native['setting_name'] or '<unknown>'}` in subscription "
+        f"`{native['account_uid']}`. Source IP: {native['src_ip'] or '<unknown>'}."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "Azure"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": native["api_operation"]},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.type", "type": "Other", "value": "diagnostic_setting"},
+        {"name": "target.uid", "type": "Other", "value": native["resource_id"]},
+        {"name": "target.name", "type": "Other", "value": native["setting_name"]},
+        {"name": "account.uid", "type": "Other", "value": native["account_uid"]},
+    ]
+    if native["region"]:
+        observables.append({"name": "region", "type": "Other", "value": native["region"]})
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["azure", "diagnostic-settings", "defense-evasion"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "Azure diagnostic setting deleted",
+            "desc": description,
+            "types": ["azure-activity-logs-disabled"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "resource_id": native["resource_id"],
+            "setting_name": native["setting_name"],
+        },
+    }
+
+
+def detect(events: Iterable[dict[str, Any]], *, output_format: str = "ocsf") -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-azure-activity producer `{producer}`",
+            )
+            continue
+        if _normalized_operation(event) != DIAGNOSTIC_DELETE_OPERATION:
+            continue
+        if not _is_success(event):
+            continue
+        resource_id = _resource_id(event)
+        if not resource_id:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_target",
+                message="diagnostic settings delete event missing resource id; skipping",
+            )
+            continue
+        setting_name = _setting_name(resource_id)
+        native = _build_native_finding(event=event, resource_id=resource_id, setting_name=setting_name)
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def load_jsonl(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, line in enumerate(stream, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="json_parse_failed",
+                message=f"skipping line {lineno}: json parse failed: {exc}",
+                line=lineno,
+            )
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect successful Azure diagnostic settings delete operations."
+    )
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(OUTPUT_FORMATS),
+        default="ocsf",
+        help="Emit OCSF Detection Finding (default) or native projection.",
+    )
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    try:
+        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+            out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-azure-activity-logs-disabled/tests/test_detect.py
+++ b/skills/detection/detect-azure-activity-logs-disabled/tests/test_detect.py
@@ -1,0 +1,114 @@
+"""Tests for detect-azure-activity-logs-disabled."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_azure_activity_logs_disabled_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ACCEPTED_PRODUCERS = MODULE.ACCEPTED_PRODUCERS
+DIAGNOSTIC_DELETE_OPERATION = MODULE.DIAGNOSTIC_DELETE_OPERATION
+TECHNIQUE_UID = MODULE.TECHNIQUE_UID
+detect = MODULE.detect
+
+
+def _az_event(
+    *,
+    operation: str = "Microsoft.Insights/diagnosticSettings/delete",
+    success: bool = True,
+    resource_id: str = (
+        "/subscriptions/00000000-0000-0000-0000-000000000001/"
+        "resourceGroups/rg-prod/providers/Microsoft.Network/networkSecurityGroups/nsg-web/"
+        "providers/Microsoft.Insights/diagnosticSettings/activity-export"
+    ),
+    actor: str = "alice@example.com",
+    account_uid: str = "00000000-0000-0000-0000-000000000001",
+    region: str = "eastus",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-azure-activity-ocsf",
+) -> dict:
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1700000000000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "actor": {"user": {"name": actor}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation},
+        "resources": [{"name": resource_id, "type": "diagnosticsettings"}] if resource_id else [],
+        "cloud": {"provider": "Azure", "account": {"uid": account_uid}, "region": region},
+    }
+
+
+def test_accepted_producer_is_azure_activity():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-azure-activity-ocsf"})
+
+
+def test_delete_operation_constant():
+    assert DIAGNOSTIC_DELETE_OPERATION == "microsoft.insights/diagnosticsettings/delete"
+
+
+def test_fires_on_diagnostic_settings_delete():
+    findings = list(detect([_az_event()]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    assert finding["finding_info"]["attacks"][0]["technique_uid"] == TECHNIQUE_UID
+    assert any(obs["name"] == "target.name" and obs["value"] == "activity-export" for obs in finding["observables"])
+
+
+def test_operation_match_is_case_insensitive():
+    findings = list(detect([_az_event(operation="MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE")]))
+    assert len(findings) == 1
+
+
+def test_native_output_contains_target_identity():
+    findings = list(detect([_az_event()], output_format="native"))
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["setting_name"] == "activity-export"
+    assert finding["resource_id"].endswith("/diagnosticSettings/activity-export")
+
+
+def test_skips_failed_event():
+    assert list(detect([_az_event(success=False)])) == []
+
+
+def test_skips_unrelated_operation():
+    assert list(detect([_az_event(operation="Microsoft.Insights/diagnosticSettings/write")])) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_az_event(producer="ingest-cloudtrail-ocsf")]))
+    assert findings == []
+    assert "non-azure-activity producer" in capsys.readouterr().err
+
+
+def test_skips_missing_resource_id(capsys):
+    findings = list(detect([_az_event(resource_id="")]))
+    assert findings == []
+    assert "missing resource id" in capsys.readouterr().err
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_az_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    event = _az_event()
+    first = list(detect([event]))[0]["finding_info"]["uid"]
+    second = list(detect([event]))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("aad-")


### PR DESCRIPTION
What changed

added a new read-only detection skill, `detect-azure-activity-logs-disabled`, for successful Azure `Microsoft.Insights/diagnosticSettings/delete` operations from `ingest-azure-activity-ocsf`
kept the rule intentionally narrow and high-confidence; it does not over-claim every Azure logging impairment path or infer policy drift the current ingester does not preserve
added unit tests for positive hits, negative cases, native output, deterministic finding ids, and malformed/missing target context
updated `docs/framework-coverage.json`, regenerated `docs/FRAMEWORK_COVERAGE.md`, refreshed `SECURITY_BAR.md`, and aligned README / visuals to the branch state (`64` skills, `17` detect, `91` benchmark checks)

Why

`#253` is the ATT&CK umbrella, and after the AWS logging-impairment slice the next clean cross-cloud move is Azure. This PR adds one shipped Azure defense-evasion detector instead of broadening ATT&CK claims in docs only.

Scope

This first slice intentionally covers only:

successful `Microsoft.Insights/diagnosticSettings/delete`

It does not claim every Azure logging impairment path yet. Workspace unlink, destination drift, and broader monitoring-policy changes remain separate follow-on work.

Validation

`pytest skills/detection/detect-azure-activity-logs-disabled/tests/test_detect.py -q`
`ruff check skills/detection/detect-azure-activity-logs-disabled/src/detect.py skills/detection/detect-azure-activity-logs-disabled/tests/test_detect.py`
`python scripts/generate_framework_coverage_doc.py`
`python scripts/generate_security_bar_matrix.py`
`python scripts/validate_skill_contract.py`
`python scripts/validate_skill_integrity.py`
`python scripts/validate_framework_coverage.py`
`xmllint --noout docs/images/hero-banner.svg docs/images/architecture-layers.svg`

Part of #253