### PR TITLE
Add GCP service-account key creation detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 74 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 75 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**74 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**75 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 27 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 28 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 74 shipped skills.**
+**Total: 75 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 13 of 27 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 28 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -275,7 +275,7 @@ Approximate roadmap progress is tracked here so the README reflects current ship
 
 | Roadmap track | Approx progress | Current shipped state |
 |---|---:|---|
-| **MITRE ATT&CK (`#253`)** | **45%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, AWS discovery burst, and AWS cross-account S3 copy are shipped |
+| **MITRE ATT&CK (`#253`)** | **50%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, the first GCP service-account-key slice, AWS discovery burst, and AWS cross-account S3 copy are shipped |
 | **CIS + auto-remediate (`#254`)** | **35%** | 91 checks shipped across AWS/GCP/Azure/K8s/container/GPU/model-serving, with the first guarded AWS `--auto-remediate` slice shipped |
 | **MITRE ATLAS (`#255` umbrella)** | **45%** | AI inventory and evidence, model-serving and GPU posture, MCP prompt injection, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
 | **OWASP LLM Top 10 (`#255` umbrella)** | **45%** | model-serving controls plus MCP prompt injection, credential leak, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
@@ -289,7 +289,7 @@ These are repo-progress estimates, not claims of full framework completion.
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 27 detectors across MITRE ATT&CK, MITRE ATLAS, OWASP LLM / MCP, and agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS + GCP model-artifact download slices, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
+| **Detect** | 28 detectors across MITRE ATT&CK, MITRE ATLAS, OWASP LLM / MCP, and agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first GCP service-account-key slice, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS + GCP model-artifact download slices, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
 | **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
 | **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -68,6 +68,7 @@ is the row you can take to your auditor.
 | `detect-gcp-audit-logs-disabled` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-model-artifact-download` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-open-firewall` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-gcp-service-account-key-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-mcp-tool-drift` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -104,7 +105,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_74 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_75 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 27 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 28 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,14 +4,14 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.8.1`
 - Registry updated: `2026-04-24`
-- Total shipped skills in registry: **74**
+- Total shipped skills in registry: **75**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **53** | — |
-| MITRE ATT&CK | v14 | **47** | 100% mapped coverage |
+| OCSF | 1.8.0 | **54** | — |
+| MITRE ATT&CK | v14 | **48** | 100% mapped coverage |
 | MITRE ATLAS | current | **13** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
