### PR TITLE
[codex] preserve GCP service account key evidence

### DIFF
--- a/skills/detection/detect-gcp-service-account-key-creation/SKILL.md
+++ b/skills/detection/detect-gcp-service-account-key-creation/SKILL.md
@@ -63,6 +63,11 @@ A finding fires on every successful Cloud Audit event from
 3. `status_id == 1`
 4. `resources[]` resolve a target service-account resource
 
+When upstream `ingest-gcp-audit-ocsf` receives a sanitized
+`protoPayload.response.name` for the created key, the detector also emits the
+exact `target_key_resource` and `target_key_id` as evidence. It does not retain
+private key material.
+
 ## OCSF output
 
 OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
@@ -71,9 +76,10 @@ OCSF 1.8 Detection Finding (class 2004), severity HIGH (`severity_id=4`), with:
 - `finding_info.attacks[].technique_uid = T1098` (Account Manipulation)
 - `finding_info.attacks[].sub_technique_uid = T1098.001` (Additional Cloud Credentials)
 - `observables[]` including `target.name`, `project.uid`, `actor.name`, and `api.operation`
+- `evidence.target_key_resource` / `evidence.target_key_id` when the upstream audit event includes the created key resource name
 
 The native projection (`--output-format native`) keeps the target service
-account and actor/project context in a flatter shape.
+account, created key resource, and actor/project context in a flatter shape.
 
 ## Run
 

--- a/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
@@ -115,16 +115,35 @@ def _target_service_account(event: dict[str, Any]) -> str:
     return ""
 
 
-def _finding_uid(event_uid: str, target_sa: str, actor_name: str, time_ms: int) -> str:
-    material = f"{SKILL_NAME}|{event_uid}|{target_sa}|{actor_name}|{time_ms}"
+def _target_key_resource(event: dict[str, Any]) -> str:
+    for resource in event.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        name = str(resource.get("name") or "")
+        resource_type = str(resource.get("type") or "").lower()
+        if not name or "/keys/" not in name:
+            continue
+        if resource_type in {"service_account_key", "serviceaccountkey"} or "/serviceAccounts/" in name:
+            return name.strip("/")
+    return ""
+
+
+def _key_id(key_resource: str) -> str:
+    if "/keys/" not in key_resource:
+        return ""
+    return key_resource.rsplit("/keys/", 1)[1].strip("/")
+
+
+def _finding_uid(event_uid: str, target_sa: str, key_resource: str, actor_name: str, time_ms: int) -> str:
+    material = f"{SKILL_NAME}|{event_uid}|{target_sa}|{key_resource}|{actor_name}|{time_ms}"
     return f"gsakc-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
 
 
-def _build_native_finding(*, event: dict[str, Any], target_service_account: str) -> dict[str, Any]:
+def _build_native_finding(*, event: dict[str, Any], target_service_account: str, target_key_resource: str) -> dict[str, Any]:
     time_ms = _time_ms(event)
     event_uid = _event_uid(event)
     actor_name = _actor_name(event)
-    finding_uid = _finding_uid(event_uid, target_service_account, actor_name, time_ms)
+    finding_uid = _finding_uid(event_uid, target_service_account, target_key_resource, actor_name, time_ms)
     return {
         "schema_mode": "native",
         "canonical_schema_version": CANONICAL_VERSION,
@@ -134,6 +153,8 @@ def _build_native_finding(*, event: dict[str, Any], target_service_account: str)
         "rule": "gcp-service-account-key-creation",
         "api_operation": CREATE_SA_KEY_OPERATION,
         "target_service_account": target_service_account,
+        "target_key_resource": target_key_resource,
+        "target_key_id": _key_id(target_key_resource),
         "actor_name": actor_name,
         "project_uid": _account_uid(event),
         "region": _region(event),
@@ -160,6 +181,12 @@ def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
         {"name": "target.name", "type": "Other", "value": native["target_service_account"]},
         {"name": "project.uid", "type": "Other", "value": native["project_uid"]},
     ]
