### PR TITLE
[codex] harden MCP caller skill scopes

### DIFF
--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -70,6 +70,9 @@ Required top-level fields:
 | `input_sha256` | string | SHA-256 of stdin input text, or empty string when no input was provided |
 | `input_length` | integer | byte length of the stdin text as passed to the subprocess |
 | `caller_context_provided` | boolean | whether `_caller_context` was supplied |
+| `caller_skill_scope_provided` | boolean | whether `_caller_context.allowed_skills` was supplied |
+| `caller_skill_scope_count` | integer | number of distinct non-empty skills in the caller scope |
+| `caller_skill_scope_hash` | string | SHA-256 of the sorted caller skill scope, or empty string when absent |
 | `approval_context_provided` | boolean | whether `_approval_context` was supplied |
 | `caller_id` | string | `user_id` from `_caller_context`, or empty string |
 | `caller_session_id` | string | `session_id` from `_caller_context`, or empty string |
@@ -112,6 +115,7 @@ The wrapper preserves only the fields it knows about:
 
 - `_caller_context.user_id` -> `caller_id`
 - `_caller_context.session_id` -> `caller_session_id`
+- `_caller_context.allowed_skills` -> counted and hashed as caller skill scope
 - `_approval_context.ticket_id` -> `approval_ticket`
 
 Presence is tracked separately from value so operators can tell the difference
@@ -153,6 +157,10 @@ Before the subprocess runs, the wrapper enforces:
 - `output_format` must be a string when present
 - `_caller_context` and `_approval_context` must be objects with string values
   or string arrays
+- `_caller_context.allowed_skills`, when supplied, is intersected with
+  `CLOUD_SECURITY_MCP_ALLOWED_SKILLS`; setting
+  `CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS=1` rejects calls without a
+  caller skill scope by exposing no callable tools
 - write-capable tools must stay in safe mode at the wrapper boundary:
   `--dry-run` for generic write tools, or no `--apply` for dry-run-default
   `handler.py` / `checks.py` entrypoints

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -77,6 +77,14 @@ isn't on the allowlist. Unset / empty = all discovered skills exposed
 (default). This is the per-client least-privilege gate referenced in
 `docs/integrations/*.md`.
 
