### PR TITLE
Add GCP model artifact download detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 73 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 74 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**73 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**74 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 26 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 27 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 73 shipped skills.**
+**Total: 74 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 13 of 26 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS model-artifact download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 27 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -277,7 +277,9 @@ Approximate roadmap progress is tracked here so the README reflects current ship
 |---|---:|---|
 | **MITRE ATT&CK (`#253`)** | **45%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, AWS discovery burst, and AWS cross-account S3 copy are shipped |
 | **CIS + auto-remediate (`#254`)** | **35%** | 91 checks shipped across AWS/GCP/Azure/K8s/container/GPU/model-serving, with the first guarded AWS `--auto-remediate` slice shipped |
-| **MITRE ATLAS + OWASP LLM/MCP (`#255`)** | **40%** | AWS model-artifact download detection, MCP prompt injection, tool drift, credential leak, system-prompt extraction, tool-output policy-bypass detection, tool-output exfiltration-instruction detection, and MCP tool quarantine are shipped |
+| **MITRE ATLAS (`#255` umbrella)** | **45%** | AI inventory and evidence, model-serving and GPU posture, MCP prompt injection, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
+| **OWASP LLM Top 10 (`#255` umbrella)** | **45%** | model-serving controls plus MCP prompt injection, credential leak, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
+| **OWASP MCP Top 10 (`#255` umbrella)** | **50%** | MCP prompt injection, tool drift, credential leak, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and MCP tool quarantine are shipped |
 
 These are repo-progress estimates, not claims of full framework completion.
 
@@ -287,7 +289,7 @@ These are repo-progress estimates, not claims of full framework completion.
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 26 detectors across MITRE ATT&CK, MITRE ATLAS, and MCP / agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS model-artifact download slice, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
+| **Detect** | 27 detectors across MITRE ATT&CK, MITRE ATLAS, OWASP LLM / MCP, and agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS + GCP model-artifact download slices, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
 | **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
 | **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -66,6 +66,7 @@ is the row you can take to your auditor.
 | `detect-entra-credential-addition` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-entra-role-grant-escalation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-audit-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-gcp-model-artifact-download` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-open-firewall` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -103,7 +104,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_73 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_74 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 26 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 27 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,15 +4,15 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.8.1`
 - Registry updated: `2026-04-24`
-- Total shipped skills in registry: **73**
+- Total shipped skills in registry: **74**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **52** | — |
-| MITRE ATT&CK | v14 | **46** | 100% mapped coverage |
-| MITRE ATLAS | current | **12** | 100% mapped coverage |
+| OCSF | 1.8.0 | **53** | — |
+| MITRE ATT&CK | v14 | **47** | 100% mapped coverage |
+| MITRE ATLAS | current | **13** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
 | CIS Azure Foundations | v2.1 | **6** | — |
@@ -24,7 +24,7 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 | SOC 2 TSC | current | **20** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **3** | — |
-| OWASP LLM Top 10 | current | **7** | — |
+| OWASP LLM Top 10 | current | **8** | — |
 | OWASP MCP Top 10 | current | **7** | — |
 | CycloneDX ML-BOM | current | **2** | — |
 
@@ -36,7 +36,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **52**
+Shipped skills mapped: **53**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -54,6 +54,7 @@ Shipped skills mapped: **52**
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
 | [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
+| [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
@@ -100,7 +101,7 @@ Shipped skills mapped: **52**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **46**
+Shipped skills mapped: **47**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -117,6 +118,7 @@ Shipped skills mapped: **46**
 | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, federated-credentials |
 | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation) | detection | azure, entra, microsoft-graph | identities, applications, service-principals, app-role-assignments |
 | [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
+| [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
@@ -158,11 +160,12 @@ Shipped skills mapped: **46**
 - Asset classes in scope: ai-endpoints, models, datasets, vector-stores, gpu-fleets, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **12**
+Shipped skills mapped: **13**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download) | detection | aws | object-storage, objects, model-artifacts, audit-logs |
+| [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-prompt-injection-mcp-proxy`](../skills/detection/detect-prompt-injection-mcp-proxy) | detection | mcp, multi | agent-tools, tool-metadata, guardrails |
 | [`detect-system-prompt-extraction`](../skills/detection/detect-system-prompt-extraction) | detection | mcp | agent-tools, tool-results, prompts, instructions |
 | [`detect-tool-output-exfiltration-instructions`](../skills/detection/detect-tool-output-exfiltration-instructions) | detection | mcp | agent-tools, tool-results, instructions, artifacts |
