### PR TITLE
[codex] add label-gated auto-merge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,52 @@
+name: Auto Merge
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    name: enable-automerge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.state == 'open'
+    steps:
+      - name: Enable native auto-merge for trusted labeled PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
+          is_draft="$(jq -r '.draft' <<<"${pr_json}")"
+          head_repo="$(jq -r '.head.repo.full_name' <<<"${pr_json}")"
+          head_ref="$(jq -r '.head.ref' <<<"${pr_json}")"
+
+          if [[ "${is_draft}" == "true" ]]; then
+            echo "PR #${PR_NUMBER} is draft; skipping auto-merge enablement."
+            exit 0
+          fi
+
+          if [[ "${head_repo}" != "${REPOSITORY}" ]]; then
+            echo "PR #${PR_NUMBER} is from ${head_repo}; skipping fork auto-merge."
+            exit 0
+          fi
+
+          if ! gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" --jq '.[].name' | grep -Fxq "automerge"; then
+            echo "PR #${PR_NUMBER} does not have the automerge label; skipping."
+            exit 0
+          fi
+
+          echo "Enabling native auto-merge for PR #${PR_NUMBER} from ${head_ref}."
+          gh pr merge "${PR_NUMBER}" \
+            --repo "${REPOSITORY}" \
+            --auto \
+            --squash \
+            --delete-branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,8 +297,12 @@ jobs:
           tflint_version: v0.58.0
       - name: Install Azure Bicep CLI
         run: |
+          set -euo pipefail
           mkdir -p "${HOME}/.local/bin"
-          curl -sSL https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 -o "${HOME}/.local/bin/bicep"
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 \
+            --output "${HOME}/.local/bin/bicep"
+          file "${HOME}/.local/bin/bicep" | grep -q "ELF 64-bit"
           chmod +x "${HOME}/.local/bin/bicep"
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
           "${HOME}/.local/bin/bicep" --version

--- a/docs/CI_WORKFLOW.md
+++ b/docs/CI_WORKFLOW.md
@@ -34,6 +34,8 @@ The CI pipeline is split into independent lanes so failures point at the right k
   - CloudFormation and Terraform validation
 - `agent-bom`
   - advisory artifact and SARIF generation
+- `Auto Merge`
+  - label-gated workflow that enables GitHub native auto-merge for trusted PRs
 
 ## Simplification Rules
 
@@ -43,6 +45,19 @@ The CI pipeline is split into independent lanes so failures point at the right k
 - Install only the packages each lane needs.
 - Prefer grouped layer lanes over per-skill matrix fan-out when the skill family can share one dependency set.
 - Cancel stale in-flight runs on the same PR branch so queued checks do not pile up behind superseded pushes.
+
+## Auto-Merge Policy
+
+Auto-merge is opt-in per PR:
+
+1. The PR must come from the same repository, not a fork.
+2. The PR must not be a draft.
+3. The PR must have the `automerge` label.
+
+When those conditions are true, `.github/workflows/automerge.yml` runs with
+`pull_request_target` and does not check out or execute PR code. It calls
+GitHub native auto-merge with squash merge and delete-branch enabled. GitHub
+then waits for required checks and branch protection before merging.
 
 ## Next Tightenings
 


### PR DESCRIPTION
## Summary
- add a pull_request_target workflow that enables GitHub native auto-merge for same-repo PRs labeled automerge
- skip draft PRs and fork PRs, and never check out or execute PR code in the privileged workflow
- document the auto-merge policy in the CI workflow guide

## Operational notes
- Repository native auto-merge has been enabled.
- The automerge label has been created.
- GitHub still waits for required checks and branch protection before merging.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/automerge.yml'); YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml ok'"
- uv run ruff check scripts tests mcp-server skills
- git diff --check