+    if native["target_key_resource"]:
+        observables.append(
+            {"name": "target.key_resource", "type": "Other", "value": native["target_key_resource"]}
+        )
+    if native["target_key_id"]:
+        observables.append({"name": "target.key_id", "type": "Other", "value": native["target_key_id"]})
     if native["region"]:
         observables.append({"name": "region", "type": "Other", "value": native["region"]})
     if native["src_ip"]:
@@ -208,6 +235,8 @@ def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
             "events_observed": 1,
             "api_operation": native["api_operation"],
             "target_service_account": native["target_service_account"],
+            "target_key_resource": native["target_key_resource"],
+            "target_key_id": native["target_key_id"],
         },
     }
 
@@ -243,7 +272,11 @@ def detect(
                 message="skipping CreateServiceAccountKey event with no target service account",
             )
             continue
-        native = _build_native_finding(event=event, target_service_account=target_service_account)
+        native = _build_native_finding(
+            event=event,
+            target_service_account=target_service_account,
+            target_key_resource=_target_key_resource(event),
+        )
         yield native if output_format == "native" else _to_ocsf(native)
 
 

--- a/skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
@@ -26,6 +26,7 @@ def _event(
     service: str = "iam.googleapis.com",
     success: bool = True,
     target_service_account: str = "sa-deploy@my-project.iam.gserviceaccount.com",
+    target_key_resource: str = "",
     actor_name: str = "alice@example.com",
     project_uid: str = "my-project",
     src_ip: str = "203.0.113.42",
@@ -40,6 +41,8 @@ def _event(
                 "type": resource_type,
             }
         )