@@ -358,12 +361,13 @@ Shipped skills mapped: **3**
 
 - Registry id: `owasp-llm-top-10`
 
-Shipped skills mapped: **7**
+Shipped skills mapped: **8**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-agent-credential-leak-mcp`](../skills/detection/detect-agent-credential-leak-mcp) | detection | mcp, multi | agent-tools, tool-results, credentials |
 | [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download) | detection | aws | object-storage, objects, model-artifacts, audit-logs |
+| [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-prompt-injection-mcp-proxy`](../skills/detection/detect-prompt-injection-mcp-proxy) | detection | mcp, multi | agent-tools, tool-metadata, guardrails |
 | [`detect-system-prompt-extraction`](../skills/detection/detect-system-prompt-extraction) | detection | mcp | agent-tools, tool-results, prompts, instructions |
 | [`detect-tool-output-exfiltration-instructions`](../skills/detection/detect-tool-output-exfiltration-instructions) | detection | mcp | agent-tools, tool-results, instructions, artifacts |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -20,11 +20,11 @@ from individual `SKILL.md` files.
 | Framework | Status | Where it appears |
 |---|---|---|
 | **OCSF 1.8** | core wire contract | all ingestion, detection, and view flows |
-| **MITRE ATT&CK v14** | strong and broader | 46 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, and the first AWS model-artifact download slice |
-| **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, MCP prompt-injection plus response-layer override and exfiltration detection, and the first cloud-native model-artifact collection slice |
+| **MITRE ATT&CK v14** | strong and broader | 47 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, and the first AWS + GCP model-artifact download slices |
+| **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, MCP prompt-injection plus response-layer override and exfiltration detection, and the first AWS + GCP cloud-native model-artifact collection slices |
 | **CIS Benchmarks / Controls** | strong | AWS, GCP, Azure, Kubernetes, container evaluation skills |
 | **NIST CSF 2.0** | strong | evaluation and some remediation skills |
-| **OWASP LLM Top 10** | partial and growing | model-serving controls plus `detect-prompt-injection-mcp-proxy`, `detect-agent-credential-leak-mcp`, `detect-system-prompt-extraction`, `detect-tool-output-policy-bypass`, `detect-tool-output-exfiltration-instructions`, and `detect-aws-model-artifact-download` |
+| **OWASP LLM Top 10** | partial and growing | model-serving controls plus `detect-prompt-injection-mcp-proxy`, `detect-agent-credential-leak-mcp`, `detect-system-prompt-extraction`, `detect-tool-output-policy-bypass`, `detect-tool-output-exfiltration-instructions`, `detect-aws-model-artifact-download`, and `detect-gcp-model-artifact-download` |
 | **OWASP MCP Top 10** | partial and growing | `detect-mcp-tool-drift`, `detect-prompt-injection-mcp-proxy`, `detect-agent-credential-leak-mcp`, `detect-system-prompt-extraction`, `detect-tool-output-policy-bypass`, `detect-tool-output-exfiltration-instructions`, and MCP-related repo controls |
 | **SOC 2 TSC** | partial | evaluation and remediation mappings |
 | **ISO 27001:2022** | partial | CSPM/evaluation mappings |
@@ -54,6 +54,7 @@ Strongest current ATT&CK coverage:
 | `detect-aws-enumeration-burst` | T1526 for short-window bursts of high-signal AWS discovery APIs in CloudTrail across IAM, EC2, S3, KMS, Organizations, EKS, Lambda, and CloudTrail |
 | `detect-s3-cross-account-copy` | T1537 for successful AWS S3 `CopyObject` calls where the acting principal account differs from the recipient bucket-owner account |
 | `detect-aws-model-artifact-download` | T1530 plus ATLAS AML.T0035 for successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts |
