### PR TITLE
Harden Kubernetes RBAC revoke cluster boundary

### DIFF
--- a/skills/remediation/remediate-k8s-rbac-revoke/SKILL.md
+++ b/skills/remediation/remediate-k8s-rbac-revoke/SKILL.md
@@ -8,8 +8,9 @@ description: >-
   binding.type and binding.name observables. Every action is dry-run by
   default, deny-listed for protected namespaces (kube-system, kube-public,
   istio-system, linkerd*) and protected binding names (any binding whose name
-  starts with system:), gated behind an incident ID plus approver for --apply,
-  and dual-audited (DynamoDB + KMS-encrypted S3). Use when the user mentions
+  starts with system:), gated behind an incident ID plus approver plus an
+  explicit cluster allow-list for --apply, and dual-audited (DynamoDB +
+  KMS-encrypted S3). Use when the user mentions
   "revoke a Kubernetes RoleBinding," "remove a ClusterRoleBinding after
   privilege escalation," "respond to RBAC self-grant alert," or "re-verify a
   K8s RBAC revocation." Do NOT use for NetworkPolicy quarantine, pod
@@ -95,6 +96,7 @@ JSONL records on stdout. Three record types:
 | Protected namespaces | Default deny-list: `kube-system`, `kube-public`, `istio-system`, `linkerd*` (see `DEFAULT_DENY_NAMESPACES`); applies to `rolebindings` only (ClusterRoleBindings are namespace-less) |
 | Protected binding names | Any binding whose name starts with `system:` is denied (`DEFAULT_DENY_BINDING_PREFIXES`) — keeps `system:masters`, `system:basic-user`, `system:public-info-viewer`, etc. out of revocation scope |
 | Apply gate | `--apply` requires `K8S_RBAC_REVOKE_INCIDENT_ID` + `K8S_RBAC_REVOKE_APPROVER` env vars — set out-of-band by the responder, not by the agent |
+| Cluster boundary | `--apply` also requires `K8S_CLUSTER_NAME` and `K8S_RBAC_REVOKE_ALLOWED_CLUSTERS`; the active cluster must be allow-listed explicitly before a delete can run |
 | Audit | Dual write (DynamoDB + KMS-encrypted S3) BEFORE and AFTER the delete; failure paths still write the failure audit row |
 | Re-verify | `--reverify` confirms the binding is no longer present; emits `drift` if the binding came back |
 
@@ -107,6 +109,8 @@ python skills/remediation/remediate-k8s-rbac-revoke/src/handler.py findings.ocsf
 # Apply (after out-of-band approval)
 export K8S_RBAC_REVOKE_INCIDENT_ID=INC-2026-04-19-001
 export K8S_RBAC_REVOKE_APPROVER=alice@security
+export K8S_CLUSTER_NAME=prod-eks-us-east-1
+export K8S_RBAC_REVOKE_ALLOWED_CLUSTERS=prod-eks-us-east-1
 export K8S_REMEDIATION_AUDIT_DYNAMODB_TABLE=k8s-remediation-audit
 export K8S_REMEDIATION_AUDIT_BUCKET=acme-k8s-audit
 export KMS_KEY_ARN=arn:aws:kms:us-east-1:111122223333:key/...
@@ -122,6 +126,7 @@ python skills/remediation/remediate-k8s-rbac-revoke/src/handler.py findings.ocsf
 - Edit binding subjects in place (delete-only — partial edits introduce more failure modes)
 - Recreate the binding after a window — this skill is a one-way revocation
 - Cross-cluster propagation — operates on a single API server target
+- Acting against whichever cluster ambient kubeconfig happens to point at — `--apply` now fails closed unless the active cluster name is allow-listed explicitly
 
 ## See also
 

--- a/skills/remediation/remediate-k8s-rbac-revoke/src/handler.py
+++ b/skills/remediation/remediate-k8s-rbac-revoke/src/handler.py
@@ -81,6 +81,7 @@ STATUS_SKIPPED_PROTECTED_BINDING = "skipped_protected_binding"
 STATUS_WOULD_VIOLATE_PROTECTED_BINDING = "would-violate-protected-binding"
 STATUS_SKIPPED_NO_BINDING = "skipped_no_binding_pointer"
 STATUS_SKIPPED_UNSUPPORTED_TYPE = "skipped_unsupported_binding_type"
