### PR TITLE
Add AWS model artifact download detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 72 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 73 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**72 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**73 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 25 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 26 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 72 shipped skills.**
+**Total: 73 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 13 of 25 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 26 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS model-artifact download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -277,7 +277,7 @@ Approximate roadmap progress is tracked here so the README reflects current ship
 |---|---:|---|
 | **MITRE ATT&CK (`#253`)** | **45%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, AWS discovery burst, and AWS cross-account S3 copy are shipped |
 | **CIS + auto-remediate (`#254`)** | **35%** | 91 checks shipped across AWS/GCP/Azure/K8s/container/GPU/model-serving, with the first guarded AWS `--auto-remediate` slice shipped |
-| **MITRE ATLAS + OWASP LLM/MCP (`#255`)** | **35%** | MCP prompt injection, tool drift, credential leak, system-prompt extraction, tool-output policy-bypass detection, tool-output exfiltration-instruction detection, and MCP tool quarantine are shipped |
+| **MITRE ATLAS + OWASP LLM/MCP (`#255`)** | **40%** | AWS model-artifact download detection, MCP prompt injection, tool drift, credential leak, system-prompt extraction, tool-output policy-bypass detection, tool-output exfiltration-instruction detection, and MCP tool quarantine are shipped |
 
 These are repo-progress estimates, not claims of full framework completion.
 
@@ -287,7 +287,7 @@ These are repo-progress estimates, not claims of full framework completion.
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 25 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
+| **Detect** | 26 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS model-artifact download slice, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
 | **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
 | **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -56,6 +56,7 @@ is the row you can take to your auditor.
 | `detect-aws-access-key-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-enumeration-burst` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-login-profile-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-aws-model-artifact-download` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-aws-open-security-group` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-activity-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-azure-open-nsg` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -102,7 +103,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_72 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_73 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 25 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 26 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,15 +4,15 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.8.0`
 - Registry updated: `2026-04-24`
-- Total shipped skills in registry: **72**
+- Total shipped skills in registry: **73**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **51** | — |
-| MITRE ATT&CK | v14 | **45** | 100% mapped coverage |
-| MITRE ATLAS | current | **11** | 100% mapped coverage |
+| OCSF | 1.8.0 | **52** | — |
+| MITRE ATT&CK | v14 | **46** | 100% mapped coverage |
+| MITRE ATLAS | current | **12** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
 | CIS Azure Foundations | v2.1 | **6** | — |
@@ -24,7 +24,7 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 | SOC 2 TSC | current | **20** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **3** | — |
-| OWASP LLM Top 10 | current | **6** | — |
+| OWASP LLM Top 10 | current | **7** | — |
 | OWASP MCP Top 10 | current | **7** | — |
 | CycloneDX ML-BOM | current | **2** | — |
 
@@ -36,7 +36,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **51**
+Shipped skills mapped: **52**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -44,6 +44,7 @@ Shipped skills mapped: **51**
 | [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation) | detection | aws | iam-users, access-keys, credentials, cloudtrail |
 | [`detect-aws-enumeration-burst`](../skills/detection/detect-aws-enumeration-burst) | detection | aws | identities, compute, storage, network, organizations, cloudtrail |
 | [`detect-aws-login-profile-creation`](../skills/detection/detect-aws-login-profile-creation) | detection | aws | iam-users, login-profiles, credentials, cloudtrail |
+| [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download) | detection | aws | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
@@ -99,13 +100,14 @@ Shipped skills mapped: **51**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **45**
+Shipped skills mapped: **46**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation) | detection | aws | iam-users, access-keys, credentials, cloudtrail |
 | [`detect-aws-enumeration-burst`](../skills/detection/detect-aws-enumeration-burst) | detection | aws | identities, compute, storage, network, organizations, cloudtrail |
 | [`detect-aws-login-profile-creation`](../skills/detection/detect-aws-login-profile-creation) | detection | aws | iam-users, login-profiles, credentials, cloudtrail |
+| [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download) | detection | aws | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled) | detection | azure | activity-logs, diagnostic-settings, logging |
 | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg) | detection | azure | network-security-groups, ingress-rules, azure-activity |