+| `detect-gcp-model-artifact-download` | T1530 plus ATLAS AML.T0035 for successful GCS `storage.objects.get` downloads of model-weight and checkpoint artifacts |
 | `detect-okta-mfa-fatigue` | T1621 for repeated Okta Verify push challenge + deny bursts |
 | `detect-entra-credential-addition` | T1098.001 for successful Entra application or service-principal credential additions and federated identity credential creation |
 | `detect-entra-role-grant-escalation` | T1098.003 for successful Entra app-role assignments that grant additional application permissions to service principals |
@@ -131,6 +132,7 @@ ATLAS is present today, but coverage is narrower than ATT&CK.
 | `detect-tool-output-policy-bypass` | response-layer prompt-injection detection for explicit policy-bypass and approval-evasion instructions in MCP `tools/call` responses |
 | `detect-tool-output-exfiltration-instructions` | response-layer prompt-injection detection for explicit data-exfiltration instructions in MCP `tools/call` responses |
 | `detect-aws-model-artifact-download` | cloud-native AI artifact collection detection for successful S3 downloads of model weights and checkpoints |
+| `detect-gcp-model-artifact-download` | cloud-native AI artifact collection detection for successful GCS downloads of model weights and checkpoints |
 | `discover-ai-bom` | inventory artifact plus optional AI BOM policy findings for ATLAS / AI RMF evidence and CI joins |
 | `discover-control-evidence` | evidence package that preserves ATLAS / AI RMF context from discovery artifacts |
 | `discover-cloud-control-evidence` | cross-cloud evidence package with explicit NIST AI RMF evidence mode, ATT&CK / ATLAS / AI RMF inventory context, and per-provider logging / segmentation / encryption / key-management depth |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ The current north star is not "more skills" by itself. It is:
 
 ### Current shipped progress snapshot
 
-- **ATT&CK depth:** 45 mapped skills in the coverage registry, with the first
+- **ATT&CK depth:** 47 mapped skills in the coverage registry, with the first
   AWS IAM-user credential-creation slices now shipped via access-key and
   login-profile detection, the first AWS cloud-discovery burst slice now
   shipped, the first AWS exfiltration-to-cloud-account slice now shipped via
@@ -31,13 +31,16 @@ The current north star is not "more skills" by itself. It is:
 - **CIS and posture depth:** 91 shipped benchmark checks across AWS, GCP,
   Azure, Kubernetes, container, GPU, and model-serving surfaces; AWS also has
   the first guarded `--auto-remediate` slice.
