### PR TITLE
[codex] add GCP service-account token minting detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 75 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 76 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,20 +16,20 @@
 
 ## What this repo gives you
 
-**75 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**76 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
 | **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 28 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
+| **Detect** | 29 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
 | **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
 | **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
-**Total: 75 shipped skills.**
+**Total: 76 shipped skills.**
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -109,7 +109,7 @@ Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
 
 ### Closed-loop coverage at a glance
 
-![Closed-loop coverage matrix — 13 of 28 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 29 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, GCP service-account-token minting, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
 
@@ -275,7 +275,7 @@ Approximate roadmap progress is tracked here so the README reflects current ship
 
 | Roadmap track | Approx progress | Current shipped state |
 |---|---:|---|
-| **MITRE ATT&CK (`#253`)** | **50%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, the first GCP service-account-key slice, AWS discovery burst, and AWS cross-account S3 copy are shipped |
+| **MITRE ATT&CK (`#253`)** | **50%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, the first GCP service-account-key and token-minting slices, AWS discovery burst, and AWS cross-account S3 copy are shipped |
 | **CIS + auto-remediate (`#254`)** | **35%** | 91 checks shipped across AWS/GCP/Azure/K8s/container/GPU/model-serving, with the first guarded AWS `--auto-remediate` slice shipped |
 | **MITRE ATLAS (`#255` umbrella)** | **45%** | AI inventory and evidence, model-serving and GPU posture, MCP prompt injection, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
 | **OWASP LLM Top 10 (`#255` umbrella)** | **45%** | model-serving controls plus MCP prompt injection, credential leak, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
@@ -289,7 +289,7 @@ These are repo-progress estimates, not claims of full framework completion.
 |---|---|---|
 | **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
 | **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 28 detectors across MITRE ATT&CK, MITRE ATLAS, OWASP LLM / MCP, and agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first GCP service-account-key slice, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS + GCP model-artifact download slices, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
+| **Detect** | 29 detectors across MITRE ATT&CK, MITRE ATLAS, OWASP LLM / MCP, and agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first GCP service-account-key and token-minting slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS + GCP model-artifact download slices, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
 | **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
 | **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
 | **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -69,6 +69,7 @@ is the row you can take to your auditor.
 | `detect-gcp-model-artifact-download` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-open-firewall` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-gcp-service-account-key-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-gcp-service-account-token-minting` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-mcp-tool-drift` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -105,7 +106,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_75 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_76 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ For the detailed contract, see:
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
 | L1 ingest | shipping | 15 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 28 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
+| L3 detect | shipping | 29 shipped detectors across cloud, identity, Kubernetes, and MCP / agent signals |
 | L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
 | L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,14 +4,14 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.8.1`
 - Registry updated: `2026-04-24`
-- Total shipped skills in registry: **75**
+- Total shipped skills in registry: **76**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **54** | — |
-| MITRE ATT&CK | v14 | **48** | 100% mapped coverage |
+| OCSF | 1.8.0 | **55** | — |
+| MITRE ATT&CK | v14 | **49** | 100% mapped coverage |
 | MITRE ATLAS | current | **13** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **4** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
@@ -36,7 +36,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **54**
+Shipped skills mapped: **55**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -57,6 +57,7 @@ Shipped skills mapped: **54**
 | [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-gcp-service-account-key-creation`](../skills/detection/detect-gcp-service-account-key-creation) | detection | gcp | identities, service-accounts, credentials, audit-logs |
+| [`detect-gcp-service-account-token-minting`](../skills/detection/detect-gcp-service-account-token-minting) | detection | gcp | identities, service-accounts, credentials, audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
@@ -102,7 +103,7 @@ Shipped skills mapped: **54**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **48**
+Shipped skills mapped: **49**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -122,6 +123,7 @@ Shipped skills mapped: **48**
 | [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download) | detection | gcp | object-storage, objects, model-artifacts, audit-logs |
 | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall) | detection | gcp | vpc-firewall-rules, ingress-rules, cloud-audit-logs |
 | [`detect-gcp-service-account-key-creation`](../skills/detection/detect-gcp-service-account-key-creation) | detection | gcp | identities, service-accounts, credentials, audit-logs |
+| [`detect-gcp-service-account-token-minting`](../skills/detection/detect-gcp-service-account-token-minting) | detection | gcp | identities, service-accounts, credentials, audit-logs |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -998,6 +998,30 @@
       ]
     },
     {
+      "path": "skills/detection/detect-gcp-service-account-token-minting",
+      "layer": "detection",
+      "providers": [
+        "gcp"
+      ],
+      "asset_classes": [
+        "identities",
+        "service-accounts",
+        "credentials",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-open-security-group",
       "layer": "detection",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 28 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 29 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 7 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">28</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">29</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1560" viewBox="0 0 1400 1560" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1600" viewBox="0 0 1400 1600" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (28) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-eight detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, GCP service-account-key, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (29) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-nine detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, GCP service-account-key, GCP service-account-token-minting, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (28)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (29)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -202,90 +202,97 @@
     <text x="1020" y="1050" fill="#fee2e2" font-size="13">detection-first GCP service-account key persistence slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1088" fill="#f1f5f9" font-size="15">detect-aws-enumeration-burst</text>
-    <text x="430"  y="1088" fill="#cbd5e1" font-size="14">T1526 (TA0007)</text>
+    <text x="48"   y="1088" fill="#f1f5f9" font-size="12">detect-gcp-service-account-token-minting</text>
+    <text x="430"  y="1088" fill="#cbd5e1" font-size="14">T1098.001 (TA0003)</text>
     <rect x="760"  y="1072" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1072" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1088" fill="#fee2e2" font-size="13">detection-first AWS cloud discovery burst slice</text>
+    <text x="1020" y="1088" fill="#fee2e2" font-size="13">detection-first GCP service-account token persistence slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1126" fill="#f1f5f9" font-size="15">detect-s3-cross-account-copy</text>
-    <text x="430"  y="1126" fill="#cbd5e1" font-size="14">T1537 (TA0010)</text>
+    <text x="48"   y="1126" fill="#f1f5f9" font-size="15">detect-aws-enumeration-burst</text>
+    <text x="430"  y="1126" fill="#cbd5e1" font-size="14">T1526 (TA0007)</text>
     <rect x="760"  y="1110" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1110" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1126" fill="#fee2e2" font-size="13">detection-first AWS exfiltration to cloud account slice</text>
+    <text x="1020" y="1126" fill="#fee2e2" font-size="13">detection-first AWS cloud discovery burst slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1164" fill="#f1f5f9" font-size="15">detect-system-prompt-extraction</text>
-    <text x="430"  y="1164" fill="#cbd5e1" font-size="14">ATLAS AML.T0004 · AML.T0041</text>
+    <text x="48"   y="1164" fill="#f1f5f9" font-size="15">detect-s3-cross-account-copy</text>
+    <text x="430"  y="1164" fill="#cbd5e1" font-size="14">T1537 (TA0010)</text>
     <rect x="760"  y="1148" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1148" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1164" fill="#fee2e2" font-size="13">detection-first AI system-prompt leakage slice</text>
+    <text x="1020" y="1164" fill="#fee2e2" font-size="13">detection-first AWS exfiltration to cloud account slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1202" fill="#f1f5f9" font-size="15">detect-tool-output-policy-bypass</text>
-    <text x="430"  y="1202" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
+    <text x="48"   y="1202" fill="#f1f5f9" font-size="15">detect-system-prompt-extraction</text>
+    <text x="430"  y="1202" fill="#cbd5e1" font-size="14">ATLAS AML.T0004 · AML.T0041</text>
     <rect x="760"  y="1186" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1186" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1202" fill="#fee2e2" font-size="13">detection-first AI response-layer policy-bypass slice</text>
+    <text x="1020" y="1202" fill="#fee2e2" font-size="13">detection-first AI system-prompt leakage slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1240" fill="#f1f5f9" font-size="13">detect-tool-output-exfiltration-instructions</text>
+    <text x="48"   y="1240" fill="#f1f5f9" font-size="15">detect-tool-output-policy-bypass</text>
     <text x="430"  y="1240" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
     <rect x="760"  y="1224" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1224" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1240" fill="#fee2e2" font-size="13">detection-first AI response exfiltration-instruction slice</text>
+    <text x="1020" y="1240" fill="#fee2e2" font-size="13">detection-first AI response-layer policy-bypass slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1278" fill="#f1f5f9" font-size="14">detect-aws-model-artifact-download</text>
-    <text x="430"  y="1278" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
+    <text x="48"   y="1278" fill="#f1f5f9" font-size="13">detect-tool-output-exfiltration-instructions</text>
+    <text x="430"  y="1278" fill="#cbd5e1" font-size="14">ATLAS AML.T0051</text>
     <rect x="760"  y="1262" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1262" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1278" fill="#fee2e2" font-size="13">detection-first AWS AI model-artifact collection slice</text>
+    <text x="1020" y="1278" fill="#fee2e2" font-size="13">detection-first AI response exfiltration-instruction slice</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1316" fill="#f1f5f9" font-size="14">detect-gcp-model-artifact-download</text>
+    <text x="48"   y="1316" fill="#f1f5f9" font-size="14">detect-aws-model-artifact-download</text>
     <text x="430"  y="1316" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
     <rect x="760"  y="1300" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1300" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1316" fill="#fee2e2" font-size="13">detection-first GCP AI model-artifact collection slice</text>
+    <text x="1020" y="1316" fill="#fee2e2" font-size="13">detection-first AWS AI model-artifact collection slice</text>
+  </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="1354" fill="#f1f5f9" font-size="14">detect-gcp-model-artifact-download</text>
+    <text x="430"  y="1354" fill="#cbd5e1" font-size="14">T1530 · AML.T0035</text>
+    <rect x="760"  y="1338" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1338" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="1354" fill="#fee2e2" font-size="13">detection-first GCP AI model-artifact collection slice</text>
   </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="1370" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1408" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1404" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
-    <text x="430"  y="1404" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
-    <rect x="760"  y="1388" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1388" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1404" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
+    <text x="48"   y="1442" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
+    <text x="430"  y="1442" fill="#cbd5e1" font-size="14">CIS AWS Foundations 3.0</text>
+    <rect x="760"  y="1426" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1426" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1442" fill="#fef3c7" font-size="13">#242 #254 · guarded --auto-remediate shipped</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1434" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
-    <text x="430"  y="1434" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
-    <rect x="760"  y="1418" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1418" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1434" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1472" fill="#f1f5f9" font-size="15">cspm-gcp-cis-benchmark</text>
+    <text x="430"  y="1472" fill="#cbd5e1" font-size="14">CIS GCP Foundations 3.0</text>
+    <rect x="760"  y="1456" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1456" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1472" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1464" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
-    <text x="430"  y="1464" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
-    <rect x="760"  y="1448" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1448" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
-    <text x="1020" y="1464" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
+    <text x="48"   y="1502" fill="#f1f5f9" font-size="15">cspm-azure-cis-benchmark</text>
+    <text x="430"  y="1502" fill="#cbd5e1" font-size="14">CIS Azure Foundations 2.1</text>
+    <rect x="760"  y="1486" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1486" width="40" height="22" rx="4" fill="#b45309" stroke="#f59e0b"/>
+    <text x="1020" y="1502" fill="#fef3c7" font-size="13">#242 #254 · auto-remediate tracked</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48"   y="1494" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
-    <text x="430"  y="1494" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
-    <rect x="760"  y="1478" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
-    <rect x="880"  y="1478" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
-    <text x="1020" y="1494" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+    <text x="48"   y="1532" fill="#f1f5f9" font-size="15">k8s + container + model + gpu benchmarks</text>
+    <text x="430"  y="1532" fill="#cbd5e1" font-size="14">CIS K8s · NIST SSDF · OWASP LLM</text>
+    <rect x="760"  y="1516" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1516" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1532" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
   </g>
 
   <!-- Footer (two lines to fit 1200px canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1528" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 28</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, GCP service-account-key, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
-    <text x="48" y="1546" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1566" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 29</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, GCP service-account-key/token-minting, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, and response-exfiltration slices are detection-first today</tspan></text>
+    <text x="48" y="1584" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
   <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 75 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 28 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 76 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 29 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
     <g transform="translate(88,252)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">75</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">76</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -107,7 +107,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">28</text>
+        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">29</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 75 shipped skills — 15 ingest, 28 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 76 shipped skills — 15 ingest, 29 detect, 5 discover, 7 eval, 12 remediate, 2 view, 3 sink, 3 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -85,11 +85,11 @@
       <text x="704" y="158" font-size="22" font-weight="800" fill="#ecfeff">Shared skill bundle</text>
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
-      <!-- Counts: 75 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">75</text>
+      <!-- Counts: 76 total, current breakdown -->
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">76</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 28 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 29 detect · 5 discover · 7 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -53,6 +53,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-aws-access-key-creation`](detection/detect-aws-access-key-creation/) | successful AWS IAM `CreateAccessKey` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-login-profile-creation`](detection/detect-aws-login-profile-creation/) | successful AWS IAM `CreateLoginProfile` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-gcp-service-account-key-creation`](detection/detect-gcp-service-account-key-creation/) | successful GCP IAM `CreateServiceAccountKey` operations against service accounts (T1098.001 Additional Cloud Credentials) |
+| [`detect-gcp-service-account-token-minting`](detection/detect-gcp-service-account-token-minting/) | successful GCP IAM Credentials `GenerateAccessToken` / `GenerateIdToken` operations against service accounts (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-enumeration-burst`](detection/detect-aws-enumeration-burst/) | short-window burst of high-signal AWS discovery APIs in CloudTrail (T1526 Cloud Service Discovery) |
 | [`detect-aws-model-artifact-download`](detection/detect-aws-model-artifact-download/) | successful AWS S3 `GetObject` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |
 | [`detect-gcp-model-artifact-download`](detection/detect-gcp-model-artifact-download/) | successful GCS `storage.objects.get` downloads of model-weight and checkpoint artifacts (T1530, ATLAS AML.T0035) |

--- a/skills/detection/detect-gcp-service-account-token-minting/REFERENCES.md
+++ b/skills/detection/detect-gcp-service-account-token-minting/REFERENCES.md
@@ -1,0 +1,11 @@
+# References
+
+- Google Cloud IAM Credentials API: `GenerateAccessToken`
+  https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+- Google Cloud IAM Credentials API: `GenerateIdToken`
+  https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken
+- Google Cloud Audit Logs overview
+  https://cloud.google.com/logging/docs/audit
+- MITRE ATT&CK T1098.001 Additional Cloud Credentials
+  https://attack.mitre.org/techniques/T1098/001/
+

--- a/skills/detection/detect-gcp-service-account-token-minting/SKILL.md
+++ b/skills/detection/detect-gcp-service-account-token-minting/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: detect-gcp-service-account-token-minting
+description: >-
+  Detect successful GCP IAM Credentials API token minting for service accounts
+  from OCSF 1.8 API Activity records emitted by ingest-gcp-audit-ocsf. Emits
+  an OCSF 1.8 Detection Finding (class 2004) tagged with MITRE ATT&CK
+  T1098.001 when a principal successfully calls GenerateAccessToken or
+  GenerateIdToken for a service account. Use when the user mentions GCP
+  service-account token minting, IAM Credentials API abuse, GenerateAccessToken,
+  GenerateIdToken, or short-lived service-account impersonation tokens. Do NOT
+  use for service-account key creation, workload-identity federation
+  configuration, or generic IAM policy changes.
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. Read-only — consumes OCSF 1.8 API Activity records
+  from stdin/file and emits OCSF 1.8 Detection Finding 2004 to stdout. No GCP
+  SDK; pairs with ingest-gcp-audit-ocsf upstream.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-gcp-service-account-token-minting
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+  cloud: gcp
+  capability: read-only
+---
+
+# detect-gcp-service-account-token-minting
+
+Streaming detector for GCP service-account token minting through Cloud Audit
+Logs. This complements `detect-gcp-service-account-key-creation`: key creation
+finds long-lived credential material, while this detector finds short-lived
+impersonation tokens minted through the IAM Credentials API.
+
+## Use when
+
+- You stream Cloud Audit Logs through `ingest-gcp-audit-ocsf`
+- You want a high-confidence finding for service-account impersonation token minting
+- You need coverage for `GenerateAccessToken` and `GenerateIdToken` events
+
+## Do NOT use
+
+- To detect user-managed service-account key creation; use
+  [`detect-gcp-service-account-key-creation`](../detect-gcp-service-account-key-creation/)
+- To infer workload-identity federation configuration changes
+- To claim all GCP service-account abuse paths; this slice covers only
+  successful IAM Credentials token generation
+
+## Rule
+
+A finding fires on every successful Cloud Audit event from
+`ingest-gcp-audit-ocsf` where:
+
+1. `api.service.name` is `iamcredentials.googleapis.com`
+2. `api.operation` is one of:
+   - `google.iam.credentials.v1.GenerateAccessToken`
+   - `google.iam.credentials.v1.GenerateIdToken`
+3. `status_id == 1`
+4. `resources[]` resolve a target service-account resource
+
+## OCSF output
+
+OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
+
+- `finding_info.attacks[].tactic_uid = TA0003` (Persistence)
+- `finding_info.attacks[].technique_uid = T1098` (Account Manipulation)
+- `finding_info.attacks[].sub_technique_uid = T1098.001` (Additional Cloud Credentials)
+- `observables[]` including `target.name`, `project.uid`, `actor.name`, and `api.operation`
+
+The native projection (`--output-format native`) keeps the target service
+account and actor/project context in a flatter shape.
+
+## Run
+
+```bash
+python skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py raw.jsonl \
+  | python skills/detection/detect-gcp-service-account-token-minting/src/detect.py \
+  > findings.ocsf.jsonl
+
+python skills/detection/detect-gcp-service-account-token-minting/src/detect.py findings-input.jsonl --output-format native
+```
+

--- a/skills/detection/detect-gcp-service-account-token-minting/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-token-minting/src/detect.py
@@ -1,0 +1,312 @@
+"""Detect GCP service-account token minting via Cloud Audit Logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-gcp-service-account-token-minting"
+CANONICAL_VERSION = "2026-04"
+OCSF_VERSION = "1.8.0"
+REPO_NAME = "cloud-ai-security-skills"
+REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+MITRE_VERSION = "v14"
+TACTIC_UID = "TA0003"
+TACTIC_NAME = "Persistence"
+TECHNIQUE_UID = "T1098"
+TECHNIQUE_NAME = "Account Manipulation"
+SUBTECHNIQUE_UID = "T1098.001"
+SUBTECHNIQUE_NAME = "Additional Cloud Credentials"
+
+ACCEPTED_PRODUCERS = frozenset({"ingest-gcp-audit-ocsf"})
+IAM_CREDENTIALS_SERVICE = "iamcredentials.googleapis.com"
+TOKEN_MINT_OPERATIONS = frozenset(
+    {
+        "google.iam.credentials.v1.GenerateAccessToken",
+        "google.iam.credentials.v1.GenerateIdToken",
+    }
+)
+OUTPUT_FORMATS = frozenset({"ocsf", "native"})
+
+
+def _producer(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _api_operation(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    return str(api.get("operation") or "")
+
+
+def _api_service(event: dict[str, Any]) -> str:
+    api = event.get("api") or {}
+    service = api.get("service") or {}
+    return str(service.get("name") or "")
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("status_id") == STATUS_SUCCESS
+
+
+def _actor_name(event: dict[str, Any]) -> str:
+    actor = event.get("actor") or {}
+    user = actor.get("user") or {}
+    return str(user.get("name") or user.get("uid") or "")
+
+
+def _account_uid(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    account = cloud.get("account") or {}
+    return str(account.get("uid") or "")
+
+
+def _region(event: dict[str, Any]) -> str:
+    cloud = event.get("cloud") or {}
+    return str(cloud.get("region") or "")
+
+
+def _src_ip(event: dict[str, Any]) -> str:
+    endpoint = event.get("src_endpoint") or {}
+    return str(endpoint.get("ip") or "")
+
+
+def _time_ms(event: dict[str, Any]) -> int:
+    return int(event.get("time") or datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _event_uid(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") or {}
+    return str(metadata.get("uid") or "")
+
+
+def _target_service_account(event: dict[str, Any]) -> str:
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        name = str(resource.get("name") or "")
+        if not name:
+            continue
+        marker = "serviceAccounts/"
+        if marker in name:
+            return name.split(marker, 1)[1].strip("/")
+        if name.endswith(".iam.gserviceaccount.com"):
+            return name
+    return ""
+
+
+def _token_type(operation: str) -> str:
+    if operation.endswith("GenerateAccessToken"):
+        return "access_token"
+    if operation.endswith("GenerateIdToken"):
+        return "id_token"
+    return "unknown"
+
+
+def _finding_uid(event_uid: str, target_sa: str, actor_name: str, operation: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{target_sa}|{actor_name}|{operation}|{time_ms}"
+    return f"gsatm-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _build_native_finding(*, event: dict[str, Any], target_service_account: str) -> dict[str, Any]:
+    time_ms = _time_ms(event)
+    operation = _api_operation(event)
+    actor_name = _actor_name(event)
+    finding_uid = _finding_uid(_event_uid(event), target_service_account, actor_name, operation, time_ms)
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "finding_uid": finding_uid,
+        "rule": "gcp-service-account-token-minting",
+        "api_operation": operation,
+        "token_type": _token_type(operation),
+        "target_service_account": target_service_account,
+        "actor_name": actor_name,
+        "project_uid": _account_uid(event),
+        "region": _region(event),
+        "src_ip": _src_ip(event),
+        "first_seen_time_ms": time_ms,
+        "last_seen_time_ms": time_ms,
+    }
+
+
+def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
+    description = (
+        f"Actor `{native['actor_name'] or 'unknown'}` successfully called "
+        f"`{native['api_operation']}` for service account "
+        f"`{native['target_service_account']}` in project `{native['project_uid']}`. "
+        f"Token type: {native['token_type']}. Source IP: {native['src_ip'] or '<unknown>'}. "
+        "This can create short-lived credential material for service-account impersonation."
+    )
+    observables = [
+        {"name": "cloud.provider", "type": "Other", "value": "GCP"},
+        {"name": "actor.name", "type": "Other", "value": native["actor_name"] or "unknown"},
+        {"name": "api.operation", "type": "Other", "value": native["api_operation"]},
+        {"name": "token.type", "type": "Other", "value": native["token_type"]},
+        {"name": "rule", "type": "Other", "value": native["rule"]},
+        {"name": "target.type", "type": "Other", "value": "ServiceAccount"},
+        {"name": "target.name", "type": "Other", "value": native["target_service_account"]},
+        {"name": "project.uid", "type": "Other", "value": native["project_uid"]},
+    ]
+    if native["region"]:
+        observables.append({"name": "region", "type": "Other", "value": native["region"]})
+    if native["src_ip"]:
+        observables.append({"name": "src.ip", "type": "IP Address", "value": native["src_ip"]})
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": SEVERITY_HIGH,
+        "status_id": STATUS_SUCCESS,
+        "time": native["first_seen_time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native["finding_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["gcp", "iam", "service-account", "iam-credentials", "persistence"],
+        },
+        "finding_info": {
+            "uid": native["finding_uid"],
+            "title": "GCP service account token minted",
+            "desc": description,
+            "types": ["gcp-service-account-token-minting"],
+            "first_seen_time": native["first_seen_time_ms"],
+            "last_seen_time": native["last_seen_time_ms"],
+            "attacks": [
+                {
+                    "version": MITRE_VERSION,
+                    "tactic_uid": TACTIC_UID,
+                    "tactic_name": TACTIC_NAME,
+                    "technique_uid": TECHNIQUE_UID,
+                    "technique_name": TECHNIQUE_NAME,
+                    "sub_technique_uid": SUBTECHNIQUE_UID,
+                    "sub_technique_name": SUBTECHNIQUE_NAME,
+                }
+            ],
+        },
+        "observables": observables,
+        "evidence": {
+            "events_observed": 1,
+            "api_operation": native["api_operation"],
+            "token_type": native["token_type"],
+            "target_service_account": native["target_service_account"],
+        },
+    }
+
+
+def detect(
+    events: Iterable[dict[str, Any]],
+    *,
+    output_format: str = "ocsf",
+) -> Iterator[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+
+    for event in events:
+        producer = _producer(event)
+        if producer not in ACCEPTED_PRODUCERS:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="wrong_source",
+                message=f"skipping event from non-gcp-audit producer `{producer}`",
+            )
+            continue
+        operation = _api_operation(event)
+        if _api_service(event) != IAM_CREDENTIALS_SERVICE or operation not in TOKEN_MINT_OPERATIONS:
+            continue
+        if not _is_success(event):
+            continue
+        target_service_account = _target_service_account(event)
+        if not target_service_account:
+            emit_stderr_event(
+                SKILL_NAME,
+                level="warning",
+                event="missing_target_service_account",
+                message="skipping IAM Credentials event with no target service account",
+            )
+            continue
+        native = _build_native_finding(event=event, target_service_account=target_service_account)
+        yield native if output_format == "native" else _to_ocsf(native)
+
+
+def _iter_jsonl(path: str | None) -> Iterator[dict[str, Any]]:
+    handle = open(path, "r", encoding="utf-8") if path else sys.stdin
+    with handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="invalid_json",
+                    message=f"skipping line {line_number}: invalid JSON ({exc.msg})",
+                )
+                continue
+            if isinstance(obj, dict):
+                yield obj
+            else:
+                emit_stderr_event(
+                    SKILL_NAME,
+                    level="warning",
+                    event="wrong_shape",
+                    message=f"skipping line {line_number}: expected JSON object",
+                )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect GCP service-account token minting from audit logs.")
+    parser.add_argument("input", nargs="?", help="Optional JSONL input file. Defaults to stdin.")
+    parser.add_argument(
+        "--output-format",
+        default="ocsf",
+        choices=sorted(OUTPUT_FORMATS),
+        help="Emit OCSF detection findings or the native repo shape.",
+    )
+    args = parser.parse_args(argv)
+
+    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
+        sys.stdout.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/skills/detection/detect-gcp-service-account-token-minting/tests/test_detect.py
+++ b/skills/detection/detect-gcp-service-account-token-minting/tests/test_detect.py
@@ -1,0 +1,140 @@
+"""Tests for detect-gcp-service-account-token-minting."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+THIS = Path(__file__).resolve().parent
+SRC = THIS.parent / "src" / "detect.py"
+SPEC = importlib.util.spec_from_file_location("detect_gcp_service_account_token_minting_under_test", SRC)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+detect = MODULE.detect
+GENERATE_ACCESS_TOKEN_OPERATION = "google.iam.credentials.v1.GenerateAccessToken"
+GENERATE_ID_TOKEN_OPERATION = "google.iam.credentials.v1.GenerateIdToken"
+
+
+def _event(
+    *,
+    operation: str = GENERATE_ACCESS_TOKEN_OPERATION,
+    service: str = "iamcredentials.googleapis.com",
+    success: bool = True,
+    target_service_account: str = "sa-deploy@my-project.iam.gserviceaccount.com",
+    actor_name: str = "alice@example.com",
+    project_uid: str = "my-project",
+    src_ip: str = "203.0.113.42",
+    producer: str = "ingest-gcp-audit-ocsf",
+    resource_type: str = "service_account",
+) -> dict:
+    resources = []
+    if target_service_account:
+        resources.append(
+            {
+                "name": f"projects/-/serviceAccounts/{target_service_account}",
+                "type": resource_type,
+            }
+        )
+    return {
+        "class_uid": 6003,
+        "status_id": 1 if success else 2,
+        "time": 1775797200000,
+        "metadata": {"uid": "evt-1", "product": {"feature": {"name": producer}}},
+        "actor": {"user": {"name": actor_name}},
+        "src_endpoint": {"ip": src_ip},
+        "api": {"operation": operation, "service": {"name": service}},
+        "cloud": {"provider": "GCP", "account": {"uid": project_uid}},
+        "resources": resources,
+    }
+
+
+def test_accepted_producer_is_gcp_audit():
+    assert MODULE.ACCEPTED_PRODUCERS == frozenset({"ingest-gcp-audit-ocsf"})
+
+
+def test_fires_on_generate_access_token():
+    findings = list(detect([_event()]))
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["class_uid"] == 2004
+    assert finding["finding_info"]["title"] == "GCP service account token minted"
+    assert finding["evidence"]["token_type"] == "access_token"
+    attack = finding["finding_info"]["attacks"][0]
+    assert attack["sub_technique_uid"] == "T1098.001"
+
+
+def test_fires_on_generate_id_token():
+    findings = list(detect([_event(operation=GENERATE_ID_TOKEN_OPERATION)]))
+    assert len(findings) == 1
+    assert findings[0]["evidence"]["token_type"] == "id_token"
+    assert any(obs["name"] == "token.type" and obs["value"] == "id_token" for obs in findings[0]["observables"])
+
+
+def test_native_output_contains_target_service_account_and_token_type():
+    findings = list(
+        detect(
+            [_event(target_service_account="sa-ci@my-project.iam.gserviceaccount.com")],
+            output_format="native",
+        )
+    )
+    finding = findings[0]
+    assert finding["schema_mode"] == "native"
+    assert finding["target_service_account"] == "sa-ci@my-project.iam.gserviceaccount.com"
+    assert finding["token_type"] == "access_token"
+    assert finding["rule"] == "gcp-service-account-token-minting"
+
+
+def test_skips_failed_event():
+    assert list(detect([_event(success=False)])) == []
+
+
+def test_skips_unrelated_operation():
+    assert list(detect([_event(operation="google.iam.credentials.v1.SignJwt")])) == []
+
+
+def test_skips_wrong_service():
+    assert list(detect([_event(service="iam.googleapis.com")])) == []
+
+
+def test_skips_wrong_producer(capsys):
+    findings = list(detect([_event(producer="ingest-cloudtrail-ocsf")]))
+    assert findings == []
+    assert "non-gcp-audit producer" in capsys.readouterr().err
+
+
+def test_skips_missing_target_service_account(capsys):
+    findings = list(detect([_event(target_service_account="")]))
+    assert findings == []
+    assert "no target service account" in capsys.readouterr().err
+
+
+def test_accepts_raw_service_account_resource_name_without_prefix():
+    findings = list(
+        detect(
+            [
+                {
+                    **_event(),
+                    "resources": [{"name": "sa-deploy@my-project.iam.gserviceaccount.com", "type": "service_account"}],
+                }
+            ]
+        )
+    )
+    assert len(findings) == 1
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(ValueError, match="unsupported output_format"):
+        list(detect([_event()], output_format="weird"))
+
+
+def test_finding_uid_is_deterministic():
+    event = _event()
+    first = list(detect([event]))[0]["finding_info"]["uid"]
+    second = list(detect([event]))[0]["finding_info"]["uid"]
+    assert first == second
+    assert first.startswith("gsatm-")
+


### PR DESCRIPTION
## Summary
- add detect-gcp-service-account-token-minting for successful GenerateAccessToken and GenerateIdToken calls from ingest-gcp-audit-ocsf
- emit OCSF 1.8 Detection Finding 2004 with MITRE ATT&CK T1098.001 tagging and deterministic gsatm finding UIDs
- update registry, framework coverage, security bar, README counts, and SVG coverage visuals from 75/28 to 76/29

## Validation
- uv run pytest skills/detection/detect-gcp-service-account-token-minting/tests/test_detect.py -q
- uv run ruff check .
- uv run pytest -q
- bash scripts/run_mypy.sh
- uv run python scripts/validate_skill_contract.py
- uv run python scripts/validate_skill_integrity.py
- uv run python scripts/validate_skill_count_consistency.py
- uv run python scripts/validate_framework_coverage.py
- uv run python scripts/validate_safe_skill_bar.py
- uv run python scripts/validate_ocsf_metadata.py

## Notes
- closes the audited GCP IAM Credentials token-minting detection gap
- remediation remains follow-up work; this PR is detection-only