### PR TITLE
Add AWS access-key creation detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 65 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 66 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**65 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**66 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 18 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 19 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 65 shipped skills.**
+**Total: 66 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 13 of 18 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS, GCP, and Azure logging-impairment plus MCP credential-leak slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 19 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key creation, AWS/GCP/Azure logging-impairment, plus MCP credential-leak slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -275,7 +275,7 @@ Per-skill framework mapping: [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPING
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 18 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS / GCP / Azure logging-impairment trio and MCP credential-leak detection | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
+| **Detect** | 19 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS IAM access-key creation slice, the AWS / GCP / Azure logging-impairment trio, and MCP credential-leak detection | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
 | **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
 | **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -53,6 +53,7 @@ is the row you can take to your auditor.
 | `discover-environment` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `iam-departures-reconciler` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `detect-agent-credential-leak-mcp` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-aws-access-key-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-open-security-group` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-activity-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-open-nsg` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -95,7 +96,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_65 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_66 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 18 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 19 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,14 +4,14 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.8.0`
 - Registry updated: `2026-04-24`
-- Total shipped skills in registry: **65**
+- Total shipped skills in registry: **66**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **44** | — |
-| MITRE ATT&CK | v14 | **41** | 100% mapped coverage |
+| OCSF | 1.8.0 | **45** | — |
+| MITRE ATT&CK | v14 | **42** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
@@ -36,11 +36,12 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **44**
+Shipped skills mapped: **45**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-agent-credential-leak-mcp`](../skills/detection/detect-agent-credential-leak-mcp) | detection | mcp, multi | agent-tools, tool-results, credentials |
+| [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation) | detection | aws | iam-users, access-keys, credentials, cloudtrail |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
@@ -92,10 +93,11 @@ Shipped skills mapped: **44**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **41**
+Shipped skills mapped: **42**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
+| [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation) | detection | aws | iam-users, access-keys, credentials, cloudtrail |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -20,7 +20,7 @@ from individual `SKILL.md` files.
 | Framework | Status | Where it appears |
 |---|---|---|
 | **OCSF 1.8** | core wire contract | all ingestion, detection, and view flows |
-| **MITRE ATT&CK v14** | strong and broader | 41 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS / GCP / Azure logging-impairment trio |
+| **MITRE ATT&CK v14** | strong and broader | 42 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key creation slice and the AWS / GCP / Azure logging-impairment trio |
 | **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, and MCP prompt-injection detection |
 | **CIS Benchmarks / Controls** | strong | AWS, GCP, Azure, Kubernetes, container evaluation skills |
 | **NIST CSF 2.0** | strong | evaluation and some remediation skills |
@@ -48,7 +48,8 @@ Strongest current ATT&CK coverage:
 
 | Skill | Coverage |
 |---|---|
-| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; AWS IAM-user/access-key pivots and GCP workload-identity federation abuse remain tracked follow-up gaps |
+| `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; AWS IAM-user login-profile and temporary-credential pivots plus GCP workload-identity federation abuse remain tracked follow-up gaps |
+| `detect-aws-access-key-creation` | T1098.001 for successful AWS IAM `CreateAccessKey` operations that add credential material to an IAM user |
 | `detect-okta-mfa-fatigue` | T1621 for repeated Okta Verify push challenge + deny bursts |
 | `detect-entra-credential-addition` | T1098.001 for successful Entra application or service-principal credential additions and federated identity credential creation |
 | `detect-entra-role-grant-escalation` | T1098.003 for successful Entra app-role assignments that grant additional application permissions to service principals |
@@ -73,7 +74,10 @@ Notes:
   weakening, and policy-drift depth remain separate follow-on work.
 - Current cross-cloud identity depth is strongest in `detect-lateral-movement`; the Azure slice now distinguishes Azure Activity control-plane pivots from Entra / Graph application-service-principal credential pivots.
 - The GCP slice in `detect-lateral-movement` is currently pinned to service-account and IAM Credentials anchors; workload-identity federation abuse is tracked separately so the docs do not overstate provider depth.
-- The AWS slice in `detect-lateral-movement` is currently role-session-centric; IAM users, access keys, and temporary-credential pivots are tracked separately so the docs do not overstate provider depth.
+- The AWS role-session slice stays in `detect-lateral-movement`, while
+  `detect-aws-access-key-creation` now covers the first IAM-user persistence
+  path. Login-profile and temporary-credential pivots remain tracked separately
+  so the docs do not overstate provider depth.
 
 ## OCSF identity normalization
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,8 +22,10 @@ The current north star is not "more skills" by itself. It is:
 
 ### Current shipped progress snapshot
 
-- **ATT&CK depth:** 41 mapped skills in the coverage registry, with the first
-  cross-cloud logging-impairment trio now shipped across AWS, GCP, and Azure.
+- **ATT&CK depth:** 42 mapped skills in the coverage registry, with the first
+  AWS IAM-user persistence slice now shipped via access-key creation detection
+  and the first cross-cloud logging-impairment trio now shipped across AWS,
+  GCP, and Azure.
 - **CIS and posture depth:** 91 shipped benchmark checks across AWS, GCP,
   Azure, Kubernetes, container, GPU, and model-serving surfaces; AWS also has
   the first guarded `--auto-remediate` slice.
@@ -163,7 +165,7 @@ Open roadmap issues should be:
 Good examples:
 
 - `ATT&CK gap: Azure Entra and service principal credential detections`
-- `ATT&CK gap: AWS IAM users, access keys, and temporary-credential identity pivots`
+- `ATT&CK gap: AWS IAM-user login-profile and temporary-credential identity pivots`
 - `ATT&CK gap: GCP service accounts, service-account keys, and workload-identity federation abuse detections`
 - `ATLAS gap: AI endpoint and model registry evaluation coverage`
 - `PCI and SOC 2 gap: remaining cross-cloud evidence depth beyond provider-native logging, segmentation, encryption, and key-management inventory`

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -746,6 +746,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-aws-access-key-creation",
+      "layer": "detection",
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "iam-users",
+        "access-keys",
+        "credentials",
+        "cloudtrail"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-open-security-group",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 18 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 19 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">18</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">19</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1180" viewBox="0 0 1400 1180" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1218" viewBox="0 0 1400 1218" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (18) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of eighteen detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the logging-impairment plus MCP credential-leak slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (19) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of nineteen detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key creation, logging-impairment, and MCP credential-leak slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="1180" fill="url(#bg2)"/>
-  <rect width="1400" height="1180" fill="url(#grid2)"/>
+  <rect width="1400" height="1218" fill="url(#bg2)"/>
+  <rect width="1400" height="1218" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (18)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (19)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -180,42 +180,49 @@
     <rect x="880"  y="920" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
     <text x="1020" y="936" fill="#fef3c7" font-size="13">→ credential rotation / quarantine follow-up in #255</text>
   </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="974" fill="#f1f5f9" font-size="15">detect-aws-access-key-creation</text>
+    <text x="430"  y="974" fill="#cbd5e1" font-size="14">T1098.001 (TA0003)</text>
+    <rect x="760"  y="958" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="958" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="974" fill="#fee2e2" font-size="13">detection-first AWS IAM-user persistence slice</text>
+  </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="990" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1028" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1024" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
-    <text x="430"  y="1024" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
-    <rect x="760"  y="1008" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1008" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1024" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
+    <text x="48"   y="1062" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="1062" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
+    <rect x="760"  y="1046" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1046" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1062" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1054" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
-    <text x="430"  y="1054" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
-    <rect x="760"  y="1038" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1038" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1054" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1092" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="1092" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
+    <rect x="760"  y="1076" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1076" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1092" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1084" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
-    <text x="430"  y="1084" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
-    <rect x="760"  y="1068" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1068" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1084" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1122" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="1122" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="1106" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1106" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1122" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1114" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
-    <text x="430"  y="1114" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="760"  y="1098" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1098" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="1020" y="1114" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+    <text x="48"   y="1152" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="1152" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="1136" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1136" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1152" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
   </g>
 
   <!-- Footer (two lines to fit 1200px canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1148" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 18</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and new logging / MCP leakage slices are detection-first today</tspan></text>
-    <text x="48" y="1166" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1186" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 19</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the new AWS access-key, logging, and MCP leakage slices are detection-first today</tspan></text>
+    <text x="48" y="1204" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 65 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 18 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 66 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 19 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">65</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">66</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">18</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">19</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 65 shipped skills — 15 ingest, 18 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 66 shipped skills — 15 ingest, 19 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 65 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">65</text>
+      <!-- Counts: 66 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">66</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 18 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 19 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -50,6 +50,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-entra-credential-addition`](detection/detect-entra-credential-addition/) | successful Entra application or service-principal credential additions |
 | [`detect-entra-role-grant-escalation`](detection/detect-entra-role-grant-escalation/) | successful Entra app-role grants to service principals |
 | [`detect-google-workspace-suspicious-login`](detection/detect-google-workspace-suspicious-login/) | provider-marked suspicious Workspace login or repeated failures followed by success |
