### PR TITLE
Add AWS enumeration burst detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 67 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 68 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**67 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**68 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 20 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 21 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 67 shipped skills.**
+**Total: 68 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 13 of 20 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS/GCP/Azure logging-impairment, plus MCP credential-leak slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 21 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS/GCP/Azure logging-impairment, plus MCP credential-leak slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -275,7 +275,7 @@ Per-skill framework mapping: [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPING
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 20 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the AWS / GCP / Azure logging-impairment trio, and MCP credential-leak detection | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
+| **Detect** | 21 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst slice, the AWS / GCP / Azure logging-impairment trio, and MCP credential-leak detection | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
 | **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
 | **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -54,6 +54,7 @@ is the row you can take to your auditor.
 | `iam-departures-reconciler` | discovery | ✅ | ✅ | ✅ | ✅ deterministic | n/a | ✅ |
 | `detect-agent-credential-leak-mcp` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-access-key-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-aws-enumeration-burst` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-login-profile-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-open-security-group` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-activity-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -97,7 +98,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_67 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_68 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 20 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 21 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,14 +4,14 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.8.0`
 - Registry updated: `2026-04-24`
-- Total shipped skills in registry: **67**
+- Total shipped skills in registry: **68**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **46** | — |
-| MITRE ATT&CK | v14 | **43** | 100% mapped coverage |
+| OCSF | 1.8.0 | **47** | — |
+| MITRE ATT&CK | v14 | **44** | 100% mapped coverage |
 | MITRE ATLAS | current | **8** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
@@ -36,12 +36,13 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **46**
+Shipped skills mapped: **47**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-agent-credential-leak-mcp`](../skills/detection/detect-agent-credential-leak-mcp) | detection | mcp, multi | agent-tools, tool-results, credentials |
 | [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation) | detection | aws | iam-users, access-keys, credentials, cloudtrail |
+| [`detect-aws-enumeration-burst`](../skills/detection/detect-aws-enumeration-burst) | detection | aws | identities, compute, storage, network, organizations, cloudtrail |
 | [`detect-aws-login-profile-creation`](../skills/detection/detect-aws-login-profile-creation) | detection | aws | iam-users, login-profiles, credentials, cloudtrail |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
@@ -94,11 +95,12 @@ Shipped skills mapped: **46**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **43**
+Shipped skills mapped: **44**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation) | detection | aws | iam-users, access-keys, credentials, cloudtrail |
+| [`detect-aws-enumeration-burst`](../skills/detection/detect-aws-enumeration-burst) | detection | aws | identities, compute, storage, network, organizations, cloudtrail |
 | [`detect-aws-login-profile-creation`](../skills/detection/detect-aws-login-profile-creation) | detection | aws | iam-users, login-profiles, credentials, cloudtrail |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -20,7 +20,7 @@ from individual `SKILL.md` files.
 | Framework | Status | Where it appears |
 |---|---|---|
 | **OCSF 1.8** | core wire contract | all ingestion, detection, and view flows |
-| **MITRE ATT&CK v14** | strong and broader | 43 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices and the AWS / GCP / Azure logging-impairment trio |
+| **MITRE ATT&CK v14** | strong and broader | 44 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst slice, and the AWS / GCP / Azure logging-impairment trio |
 | **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, and MCP prompt-injection detection |
 | **CIS Benchmarks / Controls** | strong | AWS, GCP, Azure, Kubernetes, container evaluation skills |
 | **NIST CSF 2.0** | strong | evaluation and some remediation skills |
