### PR TITLE
mcp: harden frontmatter parser, min_approvers, and timeout error code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
+          packages: pyyaml
       - run: python scripts/validate_skill_contract.py
       - run: python scripts/validate_skill_integrity.py
       - run: python scripts/validate_dependency_consistency.py
@@ -224,7 +225,7 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: boto3 moto pytest pytest-cov defusedxml
+          packages: boto3 moto pytest pytest-cov defusedxml pyyaml
       - run: pytest tests/integration/ tests/conformance/ mcp-server/tests/ -v -o "testpaths=tests"
 
   coverage:
@@ -237,7 +238,7 @@ jobs:
           python-version: "3.11"
           packages: >-
             boto3 moto pytest pytest-cov
-            defusedxml
+            defusedxml pyyaml
             google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage
             azure-identity azure-mgmt-network azure-mgmt-resource azure-mgmt-storage
             google-api-python-client

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -88,6 +88,12 @@ IAM departures planning and source adapters:
 uv sync --group iam_departures
 ```
 
+MCP stdio wrapper (`mcp-server/src/server.py`):
+
+```bash
+uv sync --group mcp
+```
+
 Development and validation:
 
 ```bash

--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -198,3 +198,20 @@ The wrapper should preserve this audit contract across supported tool calls:
 
 If the audit shape changes, update this document and the relevant wrapper tests
 in the same change.
+
+## JSON-RPC Error Codes
+
+The wrapper uses the server-defined range (-32000..-32099) so clients can tell
+operational failures apart from each other. Standard JSON-RPC codes (-32600
+parse error, -32601 method/tool not found, -32602 invalid params) keep their
+spec meaning.
+
+| Code | Constant | Cause |
+|------|----------|-------|
+| `-32001` | `ERROR_TOOL_TIMEOUT` | skill subprocess exceeded the resolved timeout |
+| `-32002` | `ERROR_TOOL_NOT_ALLOWED` | reserved for future explicit allowlist denials |
+| `-32003` | `ERROR_APPROVAL_REQUIRED` | reserved for future approval-context errors |
+| `-32004` | `ERROR_TOOL_CRASHED` | reserved for future non-timeout subprocess failures |
+
+Constants live in `mcp-server/src/server.py`. Update this table whenever a new
+code is reserved or a placeholder is wired in.

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -29,6 +29,13 @@ PROTOCOL_VERSION = "2025-06-18"
 DEFAULT_TIMEOUT_SECONDS = 60
 ALLOWED_SKILLS_ENV = "CLOUD_SECURITY_MCP_ALLOWED_SKILLS"
 REQUIRE_CALLER_ALLOWED_SKILLS_ENV = "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"
