### PR TITLE
[codex] fix optional httpx test collection

### DIFF
--- a/skills/discovery/iam-departures-reconciler/tests/test_reconciler.py
+++ b/skills/discovery/iam-departures-reconciler/tests/test_reconciler.py
@@ -8,7 +8,6 @@ import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -307,6 +306,7 @@ class TestWorkdayRedaction:
     """Workday token errors must never leak response bodies or credentials."""
 
     def test_http_error_does_not_include_response_body(self):
+        httpx = pytest.importorskip("httpx")
         from reconciler import sources
 
         with patch.dict(os.environ, {
@@ -332,6 +332,7 @@ class TestWorkdayRedaction:
         assert "invalid_client" not in msg
 
     def test_network_error_hides_exception_detail(self):
+        httpx = pytest.importorskip("httpx")
         from reconciler import sources
 
         with patch.dict(os.environ, {


### PR DESCRIPTION
## What changed

- Remove the top-level test import of optional httpx from the IAM departures reconciler tests.
- Use pytest.importorskip inside the two Workday redaction tests that specifically exercise httpx response/error shapes.

## Why

The audit found that plain uv run pytest -q failed during collection when the optional iam_departures dependency group was not installed. The first attempted fix duplicated httpx into dev, but the repo dependency validator correctly rejects packages declared in multiple groups. This keeps httpx owned by the runtime iam_departures group while allowing default test collection to proceed cleanly.

## Validation

- uv run python scripts/validate_dependency_consistency.py
- uv run pytest -q
- uv run --all-groups pytest skills/discovery/iam-departures-reconciler/tests/test_reconciler.py -q
- uv run ruff check skills/discovery/iam-departures-reconciler/tests/test_reconciler.py