+| [`detect-aws-access-key-creation`](detection/detect-aws-access-key-creation/) | successful AWS IAM `CreateAccessKey` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-open-security-group`](detection/detect-aws-open-security-group/) | AWS Security Group ingress opened to 0.0.0.0/0 or ::/0 on risky admin / database / cache ports (T1190 Exploit Public-Facing Application) |
 | [`detect-azure-open-nsg`](detection/detect-azure-open-nsg/) | Azure NSG inbound rule opened to `*` / `Internet` / `0.0.0.0/0` / `::/0` on risky admin / database / cache ports (T1190 Exploit Public-Facing Application) |
 | [`detect-gcp-open-firewall`](detection/detect-gcp-open-firewall/) | GCP VPC firewall rule opened to 0.0.0.0/0 or ::/0 on risky admin / database / cache ports via `compute.firewalls.insert` or `compute.firewalls.patch` (T1190 Exploit Public-Facing Application) |

--- a/skills/detection/detect-aws-access-key-creation/REFERENCES.md
+++ b/skills/detection/detect-aws-access-key-creation/REFERENCES.md
@@ -1,0 +1,10 @@
+# References — detect-aws-access-key-creation
+
+- AWS IAM API Reference — `CreateAccessKey`:
+  https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html
+- AWS CloudTrail user identity reference:
+  https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html
+- MITRE ATT&CK T1098.001 — Additional Cloud Credentials:
+  https://attack.mitre.org/techniques/T1098/001/
+- Upstream ingester:
+  [`../../ingestion/ingest-cloudtrail-ocsf/`](../../ingestion/ingest-cloudtrail-ocsf/)

--- a/skills/detection/detect-aws-access-key-creation/SKILL.md
+++ b/skills/detection/detect-aws-access-key-creation/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: detect-aws-access-key-creation
+description: >-
+  Detect successful AWS IAM `CreateAccessKey` API calls against IAM users from
+  OCSF 1.8 API Activity records emitted by ingest-cloudtrail-ocsf. Emits an
+  OCSF 1.8 Detection Finding (class 2004) tagged with MITRE ATT&CK T1098.001
+  (Additional Cloud Credentials) when a principal creates an access key for an
+  IAM user. Use when the user mentions "AWS access key created", "IAM user key
+  issuance", "additional cloud credentials in AWS", or "T1098.001 via
+  CloudTrail". Do NOT use as a posture-at-rest access-key inventory check, to
+  infer console-password or login-profile creation, or to claim every AWS
+  identity-pivot path. This first slice only covers successful
+  `CreateAccessKey` operations.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No AWS
+  SDK; pairs with ingest-cloudtrail-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-aws-access-key-creation
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+  cloud: aws
+  capability: read-only
+---
+
+# detect-aws-access-key-creation
+
+Streaming detector for new AWS IAM user access keys created through CloudTrail.
+This is the first honest shipped AWS IAM-user persistence slice after the
+role-session-centric depth in `detect-lateral-movement`.
+
+## Use when
+
+- You stream CloudTrail through `ingest-cloudtrail-ocsf` and want near-real-time findings on new IAM user access keys
+- You want a narrow, high-confidence AWS persistence detector for additional cloud credentials
+- You are closing the first AWS IAM-user / access-key gap under the ATT&CK roadmap without over-claiming login-profile or temporary-credential coverage
+
+## Do NOT use
+
+- As a posture-at-rest access-key inventory or age check; use [`cspm-aws-cis-benchmark`](../../evaluation/cspm-aws-cis-benchmark/)
+- To infer console-password creation or login-profile changes; that is a separate follow-on detector
+- To claim every AWS temporary-credential or IAM-user pivot path; this first slice is only `CreateAccessKey`
+
+## Rule
+
+A finding fires on every successful CloudTrail event from `ingest-cloudtrail-ocsf` where:
+
+1. `api.operation` is `CreateAccessKey`
+2. `status_id == 1`
+3. request parameters resolve a target IAM username
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0003` (Persistence)
+- `finding_info.attacks[].technique_uid = T1098` (Account Manipulation)
+- `finding_info.attacks[].sub_technique_uid = T1098.001` (Additional Cloud Credentials)
+- `observables[]` including `target.name`, `account.uid`, `region`, `actor.name`, and `api.operation`
+
+The native projection (`--output-format native`) keeps the target IAM user and
+actor/account context in a flatter shape.
+
+## Run
+
+```bash
+# CloudTrail -> ingest -> detect (default OCSF output)
+python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-aws-access-key-creation/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-aws-access-key-creation/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-cloudtrail-ocsf`](../../ingestion/ingest-cloudtrail-ocsf/) — upstream ingester
+- [`detect-lateral-movement`](../detect-lateral-movement/) — AWS role-session pivot coverage
+- [`cspm-aws-cis-benchmark`](../../evaluation/cspm-aws-cis-benchmark/) — posture-at-rest AWS credential hygiene