+
+# Server-defined JSON-RPC error codes (reserved range -32000..-32099 per spec).
+# Documented in docs/MCP_AUDIT_CONTRACT.md so clients can distinguish causes.
+ERROR_TOOL_TIMEOUT = -32001
+ERROR_TOOL_NOT_ALLOWED = -32002
+ERROR_APPROVAL_REQUIRED = -32003
+ERROR_TOOL_CRASHED = -32004
 SAFE_CHILD_ENV_VARS = (
     "HOME",
     "LANG",
@@ -485,7 +492,9 @@ def _handle_request(message: dict[str, Any]) -> dict[str, Any] | None:
         except ValueError as exc:
             return _error_response(request_id, -32602, str(exc))
         except subprocess.TimeoutExpired as exc:
-            return _error_response(request_id, -32000, f"tool timed out after {exc.timeout}s")
+            return _error_response(
+                request_id, ERROR_TOOL_TIMEOUT, f"tool timed out after {exc.timeout}s"
+            )
 
     return _error_response(request_id, -32601, f"method not found: {method}")
 

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -4,6 +4,9 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
 
@@ -67,47 +70,38 @@ def _extract_frontmatter(skill_md: Path) -> str:
     return match.group(1)
 
 
+def _flatten_value(value: Any) -> str:
+    """Render a YAML scalar/list/dict back into the string shape the rest of the
+    registry consumes. Lists are joined with commas (matches `_parse_modes`),
+    folded multi-line scalars collapse into a single space-separated string.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ", ".join(_flatten_value(item) for item in value if item not in (None, ""))
+    if isinstance(value, dict):
+        return ", ".join(f"{k}={_flatten_value(v)}" for k, v in value.items())
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return " ".join(str(value).split())
+
+
 def _parse_frontmatter(frontmatter: str) -> dict[str, str]:
-    data: dict[str, str] = {}
-    lines = frontmatter.splitlines()
-    idx = 0
+    """Parse SKILL.md frontmatter using PyYAML.
 
-    while idx < len(lines):
-        line = lines[idx]
-        if not line.strip():
-            idx += 1
-            continue
-        if line.startswith(" "):
-            idx += 1
-            continue
-        if ":" not in line:
-            idx += 1
-            continue
-
-        key, raw_value = line.split(":", 1)
-        key = key.strip()
-        value = raw_value.strip()
-
-        if not value or value in {">-", "|", ">"}:
-            idx += 1
-            block: list[str] = []
-            while idx < len(lines):
-                child = lines[idx]
-                if child.startswith("  "):
-                    block.append(child.strip())
-                    idx += 1
-                    continue
-                if not child.strip():
-                    idx += 1
-                    continue
-                break
-            data[key] = " ".join(part for part in block if part)
-            continue
-
-        data[key] = value.strip("\"'")
-        idx += 1
-
-    return data
+    Historically this was a hand-rolled splitter that failed on quoted values
+    containing colons and on standard YAML constructs. `yaml.safe_load` handles
+    the full subset we use; `_flatten_value` collapses scalars/lists into the
+    string shape the rest of the registry already expects.
+    """
+    raw = yaml.safe_load(frontmatter)
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"SKILL.md frontmatter must parse to a mapping, got {type(raw).__name__}"
+        )
+    return {str(key): _flatten_value(value) for key, value in raw.items()}
 
 
 def _derive_capability(skill_dir: Path, metadata: dict[str, str]) -> str:
@@ -158,11 +152,28 @@ def discover_skills(root: Path | None = None) -> list[SkillSpec]:
                 network_egress=_parse_modes(metadata.get("network_egress")),
                 caller_roles=_parse_modes(metadata.get("caller_roles")),
                 approver_roles=_parse_modes(metadata.get("approver_roles")),
-                min_approvers=int(metadata["min_approvers"]) if metadata.get("min_approvers") else None,
+                min_approvers=_parse_min_approvers(metadata.get("min_approvers"), skill_dir),
                 mcp_timeout_seconds=_parse_mcp_timeout(metadata.get("mcp_timeout_seconds"), skill_dir),
             )
         )
     return specs
+
+
+def _parse_min_approvers(raw: str | None, skill_dir: Path) -> int | None:
+    """Defensive parse for `min_approvers`. Missing / empty -> None.
+
+    Surfaces a clear error if a SKILL.md author writes a non-integer value.
+    Without this, a malformed value crashed `discover_skills` at import time
+    and made the whole MCP server fail to start.
+    """
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return int(str(raw).strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"{skill_dir}/SKILL.md: min_approvers must be an integer, got {raw!r}"
+        ) from exc
 
 
 def _parse_mcp_timeout(raw: str | None, skill_dir: Path) -> int | None:

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -560,6 +560,33 @@ def test_call_tool_rejects_skill_outside_allowlist(monkeypatch):
         raise AssertionError("expected KeyError for allowlist-blocked tool")
 
 
+def test_handle_request_returns_distinct_timeout_error_code(monkeypatch):
+    """Timeouts must use ERROR_TOOL_TIMEOUT (-32001) so clients can distinguish
+    a slow skill from any other server-side error.
+    """
+    monkeypatch.setattr(MODULE, "tool_map", lambda: {"fake-skill": _FakeSkill(read_only=True)})
+    monkeypatch.setattr(MODULE, "build_command", lambda skill, args, output_format=None: ["python", "fake.py"])
+    monkeypatch.setattr(MODULE, "_emit_audit_event", lambda event: None)
+
+    def _raise_timeout(*args, **kwargs):
+        raise MODULE.subprocess.TimeoutExpired(cmd=["python", "fake.py"], timeout=42)
+
+    monkeypatch.setattr(MODULE.subprocess, "run", _raise_timeout)
+
+    response = MODULE._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {"name": "fake-skill", "arguments": {"args": []}},
+        }
+    )
+
+    assert response["error"]["code"] == MODULE.ERROR_TOOL_TIMEOUT
+    assert response["error"]["code"] == -32001
+    assert "timed out" in response["error"]["message"]
+
+
 def test_runtime_telemetry_includes_env_correlation_id(monkeypatch, capsys):
     monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
     monkeypatch.setenv("SKILL_CORRELATION_ID", "corr-123")

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -241,3 +241,68 @@ class TestMcpTimeoutParsing:
                 "make sure its SKILL.md declares the value explicitly and "
                 "that this test is updated to allowlist it"
             )
+
+
+class TestFrontmatterParsing:
+    def test_parses_quoted_value_with_colon(self):
+        frontmatter = (
+            'name: example-skill\n'
+            'description: "Detect: suspicious behavior in foo:bar streams"\n'
+            'license: Apache-2.0\n'
+        )
+        data = MODULE._parse_frontmatter(frontmatter)
+        assert data["description"] == "Detect: suspicious behavior in foo:bar streams"
+        assert data["name"] == "example-skill"
+
+    def test_parses_block_scalar_description(self):
+        frontmatter = (
+            'name: block-scalar-skill\n'
+            'description: >-\n'
+            '  this description spans\n'
+            '  multiple wrapped lines\n'
+            'license: Apache-2.0\n'
+        )
+        data = MODULE._parse_frontmatter(frontmatter)
+        assert "multiple wrapped lines" in data["description"]
+        assert data["name"] == "block-scalar-skill"
+
+    def test_parses_list_value_into_comma_string(self):
+        frontmatter = (
+            'name: list-skill\n'
+            'execution_modes:\n'
+            '  - jit\n'
+            '  - mcp\n'
+            '  - ci\n'
+        )
+        data = MODULE._parse_frontmatter(frontmatter)
+        assert data["execution_modes"] == "jit, mcp, ci"
+
+    def test_rejects_non_mapping_frontmatter(self):
+        try:
+            MODULE._parse_frontmatter("- just\n- a\n- list\n")
+        except ValueError as exc:
+            assert "must parse to a mapping" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestMinApproversParsing:
+    def test_missing_value_returns_none(self):
+        assert MODULE._parse_min_approvers(None, Path("/fake")) is None
+
+    def test_empty_value_returns_none(self):
+        assert MODULE._parse_min_approvers("", Path("/fake")) is None
+        assert MODULE._parse_min_approvers("   ", Path("/fake")) is None
+
+    def test_integer_value_parses(self):
+        assert MODULE._parse_min_approvers("2", Path("/fake")) == 2
+        assert MODULE._parse_min_approvers("0", Path("/fake")) == 0
+
+    def test_non_integer_value_errors_with_skill_path(self):
+        try:
+            MODULE._parse_min_approvers("two", Path("/fake/skill"))
+        except ValueError as exc:
+            assert "min_approvers must be an integer" in str(exc)
+            assert "/fake/skill" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,13 @@ dev = [
   "mypy>=1.11,<2",
   "pip-audit>=2.7,<3",
   "pre-commit>=3.8,<5",
+  "pyyaml>=6,<7",
   "pytest>=8.3,<10",
   "pytest-cov>=5,<8",
   "ruff>=0.6.9,<1",
+]
+mcp = [
+  "pyyaml>=6,<7",
 ]
 aws = [
   "boto3>=1.35,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dev = [
   "mypy>=1.11,<2",
   "pip-audit>=2.7,<3",
   "pre-commit>=3.8,<5",
-  "pyyaml>=6,<7",
   "pytest>=8.3,<10",
   "pytest-cov>=5,<8",
   "ruff>=0.6.9,<1",

--- a/uv.lock
+++ b/uv.lock
@@ -449,6 +449,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 gcp = [
@@ -463,6 +464,9 @@ iam-departures = [
     { name = "google-api-python-client" },
     { name = "httpx" },
     { name = "snowflake-connector-python" },
+]
+mcp = [
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -484,6 +488,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.8,<5" },
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=5,<8" },
+    { name = "pyyaml", specifier = ">=6,<7" },
     { name = "ruff", specifier = ">=0.6.9,<1" },
 ]
 gcp = [
@@ -499,6 +504,7 @@ iam-departures = [
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "snowflake-connector-python", specifier = ">=4.4.0,<5" },
 ]
+mcp = [{ name = "pyyaml", specifier = ">=6,<7" }]
 
 [[package]]
 name = "colorama"

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pyyaml" },
     { name = "ruff" },
 ]
 gcp = [
@@ -488,7 +487,6 @@ dev = [
     { name = "pre-commit", specifier = ">=3.8,<5" },
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=5,<8" },
-    { name = "pyyaml", specifier = ">=6,<7" },
     { name = "ruff", specifier = ">=0.6.9,<1" },
 ]
 gcp = [


### PR DESCRIPTION
## Summary

Three contained MCP-server hardening changes from the 2026-04-28 code-level audit. All in `mcp-server/`; no skill behavior changes.

- **#395** Replace the hand-rolled SKILL.md frontmatter splitter with `yaml.safe_load`. The previous parser failed on standard YAML with quoted colons or block scalars and would silently drop skills from MCP discovery.
- **#400** Wrap `min_approvers` parsing so a non-integer value surfaces a clear per-skill error instead of crashing `tool_registry` build at import time (which would take down all 76 MCP tools).
- **#402** Reserve the server-defined JSON-RPC error range and emit `ERROR_TOOL_TIMEOUT` (-32001) for subprocess timeouts so clients can distinguish a slow skill from any other server error. -32002/-32003/-32004 reserved for future explicit allowlist / approval / crash codes.

Adds `pyyaml` as a new `mcp` dep group (also pulled into `dev` so tests run), documents the JSON-RPC error code table in `MCP_AUDIT_CONTRACT.md`, and extends `test_tool_registry.py` / `test_server_unit.py` to cover quoted colons, block scalars, list values, malformed `min_approvers`, and the new timeout error code.

## Test plan

- [x] `pytest mcp-server/tests/` — 65/65 pass (9 new)
- [x] `ruff check mcp-server/` — clean
- [x] `uv run mypy mcp-server/src` (strict flags from `scripts/run_mypy.sh`) — clean
- [x] `uv run python scripts/validate_skill_contract.py` — 76/76 pass
- [x] `uv lock` regenerated for the new pyyaml dep

Closes #395, #400, #402.