@@ -51,6 +51,7 @@ Strongest current ATT&CK coverage:
 | `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; AWS IAM-user temporary-credential pivots plus GCP workload-identity federation abuse remain tracked follow-up gaps |
 | `detect-aws-access-key-creation` | T1098.001 for successful AWS IAM `CreateAccessKey` operations that add credential material to an IAM user |
 | `detect-aws-login-profile-creation` | T1098.001 for successful AWS IAM `CreateLoginProfile` operations that add console-password credential material to an IAM user |
+| `detect-aws-enumeration-burst` | T1526 for short-window bursts of high-signal AWS discovery APIs in CloudTrail across IAM, EC2, S3, KMS, Organizations, EKS, Lambda, and CloudTrail |
 | `detect-okta-mfa-fatigue` | T1621 for repeated Okta Verify push challenge + deny bursts |
 | `detect-entra-credential-addition` | T1098.001 for successful Entra application or service-principal credential additions and federated identity credential creation |
 | `detect-entra-role-grant-escalation` | T1098.003 for successful Entra app-role assignments that grant additional application permissions to service principals |
@@ -80,6 +81,9 @@ Notes:
   `detect-aws-login-profile-creation` now cover the first IAM-user
   credential-creation paths. Temporary-credential pivots remain tracked
   separately so the docs do not overstate provider depth.
+- The first AWS cloud-discovery slice now ships as
+  `detect-aws-enumeration-burst`, but it is intentionally a curated API
+  burst detector, not a claim that all AWS discovery behavior is covered.
 
 ## OCSF identity normalization
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,10 +22,11 @@ The current north star is not "more skills" by itself. It is:
 
 ### Current shipped progress snapshot
 
-- **ATT&CK depth:** 43 mapped skills in the coverage registry, with the first
+- **ATT&CK depth:** 44 mapped skills in the coverage registry, with the first
   AWS IAM-user credential-creation slices now shipped via access-key and
-  login-profile detection, plus the first cross-cloud logging-impairment trio
-  now shipped across AWS, GCP, and Azure.
+  login-profile detection, the first AWS cloud-discovery burst slice now
+  shipped, and the first cross-cloud logging-impairment trio now shipped
+  across AWS, GCP, and Azure.
 - **CIS and posture depth:** 91 shipped benchmark checks across AWS, GCP,
   Azure, Kubernetes, container, GPU, and model-serving surfaces; AWS also has
   the first guarded `--auto-remediate` slice.

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -794,6 +794,32 @@
       ]
     },
     {
+      "path": "skills/detection/detect-aws-enumeration-burst",
+      "layer": "detection",
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "identities",
+        "compute",
+        "storage",
+        "network",
+        "organizations",
+        "cloudtrail"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-open-security-group",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 20 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 21 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">20</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">21</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1256" viewBox="0 0 1400 1256" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1294" viewBox="0 0 1400 1294" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (20) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, logging-impairment, and MCP credential-leak slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (21) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-one detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, discovery-burst, logging-impairment, and MCP credential-leak slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="1256" fill="url(#bg2)"/>
-  <rect width="1400" height="1256" fill="url(#grid2)"/>
+  <rect width="1400" height="1294" fill="url(#bg2)"/>
+  <rect width="1400" height="1294" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (20)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (21)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -194,42 +194,49 @@
     <rect x="880"  y="996" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
     <text x="1020" y="1012" fill="#fee2e2" font-size="13">detection-first AWS IAM-user console persistence slice</text>
   </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="1050" fill="#f1f5f9" font-size="15">detect-aws-enumeration-burst</text>
+    <text x="430"  y="1050" fill="#cbd5e1" font-size="14">T1526 (TA0007)</text>
+    <rect x="760"  y="1034" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1034" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="1050" fill="#fee2e2" font-size="13">detection-first AWS cloud discovery burst slice</text>
+  </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="1066" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1104" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1100" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
-    <text x="430"  y="1100" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
-    <rect x="760"  y="1084" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1084" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1100" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
+    <text x="48"   y="1138" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="1138" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
+    <rect x="760"  y="1122" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1122" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1138" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1130" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
-    <text x="430"  y="1130" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
-    <rect x="760"  y="1114" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1114" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1130" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1168" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="1168" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
+    <rect x="760"  y="1152" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1152" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1168" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1160" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
-    <text x="430"  y="1160" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
-    <rect x="760"  y="1144" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1144" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1160" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1198" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="1198" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="1182" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1182" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1198" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1190" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
-    <text x="430"  y="1190" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="760"  y="1174" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1174" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="1020" y="1190" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+    <text x="48"   y="1228" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="1228" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="1212" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1212" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1228" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
   </g>
 
   <!-- Footer (two lines to fit 1200px canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1224" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 20</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, logging, and MCP leakage slices are detection-first today</tspan></text>
-    <text x="48" y="1242" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1262" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 21</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, discovery, logging, and MCP leakage slices are detection-first today</tspan></text>
+    <text x="48" y="1280" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 67 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 20 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 68 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 21 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">67</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">68</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">20</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">21</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 67 shipped skills — 15 ingest, 20 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 68 shipped skills — 15 ingest, 21 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 67 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">67</text>
+      <!-- Counts: 68 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">68</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 20 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 21 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -52,6 +52,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-google-workspace-suspicious-login`](detection/detect-google-workspace-suspicious-login/) | provider-marked suspicious Workspace login or repeated failures followed by success |
 | [`detect-aws-access-key-creation`](detection/detect-aws-access-key-creation/) | successful AWS IAM `CreateAccessKey` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-login-profile-creation`](detection/detect-aws-login-profile-creation/) | successful AWS IAM `CreateLoginProfile` operations against IAM users (T1098.001 Additional Cloud Credentials) |
+| [`detect-aws-enumeration-burst`](detection/detect-aws-enumeration-burst/) | short-window burst of high-signal AWS discovery APIs in CloudTrail (T1526 Cloud Service Discovery) |
 | [`detect-aws-open-security-group`](detection/detect-aws-open-security-group/) | AWS Security Group ingress opened to 0.0.0.0/0 or ::/0 on risky admin / database / cache ports (T1190 Exploit Public-Facing Application) |
 | [`detect-azure-open-nsg`](detection/detect-azure-open-nsg/) | Azure NSG inbound rule opened to `*` / `Internet` / `0.0.0.0/0` / `::/0` on risky admin / database / cache ports (T1190 Exploit Public-Facing Application) |
 | [`detect-gcp-open-firewall`](detection/detect-gcp-open-firewall/) | GCP VPC firewall rule opened to 0.0.0.0/0 or ::/0 on risky admin / database / cache ports via `compute.firewalls.insert` or `compute.firewalls.patch` (T1190 Exploit Public-Facing Application) |

--- a/skills/detection/detect-aws-enumeration-burst/REFERENCES.md
+++ b/skills/detection/detect-aws-enumeration-burst/REFERENCES.md
@@ -1,0 +1,13 @@
+# References — detect-aws-enumeration-burst
+
+- AWS CloudTrail event reference:
+  <https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html>
+- AWS IAM API reference (`GetAccountAuthorizationDetails`, `ListUsers`, `ListRoles`, `ListPolicies`):
+  <https://docs.aws.amazon.com/IAM/latest/APIReference/API_Operations.html>
+- AWS EC2 API reference (`DescribeInstances`, `DescribeSecurityGroups`, `DescribeSubnets`, `DescribeVpcs`):
+  <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/OperationList-query-ec2.html>
+- AWS Organizations API reference (`DescribeOrganization`, `ListAccounts`):
+  <https://docs.aws.amazon.com/organizations/latest/APIReference/Welcome.html>
+- MITRE ATT&CK T1526 Cloud Service Discovery:
+  <https://attack.mitre.org/techniques/T1526/>
+- Upstream ingester: [`ingest-cloudtrail-ocsf`](../../ingestion/ingest-cloudtrail-ocsf/)

--- a/skills/detection/detect-aws-enumeration-burst/SKILL.md
+++ b/skills/detection/detect-aws-enumeration-burst/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: detect-aws-enumeration-burst
+description: >-
+  Detect short-window bursts of high-signal AWS discovery APIs from OCSF 1.8
+  API Activity records emitted by ingest-cloudtrail-ocsf. Emits an OCSF 1.8
+  Detection Finding (class 2004) tagged with MITRE ATT&CK T1526 (Cloud Service
+  Discovery) when one principal rapidly calls a narrow allow-list of CloudTrail
+  discovery APIs across IAM, EC2, S3, KMS, Lambda, EKS, CloudTrail, and
+  Organizations. Use when the user mentions "AWS discovery burst", "CloudTrail
+  enumeration spree", "rapid Describe/List calls", or "T1526 via CloudTrail".
+  Do NOT use as a generic anomaly detector for every read API, to claim all AWS
+  discovery paths, or to infer exfiltration from read-only control-plane calls.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No AWS
+  SDK; pairs with ingest-cloudtrail-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-aws-enumeration-burst
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+  cloud: aws
+  capability: read-only
+---
+
+# detect-aws-enumeration-burst
+
+Streaming detector for rapid AWS discovery bursts in CloudTrail. This is the
+first shipped AWS cloud-discovery slice under the ATT&CK roadmap, and it stays
+intentionally narrow so the repo does not over-claim generic discovery coverage.
+
+## Use when
+
+- You stream CloudTrail through `ingest-cloudtrail-ocsf` and want near-real-time findings on suspicious enumeration bursts
+- You want a deterministic, read-only AWS discovery detector aligned to ATT&CK `T1526`
+- You need a narrow follow-on slice after the shipped AWS IAM-user access-key and login-profile persistence detectors
+
+## Do NOT use
+
+- As a generic anomaly detector for every `Describe*`, `Get*`, or `List*` call in AWS
+- To infer exfiltration or data access; use a dedicated egress or data-transfer detector
+- To claim every AWS discovery path is covered; this first slice is only a curated allow-list of high-signal control-plane APIs
+
+## Rule
+
+A finding fires when one AWS principal, within a rolling five-minute window:
+
+1. emits at least `6` successful CloudTrail events from `ingest-cloudtrail-ocsf`
+2. across at least `5` distinct allow-listed discovery API calls
+3. against the same account / region / principal key
+
+Today the allow-list covers high-signal AWS discovery APIs such as:
+
+- IAM: `ListUsers`, `ListRoles`, `ListPolicies`, `GetAccountAuthorizationDetails`
+- EC2: `DescribeInstances`, `DescribeSecurityGroups`, `DescribeSubnets`, `DescribeVpcs`
+- S3: `ListBuckets`
+- Organizations: `DescribeOrganization`, `ListAccounts`
+- KMS: `ListKeys`
+- Lambda: `ListFunctions`
+- EKS: `ListClusters`
+- CloudTrail: `DescribeTrails`
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity MEDIUM (`severity_id=3`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0007` (Discovery)
+- `finding_info.attacks[].technique_uid = T1526` (Cloud Service Discovery)
+- `observables[]` including actor, account, region, source IP, total event count, distinct API count, and the concrete API set seen in the burst
+
+The native projection (`--output-format native`) keeps the same burst summary in
+a flatter shape.
+
+## Run
+
+```bash
+# CloudTrail -> ingest -> detect (default OCSF output)
+python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-aws-enumeration-burst/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-aws-enumeration-burst/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-cloudtrail-ocsf`](../../ingestion/ingest-cloudtrail-ocsf/) — upstream ingester
+- [`detect-lateral-movement`](../detect-lateral-movement/) — cross-cloud movement after successful pivots
+- [`detect-cloudtrail-disabled`](../detect-cloudtrail-disabled/) — AWS defense-evasion depth