-- **AI-native baseline:** MCP prompt injection, tool drift, credential leak
-  detection, explicit system-prompt extraction detection, explicit
-  tool-output policy-bypass detection, explicit tool-output
-  exfiltration-instruction detection, AWS model-artifact download detection,
-  and MCP tool quarantine are all shipped. The next open work is
-  broader AI-native detection depth and stronger closed loops, not first
-  presence.
+- **MITRE ATLAS depth:** AI inventory and evidence, model-serving and GPU
+  posture, MCP prompt injection, explicit system-prompt extraction, explicit
+  tool-output policy-bypass, explicit tool-output exfiltration-instruction
+  detection, and AWS + GCP model-artifact download detection are all shipped.
+- **OWASP LLM / MCP depth:** model-serving controls, MCP prompt injection,
+  tool drift, credential leak detection, explicit system-prompt extraction,
+  explicit tool-output policy-bypass, explicit tool-output exfiltration-
+  instruction detection, and MCP tool quarantine are all shipped. The next
+  open work is broader AI-native detection depth and stronger closed loops,
+  not first presence.
 
 ### AI-native status checkpoint
 

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -948,6 +948,32 @@
       ]
     },
     {
+      "path": "skills/detection/detect-gcp-model-artifact-download",
+      "layer": "detection",
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "object-storage",
+        "objects",
+        "model-artifacts",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14",
+        "mitre-atlas",
+        "owasp-llm-top-10"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-open-security-group",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 26 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 27 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">26</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">27</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1484" viewBox="0 0 1400 1484" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1522" viewBox="0 0 1400 1522" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (26) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-six detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, discovery-burst, cross-account-copy, logging-impairment, AWS model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (27) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-seven detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="1484" fill="url(#bg2)"/>
-  <rect width="1400" height="1484" fill="url(#grid2)"/>
+  <rect width="1400" height="1522" fill="url(#bg2)"/>
+  <rect width="1400" height="1522" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (26)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (27)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -236,42 +236,49 @@
     <rect x="880"  y="1224" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
     <text x="1020" y="1240" fill="#fee2e2" font-size="13">detection-first AWS AI model-artifact collection slice</text>
   </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="1278" fill="#f1f5f9" font-size="14">detect-gcp-model-artifact-download</text>
+    <text x="430"  y="1278" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
+    <rect x="760"  y="1262" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1262" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="1278" fill="#fee2e2" font-size="13">detection-first GCP AI model-artifact collection slice</text>
+  </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="1294" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1332" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1328" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
-    <text x="430"  y="1328" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
-    <rect x="760"  y="1312" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1312" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1328" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
+    <text x="48"   y="1366" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="1366" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
+    <rect x="760"  y="1350" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1350" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1366" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1358" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
-    <text x="430"  y="1358" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
-    <rect x="760"  y="1342" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1342" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1358" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1396" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="1396" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
+    <rect x="760"  y="1380" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1380" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1396" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1388" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
-    <text x="430"  y="1388" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
-    <rect x="760"  y="1372" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1372" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1388" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1426" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="1426" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="1410" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1410" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1426" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1418" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
-    <text x="430"  y="1418" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="760"  y="1402" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1402" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="1020" y="1418" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+    <text x="48"   y="1456" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="1456" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="1440" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1440" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1456" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
   </g>
 
   <!-- Footer (two lines to fit 1200px canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1452" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 26</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, discovery, exfiltration, logging, AWS model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
-    <text x="48" y="1470" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1490" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 27</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
+    <text x="48" y="1508" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 73 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 26 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 74 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 27 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">73</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">74</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">26</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">27</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 73 shipped skills — 15 ingest, 26 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 74 shipped skills — 15 ingest, 27 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 73 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">73</text>
+      <!-- Counts: 74 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">74</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 26 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 27 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -54,6 +54,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-aws-login-profile-creation`](detection/detect-aws-login-profile-creation/) | successful AWS IAM `CreateLoginProfile` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-enumeration-burst`](detection/detect-aws-enumeration-burst/) | short-window burst of high-signal AWS discovery APIs in CloudTrail (T1526 Cloud Service Discovery) |
 | [`detect-aws-model-artifact-download`](detection/detect-aws-model-artifact-download/) | successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |
+| [`detect-gcp-model-artifact-download`](detection/detect-gcp-model-artifact-download/) | successful GCS `storage.objects.get` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |
 | [`detect-s3-cross-account-copy`](detection/detect-s3-cross-account-copy/) | successful AWS S3 `CopyObject` into another account's bucket-owner context (T1537 Transfer Data to Cloud Account) |
 | [`detect-system-prompt-extraction`](detection/detect-system-prompt-extraction/) | explicit system-prompt or hidden-instruction leakage markers in MCP tool-call responses (ATLAS AML.T0004 / AML.T0041) |
 | [`detect-tool-output-policy-bypass`](detection/detect-tool-output-policy-bypass/) | explicit policy-bypass, approval-evasion, or user-concealment instructions in MCP tool-call responses (ATLAS AML.T0051) |

--- a/skills/detection/detect-gcp-model-artifact-download/REFERENCES.md
+++ b/skills/detection/detect-gcp-model-artifact-download/REFERENCES.md
@@ -1,0 +1,6 @@
+# References
+
+- GCS Audit Logs / Cloud Audit Logs: https://cloud.google.com/storage/docs/audit-logging
+- GCS object get method shape: https://cloud.google.com/storage/docs/json_api/v1/objects/get
+- MITRE ATT&CK `T1530` Data from Cloud Storage: https://attack.mitre.org/techniques/T1530/
+- MITRE ATLAS `AML.T0035` ML Artifact Collection: https://atlas.mitre.org/techniques/AML.T0035

--- a/skills/detection/detect-gcp-model-artifact-download/SKILL.md
+++ b/skills/detection/detect-gcp-model-artifact-download/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: detect-gcp-model-artifact-download
+description: >-
+  Detect successful GCS object downloads that look like model-weight or
+  checkpoint artifact collection. Consumes OCSF 1.8 API Activity emitted by
+  ingest-gcp-audit-ocsf and fires only on successful
+  storage.googleapis.com/storage.objects.get events whose object path matches
+  explicit model-artifact filename or suffix heuristics. Emits OCSF Detection
+  Finding 2004 by default, with a native output mode for repo-local pipelines.
+  Use when the user wants to spot suspicious model artifact collection from
+  Cloud Storage. Do NOT use for generic bucket access monitoring, generic data
+  exfiltration, or Azure/AWS object-store reads.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf, native
+output_formats: ocsf, native
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Input must be the OCSF / native API Activity stream
+  from ingest-gcp-audit-ocsf. The detector is read-only and deterministic.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-gcp-model-artifact-download
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - MITRE ATLAS
+    - OWASP LLM Top 10
+  cloud: gcp
+  capability: read-only
+---
+
+# detect-gcp-model-artifact-download
+
+## What it does
+
+Flags successful GCS object reads that look like model weights, checkpoints, or
+other ML artifact collection.
+
+The detector is intentionally narrow:
+
+- only `ingest-gcp-audit-ocsf` input
+- only successful `storage.objects.get`
+- only explicit model-artifact filename / suffix matches
+
+It does **not** claim generic GCS exfiltration coverage.
+
+## Mappings
+
+- **MITRE ATT&CK**: `T1530` Data from Cloud Storage
+- **MITRE ATLAS**: `AML.T0035` ML Artifact Collection
+
+## Input contract
+
+Reads JSONL API Activity records and expects:
+
+- `metadata.product.feature.name = ingest-gcp-audit-ocsf`
+- `api.service.name = storage.googleapis.com`
+- `api.operation = storage.objects.get`
+- `resources[].name` carrying a GCS-style resource path such as:
+  `projects/_/buckets/<bucket>/objects/<object>`
+
+The detector URL-decodes the object path before applying artifact matching.
+
+## Artifact heuristics
+
+High-confidence model artifact hits include:
+
+- `.safetensors`, `.pt`, `.pth`, `.ckpt`, `.onnx`, `.gguf`, `.tflite`, `.keras`, `.h5`
+- exact filenames like `pytorch_model.bin`, `adapter_model.bin`, `saved_model.pb`
+- `.bin` only when the path also contains model hints such as `model`,
+  `checkpoint`, `weights`, `vertex`, or `aiplatform`
+
+## Output
+
+- default: OCSF Detection Finding 2004
+- optional: native repo finding via `--output-format native`
+
+## Example
+
+```bash
+python skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py gcp-audit.jsonl \
+  | python skills/detection/detect-gcp-model-artifact-download/src/detect.py
+```

--- a/skills/detection/detect-gcp-model-artifact-download/src/detect.py
+++ b/skills/detection/detect-gcp-model-artifact-download/src/detect.py
@@ -1,0 +1,383 @@
+"""Detect suspicious GCS model-artifact downloads via GCP Audit Logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+from urllib.parse import unquote
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-gcp-model-artifact-download"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+ATTACK_TACTIC_UID = "TA0009"
+ATTACK_TACTIC_NAME = "Collection"
+ATTACK_TECHNIQUE_UID = "T1530"
+ATTACK_TECHNIQUE_NAME = "Data from Cloud Storage"
+
+ATLAS_VERSION = "current"
+ATLAS_TACTIC_UID = "AML.TA0009"
+ATLAS_TACTIC_NAME = "Collection"
+ATLAS_TECHNIQUE_UID = "AML.T0035"
+ATLAS_TECHNIQUE_NAME = "ML Artifact Collection"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-gcp-audit-ocsf"})
+GCS_SERVICE = "storage.googleapis.com"
+GET_OBJECT_OPERATION = "storage.objects.get"
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+STRICT_SUFFIXES = (
+    ".safetensors",
+    ".pt",
+    ".pth",
+    ".ckpt",
+    ".onnx",
+    ".gguf",
+    ".tflite",
+    ".keras",
+    ".h5",
+)
+EXACT_FILENAMES = frozenset(
+    {
+        "pytorch_model.bin",
+        "adapter_model.bin",
+        "consolidated.safetensors",
+        "model.safetensors",
+        "model.ckpt",
+        "saved_model.pb",
+    }
+)
+MODEL_HINTS = (
+    "model",
+    "models",
+    "artifact",
+    "artifacts",
+    "checkpoint",
+    "checkpoints",
+    "weights",
+    "huggingface",
+    "finetune",
+    "fine-tune",
+    "lora",
+    "adapter",
+    "vertex",
+    "aiplatform",
+    "ml",
+)
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _api_service(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    service = api.get("service") or {}
+    return str(service.get("name") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _actor_name(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _actor_type(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("type") or "")
+
+
+def _target_project(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _time_ms(event: dict[str, Any]) -> int:
+    return int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _event_uid(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    return str(metadata.get("uid") or "")
+
+
+def _resource_name(event: dict[str, Any]) -> str:
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        name = str(resource.get("name") or "")
+        if name:
+            return name
+    return ""
+
+
+def _bucket_and_object(resource_name: str) -> tuple[str, str]:
+    cleaned = unquote(resource_name.strip())
+    marker = "/buckets/"
+    objects_marker = "/objects/"
+    if marker not in cleaned or objects_marker not in cleaned:
+        return "", ""
+    after_bucket = cleaned.split(marker, 1)[1]
+    bucket_name, sep, object_part = after_bucket.partition(objects_marker)
+    if not sep:
+        return "", ""
+    return bucket_name.strip("/"), object_part.lstrip("/")
+
+
+def _artifact_match(key: str) -> tuple[bool, str]:
+    lowered = key.strip().lower()
+    if not lowered:
+        return False, ""
+    filename = lowered.rsplit("/", 1)[-1]
+    if filename in EXACT_FILENAMES:
+        return True, filename
+    for suffix in STRICT_SUFFIXES:
+        if lowered.endswith(suffix):
+            return True, suffix
+    if lowered.endswith(".bin") and any(token in lowered for token in MODEL_HINTS):
+        return True, ".bin+model-hint"
+    return False, ""
+
+
+def _finding_uid(
+    *,
+    event_uid: str,
+    actor_name: str,
+    bucket_name: str,
+    object_key: str,
+    time_ms: int,
+) -> str:
+    material = "|".join([SKILL_NAME, event_uid, actor_name, bucket_name, object_key, str(time_ms)])
+    return f"gmad-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(
+    *,
+    event: dict[str, Any],
+    bucket_name: str,
+    object_key: str,
+    artifact_match: str,
+) -> dict[str, Any]:
+    time_ms = _time_ms(event)
+    finding_uid = _finding_uid(
+        event_uid=_event_uid(event),
+        actor_name=_actor_name(event),
+        bucket_name=bucket_name,
+        object_key=object_key,
+        time_ms=time_ms,
+    )
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "gcp-model-artifact-download",
+        "api_operation": GET_OBJECT_OPERATION,
+        "bucket_name": bucket_name,
+        "object_key": object_key,
+        "artifact_match": artifact_match,
+        "actor_name": _actor_name(event),
+        "actor_type": _actor_type(event),
+        "target_project_uid": _target_project(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": ATTACK_TACTIC_UID,
+                "tactic_name": ATTACK_TACTIC_NAME,
+                "technique_uid": ATTACK_TECHNIQUE_UID,
+                "technique_name": ATTACK_TECHNIQUE_NAME,
+            },
+            {
+                "version": ATLAS_VERSION,
+                "tactic_uid": ATLAS_TACTIC_UID,
+                "tactic_name": ATLAS_TACTIC_NAME,
+                "technique_uid": ATLAS_TECHNIQUE_UID,
+                "technique_name": ATLAS_TECHNIQUE_NAME,
+            },
+        ],
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Principal `{native['actor_name'] or 'unknown'}` successfully downloaded "
+        f"`gs://{native['bucket_name']}/{native['object_key']}` via `storage.objects.get`. "
+        "The accessed object path matched model-weight or checkpoint artifact heuristics, "
+        "which can indicate model theft, staging, or unauthorized artifact collection."
+    )
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["detection-engineering", "gcp", "gcs", "model-artifact-download", "ai"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "GCP model artifact downloaded from Cloud Storage",
+            "desc": description,
+            "types": ["gcp-model-artifact-download", "ml-artifact-collection"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic": {"uid": ATTACK_TACTIC_UID, "name": ATTACK_TACTIC_NAME},
+                    "technique": {"uid": ATTACK_TECHNIQUE_UID, "name": ATTACK_TECHNIQUE_NAME},
+                },
+                {
+                    "version": ATLAS_VERSION,
+                    "tactic": {"uid": ATLAS_TACTIC_UID, "name": ATLAS_TACTIC_NAME},
+                    "technique": {"uid": ATLAS_TECHNIQUE_UID, "name": ATLAS_TECHNIQUE_NAME},
+                },
+            ],
+        },
+        "cloud": {
+            "provider": "GCP",
+            "account": {"uid": native["target_project_uid"]},
+            "region": native["region"],
+        },
+        "src_endpoint": {"ip": native["src_ip"]},
+        "observables": [
+            {"name": "bucket.name", "type": "Other", "value": native["bucket_name"]},
+            {"name": "object.key", "type": "Other", "value": native["object_key"]},
+            {"name": "artifact.match", "type": "Other", "value": native["artifact_match"]},
+        ],
+    }
+
+
+def detect(events: Iterable[dict[str, Any]], *, output_format: str = "ocsf") -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        if _producer(event) not in ACCEPTED_PRODUCERS:
+            continue
+        if not _is_success(event):
+            continue
+        if _api_service(event) != GCS_SERVICE or _api_operation(event) != GET_OBJECT_OPERATION:
+            continue
+
+        resource_name = _resource_name(event)
+        bucket_name, object_key = _bucket_and_object(resource_name)
+        if not bucket_name or not object_key:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_object_context",
+                message="skipping event with missing bucket or object context in GCS resourceName",
+                resource_name=resource_name,
+            )
+            continue
+
+        matched, artifact_match = _artifact_match(object_key)
+        if not matched:
+            continue
+
+        native = _build_native_finding(
+            event=event,
+            bucket_name=bucket_name,
+            object_key=object_key,
+            artifact_match=artifact_match,
+        )
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def _load_jsonl(stream: Iterable[str]) -> Iterator[dict[str, Any]]:
+    for line in stream:
+        line = line.strip()
+        if not line:
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, dict):
+            yield payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect GCP model artifact downloads from GCS audit logs.")
+    parser.add_argument("input", nargs="?", help="JSONL input. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="JSONL output. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=sorted(OUTPUT_FORMATS), default="ocsf")
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    try:
+        for finding in detect(_load_jsonl(in_stream), output_format=args.output_format):
+            out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-gcp-model-artifact-download/tests/test_detect.py
+++ b/skills/detection/detect-gcp-model-artifact-download/tests/test_detect.py
@@ -1,0 +1,113 @@
+"""Tests for detect-gcp-model-artifact-download."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_gcp_model_artifact_download_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _event(
+    *,
+    producer: str = "ingest-gcp-audit-ocsf",
+    operation: str = "storage.objects.get",
+    service: str = "storage.googleapis.com",
+    status_id: int = 1,
+    actor_name: str = "alice@example.com",
+    actor_type: str = "",
+    project_uid: str = "prod-ml-project",
+    resource_name: str = "projects/_/buckets/model-artifacts-prod/objects/vertex/checkpoints/model.safetensors",
+    src_ip: str = "198.51.100.25",
+) -> dict:
+    actor_user = {"name": actor_name}
+    if actor_type:
+        actor_user["type"] = actor_type
+    return {
+        "class_uid": 6003,
+        "status_id": status_id,
+        "time": 1775797200000,
+        "metadata": {
+            "uid": "evt-1",
+            "product": {"feature": {"name": producer}},
+        },
+        "api": {
+            "operation": operation,
+            "service": {"name": service},
+        },
+        "actor": {"user": actor_user},
+        "cloud": {
+            "provider": "GCP",
+            "account": {"uid": project_uid},
+            "region": "us-central1",
+        },
+        "src_endpoint": {"ip": src_ip},
+        "resources": [
+            {"name": resource_name, "type": "gcs_bucket"},
+        ],
+    }
+
+
+def test_fires_on_model_safetensors_get_object():
+    findings = list(MODULE.detect([_event()]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["finding_info"]["title"] == "GCP model artifact downloaded from Cloud Storage"
+    attacks = finding["finding_info"]["attacks"]
+    assert any(item["technique"]["uid"] == "T1530" for item in attacks)
+    assert any(item["technique"]["uid"] == "AML.T0035" for item in attacks)
+    assert any(obs["name"] == "object.key" and obs["value"].endswith("model.safetensors") for obs in finding["observables"])
+
+
+def test_native_output_includes_bucket_key_and_match():
+    findings = list(
+        MODULE.detect(
+            [
+                _event(
+                    resource_name="projects/_/buckets/model-artifacts-prod/objects/training%2Frun-42%2Fpytorch_model.bin"
+                )
+            ],
+            output_format="native",
+        )
+    )
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["rule"] == "gcp-model-artifact-download"
+    assert finding["bucket_name"] == "model-artifacts-prod"
+    assert finding["object_key"] == "training/run-42/pytorch_model.bin"
+    assert finding["artifact_match"] == "pytorch_model.bin"
+
+
+def test_non_model_object_is_ignored():
+    findings = list(
+        MODULE.detect(
+            [_event(resource_name="projects/_/buckets/model-artifacts-prod/objects/reports/quarterly.csv")]
+        )
+    )
+    assert findings == []
+
+
+def test_wrong_operation_is_ignored():
+    findings = list(MODULE.detect([_event(operation="storage.objects.list")]))
+    assert findings == []
+
+
+def test_failed_event_is_ignored():
+    findings = list(MODULE.detect([_event(status_id=2)]))
+    assert findings == []
+
+
+def test_wrong_source_is_ignored():
+    findings = list(MODULE.detect([_event(producer="ingest-cloudtrail-ocsf")]))
+    assert findings == []
+
+
+def test_missing_bucket_or_key_is_skipped(capsys):
+    findings = list(MODULE.detect([_event(resource_name="projects/_/buckets/model-artifacts-prod")]))
+    assert findings == []
+    assert "missing bucket or object context" in capsys.readouterr().err


### PR DESCRIPTION
What changed

- added a new read-only detection skill, `detect-gcp-model-artifact-download`, for successful `storage.objects.get` reads of model-weight and checkpoint artifacts from `ingest-gcp-audit-ocsf`
- kept the rule intentionally narrow: explicit model-artifact filenames and suffixes only, with `.bin` allowed only when the key also carries model hints such as `model`, `checkpoint`, `weights`, `vertex`, or `aiplatform`
- updated `README.md`, `docs/ROADMAP.md`, and `docs/FRAMEWORK_MAPPINGS.md` so MITRE ATT&CK, MITRE ATLAS, and OWASP progress are shown as distinct framework lines instead of being blended into one umbrella row
- refreshed `docs/framework-coverage.json`, regenerated `docs/FRAMEWORK_COVERAGE.md` and `SECURITY_BAR.md`, and aligned the count-bearing visuals to the branch state: 74 skills / 27 detect / 91 checks
- updated `skills/README.md` and the coverage matrix to include the new GCP model-artifact slice

Why

Issue `#255` needs to become less MCP-only and more honestly cross-cloud. After the first AWS model-artifact collection slice, the clean next move is a provider-equivalent GCP detector built on shipped audit ingestion. This PR also fixes the repo-front progress snapshot so it reflects that MITRE ATLAS and OWASP are different frameworks, even though they currently share the same roadmap umbrella issue.

Scope

This slice intentionally covers only:

- `ingest-gcp-audit-ocsf` input
- successful `storage.objects.get`
- explicit model-artifact filename / suffix heuristics

It does not claim generic GCS exfiltration coverage, generic object reads, or broader Vertex AI / model-registry abuse.

Validation

- `python scripts/generate_framework_coverage_doc.py`
- `python scripts/generate_security_bar_matrix.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_ocsf_metadata.py`
- `pytest skills/detection/detect-gcp-model-artifact-download/tests/test_detect.py -q`
- `ruff check skills/detection/detect-gcp-model-artifact-download/src/detect.py skills/detection/detect-gcp-model-artifact-download/tests/test_detect.py`
- `xmllint --noout docs/images/hero-banner.svg docs/images/runtime-surfaces.svg docs/images/architecture-layers.svg docs/images/coverage-matrix.svg`

Part of #255
