### PR TITLE
[codex] fix mypy gcp sdk gate

### DIFF
--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 : "${UV_CACHE_DIR:=/tmp/cloud-security-core-foundation-uv-cache}"
 export UV_CACHE_DIR
+: "${MYPY_CACHE_DIR:=/tmp/cloud-security-mypy-cache}"
 
 if command -v uv >/dev/null 2>&1; then
   MYPY_CMD=(uv run mypy)
@@ -17,6 +18,7 @@ fi
   mcp-server/src \
   scripts \
   --config-file pyproject.toml \
+  --cache-dir "$MYPY_CACHE_DIR" \
   --disallow-untyped-defs \
   --disallow-incomplete-defs \
   --warn-return-any
@@ -31,6 +33,7 @@ for dir in "${STRICT_SKILL_DIRS[@]}"; do
   "${MYPY_CMD[@]}" \
     "$dir" \
     --config-file pyproject.toml \
+    --cache-dir "$MYPY_CACHE_DIR" \
     --disallow-untyped-defs \
     --disallow-incomplete-defs \
     --warn-return-any
@@ -43,7 +46,7 @@ for dir in skills/*/*/src; do
   if ! find "$dir" -maxdepth 1 \( -name '*.py' -o -name '*.pyi' \) | grep -q .; then
     continue
   fi
-  "${MYPY_CMD[@]}" "$dir" --config-file pyproject.toml
+  "${MYPY_CMD[@]}" "$dir" --config-file pyproject.toml --cache-dir "$MYPY_CACHE_DIR"
 done
 
-"${MYPY_CMD[@]}" mcp-server/src scripts --config-file pyproject.toml
+"${MYPY_CMD[@]}" mcp-server/src scripts --config-file pyproject.toml --cache-dir "$MYPY_CACHE_DIR"

--- a/skills/discovery/discover-environment/src/discover.py
+++ b/skills/discovery/discover-environment/src/discover.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
 import json
 import sys
 from dataclasses import asdict, dataclass, field
@@ -478,7 +479,7 @@ def discover_gcp(project: str) -> EnvironmentGraph:
 
     # Service Accounts
     try:
-        from google.cloud import iam_v1
+        iam_v1 = importlib.import_module("google.cloud.iam_v1")
 
         iam_client = iam_v1.IAMClient()
         request = iam_v1.ListServiceAccountsRequest(name=f"projects/{project}")
@@ -507,7 +508,7 @@ def discover_gcp(project: str) -> EnvironmentGraph:
 
     # Cloud Storage Buckets
     try:
-        from google.cloud import storage
+        storage = importlib.import_module("google.cloud.storage")
 
         storage_client = storage.Client(project=project)
         for bucket in storage_client.list_buckets():
@@ -567,12 +568,15 @@ def discover_azure(subscription_id: str) -> EnvironmentGraph:
 
         client = ResourceManagementClient(credential, subscription_id)
         for rg in client.resource_groups.list():
-            rg_id = f"azure:rg:{rg.name}"
+            rg_name = rg.name
+            if not rg_name:
+                continue
+            rg_id = f"azure:rg:{rg_name}"
             graph.add_node(
                 GraphNode(
                     id=rg_id,
                     entity_type="cloud_resource",
-                    label=rg.name,
+                    label=rg_name,
                     attributes={"location": rg.location},
                     dimensions={"cloud_provider": "azure", "surface": "resource_group"},
                 )
@@ -586,14 +590,17 @@ def discover_azure(subscription_id: str) -> EnvironmentGraph:
             )
 
             # Resources in group
-            for resource in client.resources.list_by_resource_group(rg.name):
-                res_id = f"azure:resource:{resource.name}"
+            for resource in client.resources.list_by_resource_group(rg_name):
+                resource_name = resource.name
+                if not resource_name:
+                    continue
+                res_id = f"azure:resource:{resource_name}"
                 res_type = resource.type.split("/")[-1] if resource.type else "unknown"
                 graph.add_node(
                     GraphNode(
                         id=res_id,
                         entity_type="cloud_resource",
-                        label=resource.name,
+                        label=resource_name,
                         attributes={"type": resource.type, "location": resource.location, "kind": resource.kind or ""},
                         dimensions={"cloud_provider": "azure", "surface": res_type},
                     )

--- a/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
@@ -13,6 +13,7 @@ Frameworks:
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sys
 from dataclasses import dataclass, field
@@ -439,10 +440,12 @@ def _status_symbol(status: str) -> str:
 def run_assessment(project_id: str, section: str | None = None) -> list[Finding]:
     """Run all checks. Imports GCP SDKs at call time to fail gracefully."""
     try:
-        from google.cloud import iam_admin_v1, resourcemanager_v3, storage
+        from google.cloud import iam_admin_v1, resourcemanager_v3
         from google.cloud.compute_v1.services.firewalls import FirewallsClient
         from google.cloud.compute_v1.services.networks import NetworksClient
         from google.cloud.compute_v1.services.subnetworks import SubnetworksClient
+
+        storage = importlib.import_module("google.cloud.storage")
     except ImportError:
         print(
             "ERROR: Install GCP SDKs: pip install google-cloud-iam google-cloud-storage google-cloud-resource-manager google-cloud-compute"


### PR DESCRIPTION
## What changed

- Move the canonical mypy script to a stable temp cache via MYPY_CACHE_DIR, avoiding repo-local .mypy_cache write failures.
- Use dynamic optional GCP SDK imports where mypy cannot resolve google.cloud re-exports.
- Guard nullable Azure SDK resource-group and resource names before using them as labels or API inputs.

## Why

The latest audit found a P1 quality-gate regression: current main passed tests, but bash scripts/run_mypy.sh failed in a fully hydrated environment with GCP SDK type errors and a mypy cache PermissionError. That made the advertised mypy gate unreliable.

## Validation

- uv run --all-groups pytest -q
- uv run ruff check .
- bash scripts/run_mypy.sh
- uv run --all-groups pytest skills/discovery/discover-environment/tests -q
- uv run --all-groups pytest skills/evaluation/cspm-gcp-cis-benchmark/tests -q