--- a/skills/detection/detect-aws-access-key-creation/src/detect.py
+++ b/skills/detection/detect-aws-access-key-creation/src/detect.py
@@ -1,0 +1,280 @@
+"""Detect AWS IAM user access-key creation via CloudTrail.
+
+Reads OCSF 1.8 API Activity (class 6003) records emitted by
+`ingest-cloudtrail-ocsf` from stdin or a file. Fires on successful
+`CreateAccessKey` calls against IAM users and emits an OCSF 1.8 Detection
+Finding (class 2004) tagged with MITRE ATT&CK T1098.001
+(Additional Cloud Credentials).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-aws-access-key-creation"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0003"
+TACTIC_NAME = "Persistence"
+TECHNIQUE_UID = "T1098"
+TECHNIQUE_NAME = "Account Manipulation"
+SUBTECHNIQUE_UID = "T1098.001"
+SUBTECHNIQUE_NAME = "Additional Cloud Credentials"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-cloudtrail-ocsf"})
+ACCESS_KEY_CREATE_OPERATION = "CreateAccessKey"
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _target_user(event: dict[str, Any]) -> str:
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        resource_type = str(resource.get("type") or "")
+        resource_name = str(resource.get("name") or "")
+        if resource_type.lower() in {"username", "user", "iamusername"} and resource_name:
+            return resource_name
+    return ""
+
+
+def _actor(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _finding_uid(event_uid: str, target_user: str, actor_name: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{target_user}|{actor_name}|{time_ms}"
+    return f"aakc-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(*, event: dict[str, Any], target_user: str) -> dict[str, Any]:
+    time_ms = int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+    event_uid = str((event.get("metadata") or {}).get("uid") or "")
+    actor_name = _actor(event)
+    finding_uid = _finding_uid(event_uid, target_user, actor_name, time_ms)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "aws-access-key-creation",
+        "api_operation": ACCESS_KEY_CREATE_OPERATION,
+        "target_user_name": target_user,
+        "actor_name": actor_name,
+        "account_uid": _account(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Actor `{native['actor_name'] or 'unknown'}` successfully called "
+        f"`{native['api_operation']}` for IAM user `{native['target_user_name']}` in account "
+        f"`{native['account_uid']}` ({native['region']}). Source IP: "
+        f"{native['src_ip'] or '<unknown>'}. This creates additional AWS credential "
+        "material for a valid cloud account."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "AWS"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": native["api_operation"]},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.type", "type": "Other", "value": "IAMUser"},
+        {"name": "target.name", "type": "Other", "value": native["target_user_name"]},
+        {"name": "account.uid", "type": "Other", "value": native["account_uid"]},
+        {"name": "region", "type": "Other", "value": native["region"]},
+    ]
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["aws", "iam", "credentials", "persistence"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "AWS IAM access key created",
+            "desc": description,
+            "types": ["aws-access-key-creation"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                    "sub_technique_uid": SUBTECHNIQUE_UID,
+                    "sub_technique_name": SUBTECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "target_user_name": native["target_user_name"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-cloudtrail producer `{producer}`",
+            )
+            continue
+        if _api_operation(event) != ACCESS_KEY_CREATE_OPERATION:
+            continue
+        if not _is_success(event):
+            continue
+        target_user = _target_user(event)
+        if not target_user:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_target_user",
+                message="skipping CreateAccessKey event with no target IAM username",
+            )
+            continue
+        native = _build_native_finding(event=event, target_user=target_user)
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def _iter_jsonl(path: str | None) -> Iterator[dict[str, Any]]:
+    handle = open(path, "r", encoding="utf-8") if path else sys.stdin
+    with handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="invalid_json",
+                    message=f"skipping line {line_number}: invalid JSON ({exc.msg})",
+                )
+                continue
+            if isinstance(obj, dict):
+                yield obj
+            else:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="wrong_shape",
+                    message=f"skipping line {line_number}: expected JSON object",
+                )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", nargs="?", help="JSONL file path (default: stdin)")
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(OUTPUT_FORMATS),
+        default="ocsf",
+        help="Emit repo-native or OCSF findings (default: ocsf)",
+    )
+    args = parser.parse_args(argv)
+
+    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
+        print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-aws-access-key-creation/tests/test_detect.py
+++ b/skills/detection/detect-aws-access-key-creation/tests/test_detect.py
@@ -1,0 +1,116 @@
+"""Tests for detect-aws-access-key-creation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_aws_access_key_creation_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ACCEPTED_PRODUCERS = MODULE.ACCEPTED_PRODUCERS
+ACCESS_KEY_CREATE_OPERATION = MODULE.ACCESS_KEY_CREATE_OPERATION
+SUBTECHNIQUE_UID = MODULE.SUBTECHNIQUE_UID
+detect = MODULE.detect
+
+
+def _ct_event(
+    *,
+    operation: str = "CreateAccessKey",
+    success: bool = True,
+    target_user: str = "bob",
+    actor: str = "AROAEXAMPLEID:alice",
+    account_uid: str = "111122223333",
+    region: str = "us-east-1",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-cloudtrail-ocsf",
+    resource_type: str = "userName",
+) -> dict:
+    resources = []
+    if target_user:
+        resources.append({"name": target_user, "type": resource_type})
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1700000000000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "actor": {"user": {"name": actor}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation},
+        "cloud": {"provider": "AWS", "account": {"uid": account_uid}, "region": region},
+        "resources": resources,
+    }
+
+
+def test_accepted_producer_is_cloudtrail():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-cloudtrail-ocsf"})
+
+
+def test_operation_is_create_access_key_only():
+    assert ACCESS_KEY_CREATE_OPERATION == "CreateAccessKey"
+
+
+def test_fires_on_create_access_key():
+    findings = list(detect([_ct_event()]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    attack = finding["finding_info"]["attacks"][0]
+    assert attack["sub_technique_uid"] == SUBTECHNIQUE_UID
+    assert finding["finding_info"]["title"] == "AWS IAM access key created"
+    assert any(obs["name"] == "target.name" and obs["value"] == "bob" for obs in finding["observables"])
+
+
+def test_native_output_contains_target_user():
+    findings = list(detect([_ct_event(target_user="carol")], output_format="native"))
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["target_user_name"] == "carol"
+    assert finding["rule"] == "aws-access-key-creation"
+
+
+def test_skips_failed_event():
+    assert list(detect([_ct_event(success=False)])) == []
+
+
+def test_skips_unrelated_operation():
+    assert list(detect([_ct_event(operation="ListUsers")])) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_ct_event(producer="ingest-okta-system-log-ocsf")]))
+    assert findings == []
+    assert "non-cloudtrail producer" in capsys.readouterr().err
+
+
+def test_skips_missing_target_user(capsys):
+    findings = list(detect([_ct_event(target_user="")]))
+    assert findings == []
+    assert "no target IAM username" in capsys.readouterr().err
+
+
+def test_accepts_resource_type_user():
+    findings = list(detect([_ct_event(resource_type="user")]))
+    assert len(findings) == 1
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_ct_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    event = _ct_event()
+    first = list(detect([event]))[0]["finding_info"]["uid"]
+    second = list(detect([event]))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("aakc-")


