### PR TITLE
Harden container escape cluster boundary

### DIFF
--- a/skills/remediation/remediate-container-escape-k8s/SKILL.md
+++ b/skills/remediation/remediate-container-escape-k8s/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   emitted by detect-container-escape-k8s and resolves the live selector from
   the Kubernetes API before emitting a native remediation plan or action
   record. Every action is dry-run by default, deny-listed for protected
-  namespaces, gated behind an incident ID plus approver for --apply, and
-  dual-audited (DynamoDB + KMS-encrypted S3). The low-risk default remains
+  namespaces, gated behind an incident ID plus approver plus an explicit
+  cluster allow-list for --apply, and dual-audited (DynamoDB +
+  KMS-encrypted S3). The low-risk default remains
   reversible quarantine; explicit destructive follow-ups are also supported
   via `--approve-pod-kill` and `--approve-node-drain`, with the node-drain
   path requiring a second approver. Use when the user mentions "quarantine a
@@ -127,15 +128,22 @@ containing the exact `NetworkPolicy` manifest, the resolved selector, and the
 mutating Kubernetes endpoint it WOULD call. Zero cluster writes occur in this
 mode.
 
-### 4. `--apply` requires an incident gate
+### 4. `--apply` requires an incident gate and explicit cluster boundary
 
 `--apply` is refused unless both env vars are set before any write:
 
 - `K8S_CONTAINER_ESCAPE_INCIDENT_ID`
 - `K8S_CONTAINER_ESCAPE_APPROVER`
+- `K8S_CLUSTER_NAME`
+- `K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS`
 
 The gate sits outside the agent loop. An alert or agent suggestion alone is not
 sufficient to mutate cluster state.
+
+The active cluster name must be listed explicitly in
+`K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS` before the skill will quarantine,
+delete a pod, or drain a node. This keeps the handler from acting against
+whichever kube context ambient credentials happen to resolve to.
 
 Destructive follow-up paths tighten that bar further:
 
@@ -229,6 +237,8 @@ cat finding.ocsf.jsonl | python src/handler.py
 # Apply quarantine — requires incident gate and audit destinations
 export K8S_CONTAINER_ESCAPE_INCIDENT_ID=inc-2026-04-19-001
 export K8S_CONTAINER_ESCAPE_APPROVER=alice@example.com
+export K8S_CLUSTER_NAME=prod-eks-us-east-1
+export K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS=prod-eks-us-east-1
 export K8S_REMEDIATION_AUDIT_DYNAMODB_TABLE=k8s-remediation-audit
 export K8S_REMEDIATION_AUDIT_BUCKET=sec-k8s-remediation
 export KMS_KEY_ARN=arn:aws:kms:us-east-1:123456789012:key/...
@@ -297,6 +307,8 @@ cat finding.ocsf.jsonl | python src/forensic_collector.py \
 - as a generic "pause traffic" control for planned maintenance
 - without setting `K8S_CONTAINER_ESCAPE_INCIDENT_ID` and
   `K8S_CONTAINER_ESCAPE_APPROVER` under `--apply`
+- without setting `K8S_CLUSTER_NAME` and
+  `K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS` under `--apply`
 - without setting `K8S_CONTAINER_ESCAPE_SECOND_APPROVER` for
   `--approve-node-drain --apply`
 

--- a/skills/remediation/remediate-container-escape-k8s/src/handler.py
+++ b/skills/remediation/remediate-container-escape-k8s/src/handler.py
@@ -83,6 +83,7 @@ STATUS_SKIPPED_SOURCE = "skipped_wrong_source"
 STATUS_SKIPPED_DENY_LIST = "skipped_deny_list"
 STATUS_WOULD_VIOLATE_DENY_LIST = "would-violate-deny-list"
 STATUS_SKIPPED_UNSUPPORTED_TARGET = "skipped_unsupported_target"
+STATUS_SKIPPED_CLUSTER_BOUNDARY = "skipped_cluster_boundary"
 
 ACTION_QUARANTINE = "quarantine"
 ACTION_POD_KILL = "pod-kill"
@@ -445,6 +446,11 @@ def load_deny_namespaces() -> tuple[str, ...]:
     return DEFAULT_DENY_NAMESPACES
 
 