@@ -36,7 +36,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **53**
+Shipped skills mapped: **54**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -56,6 +56,7 @@ Shipped skills mapped: **53**
 | [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
 | [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
+| [`detect-gcp-service-account-key-creation`](../skills/detection/detect-gcp-service-account-key-creation) | detection | gcp | identities, service-accounts, credentials, audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
@@ -101,7 +102,7 @@ Shipped skills mapped: **53**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **47**
+Shipped skills mapped: **48**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -120,6 +121,7 @@ Shipped skills mapped: **47**
 | [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled) | detection | gcp | audit-logs, logging-sinks, log-streams |
 | [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
+| [`detect-gcp-service-account-key-creation`](../skills/detection/detect-gcp-service-account-key-creation) | detection | gcp | identities, service-accounts, credentials, audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -20,7 +20,7 @@ from individual `SKILL.md` files.
 | Framework | Status | Where it appears |
 |---|---|---|
 | **OCSF 1.8** | core wire contract | all ingestion, detection, and view flows |
-| **MITRE ATT&CK v14** | strong and broader | 47 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, and the first AWS + GCP model-artifact download slices |
+| **MITRE ATT&CK v14** | strong and broader | 48 mapped skills across cloud, identity, Kubernetes, container, MCP, and remediation paths, including the shipped AWS IAM access-key and login-profile slices, the first GCP service-account-key slice, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, and the first AWS + GCP model-artifact download slices |
 | **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, MCP prompt-injection plus response-layer override and exfiltration detection, and the first AWS + GCP cloud-native model-artifact collection slices |
 | **CIS Benchmarks / Controls** | strong | AWS, GCP, Azure, Kubernetes, container evaluation skills |
 | **NIST CSF 2.0** | strong | evaluation and some remediation skills |
@@ -51,6 +51,7 @@ Strongest current ATT&CK coverage:
 | `detect-lateral-movement` | T1021, T1078.004 across AWS role sessions, GCP service-account pivots anchored in IAM Credentials and key-creation events, Azure Activity role/managed-identity pivots, and Azure Entra / Graph application-service-principal credential pivots; AWS IAM-user temporary-credential pivots plus GCP workload-identity federation abuse remain tracked follow-up gaps |
 | `detect-aws-access-key-creation` | T1098.001 for successful AWS IAM `CreateAccessKey` operations that add credential material to an IAM user |
 | `detect-aws-login-profile-creation` | T1098.001 for successful AWS IAM `CreateLoginProfile` operations that add console-password credential material to an IAM user |
+| `detect-gcp-service-account-key-creation` | T1098.001 for successful GCP IAM `CreateServiceAccountKey` operations that add credential material to a service account |
 | `detect-aws-enumeration-burst` | T1526 for short-window bursts of high-signal AWS discovery APIs in CloudTrail across IAM, EC2, S3, KMS, Organizations, EKS, Lambda, and CloudTrail |
 | `detect-s3-cross-account-copy` | T1537 for successful AWS S3 `CopyObject` calls where the acting principal account differs from the recipient bucket-owner account |
 | `detect-aws-model-artifact-download` | T1530 plus ATLAS AML.T0035 for successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts |
@@ -82,6 +83,9 @@ Notes:
   weakening, and policy-drift depth remain separate follow-on work.
 - Current cross-cloud identity depth is strongest in `detect-lateral-movement`; the Azure slice now distinguishes Azure Activity control-plane pivots from Entra / Graph application-service-principal credential pivots.
 - The GCP slice in `detect-lateral-movement` is currently pinned to service-account and IAM Credentials anchors; workload-identity federation abuse is tracked separately so the docs do not overstate provider depth.
+- `detect-gcp-service-account-key-creation` now ships the first narrow GCP
+  service-account credential-creation slice, but workload-identity federation
+  abuse and broader token-minting depth remain separate follow-on work.
 - The AWS role-session slice stays in `detect-lateral-movement`, while
   `detect-aws-access-key-creation` and
   `detect-aws-login-profile-creation` now cover the first IAM-user

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,12 +22,13 @@ The current north star is not "more skills" by itself. It is:
 
 ### Current shipped progress snapshot
 
-- **ATT&CK depth:** 47 mapped skills in the coverage registry, with the first
+- **ATT&CK depth:** 48 mapped skills in the coverage registry, with the first
   AWS IAM-user credential-creation slices now shipped via access-key and
-  login-profile detection, the first AWS cloud-discovery burst slice now
-  shipped, the first AWS exfiltration-to-cloud-account slice now shipped via
-  cross-account S3 copy detection, and the first cross-cloud
-  logging-impairment trio now shipped across AWS, GCP, and Azure.
+  login-profile detection, the first GCP service-account-key slice now shipped,
+  the first AWS cloud-discovery burst slice now shipped, the first AWS
+  exfiltration-to-cloud-account slice now shipped via cross-account S3 copy
+  detection, and the first cross-cloud logging-impairment trio now shipped
+  across AWS, GCP, and Azure.
 - **CIS and posture depth:** 91 shipped benchmark checks across AWS, GCP,
   Azure, Kubernetes, container, GPU, and model-serving surfaces; AWS also has
   the first guarded `--auto-remediate` slice.

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -974,6 +974,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-gcp-service-account-key-creation",
+      "layer": "detection",
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "identities",
+        "service-accounts",
+        "credentials",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-open-security-group",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 27 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 28 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">27</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">28</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1522" viewBox="0 0 1400 1522" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1560" viewBox="0 0 1400 1560" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (27) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-seven detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (28) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-eight detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, GCP service-account-key, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="1522" fill="url(#bg2)"/>
-  <rect width="1400" height="1522" fill="url(#grid2)"/>
+  <rect width="1400" height="1560" fill="url(#bg2)"/>
+  <rect width="1400" height="1560" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (27)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (28)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -195,90 +195,97 @@
     <text x="1020" y="1012" fill="#fee2e2" font-size="13">detection-first AWS IAM-user console persistence slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1050" fill="#f1f5f9" font-size="15">detect-aws-enumeration-burst</text>
-    <text x="430"  y="1050" fill="#cbd5e1" font-size="14">T1526 (TA0007)</text>
+    <text x="48"   y="1050" fill="#f1f5f9" font-size="13">detect-gcp-service-account-key-creation</text>
+    <text x="430"  y="1050" fill="#cbd5e1" font-size="14">T1098.001 (TA0003)</text>
     <rect x="760"  y="1034" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1034" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1050" fill="#fee2e2" font-size="13">detection-first AWS cloud discovery burst slice</text>
+    <text x="1020" y="1050" fill="#fee2e2" font-size="13">detection-first GCP service-account key persistence slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1088" fill="#f1f5f9" font-size="15">detect-s3-cross-account-copy</text>
-    <text x="430"  y="1088" fill="#cbd5e1" font-size="14">T1537 (TA0010)</text>
+    <text x="48"   y="1088" fill="#f1f5f9" font-size="15">detect-aws-enumeration-burst</text>
+    <text x="430"  y="1088" fill="#cbd5e1" font-size="14">T1526 (TA0007)</text>
     <rect x="760"  y="1072" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1072" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1088" fill="#fee2e2" font-size="13">detection-first AWS exfiltration to cloud account slice</text>
+    <text x="1020" y="1088" fill="#fee2e2" font-size="13">detection-first AWS cloud discovery burst slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1126" fill="#f1f5f9" font-size="15">detect-system-prompt-extraction</text>
-    <text x="430"  y="1126" fill="#cbd5e1" font-size="14">ATLAS AML.T0004 · AML.T0041</text>
+    <text x="48"   y="1126" fill="#f1f5f9" font-size="15">detect-s3-cross-account-copy</text>
+    <text x="430"  y="1126" fill="#cbd5e1" font-size="14">T1537 (TA0010)</text>
     <rect x="760"  y="1110" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1110" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1126" fill="#fee2e2" font-size="13">detection-first AI system-prompt leakage slice</text>
+    <text x="1020" y="1126" fill="#fee2e2" font-size="13">detection-first AWS exfiltration to cloud account slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1164" fill="#f1f5f9" font-size="15">detect-tool-output-policy-bypass</text>
-    <text x="430"  y="1164" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
+    <text x="48"   y="1164" fill="#f1f5f9" font-size="15">detect-system-prompt-extraction</text>
+    <text x="430"  y="1164" fill="#cbd5e1" font-size="14">ATLAS AML.T0004 · AML.T0041</text>
     <rect x="760"  y="1148" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1148" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1164" fill="#fee2e2" font-size="13">detection-first AI response-layer policy-bypass slice</text>
+    <text x="1020" y="1164" fill="#fee2e2" font-size="13">detection-first AI system-prompt leakage slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1202" fill="#f1f5f9" font-size="13">detect-tool-output-exfiltration-instructions</text>
+    <text x="48"   y="1202" fill="#f1f5f9" font-size="15">detect-tool-output-policy-bypass</text>
     <text x="430"  y="1202" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
     <rect x="760"  y="1186" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1186" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1202" fill="#fee2e2" font-size="13">detection-first AI response exfiltration-instruction slice</text>
+    <text x="1020" y="1202" fill="#fee2e2" font-size="13">detection-first AI response-layer policy-bypass slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1240" fill="#f1f5f9" font-size="14">detect-aws-model-artifact-download</text>
-    <text x="430"  y="1240" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
+    <text x="48"   y="1240" fill="#f1f5f9" font-size="13">detect-tool-output-exfiltration-instructions</text>
+    <text x="430"  y="1240" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
     <rect x="760"  y="1224" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1224" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1240" fill="#fee2e2" font-size="13">detection-first AWS AI model-artifact collection slice</text>
+    <text x="1020" y="1240" fill="#fee2e2" font-size="13">detection-first AI response exfiltration-instruction slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1278" fill="#f1f5f9" font-size="14">detect-gcp-model-artifact-download</text>
+    <text x="48"   y="1278" fill="#f1f5f9" font-size="14">detect-aws-model-artifact-download</text>
     <text x="430"  y="1278" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
     <rect x="760"  y="1262" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1262" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1278" fill="#fee2e2" font-size="13">detection-first GCP AI model-artifact collection slice</text>
+    <text x="1020" y="1278" fill="#fee2e2" font-size="13">detection-first AWS AI model-artifact collection slice</text>
+  </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="1316" fill="#f1f5f9" font-size="14">detect-gcp-model-artifact-download</text>
+    <text x="430"  y="1316" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
+    <rect x="760"  y="1300" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1300" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="1316" fill="#fee2e2" font-size="13">detection-first GCP AI model-artifact collection slice</text>
   </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="1332" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1370" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1366" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
-    <text x="430"  y="1366" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
-    <rect x="760"  y="1350" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1350" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1366" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
+    <text x="48"   y="1404" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="1404" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
+    <rect x="760"  y="1388" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1388" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1404" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1396" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
-    <text x="430"  y="1396" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
-    <rect x="760"  y="1380" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1380" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1396" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1434" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="1434" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
+    <rect x="760"  y="1418" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1418" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1434" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1426" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
-    <text x="430"  y="1426" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
-    <rect x="760"  y="1410" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1410" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1426" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1464" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="1464" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="1448" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1448" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1464" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1456" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
-    <text x="430"  y="1456" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="760"  y="1440" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1440" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="1020" y="1456" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+    <text x="48"   y="1494" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="1494" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="1478" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1478" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1494" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
   </g>
 
   <!-- Footer (two lines to fit 1200px canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1490" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 27</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
-    <text x="48" y="1508" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1528" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 28</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, GCP service-account-key, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
+    <text x="48" y="1546" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 74 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 27 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 75 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 28 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">74</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">75</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">27</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">28</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 74 shipped skills — 15 ingest, 27 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 75 shipped skills — 15 ingest, 28 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 74 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">74</text>
+      <!-- Counts: 75 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">75</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 27 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 28 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -52,6 +52,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-google-workspace-suspicious-login`](detection/detect-google-workspace-suspicious-login/) | provider-marked suspicious Workspace login or repeated failures followed by success |
 | [`detect-aws-access-key-creation`](detection/detect-aws-access-key-creation/) | successful AWS IAM `CreateAccessKey` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-login-profile-creation`](detection/detect-aws-login-profile-creation/) | successful AWS IAM `CreateLoginProfile` operations against IAM users (T1098.001 Additional Cloud Credentials) |
+| [`detect-gcp-service-account-key-creation`](detection/detect-gcp-service-account-key-creation/) | successful GCP IAM `CreateServiceAccountKey` operations against service accounts (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-enumeration-burst`](detection/detect-aws-enumeration-burst/) | short-window burst of high-signal AWS discovery APIs in CloudTrail (T1526 Cloud Service Discovery) |
 | [`detect-aws-model-artifact-download`](detection/detect-aws-model-artifact-download/) | successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |
 | [`detect-gcp-model-artifact-download`](detection/detect-gcp-model-artifact-download/) | successful GCS `storage.objects.get` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |

--- a/skills/detection/detect-gcp-service-account-key-creation/REFERENCES.md
+++ b/skills/detection/detect-gcp-service-account-key-creation/REFERENCES.md
@@ -1,0 +1,8 @@
+# References — detect-gcp-service-account-key-creation
+
+- MITRE ATT&CK T1098.001 — Additional Cloud Credentials:
+  https://attack.mitre.org/techniques/T1098/001/
+- Google Cloud IAM `projects.serviceAccounts.keys.create`:
+  https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/create
+- Google Cloud Audit Logs:
+  https://cloud.google.com/logging/docs/audit

--- a/skills/detection/detect-gcp-service-account-key-creation/SKILL.md
+++ b/skills/detection/detect-gcp-service-account-key-creation/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: detect-gcp-service-account-key-creation
+description: >-
+  Detect successful GCP IAM `CreateServiceAccountKey` API calls against service
+  accounts from OCSF 1.8 API Activity records emitted by
+  ingest-gcp-audit-ocsf. Emits an OCSF 1.8 Detection Finding (class 2004)
+  tagged with MITRE ATT&CK T1098.001 (Additional Cloud Credentials) when a
+  principal creates a user-managed key for a service account. Use when the
+  user mentions "GCP service account key created", "additional cloud
+  credentials in GCP", or "T1098.001 via Cloud Audit Logs". Do NOT use for
+  posture-at-rest key inventory, workload-identity federation coverage, or
+  generic IAM policy changes. This first slice only covers successful
+  `CreateServiceAccountKey` operations.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No GCP
+  SDK; pairs with ingest-gcp-audit-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-gcp-service-account-key-creation
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+  cloud: gcp
+  capability: read-only
+---
+
+# detect-gcp-service-account-key-creation
+
+Streaming detector for new GCP service-account keys created through Cloud Audit
+Logs. This is the first honest shipped GCP service-account key persistence
+slice after the broader service-account and IAM Credentials anchors already
+tracked in `detect-lateral-movement`.
+
+## Use when
+
+- You stream Cloud Audit Logs through `ingest-gcp-audit-ocsf` and want near-real-time findings on new service-account keys
+- You want a narrow, high-confidence GCP persistence detector for additional cloud credentials
+- You are closing the first GCP service-account key gap under the ATT&CK roadmap without over-claiming workload-identity federation or token-minting coverage
+
+## Do NOT use
+
+- As a posture-at-rest service-account key inventory or age check; use [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/)
+- To infer workload-identity federation abuse or IAM Credentials token generation; those are separate follow-on detections
+- To claim every GCP service-account pivot path; this first slice is only `CreateServiceAccountKey`
+
+## Rule
+
+A finding fires on every successful Cloud Audit event from
+`ingest-gcp-audit-ocsf` where:
+
+1. `api.service.name` is `iam.googleapis.com`
+2. `api.operation` is `google.iam.admin.v1.CreateServiceAccountKey`
+3. `status_id == 1`
+4. `resources[]` resolve a target service-account resource
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0003` (Persistence)
+- `finding_info.attacks[].technique_uid = T1098` (Account Manipulation)
+- `finding_info.attacks[].sub_technique_uid = T1098.001` (Additional Cloud Credentials)
+- `observables[]` including `target.name`, `project.uid`, `actor.name`, and `api.operation`
+
+The native projection (`--output-format native`) keeps the target service
+account and actor/project context in a flatter shape.
+
+## Run
+
+```bash
+# Cloud Audit Logs -> ingest -> detect (default OCSF output)
+python skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-gcp-service-account-key-creation/src/detect.py \
+  > findings.ocsf.jsonl
+
+# Native projection
+python skills/detection/detect-gcp-service-account-key-creation/src/detect.py findings-input.jsonl --output-format native
+```
+
+## See also
+
+- [`ingest-gcp-audit-ocsf`](../../ingestion/ingest-gcp-audit-ocsf/) — upstream ingester
+- [`detect-lateral-movement`](../detect-lateral-movement/) — broader GCP service-account pivot anchors
+- [`cspm-gcp-cis-benchmark`](../../evaluation/cspm-gcp-cis-benchmark/) — posture-at-rest GCP service-account key hygiene

--- a/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
@@ -1,0 +1,295 @@
+"""Detect GCP service-account key creation via Cloud Audit Logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-gcp-service-account-key-creation"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0003"
+TACTIC_NAME = "Persistence"
+TECHNIQUE_UID = "T1098"
+TECHNIQUE_NAME = "Account Manipulation"
+SUBTECHNIQUE_UID = "T1098.001"
+SUBTECHNIQUE_NAME = "Additional Cloud Credentials"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-gcp-audit-ocsf"})
+IAM_SERVICE = "iam.googleapis.com"
+CREATE_SA_KEY_OPERATION = "google.iam.admin.v1.CreateServiceAccountKey"
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _api_service(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    service = api.get("service") or {}
+    return str(service.get("name") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _actor_name(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account_uid(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _time_ms(event: dict[str, Any]) -> int:
+    return int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _event_uid(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    return str(metadata.get("uid") or "")
+
+
+def _target_service_account(event: dict[str, Any]) -> str:
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        if str(resource.get("type") or "").lower() != "service_account":
+            continue
+        name = str(resource.get("name") or "")
+        if not name:
+            continue
+        marker = "serviceAccounts/"
+        if marker in name:
+            return name.split(marker, 1)[1].strip("/")
+        return name
+    return ""
+
+
+def _finding_uid(event_uid: str, target_sa: str, actor_name: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{target_sa}|{actor_name}|{time_ms}"
+    return f"gsakc-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(*, event: dict[str, Any], target_service_account: str) -> dict[str, Any]:
+    time_ms = _time_ms(event)
+    event_uid = _event_uid(event)
+    actor_name = _actor_name(event)
+    finding_uid = _finding_uid(event_uid, target_service_account, actor_name, time_ms)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "gcp-service-account-key-creation",
+        "api_operation": CREATE_SA_KEY_OPERATION,
+        "target_service_account": target_service_account,
+        "actor_name": actor_name,
+        "project_uid": _account_uid(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Actor `{native['actor_name'] or 'unknown'}` successfully called "
+        f"`{native['api_operation']}` for service account "
+        f"`{native['target_service_account']}` in project `{native['project_uid']}`. "
+        f"Source IP: {native['src_ip'] or '<unknown>'}. This creates additional GCP "
+        "credential material for a valid cloud principal."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "GCP"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": native["api_operation"]},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.type", "type": "Other", "value": "ServiceAccount"},
+        {"name": "target.name", "type": "Other", "value": native["target_service_account"]},
+        {"name": "project.uid", "type": "Other", "value": native["project_uid"]},
+    ]
+    if native["region"]:
+        observables.append({"name": "region", "type": "Other", "value": native["region"]})
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["gcp", "iam", "service-account", "credentials", "persistence"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "GCP service account key created",
+            "desc": description,
+            "types": ["gcp-service-account-key-creation"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                    "sub_technique_uid": SUBTECHNIQUE_UID,
+                    "sub_technique_name": SUBTECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "target_service_account": native["target_service_account"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-gcp-audit producer `{producer}`",
+            )
+            continue
+        if _api_service(event) != IAM_SERVICE or _api_operation(event) != CREATE_SA_KEY_OPERATION:
+            continue
+        if not _is_success(event):
+            continue
+        target_service_account = _target_service_account(event)
+        if not target_service_account:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_target_service_account",
+                message="skipping CreateServiceAccountKey event with no target service account",
+            )
+            continue
+        native = _build_native_finding(event=event, target_service_account=target_service_account)
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def _iter_jsonl(path: str | None) -> Iterator[dict[str, Any]]:
+    handle = open(path, "r", encoding="utf-8") if path else sys.stdin
+    with handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="invalid_json",
+                    message=f"skipping line {line_number}: invalid JSON ({exc.msg})",
+                )
+                continue
+            if isinstance(obj, dict):
+                yield obj
+            else:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="wrong_shape",
+                    message=f"skipping line {line_number}: expected JSON object",
+                )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect GCP service-account key creation from audit logs.")
+    parser.add_argument("input", nargs="?", help="Optional JSONL input file. Defaults to stdin.")
+    parser.add_argument(
+        "--output-format",
+        default="ocsf",
+        choices=sorted(OUTPUT_FORMATS),
+        help="Emit OCSF detection findings or the native repo shape.",
+    )
+    args = parser.parse_args(argv)
+
+    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
+        sys.stdout.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
@@ -1,0 +1,134 @@
+"""Tests for detect-gcp-service-account-key-creation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_gcp_service_account_key_creation_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ACCEPTED_PRODUCERS = MODULE.ACCEPTED_PRODUCERS
+CREATE_SA_KEY_OPERATION = MODULE.CREATE_SA_KEY_OPERATION
+SUBTECHNIQUE_UID = MODULE.SUBTECHNIQUE_UID
+detect = MODULE.detect
+
+
+def _event(
+    *,
+    operation: str = "google.iam.admin.v1.CreateServiceAccountKey",
+    service: str = "iam.googleapis.com",
+    success: bool = True,
+    target_service_account: str = "sa-deploy@my-project.iam.gserviceaccount.com",
+    actor_name: str = "alice@example.com",
+    project_uid: str = "my-project",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-gcp-audit-ocsf",
+    resource_type: str = "service_account",
+) -> dict:
+    resources = []
+    if target_service_account:
+        resources.append(
+            {
+                "name": f"projects/-/serviceAccounts/{target_service_account}",
+                "type": resource_type,
+            }
+        )
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1775797200000,
+        "metadata": {"uid": "evt-1", "product": {"feature": {"name": producer}}},
+        "actor": {"user": {"name": actor_name}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation, "service": {"name": service}},
+        "cloud": {"provider": "GCP", "account": {"uid": project_uid}},
+        "resources": resources,
+    }
+
+
+def test_accepted_producer_is_gcp_audit():
+    assert ACCEPTED_PRODUCERS == frozenset({"ingest-gcp-audit-ocsf"})
+
+
+def test_operation_is_create_service_account_key_only():
+    assert CREATE_SA_KEY_OPERATION == "google.iam.admin.v1.CreateServiceAccountKey"
+
+
+def test_fires_on_create_service_account_key():
+    findings = list(detect([_event()]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    attack = finding["finding_info"]["attacks"][0]
+    assert attack["sub_technique_uid"] == SUBTECHNIQUE_UID
+    assert finding["finding_info"]["title"] == "GCP service account key created"
+    assert any(
+        obs["name"] == "target.name" and obs["value"] == "sa-deploy@my-project.iam.gserviceaccount.com"
+        for obs in finding["observables"]
+    )
+
+
+def test_native_output_contains_target_service_account():
+    findings = list(detect([_event(target_service_account="sa-ci@my-project.iam.gserviceaccount.com")], output_format="native"))
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["target_service_account"] == "sa-ci@my-project.iam.gserviceaccount.com"
+    assert finding["rule"] == "gcp-service-account-key-creation"
+
+
+def test_skips_failed_event():
+    assert list(detect([_event(success=False)])) == []
+
+
+def test_skips_unrelated_operation():
+    assert list(detect([_event(operation="google.iam.admin.v1.DeleteServiceAccountKey")])) == []
+
+
+def test_skips_wrong_service():
+    assert list(detect([_event(service="storage.googleapis.com")])) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_event(producer="ingest-cloudtrail-ocsf")]))
+    assert findings == []
+    assert "non-gcp-audit producer" in capsys.readouterr().err
+
+
+def test_skips_missing_target_service_account(capsys):
+    findings = list(detect([_event(target_service_account="")]))
+    assert findings == []
+    assert "no target service account" in capsys.readouterr().err
+
+
+def test_accepts_raw_service_account_resource_name_without_prefix():
+    findings = list(
+        detect(
+            [
+                {
+                    **_event(),
+                    "resources": [{"name": "sa-deploy@my-project.iam.gserviceaccount.com", "type": "service_account"}],
+                }
+            ]
+        )
+    )
+    assert len(findings) == 1
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    event = _event()
+    first = list(detect([event]))[0]["finding_info"]["uid"]
+    second = list(detect([event]))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("gsakc-")


### PR DESCRIPTION
What changed

- added a new read-only detection skill, `detect-gcp-service-account-key-creation`, for successful `google.iam.admin.v1.CreateServiceAccountKey` operations from `ingest-gcp-audit-ocsf`
- kept the rule intentionally narrow and high-confidence: only successful IAM service-account key creation events, not generic IAM policy changes, workload-identity federation, or token-minting claims
- updated `README.md`, `docs/ROADMAP.md`, and `docs/FRAMEWORK_MAPPINGS.md` to reflect the new ATT&CK depth and repo state: 75 skills / 28 detect / 91 checks
- refreshed `docs/framework-coverage.json`, regenerated `docs/FRAMEWORK_COVERAGE.md` and `SECURITY_BAR.md`, and aligned the count-bearing visuals and coverage matrix
- updated `skills/README.md` to include the new GCP detector

Why

This is the clean next ATT&CK slice after the GCP model-artifact work. The repo already preserved `CreateServiceAccountKey` faithfully in `ingest-gcp-audit-ocsf`, and this path maps directly to `T1098.001` Additional Cloud Credentials. It is a better next move than inventing an Azure data-plane detector the current ingestion stack does not actually support.

Scope

This slice intentionally covers only:

- `ingest-gcp-audit-ocsf` input
- `iam.googleapis.com`
- successful `google.iam.admin.v1.CreateServiceAccountKey`
- target service-account extraction from the audit resource path

It does not claim workload-identity federation abuse, IAM Credentials token generation, or broader GCP service-account pivot coverage.

Validation

- `python scripts/generate_framework_coverage_doc.py`
- `python scripts/generate_security_bar_matrix.py`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_skill_integrity.py`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/validate_ocsf_metadata.py`
- `pytest skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py -q`
- `ruff check skills/detection/detect-gcp-service-account-key-creation/src/detect.py skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py`
- `xmllint --noout docs/images/hero-banner.svg docs/images/runtime-surfaces.svg docs/images/architecture-layers.svg docs/images/coverage-matrix.svg`

Part of #253