+Trusted client wrappers can also pass `_caller_context.allowed_skills` on
+`tools/list` and `tools/call`. That caller scope is intersected with the
+operator allowlist, so process-level policy still wins and a caller can only
+narrow its own visible/callable skill set. Set
+`CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS=1` to fail closed unless each
+request supplies `_caller_context.allowed_skills`; calls without that scope see
+no tools and cannot invoke any tool.
+
 Run locally:
 
 ```bash

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -28,6 +28,7 @@ SERVER_VERSION = "0.1.0"
 PROTOCOL_VERSION = "2025-06-18"
 DEFAULT_TIMEOUT_SECONDS = 60
 ALLOWED_SKILLS_ENV = "CLOUD_SECURITY_MCP_ALLOWED_SKILLS"
+REQUIRE_CALLER_ALLOWED_SKILLS_ENV = "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"
 SAFE_CHILD_ENV_VARS = (
     "HOME",
     "LANG",
@@ -52,6 +53,10 @@ SAFE_CHILD_ENV_VARS = (
 )
 
 
+def _skill_name_set(raw: str) -> set[str]:
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
 def _allowed_skills_filter() -> set[str] | None:
     """Return the set of skill names the current process is allowed to expose.
 
@@ -63,13 +68,46 @@ def _allowed_skills_filter() -> set[str] | None:
     raw = os.environ.get(ALLOWED_SKILLS_ENV, "").strip()
     if not raw:
         return None
-    return {part.strip() for part in raw.split(",") if part.strip()}
+    return _skill_name_set(raw)
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _caller_allowed_skills_filter(caller_context: dict[str, Any] | None) -> set[str] | None:
+    if caller_context is None or "allowed_skills" not in caller_context:
+        return None
+    raw_allowed = caller_context["allowed_skills"]
+    if isinstance(raw_allowed, str):
+        return _skill_name_set(raw_allowed)
+    return {name.strip() for name in cast(list[str], raw_allowed) if name.strip()}
+
+
+def _effective_allowed_skills(caller_context: dict[str, Any] | None) -> set[str] | None:
+    process_allowed = _allowed_skills_filter()
+    caller_allowed = _caller_allowed_skills_filter(caller_context)
+    if _truthy_env(REQUIRE_CALLER_ALLOWED_SKILLS_ENV) and caller_allowed is None:
+        return set()
+    if process_allowed is None:
+        return caller_allowed
+    if caller_allowed is None:
+        return process_allowed
+    return process_allowed & caller_allowed
 
 
 def _filtered_tool_map() -> dict[str, SkillSpec]:
     """`tool_map()` plus the operator-scoped allowlist, if any."""
-    tools = tool_map()
-    allowed = _allowed_skills_filter()
+    return _scoped_tool_map()
+
+
+def _scoped_tool_map(
+    caller_context: dict[str, Any] | None = None,
+    tools: dict[str, SkillSpec] | None = None,
+) -> dict[str, SkillSpec]:
+    """`tool_map()` plus operator and caller-scoped allowlists, if any."""
+    tools = tool_map() if tools is None else tools
+    allowed = _effective_allowed_skills(caller_context)
     if allowed is None:
         return tools
     return {name: spec for name, spec in tools.items() if name in allowed}
@@ -223,6 +261,22 @@ def _approval_count(approval_context: dict[str, Any] | None) -> int:
     return len(_distinct_approvers(approval_context))
 
 
+def _caller_scope_audit_fields(caller_context: dict[str, Any] | None) -> dict[str, Any]:
+    allowed = _caller_allowed_skills_filter(caller_context)
+    if allowed is None:
+        return {
+            "caller_skill_scope_provided": False,
+            "caller_skill_scope_count": 0,
+            "caller_skill_scope_hash": "",
+        }
+    sorted_allowed = sorted(allowed)
+    return {
+        "caller_skill_scope_provided": True,
+        "caller_skill_scope_count": len(sorted_allowed),
+        "caller_skill_scope_hash": _stable_hash(sorted_allowed),
+    }
+
+
 def _build_child_env() -> dict[str, str]:
     env: dict[str, str] = {}
     for key in SAFE_CHILD_ENV_VARS:
@@ -266,16 +320,17 @@ def _requires_approval_context(skill: SkillSpec, args: list[str]) -> bool:
 
 
 def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
-    tools = _filtered_tool_map()
+    request_args = arguments or {}
+    caller_context = _validate_context(request_args.get("_caller_context"), "_caller_context")
+    tools = tool_map()
     if name not in tools:
         raise KeyError(f"unknown tool `{name}`")
 
     skill = tools[name]
-    args = _validate_args((arguments or {}).get("args"))
-    stdin_text = _validate_input((arguments or {}).get("input"))
-    output_format = _validate_output_format((arguments or {}).get("output_format"))
-    caller_context = _validate_context((arguments or {}).get("_caller_context"), "_caller_context")
-    approval_context = _validate_context((arguments or {}).get("_approval_context"), "_approval_context")
+    args = _validate_args(request_args.get("args"))
+    stdin_text = _validate_input(request_args.get("input"))
+    output_format = _validate_output_format(request_args.get("output_format"))
+    approval_context = _validate_context(request_args.get("_approval_context"), "_approval_context")
     correlation_id = str(uuid4())
     started = time.monotonic()
     audit_event: dict[str, Any] = {
@@ -299,8 +354,11 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
         "approval_ticket": approval_context.get("ticket_id", "") if approval_context else "",
         "result": "pending",
     }
+    audit_event.update(_caller_scope_audit_fields(caller_context))
 
     try:
+        if name not in _scoped_tool_map(caller_context, tools):
+            raise KeyError(f"unknown tool `{name}`")
         if not _is_safe_write_invocation(skill, args):
             raise ValueError(
                 "write-capable tools must stay in dry-run/read-only mode under MCP "
@@ -324,6 +382,9 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
                 env["SKILL_SESSION_ID"] = caller_context["session_id"]
             if "roles" in caller_context:
                 env["SKILL_CALLER_ROLES"] = ",".join(caller_context["roles"])
+            allowed_skills = _caller_allowed_skills_filter(caller_context)
+            if allowed_skills is not None:
+                env["SKILL_CALLER_ALLOWED_SKILLS"] = ",".join(sorted(allowed_skills))
         if approval_context:
             if "approver_id" in approval_context:
                 env["SKILL_APPROVER_ID"] = approval_context["approver_id"]
@@ -402,7 +463,14 @@ def _handle_request(message: dict[str, Any]) -> dict[str, Any] | None:
         return _result_response(request_id, {})
 
     if method == "tools/list":
-        tools = [tool_definition(skill) for skill in _filtered_tool_map().values()]
+        params = message.get("params") or {}
+        if not isinstance(params, dict):
+            return _error_response(request_id, -32602, "`tools/list` params must be an object when present")
+        try:
+            caller_context = _validate_context(params.get("_caller_context"), "_caller_context")
+        except ValueError as exc:
+            return _error_response(request_id, -32602, str(exc))
+        tools = [tool_definition(skill) for skill in _scoped_tool_map(caller_context).values()]
         return _result_response(request_id, {"tools": tools})
 
     if method == "tools/call":

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -208,6 +208,11 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
                 "email": {"type": "string"},
                 "session_id": {"type": "string"},
                 "roles": {"type": "array", "items": {"type": "string"}},
+                "allowed_skills": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional per-caller skill allowlist; intersects with operator allowlists.",
+                },
             },
             "additionalProperties": True,
         },

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -43,11 +43,18 @@ class _FakeSkill:
         self.name = "fake-skill"
         self.category = category
         self.capability = "read-only" if read_only else "write-remediation"
+        self.description = "fake skill"
+        self.approval_model = "none" if read_only else "human_required"
+        self.execution_modes = ("local",)
+        self.side_effects = ("none",) if read_only else ("writes-cloud",)
+        self.network_egress = ()
+        self.caller_roles = ()
         self.read_only = read_only
         self.approver_roles = approver_roles
         self.min_approvers = min_approvers
         self.mcp_timeout_seconds = mcp_timeout_seconds
         self.entrypoint = None if entrypoint_name is None else Path(entrypoint_name)
+        self.output_formats = ()
 
 
 def test_call_tool_injects_caller_and_approval_context(monkeypatch):
@@ -444,6 +451,102 @@ def test_filtered_tool_map_unset_exposes_all(monkeypatch):
     monkeypatch.setattr(MODULE, "tool_map", lambda: fake_tools)
     monkeypatch.delenv("CLOUD_SECURITY_MCP_ALLOWED_SKILLS", raising=False)
     assert set(MODULE._filtered_tool_map()) == {"a", "b"}
+
+
+def test_scoped_tool_map_intersects_operator_and_caller_allowlists(monkeypatch):
+    fake_tools = {
+        "allowed-by-both": _FakeSkill(),
+        "operator-only": _FakeSkill(),
+        "caller-only": _FakeSkill(),
+    }
+    monkeypatch.setattr(MODULE, "tool_map", lambda: fake_tools)
+    monkeypatch.setenv("CLOUD_SECURITY_MCP_ALLOWED_SKILLS", "allowed-by-both,operator-only")
+
+    scoped = MODULE._scoped_tool_map({"allowed_skills": ["allowed-by-both", "caller-only"]})
+
+    assert set(scoped) == {"allowed-by-both"}
+
+
+def test_scoped_tool_map_requires_caller_allowlist_when_enabled(monkeypatch):
+    fake_tools = {"a": _FakeSkill(), "b": _FakeSkill()}
+    monkeypatch.setattr(MODULE, "tool_map", lambda: fake_tools)
+    monkeypatch.delenv("CLOUD_SECURITY_MCP_ALLOWED_SKILLS", raising=False)
+    monkeypatch.setenv("CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS", "true")
+
+    assert MODULE._scoped_tool_map(None) == {}
+    assert set(MODULE._scoped_tool_map({"allowed_skills": ["b"]})) == {"b"}
+
+
+def test_call_tool_rejects_skill_outside_caller_scope(monkeypatch):
+    audit_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(MODULE, "tool_map", lambda: {"blocked-skill": _FakeSkill()})
+    monkeypatch.delenv("CLOUD_SECURITY_MCP_ALLOWED_SKILLS", raising=False)
+    monkeypatch.setattr(MODULE, "_emit_audit_event", lambda event: audit_events.append(event))
+
+    try:
+        MODULE._call_tool(
+            "blocked-skill",
+            {
+                "args": [],
+                "_caller_context": {"user_id": "u-123", "allowed_skills": ["other-skill"]},
+            },
+        )
+    except KeyError as exc:
+        assert "unknown tool" in str(exc)
+    else:
+        raise AssertionError("expected KeyError for caller-scope-blocked tool")
+
+    assert audit_events[0]["tool"] == "blocked-skill"
+    assert audit_events[0]["result"] == "error"
+    assert audit_events[0]["caller_skill_scope_provided"] is True
+    assert audit_events[0]["caller_skill_scope_count"] == 1
+    assert audit_events[0]["caller_skill_scope_hash"] == MODULE._stable_hash(["other-skill"])
+
+
+def test_call_tool_forwards_caller_allowed_skill_scope(monkeypatch):
+    captured: dict[str, object] = {}
+    audit_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(MODULE, "tool_map", lambda: {"fake-skill": _FakeSkill(read_only=True)})
+    monkeypatch.setattr(MODULE, "build_command", lambda skill, args, output_format=None: ["python", "fake.py"])
+    monkeypatch.setattr(MODULE, "_emit_audit_event", lambda event: audit_events.append(event))
+
+    def _fake_run(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _FakeCompleted()
+
+    monkeypatch.setattr(MODULE.subprocess, "run", _fake_run)
+
+    MODULE._call_tool(
+        "fake-skill",
+        {"args": [], "_caller_context": {"allowed_skills": ["fake-skill", "fake-skill", ""]}},
+    )
+
+    env = captured["env"]
+    assert env["SKILL_CALLER_ALLOWED_SKILLS"] == "fake-skill"
+    assert audit_events[0]["caller_skill_scope_provided"] is True
+    assert audit_events[0]["caller_skill_scope_count"] == 1
+
+
+def test_handle_tools_list_applies_caller_scope(monkeypatch):
+    fake_tools = {"a": _FakeSkill(), "b": _FakeSkill()}
+    fake_tools["a"].name = "a"
+    fake_tools["b"].name = "b"
+    monkeypatch.setattr(MODULE, "tool_map", lambda: fake_tools)
+    monkeypatch.delenv("CLOUD_SECURITY_MCP_ALLOWED_SKILLS", raising=False)
+
+    response = MODULE._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {"_caller_context": {"allowed_skills": ["b"]}},
+        }
+    )
+
+    tools = response["result"]["tools"]
+    assert [tool["name"] for tool in tools] == ["b"]
 
 
 def test_call_tool_rejects_skill_outside_allowlist(monkeypatch):

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -128,6 +128,7 @@ class TestToolDefinition:
         skill = tool_map(REPO_ROOT)["ingest-cloudtrail-ocsf"]
         schema = tool_definition(skill)["inputSchema"]
         assert "_caller_context" in schema["properties"]
+        assert "allowed_skills" in schema["properties"]["_caller_context"]["properties"]
         assert "_approval_context" in schema["properties"]
 
     def test_mcp_tool_quarantine_requires_two_approvers_in_metadata(self):


### PR DESCRIPTION
## Summary
- add per-caller MCP skill allowlists via _caller_context.allowed_skills
- intersect caller scope with the operator CLOUD_SECURITY_MCP_ALLOWED_SKILLS gate
- add fail-closed CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS mode plus audit/schema/docs coverage

## Validation
- uv run pytest mcp-server/tests/test_server_unit.py mcp-server/tests/test_tool_registry.py -q
- uv run ruff check mcp-server/src/server.py mcp-server/src/tool_registry.py mcp-server/tests/test_server_unit.py mcp-server/tests/test_tool_registry.py
- uv run pytest tests/integration/test_skill_validation_scripts.py -q
- uv run mypy mcp-server/src/server.py mcp-server/src/tool_registry.py
- uv run pytest -q
- uv run ruff check .

Note: uv run mypy . remains blocked by existing duplicate runner module names, so source mypy was run on the touched MCP modules.