+STATUS_SKIPPED_CLUSTER_BOUNDARY = "skipped_cluster_boundary"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -321,6 +322,11 @@ def load_protected_binding_prefixes() -> tuple[str, ...]:
     return DEFAULT_DENY_BINDING_PREFIXES
 
 
+def load_allowed_clusters() -> tuple[str, ...]:
+    raw = os.getenv("K8S_RBAC_REVOKE_ALLOWED_CLUSTERS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
 def is_protected_namespace(namespace: str, patterns: Iterable[str]) -> tuple[bool, str]:
     value = (namespace or "").strip().lower()
     if not value:
@@ -441,10 +447,18 @@ def _verification_record(target: Target, *, status: str, detail: str) -> dict[st
 def check_apply_gate() -> tuple[bool, str]:
     incident_id = os.getenv("K8S_RBAC_REVOKE_INCIDENT_ID", "").strip()
     approver = os.getenv("K8S_RBAC_REVOKE_APPROVER", "").strip()
+    cluster_name = os.getenv("K8S_CLUSTER_NAME", "").strip()
+    allowed_clusters = load_allowed_clusters()
     if not incident_id:
         return False, "K8S_RBAC_REVOKE_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "K8S_RBAC_REVOKE_APPROVER is required for --apply"
+    if not cluster_name:
+        return False, "K8S_CLUSTER_NAME is required for --apply"
+    if not allowed_clusters:
+        return False, "K8S_RBAC_REVOKE_ALLOWED_CLUSTERS is required for --apply"
+    if cluster_name not in allowed_clusters:
+        return False, f"K8S_CLUSTER_NAME `{cluster_name}` is not listed in K8S_RBAC_REVOKE_ALLOWED_CLUSTERS"
     return True, ""
 
 
@@ -553,9 +567,12 @@ def run(
     protected_prefixes: Iterable[str] = DEFAULT_DENY_BINDING_PREFIXES,
     incident_id: str = "",
     approver: str = "",
+    cluster_name: str = "",
+    allowed_clusters: Iterable[str] = (),
 ) -> Iterator[dict[str, Any]]:
     deny_namespaces = tuple(deny_namespaces)
     protected_prefixes = tuple(protected_prefixes)
+    allowed_clusters = tuple(allowed_clusters)
 
     for target, _ in parse_targets(events):
         if target is None:
@@ -626,6 +643,26 @@ def run(
             )
             continue
 
+        if not cluster_name:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_CLUSTER_BOUNDARY,
+                detail="K8S_CLUSTER_NAME is required for --apply",
+                dry_run=False,
+            )
+            continue
+        if cluster_name not in allowed_clusters:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_CLUSTER_BOUNDARY,
+                detail=(
+                    f"cluster `{cluster_name}` is not listed in "
+                    "K8S_RBAC_REVOKE_ALLOWED_CLUSTERS"
+                ),
+                dry_run=False,
+            )
+            continue
+
         if audit is None:
             raise ValueError("audit writer is required under --apply")
         yield revoke_binding(
@@ -688,6 +725,8 @@ def main(argv: list[str] | None = None) -> int:
             audit=audit,
             incident_id=incident_id,
             approver=approver,
+            cluster_name=os.getenv("K8S_CLUSTER_NAME", "").strip(),
+            allowed_clusters=load_allowed_clusters(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py
+++ b/skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py
@@ -16,6 +16,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_FAILURE,
     STATUS_IN_PROGRESS,
     STATUS_PLANNED,
+    STATUS_SKIPPED_CLUSTER_BOUNDARY,
     STATUS_SKIPPED_DENY_LIST,
     STATUS_SKIPPED_NO_BINDING,
     STATUS_SKIPPED_UNSUPPORTED_TYPE,
@@ -131,6 +132,8 @@ def test_accepted_producers_set_is_just_privesc():
 def test_check_apply_gate_requires_both_envs(monkeypatch):
     monkeypatch.delenv("K8S_RBAC_REVOKE_INCIDENT_ID", raising=False)
     monkeypatch.delenv("K8S_RBAC_REVOKE_APPROVER", raising=False)
+    monkeypatch.delenv("K8S_CLUSTER_NAME", raising=False)
+    monkeypatch.delenv("K8S_RBAC_REVOKE_ALLOWED_CLUSTERS", raising=False)
     ok, reason = check_apply_gate()
     assert ok is False
     assert "INCIDENT_ID" in reason
@@ -141,6 +144,21 @@ def test_check_apply_gate_requires_both_envs(monkeypatch):
     assert "APPROVER" in reason
 
     monkeypatch.setenv("K8S_RBAC_REVOKE_APPROVER", "alice@security")
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "K8S_CLUSTER_NAME" in reason
+
+    monkeypatch.setenv("K8S_CLUSTER_NAME", "prod-cluster")
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "K8S_RBAC_REVOKE_ALLOWED_CLUSTERS" in reason
+
+    monkeypatch.setenv("K8S_RBAC_REVOKE_ALLOWED_CLUSTERS", "staging-cluster")
+    ok, reason = check_apply_gate()
+    assert ok is False
+    assert "prod-cluster" in reason
+
+    monkeypatch.setenv("K8S_RBAC_REVOKE_ALLOWED_CLUSTERS", "prod-cluster,staging-cluster")
     ok, reason = check_apply_gate()
     assert ok is True
     assert reason == ""
@@ -282,6 +300,8 @@ def test_run_apply_revokes_namespaced_binding_with_dual_audit():
             audit=audit,
             incident_id="INC-1",
             approver="alice@security",
+            cluster_name="prod-cluster",
+            allowed_clusters=("prod-cluster",),
         )
     )
 