--- a/skills/detection/detect-aws-enumeration-burst/src/detect.py
+++ b/skills/detection/detect-aws-enumeration-burst/src/detect.py
@@ -1,0 +1,417 @@
+"""Detect AWS CloudTrail discovery enumeration bursts.
+
+Reads OCSF 1.8 API Activity (class 6003) records emitted by
+`ingest-cloudtrail-ocsf` from stdin or a file. Fires on short-window bursts of
+curated high-signal AWS discovery APIs and emits an OCSF 1.8 Detection Finding
+(class 2004) tagged with MITRE ATT&CK T1526 (Cloud Service Discovery).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-aws-enumeration-burst"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_MEDIUM = 3
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0007"
+TACTIC_NAME = "Discovery"
+TECHNIQUE_UID = "T1526"
+TECHNIQUE_NAME = "Cloud Service Discovery"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-cloudtrail-ocsf"})
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+WINDOW_MS = 5 * 60 * 1000
+MIN_TOTAL_EVENTS = 6
+MIN_DISTINCT_CALLS = 5
+
+DISCOVERY_CALLS = frozenset(
+    {
+        ("cloudtrail.amazonaws.com", "DescribeTrails"),
+        ("ec2.amazonaws.com", "DescribeInstances"),
+        ("ec2.amazonaws.com", "DescribeSecurityGroups"),
+        ("ec2.amazonaws.com", "DescribeSubnets"),
+        ("ec2.amazonaws.com", "DescribeVpcs"),
+        ("eks.amazonaws.com", "ListClusters"),
+        ("iam.amazonaws.com", "GetAccountAuthorizationDetails"),
+        ("iam.amazonaws.com", "ListPolicies"),
+        ("iam.amazonaws.com", "ListRoles"),
+        ("iam.amazonaws.com", "ListUsers"),
+        ("kms.amazonaws.com", "ListKeys"),
+        ("lambda.amazonaws.com", "ListFunctions"),
+        ("organizations.amazonaws.com", "DescribeOrganization"),
+        ("organizations.amazonaws.com", "ListAccounts"),
+        ("s3.amazonaws.com", "ListBuckets"),
+    }
+)
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _api_service(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    service = api.get("service") or {}
+    return str(service.get("name") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _actor_name(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _session_uid(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    session = actor.get("session") or {}
+    return str(session.get("uid") or "")
+
+
+def _account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _event_uid(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    return str(metadata.get("uid") or "")
+
+
+def _time_ms(event: dict[str, Any]) -> int:
+    return int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _call_label(service: str, operation: str) -> str:
+    return f"{service}:{operation}"
+
+
+def _principal_key(event: dict[str, Any]) -> str:
+    return _session_uid(event) or _actor_name(event)
+
+
+def _finding_uid(
+    *,
+    account_uid: str,
+    region: str,
+    principal_key: str,
+    first_seen_time_ms: int,
+    last_seen_time_ms: int,
+    calls: list[str],
+) -> str:
+    material = "|".join(
+        [
+            SKILL_NAME,
+            account_uid,
+            region,
+            principal_key,
+            str(first_seen_time_ms),
+            str(last_seen_time_ms),
+            ",".join(calls),
+        ]
+    )
+    return f"aeb-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(
+    *,
+    actor_name: str,
+    actor_session_uid: str,
+    account_uid: str,
+    region: str,
+    src_ip: str,
+    first_seen_time_ms: int,
+    last_seen_time_ms: int,
+    total_events: int,
+    distinct_calls: int,
+    observed_calls: list[str],
+) -> dict[str, Any]:
+    principal_key = actor_session_uid or actor_name
+    finding_uid = _finding_uid(
+        account_uid=account_uid,
+        region=region,
+        principal_key=principal_key,
+        first_seen_time_ms=first_seen_time_ms,
+        last_seen_time_ms=last_seen_time_ms,
+        calls=observed_calls,
+    )
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "aws-enumeration-burst",
+        "actor_name": actor_name,
+        "actor_session_uid": actor_session_uid,
+        "account_uid": account_uid,
+        "region": region,
+        "src_ip": src_ip,
+        "total_events": total_events,
+        "distinct_calls": distinct_calls,
+        "observed_calls": observed_calls,
+        "first_seen_time_ms": first_seen_time_ms,
+        "last_seen_time_ms": last_seen_time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Principal `{native['actor_name'] or native['actor_session_uid'] or 'unknown'}` "
+        f"made `{native['total_events']}` high-signal AWS discovery calls across "
+        f"`{native['distinct_calls']}` distinct APIs within five minutes in account "
+        f"`{native['account_uid']}` ({native['region']}). Calls observed: "
+        f"{', '.join(native['observed_calls'])}. Source IP: "
+        f"{native['src_ip'] or '<unknown>'}."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "AWS"},
+        {
+            "name": "actor.name",
+            "type": "Other",
+            "value": native["actor_name"] or native["actor_session_uid"] or "unknown",
+        },
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "account.uid", "type": "Other", "value": native["account_uid"]},
+        {"name": "region", "type": "Other", "value": native["region"]},
+        {"name": "events.total", "type": "Other", "value": str(native["total_events"])},
+        {"name": "calls.distinct", "type": "Other", "value": str(native["distinct_calls"])},
+        {"name": "calls.observed", "type": "Other", "value": ", ".join(native["observed_calls"])},
+    ]
+    if native["actor_session_uid"]:
+        observables.append(
+            {"name": "actor.session.uid", "type": "Other", "value": native["actor_session_uid"]}
+        )
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_MEDIUM,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["aws", "cloudtrail", "discovery", "enumeration"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "AWS discovery API burst",
+            "desc": description,
+            "types": ["aws-enumeration-burst"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": native["total_events"],
+            "distinct_calls": native["distinct_calls"],
+            "observed_calls": native["observed_calls"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-cloudtrail producer `{producer}`",
+            )
+            continue
+        if not _is_success(event):
+            continue
+        service = _api_service(event)
+        operation = _api_operation(event)
+        if (service, operation) not in DISCOVERY_CALLS:
+            continue
+        actor_name = _actor_name(event)
+        actor_session_uid = _session_uid(event)
+        principal_key = actor_session_uid or actor_name
+        if not principal_key:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_actor",
+                message="skipping discovery event with no actor or session identifier",
+            )
+            continue
+        account_uid = _account(event)
+        region = _region(event)
+        key = (account_uid, region, principal_key)
+        grouped[key].append(
+            {
+                "event_uid": _event_uid(event),
+                "time_ms": _time_ms(event),
+                "actor_name": actor_name,
+                "actor_session_uid": actor_session_uid,
+                "account_uid": account_uid,
+                "region": region,
+                "src_ip": _src_ip(event),
+                "service": service,
+                "operation": operation,
+                "call_label": _call_label(service, operation),
+            }
+        )
+
+    findings: list[dict[str, Any]] = []
+    for key in sorted(grouped):
+        window: deque[dict[str, Any]] = deque()
+        events_for_key = sorted(grouped[key], key=lambda item: (item["time_ms"], item["event_uid"]))
+        for summary in events_for_key:
+            while window and summary["time_ms"] - window[0]["time_ms"] > WINDOW_MS:
+                window.popleft()
+            window.append(summary)
+            distinct_calls = sorted({item["call_label"] for item in window})
+            if len(window) < MIN_TOTAL_EVENTS or len(distinct_calls) < MIN_DISTINCT_CALLS:
+                continue
+            native = _build_native_finding(
+                actor_name=summary["actor_name"],
+                actor_session_uid=summary["actor_session_uid"],
+                account_uid=summary["account_uid"],
+                region=summary["region"],
+                src_ip=summary["src_ip"],
+                first_seen_time_ms=window[0]["time_ms"],
+                last_seen_time_ms=window[-1]["time_ms"],
+                total_events=len(window),
+                distinct_calls=len(distinct_calls),
+                observed_calls=distinct_calls,
+            )
+            findings.append(native if output_format == "native" else _to_ocsf(native))
+            window.clear()
+
+    for finding in findings:
+        yield finding
+
+
+def _iter_jsonl(path: str | None) -> Iterator[dict[str, Any]]:
+    handle = open(path, "r", encoding="utf-8") if path else sys.stdin
+    with handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="invalid_json",
+                    message=f"skipping line {line_number}: invalid JSON ({exc.msg})",
+                )
+                continue
+            if isinstance(obj, dict):
+                yield obj
+            else:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="wrong_shape",
+                    message=f"skipping line {line_number}: expected JSON object",
+                )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", help="optional JSONL input path; defaults to stdin")
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(OUTPUT_FORMATS),
+        default="ocsf",
+        help="emit OCSF Detection Finding 2004 (default) or native findings",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    for finding in detect(_iter_jsonl(args.path), output_format=args.output_format):
+        json.dump(finding, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-aws-enumeration-burst/tests/test_detect.py
+++ b/skills/detection/detect-aws-enumeration-burst/tests/test_detect.py
@@ -1,0 +1,186 @@
+"""Tests for detect-aws-enumeration-burst."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_aws_enumeration_burst_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ACCEPTED_PRODUCERS = MODULE.ACCEPTED_PRODUCERS
+DISCOVERY_CALLS = MODULE.DISCOVERY_CALLS
+MIN_DISTINCT_CALLS = MODULE.MIN_DISTINCT_CALLS
+MIN_TOTAL_EVENTS = MODULE.MIN_TOTAL_EVENTS
+TECHNIQUE_UID = MODULE.TECHNIQUE_UID
+detect = MODULE.detect
+
+
+def _ct_event(
+    *,
+    service: str = "ec2.amazonaws.com",
+    operation: str = "DescribeInstances",
+    success: bool = True,
+    actor: str = "alice",
+    session_uid: str = "ASIAXAMPLE123",
+    account_uid: str = "111122223333",
+    region: str = "us-east-1",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-cloudtrail-ocsf",
+    time_ms: int = 1700000000000,
+    event_uid: str = "evt-1",
+) -> dict:
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": time_ms,
+        "metadata": {"uid": event_uid, "product": {"feature": {"name": producer}}},
+        "actor": {"user": {"name": actor}, "session": {"uid": session_uid} if session_uid else {}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation, "service": {"name": service}},
+        "cloud": {"provider": "AWS", "account": {"uid": account_uid}, "region": region},
+    }
+
+
+def test_accepted_producer_is_cloudtrail():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-cloudtrail-ocsf"})
+
+
+def test_threshold_constants_are_expected():
+    assert MIN_TOTAL_EVENTS == 6
+    assert MIN_DISTINCT_CALLS == 5
+
+
+def test_detection_set_contains_high_signal_discovery_calls():
+    assert ("ec2.amazonaws.com", "DescribeInstances") in DISCOVERY_CALLS
+    assert ("iam.amazonaws.com", "GetAccountAuthorizationDetails") in DISCOVERY_CALLS
+    assert ("s3.amazonaws.com", "ListBuckets") in DISCOVERY_CALLS
+
+
+def test_fires_on_short_window_enumeration_burst():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-5", time_ms=1700000040000),
+        _ct_event(service="organizations.amazonaws.com", operation="ListAccounts", event_uid="evt-6", time_ms=1700000050000),
+    ]
+    findings = list(detect(events))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    assert finding["finding_info"]["title"] == "AWS discovery API burst"
+    assert finding["finding_info"]["attacks"][0]["technique_uid"] == TECHNIQUE_UID
+    assert any(obs["name"] == "calls.distinct" and obs["value"] == "6" for obs in finding["observables"])
+
+
+def test_native_output_contains_counts_and_calls():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-5", time_ms=1700000040000),
+        _ct_event(service="organizations.amazonaws.com", operation="ListAccounts", event_uid="evt-6", time_ms=1700000050000),
+    ]
+    findings = list(detect(events, output_format="native"))
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["total_events"] == 6
+    assert finding["distinct_calls"] == 6
+    assert "ec2.amazonaws.com:DescribeInstances" in finding["observed_calls"]
+
+
+def test_skips_below_total_event_threshold():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-5", time_ms=1700000040000),
+    ]
+    assert list(detect(events)) == []
+
+
+def test_skips_below_distinct_call_threshold():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-5", time_ms=1700000040000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-6", time_ms=1700000050000),
+    ]
+    assert list(detect(events)) == []
+
+
+def test_skips_failed_event():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-5", time_ms=1700000040000),
+        _ct_event(service="organizations.amazonaws.com", operation="ListAccounts", event_uid="evt-6", time_ms=1700000050000, success=False),
+    ]
+    assert list(detect(events)) == []
+
+
+def test_skips_unrelated_operation():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="ec2.amazonaws.com", operation="ModifyInstanceAttribute", event_uid="evt-5", time_ms=1700000040000),
+        _ct_event(service="ec2.amazonaws.com", operation="CreateTags", event_uid="evt-6", time_ms=1700000050000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-7", time_ms=1700000060000),
+    ]
+    assert list(detect(events)) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_ct_event(producer="ingest-okta-system-log-ocsf")]))
+    assert findings == []
+    assert "non-cloudtrail producer" in capsys.readouterr().err
+
+
+def test_skips_missing_actor(capsys):
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000, actor="", session_uid=""),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000, actor="", session_uid=""),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000, actor="", session_uid=""),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000, actor="", session_uid=""),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-5", time_ms=1700000040000, actor="", session_uid=""),
+        _ct_event(service="organizations.amazonaws.com", operation="ListAccounts", event_uid="evt-6", time_ms=1700000050000, actor="", session_uid=""),
+    ]
+    findings = list(detect(events))
+    assert findings == []
+    assert "no actor or session identifier" in capsys.readouterr().err
+
+
+def test_finding_uid_is_deterministic():
+    events = [
+        _ct_event(service="iam.amazonaws.com", operation="ListUsers", event_uid="evt-1", time_ms=1700000000000),
+        _ct_event(service="iam.amazonaws.com", operation="ListRoles", event_uid="evt-2", time_ms=1700000010000),
+        _ct_event(service="iam.amazonaws.com", operation="GetAccountAuthorizationDetails", event_uid="evt-3", time_ms=1700000020000),
+        _ct_event(service="ec2.amazonaws.com", operation="DescribeInstances", event_uid="evt-4", time_ms=1700000030000),
+        _ct_event(service="s3.amazonaws.com", operation="ListBuckets", event_uid="evt-5", time_ms=1700000040000),
+        _ct_event(service="organizations.amazonaws.com", operation="ListAccounts", event_uid="evt-6", time_ms=1700000050000),
+    ]
+    first = list(detect(events))[0]["finding_info"]["uid"]
+    second = list(detect(events))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("aeb-")
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_ct_event()], output_format="weird"))