+    if target_key_resource:
+        resources.append({"name": target_key_resource, "type": "service_account_key"})
     return {
         "class_uid": 6003,
         "status_id": 1 if success else 2,
@@ -76,11 +79,42 @@ def test_fires_on_create_service_account_key():
 
 
 def test_native_output_contains_target_service_account():
-    findings = list(detect([_event(target_service_account="sa-ci@my-project.iam.gserviceaccount.com")], output_format="native"))
+    findings = list(
+        detect([_event(target_service_account="sa-ci@my-project.iam.gserviceaccount.com")], output_format="native")
+    )
     finding = findings[0]
     assert finding["schema_mode"] == "native"
     assert finding["target_service_account"] == "sa-ci@my-project.iam.gserviceaccount.com"
     assert finding["rule"] == "gcp-service-account-key-creation"
+
+
+def test_native_output_contains_created_key_resource_when_present():
+    key_resource = "projects/-/serviceAccounts/sa-ci@my-project.iam.gserviceaccount.com/keys/key-123"
+    finding = list(
+        detect(
+            [
+                _event(
+                    target_service_account="sa-ci@my-project.iam.gserviceaccount.com",
+                    target_key_resource=key_resource,
+                )
+            ],
+            output_format="native",
+        )
+    )[0]
+    assert finding["target_key_resource"] == key_resource
+    assert finding["target_key_id"] == "key-123"
+
+
+def test_ocsf_output_contains_created_key_evidence_when_present():
+    key_resource = "projects/-/serviceAccounts/sa-deploy@my-project.iam.gserviceaccount.com/keys/key-123"
+    finding = list(detect([_event(target_key_resource=key_resource)]))[0]
+
+    assert finding["evidence"]["target_key_resource"] == key_resource
+    assert finding["evidence"]["target_key_id"] == "key-123"
+    assert any(
+        obs["name"] == "target.key_resource" and obs["value"] == key_resource for obs in finding["observables"]
+    )
+    assert any(obs["name"] == "target.key_id" and obs["value"] == "key-123" for obs in finding["observables"])
 
 
 def test_skips_failed_event():

--- a/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/SKILL.md
@@ -138,6 +138,11 @@ gcloud logging read 'logName=~"cloudaudit.googleapis.com"' --format=json --limit
 - IAM policy delta in `protoPayload.serviceData` — would need its own follow-up skill
 - Multi-resource batch operations — first resource only
 
+Exception: for service-account key creation events, the ingester may copy only
+the sanitized `protoPayload.response.name` resource identifier into
+`resources[]` as `type: service_account_key`. It never copies
+`privateKeyData` or the full response object.
+
 ## Tests
 
 Golden fixture parity against [`../golden/gcp_audit_raw_sample.jsonl`](../golden/gcp_audit_raw_sample.jsonl) → [`../golden/gcp_audit_sample.ocsf.jsonl`](../golden/gcp_audit_sample.ocsf.jsonl).

--- a/skills/ingestion/ingest-gcp-audit-ocsf/references/field-map.md
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/references/field-map.md
@@ -26,6 +26,7 @@ stays focused on triggers and guardrails.
 | `methodName` (verb segment) | `activity_id` | `Create` → 1, `Get`/`List` → 2, `Update`/`Patch` → 3, `Delete` → 4 |
 | `serviceName` | `api.service.name` | e.g. `iam.googleapis.com` |
 | `resourceName` | `resource.uid` | Fully qualified resource path |
+| `response.name` | `resources[].name` | Only copied when it is a sanitized service-account key resource name; full response and `privateKeyData` are not retained |
 | `status.code` | `status_id` | 0 → 1 (Success); non-zero → 2 (Failure) |
 | `status.message` | `status_detail` | Human-readable error |
 | `resource.labels.project_id` | `cloud.account.uid` | |

--- a/skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py
@@ -144,6 +144,10 @@ def _build_resources(proto: dict[str, Any], log_entry: dict[str, Any]) -> list[d
     if name:
         rtype = ((log_entry.get("resource") or {}).get("type")) or ""
         resources.append({"name": name, "type": rtype})
+    response = proto.get("response") or {}
+    response_name = response.get("name")
+    if isinstance(response_name, str) and "/serviceAccounts/" in response_name and "/keys/" in response_name:
+        resources.append({"name": response_name, "type": "service_account_key"})
     return resources
 
 

--- a/skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py
@@ -206,6 +206,24 @@ class TestConvertEvent:
         assert e["resources"][0]["name"] == "projects/-/serviceAccounts/sa@p.iam.gserviceaccount.com"
         assert e["resources"][0]["type"] == "service_account"
 
+    def test_resources_include_sanitized_created_service_account_key_name(self):
+        e = convert_event(
+            self._entry(
+                response={
+                    "name": "projects/-/serviceAccounts/sa@p.iam.gserviceaccount.com/keys/key-123",
+                    "privateKeyData": "base64-secret-material",
+                }
+            )
+        )
+        assert e["resources"] == [
+            {"name": "projects/-/serviceAccounts/sa@p.iam.gserviceaccount.com", "type": "service_account"},
+            {
+                "name": "projects/-/serviceAccounts/sa@p.iam.gserviceaccount.com/keys/key-123",
+                "type": "service_account_key",
+            },
+        ]
+        assert "privateKeyData" not in e
+
     def test_failure_status(self):
         e = convert_event(self._entry(status={"code": 7, "message": "denied"}))
         assert e["status_id"] == STATUS_FAILURE


### PR DESCRIPTION
## Summary
- preserve sanitized GCP service-account key resource names from audit-log responses
- emit target_key_resource and target_key_id in the key-creation detector evidence/native output
- document the bounded response-name exception while keeping privateKeyData and full responses out of OCSF output

## Validation
- uv run pytest skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py -q
- uv run ruff check skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py skills/ingestion/ingest-gcp-audit-ocsf/tests/test_ingest.py skills/detection/detect-gcp-service-account-key-creation/src/detect.py skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
- uv run pytest tests/integration/test_skill_validation_scripts.py -q
- uv run mypy skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py skills/detection/detect-gcp-service-account-key-creation/src/detect.py
- uv run pytest -q
- uv run ruff check .