@@ -311,6 +331,8 @@ def test_run_apply_revokes_cluster_binding():
             audit=audit,
             incident_id="INC-2",
             approver="bob@security",
+            cluster_name="prod-cluster",
+            allowed_clusters=("prod-cluster",),
         )
     )
     rec = records[0]
@@ -332,6 +354,8 @@ def test_run_apply_writes_failure_audit_when_kube_call_throws():
             audit=audit,
             incident_id="INC-1",
             approver="alice@security",
+            cluster_name="prod-cluster",
+            allowed_clusters=("prod-cluster",),
         )
     )
     rec = records[0]
@@ -347,7 +371,38 @@ def test_run_apply_requires_audit_writer():
     import pytest
 
     with pytest.raises(ValueError, match="audit writer is required"):
-        list(run([_finding()], kube_client=_FakeKube(), apply=True, audit=None))
+        list(
+            run(
+                [_finding()],
+                kube_client=_FakeKube(),
+                apply=True,
+                audit=None,
+                cluster_name="prod-cluster",
+                allowed_clusters=("prod-cluster",),
+            )
+        )
+
+
+def test_run_apply_skips_cluster_outside_allow_list():
+    audit = _FakeAudit()
+    kube = _FakeKube(role_bindings={("payments", "attacker-grant"): {"metadata": {"name": "attacker-grant"}}})
+    records = list(
+        run(
+            [_finding()],
+            kube_client=kube,
+            apply=True,
+            audit=audit,
+            incident_id="INC-1",
+            approver="alice@security",
+            cluster_name="prod-cluster",
+            allowed_clusters=("staging-cluster",),
+        )
+    )
+    rec = records[0]
+    assert rec["status"] == STATUS_SKIPPED_CLUSTER_BOUNDARY
+    assert "prod-cluster" in rec["status_detail"]
+    assert audit.writes == []
+    assert kube.deletes == []
 
 
 # ----------------- run: re-verify path -----------------


### PR DESCRIPTION
What changed

added an explicit cluster boundary to `remediate-k8s-rbac-revoke`
required `K8S_CLUSTER_NAME` and `K8S_RBAC_REVOKE_ALLOWED_CLUSTERS` before any `--apply` delete can proceed
kept dry-run and reverify read-only, but made apply fail closed with `skipped_cluster_boundary` when the active cluster is not allow-listed
updated the skill docs and examples to reflect the new cluster-binding requirement
added regression tests for the apply gate and for wrong-cluster refusal inside `run(...)`

Why

The repo already fails closed on explicit account / project / tenant boundaries for cloud remediators. The Kubernetes RBAC delete path was still trusting ambient kube context. For freeze, that is the wrong default. A delete-capable remediator should be pinned to an explicit allowed cluster the same way AWS, GCP, Azure, Okta, and Workspace remediators are pinned to their intended environment.

Validation

pytest skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py -q
ruff check skills/remediation/remediate-k8s-rbac-revoke/src/handler.py skills/remediation/remediate-k8s-rbac-revoke/tests/test_handler.py
python scripts/validate_skill_contract.py
python scripts/validate_safe_skill_bar.py
python scripts/validate_skill_integrity.py