### PR DESCRIPTION
What changed

added a new read-only detection skill, detect-aws-enumeration-burst, for short-window bursts of high-signal AWS discovery APIs from ingest-cloudtrail-ocsf
added unit tests for positive hits, negative cases, native output, deterministic finding ids, and malformed or missing actor context
updated docs/framework-coverage.json, regenerated docs/FRAMEWORK_COVERAGE.md, refreshed SECURITY_BAR.md, and aligned repo truth surfaces to the branch state (`68` skills, `21` detect, `91` benchmark checks)

Why

`#253` is the ATT&CK umbrella, and after shipping the AWS/GCP/Azure logging-impairment trio plus the first AWS IAM-user persistence slices, the next honest AWS move is discovery. This PR adds one narrow T1526 detector instead of over-claiming generic AWS enumeration coverage.

Scope

This first slice intentionally covers only:

short-window bursts of an explicit allow-list of AWS discovery APIs across IAM, EC2, S3, KMS, Organizations, Lambda, EKS, and CloudTrail

It does not claim every AWS discovery path, every `List*`/`Describe*` call, or exfiltration from control-plane reads. Those remain separate follow-on slices.

Validation

pytest skills/detection/detect-aws-enumeration-burst/tests/test_detect.py -q
ruff check skills/detection/detect-aws-enumeration-burst/src/detect.py skills/detection/detect-aws-enumeration-burst/tests/test_detect.py
python scripts/generate_framework_coverage_doc.py
python scripts/generate_security_bar_matrix.py
python scripts/validate_skill_contract.py
python scripts/validate_skill_integrity.py
python scripts/validate_framework_coverage.py
python scripts/validate_skill_count_consistency.py
xmllint --noout docs/images/hero-banner.svg docs/images/runtime-surfaces.svg docs/images/architecture-layers.svg docs/images/coverage-matrix.svg
rsvg-convert docs/images/coverage-matrix.svg -o /tmp/coverage-matrix-aws-enumeration.png

Part of #253