+def load_allowed_clusters() -> tuple[str, ...]:
+    raw = os.getenv("K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
 def is_protected_namespace(namespace: str, patterns: Iterable[str]) -> tuple[bool, str]:
     value = (namespace or "").strip().lower()
     for pattern in patterns:
@@ -527,10 +533,21 @@ def resolve_target(target: Target, kube_client: KubernetesClient) -> ResolvedTar
 def check_apply_gate(*, action_mode: str = ACTION_QUARANTINE) -> tuple[bool, str]:
     incident_id = os.getenv("K8S_CONTAINER_ESCAPE_INCIDENT_ID", "").strip()
     approver = os.getenv("K8S_CONTAINER_ESCAPE_APPROVER", "").strip()
+    cluster_name = os.getenv("K8S_CLUSTER_NAME", "").strip()
+    allowed_clusters = load_allowed_clusters()
     if not incident_id:
         return False, "K8S_CONTAINER_ESCAPE_INCIDENT_ID is required for --apply"
     if not approver:
         return False, "K8S_CONTAINER_ESCAPE_APPROVER is required for --apply"
+    if not cluster_name:
+        return False, "K8S_CLUSTER_NAME is required for --apply"
+    if not allowed_clusters:
+        return False, "K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS is required for --apply"
+    if cluster_name not in allowed_clusters:
+        return False, (
+            f"K8S_CLUSTER_NAME `{cluster_name}` is not listed in "
+            "K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS"
+        )
     if action_mode == ACTION_NODE_DRAIN:
         second = os.getenv("K8S_CONTAINER_ESCAPE_SECOND_APPROVER", "").strip()
         if not second:
@@ -1127,7 +1144,10 @@ def run(
     incident_id: str = "",
     approver: str = "",
     secondary_approver: str = "",
+    cluster_name: str = "",
+    allowed_clusters: Iterable[str] = (),
 ) -> Iterator[dict[str, Any]]:
+    allowed_clusters = tuple(allowed_clusters)
     for target, _ in parse_targets(events):
         if target is None:
             continue
@@ -1140,6 +1160,27 @@ def run(
                 status=status,
                 detail=f"namespace `{target.namespace}` matched protected pattern `{matched}`",
                 dry_run=not apply and not reverify,
+            )
+            continue
+
+        if apply and not cluster_name:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_CLUSTER_BOUNDARY,
+                detail="K8S_CLUSTER_NAME is required for --apply",
+                dry_run=False,
+            )
+            continue
+
+        if apply and cluster_name not in allowed_clusters:
+            yield _skip_record(
+                target,
+                status=STATUS_SKIPPED_CLUSTER_BOUNDARY,
+                detail=(
+                    f"cluster `{cluster_name}` is not listed in "
+                    "K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS"
+                ),
+                dry_run=False,
             )
             continue
 
@@ -1295,6 +1336,8 @@ def main(argv: list[str] | None = None) -> int:
             incident_id=incident_id,
             approver=approver,
             secondary_approver=secondary_approver,
+            cluster_name=os.getenv("K8S_CLUSTER_NAME", "").strip(),
+            allowed_clusters=load_allowed_clusters(),
         ):
             out_stream.write(json.dumps(record, separators=(",", ":")) + "\n")
     finally:

--- a/skills/remediation/remediate-container-escape-k8s/tests/test_handler.py
+++ b/skills/remediation/remediate-container-escape-k8s/tests/test_handler.py
@@ -16,6 +16,7 @@ from handler import (  # type: ignore[import-not-found]
     STATUS_DRIFT,
     STATUS_IN_PROGRESS,
     STATUS_PLANNED,
+    STATUS_SKIPPED_CLUSTER_BOUNDARY,
     STATUS_SKIPPED_DENY_LIST,
     STATUS_SUCCESS,
     STATUS_VERIFIED,
@@ -280,6 +281,8 @@ class TestApplyGate:
     def test_apply_requires_incident_id_and_approver(self, monkeypatch):
         monkeypatch.delenv("K8S_CONTAINER_ESCAPE_INCIDENT_ID", raising=False)
         monkeypatch.delenv("K8S_CONTAINER_ESCAPE_APPROVER", raising=False)
+        monkeypatch.delenv("K8S_CLUSTER_NAME", raising=False)
+        monkeypatch.delenv("K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS", raising=False)
         ok, reason = check_apply_gate()
         assert ok is False
         assert "INCIDENT_ID" in reason
@@ -291,12 +294,29 @@ class TestApplyGate:
 
         monkeypatch.setenv("K8S_CONTAINER_ESCAPE_APPROVER", "alice@example.com")
         ok, reason = check_apply_gate()
+        assert ok is False
+        assert "K8S_CLUSTER_NAME" in reason
+
+        monkeypatch.setenv("K8S_CLUSTER_NAME", "prod-cluster")
+        ok, reason = check_apply_gate()
+        assert ok is False
+        assert "K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS" in reason
+
+        monkeypatch.setenv("K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS", "staging-cluster")
+        ok, reason = check_apply_gate()
+        assert ok is False
+        assert "prod-cluster" in reason
+
+        monkeypatch.setenv("K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS", "prod-cluster,staging-cluster")
+        ok, reason = check_apply_gate()
         assert ok is True
         assert reason == ""
 
     def test_node_drain_requires_second_distinct_approver(self, monkeypatch):
         monkeypatch.setenv("K8S_CONTAINER_ESCAPE_INCIDENT_ID", "inc-1")
         monkeypatch.setenv("K8S_CONTAINER_ESCAPE_APPROVER", "alice@example.com")
+        monkeypatch.setenv("K8S_CLUSTER_NAME", "prod-cluster")
+        monkeypatch.setenv("K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS", "prod-cluster")
         monkeypatch.delenv("K8S_CONTAINER_ESCAPE_SECOND_APPROVER", raising=False)
         ok, reason = check_apply_gate(action_mode=ACTION_NODE_DRAIN)
         assert ok is False
@@ -328,6 +348,8 @@ class TestApplyAndReverify:
                 audit=audit,
                 incident_id="inc-1",
                 approver="alice@example.com",
+                cluster_name="prod-cluster",
+                allowed_clusters=("prod-cluster",),
             )
         )
         assert len(records) == 1