### PR DESCRIPTION
What changed

- added a new read-only detection skill, `detect-aws-access-key-creation`, for successful AWS IAM `CreateAccessKey` operations from `ingest-cloudtrail-ocsf`
- kept the rule intentionally narrow and high-confidence; it detects additional AWS credential material on IAM users without claiming broader login-profile or temporary-credential depth yet
- added unit tests for positive hits, negative cases, native output, deterministic finding ids, wrong-source skips, and missing-target-user handling
- updated `docs/framework-coverage.json`, regenerated `docs/FRAMEWORK_COVERAGE.md`, refreshed `SECURITY_BAR.md`, and aligned the repo truth surfaces to the branch state: `66 skills`, `19 detect`, `91 benchmark checks`
- updated the README, roadmap, framework mappings, skills catalog, hero/runtime/architecture visuals, and coverage matrix to reflect the new shipped ATT&CK slice

Why

The repo already ships strong AWS role-session coverage in `detect-lateral-movement`, but the next honest AWS IAM-user depth is access-key issuance. This PR lands the first AWS IAM-user persistence slice under the ATT&CK roadmap without overstating login-profile or temporary-credential coverage that is not shipped yet.

Scope

This first slice intentionally covers only:

- successful `CreateAccessKey`

It does not yet claim:

- console login-profile creation
- password reset / console credential paths
- STS temporary-credential misuse beyond the existing role-session coverage

Validation

- `pytest skills/detection/detect-aws-access-key-creation/tests/test_detect.py -q`
- `ruff check skills/detection/detect-aws-access-key-creation/src/detect.py skills/detection/detect-aws-access-key-creation/tests/test_detect.py`
- `python scripts/generate_framework_coverage_doc.py`
- `python scripts/generate_security_bar_matrix.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_count_consistency.py`
- `xmllint --noout docs/images/hero-banner.svg docs/images/runtime-surfaces.svg docs/images/architecture-layers.svg docs/images/coverage-matrix.svg`
- `rsvg-convert docs/images/coverage-matrix.svg -o /tmp/coverage-matrix-next.png`

Part of #253