@@ -156,10 +158,11 @@ Shipped skills mapped: **45**
 - Asset classes in scope: ai-endpoints, models, datasets, vector-stores, gpu-fleets, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **11**
+Shipped skills mapped: **12**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
+| [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download) | detection | aws | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-prompt-injection-mcp-proxy`](../skills/detection/detect-prompt-injection-mcp-proxy) | detection | mcp, multi | agent-tools, tool-metadata, guardrails |
 | [`detect-system-prompt-extraction`](../skills/detection/detect-system-prompt-extraction) | detection | mcp | agent-tools, tool-results, prompts, instructions |
 | [`detect-tool-output-exfiltration-instructions`](../skills/detection/detect-tool-output-exfiltration-instructions) | detection | mcp | agent-tools, tool-results, instructions, artifacts |
@@ -355,11 +358,12 @@ Shipped skills mapped: **3**
 
 - Registry id: `owasp-llm-top-10`
 
-Shipped skills mapped: **6**
+Shipped skills mapped: **7**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-agent-credential-leak-mcp`](../skills/detection/detect-agent-credential-leak-mcp) | detection | mcp, multi | agent-tools, tool-results, credentials |
+| [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download) | detection | aws | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-prompt-injection-mcp-proxy`](../skills/detection/detect-prompt-injection-mcp-proxy) | detection | mcp, multi | agent-tools, tool-metadata, guardrails |
 | [`detect-system-prompt-extraction`](../skills/detection/detect-system-prompt-extraction) | detection | mcp | agent-tools, tool-results, prompts, instructions |
 | [`detect-tool-output-exfiltration-instructions`](../skills/detection/detect-tool-output-exfiltration-instructions) | detection | mcp | agent-tools, tool-results, instructions, artifacts |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -20,11 +20,11 @@ from individual `SKILL.md` files.
 | Framework | Status | Where it appears |
 |---|---|---|
 | **OCSF 1.8** | core wire contract | all ingestion, detection, and view flows |
-| **MITRE ATT&CK v14** | strong and broader | 45 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, and the AWS / GCP / Azure logging-impairment trio |
-| **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, and MCP prompt-injection plus response-layer override and exfiltration detection |
+| **MITRE ATT&CK v14** | strong and broader | 46 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, and the first AWS model-artifact download slice |
+| **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, MCP prompt-injection plus response-layer override and exfiltration detection, and the first cloud-native model-artifact collection slice |
 | **CIS Benchmarks / Controls** | strong | AWS, GCP, Azure, Kubernetes, container evaluation skills |
 | **NIST CSF 2.0** | strong | evaluation and some remediation skills |
-| **OWASP LLM Top 10** | partial and growing | model-serving controls plus `detect-prompt-injection-mcp-proxy`, `detect-agent-credential-leak-mcp`, `detect-system-prompt-extraction`, `detect-tool-output-policy-bypass`, and `detect-tool-output-exfiltration-instructions` |
+| **OWASP LLM Top 10** | partial and growing | model-serving controls plus `detect-prompt-injection-mcp-proxy`, `detect-agent-credential-leak-mcp`, `detect-system-prompt-extraction`, `detect-tool-output-policy-bypass`, `detect-tool-output-exfiltration-instructions`, and `detect-aws-model-artifact-download` |
 | **OWASP MCP Top 10** | partial and growing | `detect-mcp-tool-drift`, `detect-prompt-injection-mcp-proxy`, `detect-agent-credential-leak-mcp`, `detect-system-prompt-extraction`, `detect-tool-output-policy-bypass`, `detect-tool-output-exfiltration-instructions`, and MCP-related repo controls |
 | **SOC 2 TSC** | partial | evaluation and remediation mappings |
 | **ISO 27001:2022** | partial | CSPM/evaluation mappings |
@@ -53,6 +53,7 @@ Strongest current ATT&CK coverage:
 | `detect-aws-login-profile-creation` | T1098.001 for successful AWS IAM `CreateLoginProfile` operations that add console-password credential material to an IAM user |
 | `detect-aws-enumeration-burst` | T1526 for short-window bursts of high-signal AWS discovery APIs in CloudTrail across IAM, EC2, S3, KMS, Organizations, EKS, Lambda, and CloudTrail |
 | `detect-s3-cross-account-copy` | T1537 for successful AWS S3 `CopyObject` calls where the acting principal account differs from the recipient bucket-owner account |
+| `detect-aws-model-artifact-download` | T1530 plus ATLAS AML.T0035 for successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts |
 | `detect-okta-mfa-fatigue` | T1621 for repeated Okta Verify push challenge + deny bursts |
 | `detect-entra-credential-addition` | T1098.001 for successful Entra application or service-principal credential additions and federated identity credential creation |
 | `detect-entra-role-grant-escalation` | T1098.003 for successful Entra app-role assignments that grant additional application permissions to service principals |
@@ -129,6 +130,7 @@ ATLAS is present today, but coverage is narrower than ATT&CK.
 | `detect-system-prompt-extraction` | explicit system-prompt and hidden-instruction leakage detection in MCP `tools/call` responses |
 | `detect-tool-output-policy-bypass` | response-layer prompt-injection detection for explicit policy-bypass and approval-evasion instructions in MCP `tools/call` responses |
 | `detect-tool-output-exfiltration-instructions` | response-layer prompt-injection detection for explicit data-exfiltration instructions in MCP `tools/call` responses |
+| `detect-aws-model-artifact-download` | cloud-native AI artifact collection detection for successful S3 downloads of model weights and checkpoints |
 | `discover-ai-bom` | inventory artifact plus optional AI BOM policy findings for ATLAS / AI RMF evidence and CI joins |
 | `discover-control-evidence` | evidence package that preserves ATLAS / AI RMF context from discovery artifacts |
 | `discover-cloud-control-evidence` | cross-cloud evidence package with explicit NIST AI RMF evidence mode, ATT&CK / ATLAS / AI RMF inventory context, and per-provider logging / segmentation / encryption / key-management depth |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,8 +34,8 @@ The current north star is not "more skills" by itself. It is:
 - **AI-native baseline:** MCP prompt injection, tool drift, credential leak
   detection, explicit system-prompt extraction detection, explicit
   tool-output policy-bypass detection, explicit tool-output
-  exfiltration-instruction detection, and MCP tool quarantine are all shipped.
-  The next open work is
+  exfiltration-instruction detection, AWS model-artifact download detection,
+  and MCP tool quarantine are all shipped. The next open work is
   broader AI-native detection depth and stronger closed loops, not first
   presence.
 

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -922,6 +922,32 @@
       ]
     },
     {
+      "path": "skills/detection/detect-aws-model-artifact-download",
+      "layer": "detection",
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "object-storage",
+        "objects",
+        "model-artifacts",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14",
+        "mitre-atlas",
+        "owasp-llm-top-10"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-open-security-group",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 25 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 26 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">24</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">26</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1446" viewBox="0 0 1400 1446" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1484" viewBox="0 0 1400 1484" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (25) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-five detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, discovery-burst, cross-account-copy, logging-impairment, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (26) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-six detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, discovery-burst, cross-account-copy, logging-impairment, AWS model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="1446" fill="url(#bg2)"/>
-  <rect width="1400" height="1446" fill="url(#grid2)"/>
+  <rect width="1400" height="1484" fill="url(#bg2)"/>
+  <rect width="1400" height="1484" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (25)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (26)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -229,42 +229,49 @@
     <rect x="880"  y="1186" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
     <text x="1020" y="1202" fill="#fee2e2" font-size="13">detection-first AI response exfiltration-instruction slice</text>
   </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="1240" fill="#f1f5f9" font-size="14">detect-aws-model-artifact-download</text>
+    <text x="430"  y="1240" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
+    <rect x="760"  y="1224" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1224" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="1240" fill="#fee2e2" font-size="13">detection-first AWS AI model-artifact collection slice</text>
+  </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="1256" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1294" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1290" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
-    <text x="430"  y="1290" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
-    <rect x="760"  y="1274" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1274" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1290" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
+    <text x="48"   y="1328" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="1328" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
+    <rect x="760"  y="1312" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1312" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1328" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1320" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
-    <text x="430"  y="1320" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
-    <rect x="760"  y="1304" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1304" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1320" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1358" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="1358" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
+    <rect x="760"  y="1342" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1342" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1358" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1350" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
-    <text x="430"  y="1350" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
-    <rect x="760"  y="1334" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1334" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1350" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1388" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="1388" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="1372" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1372" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1388" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1380" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
-    <text x="430"  y="1380" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="760"  y="1364" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1364" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="1020" y="1380" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+    <text x="48"   y="1418" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="1418" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="1402" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1402" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1418" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
   </g>
 
   <!-- Footer (two lines to fit 1200px canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1414" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 25</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, discovery, exfiltration, logging, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
-    <text x="48" y="1432" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1452" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 26</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, discovery, exfiltration, logging, AWS model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
+    <text x="48" y="1470" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 72 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 25 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 73 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 26 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">72</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">73</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">24</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">26</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 72 shipped skills — 15 ingest, 25 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 73 shipped skills — 15 ingest, 26 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 72 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">72</text>
+      <!-- Counts: 73 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">73</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 25 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 26 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -53,6 +53,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-aws-access-key-creation`](detection/detect-aws-access-key-creation/) | successful AWS IAM `CreateAccessKey` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-login-profile-creation`](detection/detect-aws-login-profile-creation/) | successful AWS IAM `CreateLoginProfile` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-enumeration-burst`](detection/detect-aws-enumeration-burst/) | short-window burst of high-signal AWS discovery APIs in CloudTrail (T1526 Cloud Service Discovery) |
+| [`detect-aws-model-artifact-download`](detection/detect-aws-model-artifact-download/) | successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |
 | [`detect-s3-cross-account-copy`](detection/detect-s3-cross-account-copy/) | successful AWS S3 `CopyObject` into another account's bucket-owner context (T1537 Transfer Data to Cloud Account) |
 | [`detect-system-prompt-extraction`](detection/detect-system-prompt-extraction/) | explicit system-prompt or hidden-instruction leakage markers in MCP tool-call responses (ATLAS AML.T0004 / AML.T0041) |
 | [`detect-tool-output-policy-bypass`](detection/detect-tool-output-policy-bypass/) | explicit policy-bypass, approval-evasion, or user-concealment instructions in MCP tool-call responses (ATLAS AML.T0051) |