@@ -339,6 +361,30 @@ class TestApplyAndReverify:
         assert [item["status"] for item in audit.writes] == [STATUS_IN_PROGRESS, STATUS_SUCCESS]
         assert kube.order == ["kube:apply"]
         assert all(item["action_mode"] == "quarantine" for item in audit.writes)
+
+    def test_apply_skips_cluster_outside_allow_list(self):
+        audit = _FakeAudit()
+        kube = _FakeKube(
+            workload_selectors={("payments", "deployments", "api"): {"app": "api"}},
+            audit=audit,
+        )
+        records = list(
+            run(
+                [_finding()],
+                kube_client=kube,
+                apply=True,
+                audit=audit,
+                incident_id="inc-1",
+                approver="alice@example.com",
+                cluster_name="prod-cluster",
+                allowed_clusters=("staging-cluster",),
+            )
+        )
+        assert len(records) == 1
+        assert records[0]["status"] == STATUS_SKIPPED_CLUSTER_BOUNDARY
+        assert "prod-cluster" in records[0]["status_detail"]
+        assert audit.writes == []
+        assert kube.order == []
 
     def test_reverify_reports_verified_when_policy_matches(self):
         kube = _FakeKube(
@@ -423,6 +469,8 @@ class TestApplyAndReverify:
                 audit=audit,
                 incident_id="inc-1",
                 approver="alice@example.com",
+                cluster_name="prod-cluster",
+                allowed_clusters=("prod-cluster",),
             )
         )
         assert len(records) == 1
@@ -466,6 +514,8 @@ class TestApplyAndReverify:
                 incident_id="inc-1",
                 approver="alice@example.com",
                 secondary_approver="bob@example.com",
+                cluster_name="prod-cluster",
+                allowed_clusters=("prod-cluster",),
             )
         )
         assert len(records) == 1


### PR DESCRIPTION
What changed

added an explicit cluster boundary to `remediate-container-escape-k8s`
required `K8S_CLUSTER_NAME` and `K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS` before any `--apply` quarantine, pod-kill, or node-drain can proceed
made apply fail closed with `skipped_cluster_boundary` before selector resolution when the active cluster is not allow-listed
updated the skill docs and examples to reflect the new cluster-binding requirement
added regression tests for the apply gate and for wrong-cluster refusal in the quarantine path

Why

The repo already fails closed on explicit account / project / tenant boundaries for cloud remediators. The Kubernetes quarantine path was still trusting ambient kube context for write execution. For freeze, that is the wrong default: a write-capable cluster remediator should be pinned to an explicit allowed cluster before any mutation runs.

Validation

pytest skills/remediation/remediate-container-escape-k8s/tests/test_handler.py skills/remediation/remediate-container-escape-k8s/tests/test_forensic_collector.py -q
ruff check skills/remediation/remediate-container-escape-k8s/src/handler.py skills/remediation/remediate-container-escape-k8s/tests/test_handler.py
python scripts/validate_skill_contract.py
python scripts/validate_safe_skill_bar.py
python scripts/validate_skill_integrity.py
