### PR TITLE
Cut v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is loosely based on Keep a Changelog.
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-04-24 — Freeze hardening and release sweep fix
+
 Skills count on `main`: **73** (15 ingest, 5 discover, 26 detect, 7 evaluate,
 12 remediate, 2 view, 3 output, 3 sources).
 
@@ -22,6 +24,12 @@ Skills count on `main`: **73** (15 ingest, 5 discover, 26 detect, 7 evaluate,
   `K8S_CLUSTER_NAME`, and that active cluster must be named explicitly in
   `K8S_RBAC_REVOKE_ALLOWED_CLUSTERS` before a binding delete can run. Dry-run
   and reverify remain read-only.
+- **Kubernetes container-escape quarantine now has an explicit cluster boundary** —
+  [`remediate-container-escape-k8s`](skills/remediation/remediate-container-escape-k8s/)
+  now requires `K8S_CLUSTER_NAME` plus
+  `K8S_CONTAINER_ESCAPE_ALLOWED_CLUSTERS` before any `--apply` quarantine,
+  pod-kill, or node-drain can proceed. The write path fails closed with
+  `skipped_cluster_boundary` when the active cluster is outside the allow-list.
 
 ### Changed
 
@@ -29,6 +37,9 @@ Skills count on `main`: **73** (15 ingest, 5 discover, 26 detect, 7 evaluate,
   now describe writable skills as being pinned to explicit environment
   boundaries such as account, project, tenant, org, or cluster allow-lists
   before `--apply`, not just HITL-gated in the abstract.
+- **The release sweep is mechanically clean again** — `scripts/run_mypy.sh`
+  now skips empty `src/` directories instead of failing on skill paths that no
+  longer contain Python entrypoints.
 
 ## [0.8.0] — 2026-04-24 — Cross-cloud ATT&CK depth and repo truth sync
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.8.0-0ea5e9"></a>
+  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.8.1-0ea5e9"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11+-blue.svg"></a>
   <a href="https://schema.ocsf.io/1.8.0"><img alt="OCSF 1.8" src="https://img.shields.io/badge/OCSF-1.8-22d3ee"></a>

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -2,7 +2,7 @@
 
 This file is **generated from [`framework-coverage.json`](framework-coverage.json)** by `scripts/generate_framework_coverage_doc.py`. Do not edit by hand — update the registry and regenerate.
 
-- Registry version: `0.8.0`
+- Registry version: `0.8.1`
 - Registry updated: `2026-04-24`
 - Total shipped skills in registry: **73**
 

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
   "updated": "2026-04-24",
-  "repo_version": "0.8.0",
+  "repo_version": "0.8.1",
   "frameworks": [
     {
       "id": "ocsf-1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloud-ai-security-skills"
-version = "0.8.0"
+version = "0.8.1"
 description = "Security skills for cloud and AI with repo-native and OCSF modes."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -40,6 +40,9 @@ for dir in skills/*/*/src; do
   case " ${STRICT_SKILL_DIRS[*]} " in
     *" ${dir} "*) continue ;;
   esac
+  if ! find "$dir" -maxdepth 1 \( -name '*.py' -o -name '*.pyi' \) | grep -q .; then
+    continue
+  fi
   "${MYPY_CMD[@]}" "$dir" --config-file pyproject.toml
 done
 

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "cloud-ai-security-skills"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
What changed

cut the `0.8.1` maintenance release
bumped version surfaces in `pyproject.toml`, `README.md`, `docs/framework-coverage.json`, `docs/FRAMEWORK_COVERAGE.md`, and `uv.lock`
added the `0.8.1` changelog section for the Kubernetes cluster-boundary hardenings and freeze docs sync
fixed `scripts/run_mypy.sh` so the release sweep no longer fails on empty `src/` directories left behind after skill moves/renames

Why

`main` is at freeze state, but the post-freeze release sweep exposed one real blocker: the mypy runner still tried to type-check empty skill directories and exited non-zero. This PR fixes that blocker and cuts the honest maintenance release for the merged hardening work.

Validation

Post-freeze sweep on current release state:
- `bash scripts/run_mypy.sh`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_safe_skill_bar.py`
- `python scripts/generate_framework_coverage_doc.py --check`
- `python scripts/generate_security_bar_matrix.py --check`
- `uv lock --check`

Earlier full sweep on frozen main before the version cut:
- `pytest skills/ tests/integration/ tests/conformance/ mcp-server/tests/ --cov=skills --cov-report=term-missing --cov-report=xml`
- `bandit -r skills mcp-server scripts -c pyproject.toml --severity-level medium`

Results:
- `2066 passed`, overall coverage `86%`
- bandit: no medium/high issues identified