--- a/skills/detection/detect-aws-model-artifact-download/REFERENCES.md
+++ b/skills/detection/detect-aws-model-artifact-download/REFERENCES.md
@@ -1,0 +1,6 @@
+# References — detect-aws-model-artifact-download
+
+- MITRE ATT&CK `T1530` Data from Cloud Storage: https://attack.mitre.org/techniques/T1530/
+- MITRE ATLAS framework corpus (official MITRE ATLAS work products): https://atlas.mitre.org/pdf-files/SAFEAI_Full_Report.pdf
+- AWS CloudTrail data events for Amazon S3 object-level activity: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html
+- Amazon S3 `GetObject` API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html

--- a/skills/detection/detect-aws-model-artifact-download/SKILL.md
+++ b/skills/detection/detect-aws-model-artifact-download/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: detect-aws-model-artifact-download
+description: >-
+  Detect successful AWS S3 `GetObject` downloads of model-weight and
+  checkpoint artifacts from OCSF 1.8 API Activity records emitted by
+  ingest-cloudtrail-ocsf. Emits an OCSF 1.8 Detection Finding (class 2004)
+  tagged with MITRE ATT&CK T1530 and MITRE ATLAS AML.T0035 when an S3 object
+  read matches narrow model-artifact heuristics such as `.safetensors`,
+  `.pt`, `.ckpt`, `pytorch_model.bin`, or `saved_model.pb`. Use when the user
+  mentions "AWS model weights downloaded", "S3 model artifact collection",
+  "checkpoint read from CloudTrail", or "AML.T0035 in AWS". Do NOT use for
+  generic S3 egress, cross-account copy detection, or network-only
+  exfiltration claims.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No AWS
+  SDK; pairs with ingest-cloudtrail-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-aws-model-artifact-download
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - MITRE ATLAS
+    - OWASP LLM Top 10
+  cloud: aws
+  capability: read-only
+---
+
+# detect-aws-model-artifact-download
+
+Streaming detector for successful AWS S3 downloads of model-weight and
+checkpoint artifacts. This is an AWS-first cloud slice under the AI-native
+roadmap: it uses CloudTrail object-read telemetry instead of another MCP-only
+text pattern.
+
+## Use when
+
+- You stream CloudTrail through `ingest-cloudtrail-ocsf` and want a narrow AI-native detector for model-artifact collection from S3
+- You need AWS-first coverage for suspicious reads of `.safetensors`, `.pt`, `.pth`, `.ckpt`, `.onnx`, `pytorch_model.bin`, or similar checkpoint files
+- You want an honest cloud detector that can expand to GCP and Azure later without over-claiming cross-cloud support today
+
+## Do NOT use
+
+- For generic S3 data-exfiltration or storage abuse; use a storage- or network-focused detector instead
+- For cross-account object-copy coverage; use [`detect-s3-cross-account-copy`](../detect-s3-cross-account-copy/)
+- To claim confirmed network exfiltration or model-weight transfer outside AWS; this first slice is a CloudTrail object-download detector
+
+## Rule
+
+A finding fires on every successful CloudTrail event from `ingest-cloudtrail-ocsf` where:
+
+1. `api.service.name` is `s3.amazonaws.com`
+2. `api.operation` is `GetObject`
+3. `status_id == 1`
+4. `resources[]` resolve both the bucket name and object key
+5. the object key matches a narrow model-artifact heuristic:
+   - strict suffixes such as `.safetensors`, `.pt`, `.pth`, `.ckpt`, `.onnx`, `.gguf`, `.tflite`
+   - exact filenames such as `pytorch_model.bin`, `adapter_model.bin`, `saved_model.pb`
+   - `.bin` only when the key also carries model hints such as `model`, `checkpoint`, `weights`, `sagemaker`, or `bedrock`
+
+The detector intentionally skips `AWSService` actors so internal service reads
+do not flood the signal.
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[]` carrying ATT&CK `T1530` Data from Cloud Storage
+- `finding_info.attacks[]` carrying ATLAS `AML.T0035` ML Artifact Collection
+- `observables[]` including bucket, key, actor identity, account, region, and source IP
+
+The native projection (`--output-format native`) keeps the bucket, key,
+artifact match, and actor/account context in a flatter shape.
+
+## Run
+
+```bash
+python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-aws-model-artifact-download/src/detect.py
+```
+
+Native output:
+
+```bash
+python skills/detection/detect-aws-model-artifact-download/src/detect.py findings-input.jsonl --output-format native
+```
+
+## Notes
+
+- This is detection-only today.
+- The next honest expansion is provider-equivalent model-artifact download coverage on GCP and Azure, not a broader AWS over-claim.
+
+## Related
+
+- [`detect-s3-cross-account-copy`](../detect-s3-cross-account-copy/) — AWS storage exfiltration sibling
+- [`detect-agent-credential-leak-mcp`](../detect-agent-credential-leak-mcp/) — AI-native credential leakage
+- [`detect-system-prompt-extraction`](../detect-system-prompt-extraction/) — explicit prompt leakage
+- [`model-serving-security`](../../evaluation/model-serving-security/) — AI-serving posture depth

--- a/skills/detection/detect-aws-model-artifact-download/src/detect.py
+++ b/skills/detection/detect-aws-model-artifact-download/src/detect.py
@@ -1,0 +1,410 @@
+"""Detect suspicious AWS S3 model-artifact downloads via CloudTrail."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-aws-model-artifact-download"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+ATTACK_TACTIC_UID = "TA0009"
+ATTACK_TACTIC_NAME = "Collection"
+ATTACK_TECHNIQUE_UID = "T1530"
+ATTACK_TECHNIQUE_NAME = "Data from Cloud Storage"
+
+ATLAS_VERSION = "current"
+ATLAS_TACTIC_UID = "AML.TA0009"
+ATLAS_TACTIC_NAME = "Collection"
+ATLAS_TECHNIQUE_UID = "AML.T0035"
+ATLAS_TECHNIQUE_NAME = "ML Artifact Collection"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-cloudtrail-ocsf"})
+S3_SERVICE = "s3.amazonaws.com"
+GET_OBJECT_OPERATION = "GetObject"
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+STRICT_SUFFIXES = (
+    ".safetensors",
+    ".pt",
+    ".pth",
+    ".ckpt",
+    ".onnx",
+    ".gguf",
+    ".tflite",
+    ".keras",
+    ".h5",
+)
+EXACT_FILENAMES = frozenset(
+    {
+        "pytorch_model.bin",
+        "adapter_model.bin",
+        "consolidated.safetensors",
+        "model.safetensors",
+        "model.ckpt",
+        "saved_model.pb",
+    }
+)
+MODEL_HINTS = (
+    "model",
+    "models",
+    "artifact",
+    "artifacts",
+    "checkpoint",
+    "checkpoints",
+    "weights",
+    "huggingface",
+    "finetune",
+    "fine-tune",
+    "lora",
+    "adapter",
+    "sagemaker",
+    "bedrock",
+)
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _api_service(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    service = api.get("service") or {}
+    return str(service.get("name") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _resource_value(event: dict[str, Any], *resource_types: str) -> str:
+    allowed = {item.lower() for item in resource_types}
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        resource_type = str(resource.get("type") or "").lower()
+        resource_name = str(resource.get("name") or "")
+        if resource_type in allowed and resource_name:
+            return resource_name
+    return ""
+
+
+def _bucket_name(event: dict[str, Any]) -> str:
+    return _resource_value(event, "bucketname")
+
+
+def _object_key(event: dict[str, Any]) -> str:
+    return _resource_value(event, "key")
+
+
+def _actor_name(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _actor_type(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("type") or "")
+
+
+def _actor_account(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    account = user.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _target_account(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _time_ms(event: dict[str, Any]) -> int:
+    return int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _event_uid(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    return str(metadata.get("uid") or "")
+
+
+def _artifact_match(key: str) -> tuple[bool, str]:
+    lowered = key.strip().lower()
+    if not lowered:
+        return False, ""
+    filename = lowered.rsplit("/", 1)[-1]
+    if filename in EXACT_FILENAMES:
+        return True, filename
+    for suffix in STRICT_SUFFIXES:
+        if lowered.endswith(suffix):
+            return True, suffix
+    if lowered.endswith(".bin") and any(token in lowered for token in MODEL_HINTS):
+        return True, ".bin+model-hint"
+    return False, ""
+
+
+def _finding_uid(
+    *,
+    event_uid: str,
+    actor_account_uid: str,
+    bucket_name: str,
+    object_key: str,
+    time_ms: int,
+) -> str:
+    material = "|".join([SKILL_NAME, event_uid, actor_account_uid, bucket_name, object_key, str(time_ms)])
+    return f"amad-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(
+    *,
+    event: dict[str, Any],
+    bucket_name: str,
+    object_key: str,
+    artifact_match: str,
+) -> dict[str, Any]:
+    time_ms = _time_ms(event)
+    finding_uid = _finding_uid(
+        event_uid=_event_uid(event),
+        actor_account_uid=_actor_account(event),
+        bucket_name=bucket_name,
+        object_key=object_key,
+        time_ms=time_ms,
+    )
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "aws-model-artifact-download",
+        "api_operation": GET_OBJECT_OPERATION,
+        "bucket_name": bucket_name,
+        "object_key": object_key,
+        "artifact_match": artifact_match,
+        "actor_name": _actor_name(event),
+        "actor_type": _actor_type(event),
+        "actor_account_uid": _actor_account(event),
+        "target_account_uid": _target_account(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": ATTACK_TACTIC_UID,
+                "tactic_name": ATTACK_TACTIC_NAME,
+                "technique_uid": ATTACK_TECHNIQUE_UID,
+                "technique_name": ATTACK_TECHNIQUE_NAME,
+            },
+            {
+                "version": ATLAS_VERSION,
+                "tactic_uid": ATLAS_TACTIC_UID,
+                "tactic_name": ATLAS_TACTIC_NAME,
+                "technique_uid": ATLAS_TECHNIQUE_UID,
+                "technique_name": ATLAS_TECHNIQUE_NAME,
+            },
+        ],
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Principal `{native['actor_name'] or 'unknown'}` successfully downloaded "
+        f"`s3://{native['bucket_name']}/{native['object_key']}` via `GetObject`. "
+        f"The object name matched model-artifact heuristics (`{native['artifact_match']}`) "
+        f"in account `{native['target_account_uid']}` ({native['region']}). Source IP: "
+        f"{native['src_ip'] or '<unknown>'}. This is an AWS-first detector for suspicious "
+        "AI model-weight or checkpoint collection from S3-backed storage."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "AWS"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "actor.type", "type": "Other", "value": native["actor_type"] or "unknown"},
+        {"name": "actor.account.uid", "type": "Other", "value": native["actor_account_uid"]},
+        {"name": "target.account.uid", "type": "Other", "value": native["target_account_uid"]},
+        {"name": "bucket.name", "type": "Other", "value": native["bucket_name"]},
+        {"name": "object.key", "type": "Other", "value": native["object_key"]},
+        {"name": "artifact.match", "type": "Other", "value": native["artifact_match"]},
+        {"name": "region", "type": "Other", "value": native["region"]},
+    ]
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["aws", "s3", "ai", "model-artifacts", "collection"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "AWS model artifact downloaded from S3",
+            "desc": description,
+            "types": ["aws-model-artifact-download"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": native["mitre_attacks"],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "bucket_name": native["bucket_name"],
+            "object_key": native["object_key"],
+            "artifact_match": native["artifact_match"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-cloudtrail producer `{producer}`",
+            )
+            continue
+        if _api_service(event) != S3_SERVICE or _api_operation(event) != GET_OBJECT_OPERATION:
+            continue
+        if not _is_success(event):
+            continue
+        if _actor_type(event).lower() == "awsservice":
+            continue
+        bucket_name = _bucket_name(event)
+        object_key = _object_key(event)
+        if not bucket_name or not object_key:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_s3_context",
+                message="skipping GetObject event missing bucket or key context",
+            )
+            continue
+        is_artifact, artifact_match = _artifact_match(object_key)
+        if not is_artifact:
+            continue
+        native = _build_native_finding(
+            event=event,
+            bucket_name=bucket_name,
+            object_key=object_key,
+            artifact_match=artifact_match,
+        )
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def _iter_jsonl(path: str | None) -> Iterator[dict[str, Any]]:
+    handle = open(path, "r", encoding="utf-8") if path else sys.stdin
+    with handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="invalid_json",
+                    message=f"skipping line {line_number}: invalid JSON ({exc.msg})",
+                )
+                continue
+            if isinstance(obj, dict):
+                yield obj
+            else:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="wrong_shape",
+                    message=f"skipping line {line_number}: expected JSON object",
+                )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", nargs="?", help="optional path to JSONL input (default: stdin)")
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(OUTPUT_FORMATS),
+        default="ocsf",
+        help="emit OCSF findings (default) or native findings",
+    )
+    args = parser.parse_args(argv)
+
+    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
+        print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skills/detection/detect-aws-model-artifact-download/tests/test_detect.py
+++ b/skills/detection/detect-aws-model-artifact-download/tests/test_detect.py
@@ -1,0 +1,113 @@
+"""Tests for detect-aws-model-artifact-download."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_aws_model_artifact_download_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _event(
+    *,
+    producer: str = "ingest-cloudtrail-ocsf",
+    operation: str = "GetObject",
+    service: str = "s3.amazonaws.com",
+    status_id: int = 1,
+    actor_name: str = "alice",
+    actor_type: str = "IAMUser",
+    actor_account_uid: str = "111122223333",
+    target_account_uid: str = "111122223333",
+    bucket_name: str = "model-artifacts-prod",
+    key: str = "bedrock/checkpoints/fraud-model/model.safetensors",
+    src_ip: str = "198.51.100.24",
+) -> dict:
+    return {
+        "class_uid": 6003,
+        "status_id": status_id,
+        "time": 1775797200000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "api": {
+            "operation": operation,
+            "service": {"name": service},
+        },
+        "actor": {
+            "user": {
+                "name": actor_name,
+                "type": actor_type,
+                "account": {"uid": actor_account_uid},
+            }
+        },
+        "cloud": {
+            "provider": "AWS",
+            "account": {"uid": target_account_uid},
+            "region": "us-east-1",
+        },
+        "src_endpoint": {"ip": src_ip},
+        "resources": [
+            {"name": bucket_name, "type": "bucketName"},
+            {"name": key, "type": "key"},
+        ],
+    }
+
+
+def test_fires_on_model_safetensors_get_object():
+    findings = list(MODULE.detect([_event()]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["finding_info"]["title"] == "AWS model artifact downloaded from S3"
+    attacks = finding["finding_info"]["attacks"]
+    assert any(item["technique_uid"] == "T1530" for item in attacks)
+    assert any(item["technique_uid"] == "AML.T0035" for item in attacks)
+    assert any(obs["name"] == "object.key" and obs["value"].endswith("model.safetensors") for obs in finding["observables"])
+
+
+def test_native_output_includes_bucket_key_and_match():
+    findings = list(MODULE.detect([_event(key="training/run-42/pytorch_model.bin")], output_format="native"))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["rule"] == "aws-model-artifact-download"
+    assert finding["bucket_name"] == "model-artifacts-prod"
+    assert finding["object_key"] == "training/run-42/pytorch_model.bin"
+    assert finding["artifact_match"] == "pytorch_model.bin"
+
+
+def test_non_model_object_is_ignored():
+    findings = list(MODULE.detect([_event(key="reports/2026-04-24/quarterly.csv")]))
+    assert findings == []
+
+
+def test_non_get_object_is_ignored():
+    findings = list(MODULE.detect([_event(operation="HeadObject")]))
+    assert findings == []
+
+
+def test_failed_event_is_ignored():
+    findings = list(MODULE.detect([_event(status_id=2)]))
+    assert findings == []
+
+
+def test_aws_service_reads_are_ignored():
+    findings = list(MODULE.detect([_event(actor_name="s3.amazonaws.com", actor_type="AWSService")]))
+    assert findings == []
+
+
+def test_wrong_source_is_ignored():
+    findings = list(MODULE.detect([_event(producer="ingest-azure-activity-ocsf")]))
+    assert findings == []
+
+
+def test_missing_bucket_or_key_is_skipped(capsys):
+    event = _event()
+    event["resources"] = [{"name": "model-artifacts-prod", "type": "bucketName"}]
+    findings = list(MODULE.detect([event]))
+    assert findings == []
+    assert "missing bucket or key context" in capsys.readouterr().err


### PR DESCRIPTION
What changed

added a new AWS-first AI-native detection skill, detect-aws-model-artifact-download
scans OCSF API Activity from ingest-cloudtrail-ocsf for successful S3 GetObject downloads of model-weight and checkpoint artifacts
kept the rule intentionally narrow and cloud-shaped: strict model-artifact suffixes and filenames only, with .bin allowed only when the key also carries model hints like model, checkpoint, weights, sagemaker, or bedrock
maps the finding to MITRE ATT&CK T1530 and MITRE ATLAS AML.T0035, and includes OWASP LLM Top 10 coverage in the registry
updated framework coverage, roadmap/mapping docs, skills catalog, security bar, and count-bearing visuals to the branch state: 73 skills / 26 detect / 91 checks

Why

Issue #255 still needed a cloud-native AI slice, not just more MCP response-body detectors. This PR adds the first honest AWS model-artifact collection detector using shipped CloudTrail ingestion and keeps the scope tight enough to stay high-confidence.

Scope

This first slice intentionally covers only:

successful S3 GetObject reads
model-weight and checkpoint-like object names
AWS CloudTrail input only

It does not claim confirmed network exfiltration, generic S3 abuse coverage, or GCP/Azure model-artifact coverage yet.

Validation

pytest skills/detection/detect-aws-model-artifact-download/tests/test_detect.py -q
ruff check skills/detection/detect-aws-model-artifact-download/src/detect.py skills/detection/detect-aws-model-artifact-download/tests/test_detect.py
python scripts/generate_framework_coverage_doc.py
python scripts/generate_security_bar_matrix.py
python scripts/validate_skill_contract.py
python scripts/validate_skill_integrity.py
python scripts/validate_framework_coverage.py
python scripts/validate_skill_count_consistency.py
xmllint --noout docs/images/hero-banner.svg docs/images/runtime-surfaces.svg docs/images/architecture-layers.svg docs/images/coverage-matrix.svg
rsvg-convert docs/images/coverage-matrix.svg -o /tmp/coverage-matrix-aws-model-artifact-download.png

Part of #255