### PR TITLE
skills/_shared: extract identity + env helpers, sweep 47 callers

### DIFF
--- a/skills/_shared/env.py
+++ b/skills/_shared/env.py
@@ -1,0 +1,71 @@
+"""Defensive env-var parsing helpers.
+
+Skills tune behavior via env vars (window sizes, thresholds, milliseconds).
+The historical pattern was a per-skill `_env_int` that silently fell back to
+the default when the value didn't parse — operators thought they tuned the
+skill, but a typo silently kept the original behavior.
+
+These helpers fall back to the default *and* emit a structured warning so the
+fallback is visible in stderr telemetry. Setting `CLOUD_SECURITY_STRICT_ENV=1`
+makes parse failures fatal for environments that prefer fail-closed.
+"""
+
+from __future__ import annotations
+
+import os
+
+from skills._shared.runtime_telemetry import emit_stderr_event
+
+STRICT_ENV_VAR = "CLOUD_SECURITY_STRICT_ENV"
+
+
+def _strict() -> bool:
+    return os.environ.get(STRICT_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _emit_parse_failure(skill_name: str, name: str, raw: str, default: object) -> None:
+    emit_stderr_event(
+        skill_name,
+        level="warning",
+        event="env_parse_failed",
+        message=(
+            f"env var {name}={raw!r} did not parse; falling back to default {default!r}. "
+            "Set CLOUD_SECURITY_STRICT_ENV=1 to fail closed instead."
+        ),
+        env=name,
+        raw=raw,
+        default=default,
+    )
+
+
+def env_int(name: str, default: int, *, skill_name: str) -> int:
+    """Parse an integer env var, warn on failure, fall back to default."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        if _strict():
+            raise
+        _emit_parse_failure(skill_name, name, raw, default)
+        return default
+
+
+def env_float(name: str, default: float, *, skill_name: str) -> float:
+    """Parse a float env var, warn on failure, fall back to default."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw.strip())
+    except ValueError:
+        if _strict():
+            raise
+        _emit_parse_failure(skill_name, name, raw, default)
+        return default
+
+
+def env_ms(name: str, default_ms: int, *, skill_name: str) -> int:
+    """Parse a millisecond env var as int. Same semantics as `env_int`."""
+    return env_int(name, default_ms, skill_name=skill_name)

--- a/skills/_shared/identity.py
+++ b/skills/_shared/identity.py
@@ -1,0 +1,46 @@
+"""Single source of truth for vendor / product identity strings.
+
+Skills emit `metadata.product.vendor_name` and `metadata.product.name` on every
+OCSF Detection Finding. Hardcoding the strings in each skill's `detect.py` /
+`ingest.py` means a fork or org rename has to patch every entrypoint, and
+operator deployments inherit upstream identifiers they can't override.
+
+Importing `VENDOR_NAME` and `PRODUCT_NAME` from here keeps both rewriteable in
+one place; setting `CLOUD_SECURITY_VENDOR_NAME` or `CLOUD_SECURITY_PRODUCT_NAME`
+in the deployment env overrides the defaults at runtime without code changes.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_VENDOR_NAME = "msaad00/cloud-ai-security-skills"
+DEFAULT_PRODUCT_NAME = "cloud-ai-security-skills"
+DEFAULT_INFORMATION_URI = "https://github.com/msaad00/cloud-ai-security-skills"
+
+
+def vendor_name() -> str:
+    """Resolve the vendor identifier for emitted findings."""
+    override = os.environ.get("CLOUD_SECURITY_VENDOR_NAME", "").strip()
+    return override or DEFAULT_VENDOR_NAME
+
+
+def product_name() -> str:
+    """Resolve the product identifier for emitted findings."""
+    override = os.environ.get("CLOUD_SECURITY_PRODUCT_NAME", "").strip()
+    return override or DEFAULT_PRODUCT_NAME
+
+
+def information_uri() -> str:
+    """Resolve the project URL embedded in SARIF / external metadata."""
+    override = os.environ.get("CLOUD_SECURITY_INFORMATION_URI", "").strip()
+    return override or DEFAULT_INFORMATION_URI
+
+
+# Module-level constants resolved once at import. Keep these for skills that
+# treat the identifier as a static value; use `vendor_name()` / `product_name()`
+# directly when the env override should win even after the skill module is
+# already imported (e.g. long-lived MCP processes).
+VENDOR_NAME = vendor_name()
+PRODUCT_NAME = product_name()
+INFORMATION_URI = information_uri()

--- a/skills/detection/detect-agent-credential-leak-mcp/src/detect.py
+++ b/skills/detection/detect-agent-credential-leak-mcp/src/detect.py
@@ -27,7 +27,8 @@ SKILL_NAME = "detect-agent-credential-leak-mcp"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 INGEST_SKILL = "ingest-mcp-proxy-ocsf"
 

--- a/skills/detection/detect-aws-access-key-creation/src/detect.py
+++ b/skills/detection/detect-aws-access-key-creation/src/detect.py
@@ -27,7 +27,7 @@ SKILL_NAME = "detect-aws-access-key-creation"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-aws-enumeration-burst/src/detect.py
+++ b/skills/detection/detect-aws-enumeration-burst/src/detect.py
@@ -27,7 +27,7 @@ SKILL_NAME = "detect-aws-enumeration-burst"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-aws-login-profile-creation/src/detect.py
+++ b/skills/detection/detect-aws-login-profile-creation/src/detect.py
@@ -27,7 +27,7 @@ SKILL_NAME = "detect-aws-login-profile-creation"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-aws-model-artifact-download/src/detect.py
+++ b/skills/detection/detect-aws-model-artifact-download/src/detect.py
@@ -20,7 +20,7 @@ SKILL_NAME = "detect-aws-model-artifact-download"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-aws-open-security-group/src/detect.py
+++ b/skills/detection/detect-aws-open-security-group/src/detect.py
@@ -47,7 +47,7 @@ SKILL_NAME = "detect-aws-open-security-group"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 # OCSF Detection Finding 2004
 FINDING_CLASS_UID = 2004

--- a/skills/detection/detect-azure-activity-logs-disabled/src/detect.py
+++ b/skills/detection/detect-azure-activity-logs-disabled/src/detect.py
@@ -33,7 +33,7 @@ SKILL_NAME = "detect-azure-activity-logs-disabled"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-azure-open-nsg/src/detect.py
+++ b/skills/detection/detect-azure-open-nsg/src/detect.py
@@ -50,7 +50,7 @@ SKILL_NAME = "detect-azure-open-nsg"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 # OCSF Detection Finding 2004
 FINDING_CLASS_UID = 2004

--- a/skills/detection/detect-cloudtrail-disabled/src/detect.py
+++ b/skills/detection/detect-cloudtrail-disabled/src/detect.py
@@ -31,7 +31,7 @@ SKILL_NAME = "detect-cloudtrail-disabled"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-container-escape-k8s/src/detect.py
+++ b/skills/detection/detect-container-escape-k8s/src/detect.py
@@ -23,6 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-container-escape-k8s"
@@ -416,7 +417,7 @@ def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
             "uid": native_finding["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "kubernetes", "container-escape", native_finding["rule_name"]],

--- a/skills/detection/detect-credential-stuffing-okta/src/detect.py
+++ b/skills/detection/detect-credential-stuffing-okta/src/detect.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,13 +22,15 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.env import env_int  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-credential-stuffing-okta"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 
 AUTH_CLASS_UID = 3002
@@ -388,13 +389,7 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
 
 
 def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
+    value = env_int(name, default, skill_name=SKILL_NAME)
     return value if value > 0 else default
 
 

--- a/skills/detection/detect-entra-credential-addition/src/detect.py
+++ b/skills/detection/detect-entra-credential-addition/src/detect.py
@@ -21,7 +21,8 @@ SKILL_NAME = "detect-entra-credential-addition"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 
 INGEST_SKILL = "ingest-entra-directory-audit-ocsf"

--- a/skills/detection/detect-entra-role-grant-escalation/src/detect.py
+++ b/skills/detection/detect-entra-role-grant-escalation/src/detect.py
@@ -21,7 +21,8 @@ SKILL_NAME = "detect-entra-role-grant-escalation"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 
 INGEST_SKILL = "ingest-entra-directory-audit-ocsf"

--- a/skills/detection/detect-gcp-audit-logs-disabled/src/detect.py
+++ b/skills/detection/detect-gcp-audit-logs-disabled/src/detect.py
@@ -35,7 +35,7 @@ SKILL_NAME = "detect-gcp-audit-logs-disabled"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-gcp-model-artifact-download/src/detect.py
+++ b/skills/detection/detect-gcp-model-artifact-download/src/detect.py
@@ -21,7 +21,7 @@ SKILL_NAME = "detect-gcp-model-artifact-download"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-gcp-open-firewall/src/detect.py
+++ b/skills/detection/detect-gcp-open-firewall/src/detect.py
@@ -50,7 +50,7 @@ SKILL_NAME = "detect-gcp-open-firewall"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 # OCSF Detection Finding 2004
 FINDING_CLASS_UID = 2004

--- a/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
@@ -20,7 +20,7 @@ SKILL_NAME = "detect-gcp-service-account-key-creation"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-gcp-service-account-token-minting/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-token-minting/src/detect.py
@@ -20,7 +20,7 @@ SKILL_NAME = "detect-gcp-service-account-token-minting"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-google-workspace-suspicious-login/src/detect.py
+++ b/skills/detection/detect-google-workspace-suspicious-login/src/detect.py
@@ -20,7 +20,8 @@ SKILL_NAME = "detect-google-workspace-suspicious-login"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 
 WORKSPACE_INGEST_SKILL = "ingest-google-workspace-login-ocsf"

--- a/skills/detection/detect-lateral-movement/src/detect.py
+++ b/skills/detection/detect-lateral-movement/src/detect.py
@@ -17,7 +17,6 @@ import argparse
 import hashlib
 import ipaddress
 import json
-import os
 import sys
 from bisect import bisect_left
 from datetime import datetime, timezone
@@ -28,12 +27,13 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.env import env_int  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-lateral-movement"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 # Detection Finding (2004)
 FINDING_CLASS_UID = 2004
@@ -653,13 +653,7 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
 
 
 def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
+    value = env_int(name, default, skill_name=SKILL_NAME)
     return value if value > 0 else default
 
 

--- a/skills/detection/detect-mcp-tool-drift/src/detect.py
+++ b/skills/detection/detect-mcp-tool-drift/src/detect.py
@@ -15,7 +15,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "detect-mcp-tool-drift"
 OCSF_VERSION = "1.8.0"
@@ -199,7 +206,7 @@ def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
             "uid": native_finding["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "mcp", "supply-chain", "tool-drift"],

--- a/skills/detection/detect-okta-mfa-fatigue/src/detect.py
+++ b/skills/detection/detect-okta-mfa-fatigue/src/detect.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,13 +23,15 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.env import env_int  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-okta-mfa-fatigue"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 
 AUTH_CLASS_UID = 3002
@@ -391,13 +392,7 @@ def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Ite
 
 
 def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
+    value = env_int(name, default, skill_name=SKILL_NAME)
     return value if value > 0 else default
 
 

--- a/skills/detection/detect-privilege-escalation-k8s/src/detect.py
+++ b/skills/detection/detect-privilege-escalation-k8s/src/detect.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-privilege-escalation-k8s"
@@ -266,7 +267,7 @@ def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
             "uid": native_finding["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "kubernetes", "privilege-escalation", native_finding["rule_name"]],

--- a/skills/detection/detect-prompt-injection-mcp-proxy/src/detect.py
+++ b/skills/detection/detect-prompt-injection-mcp-proxy/src/detect.py
@@ -21,7 +21,8 @@ SKILL_NAME = "detect-prompt-injection-mcp-proxy"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 
 APPLICATION_ACTIVITY_UID = 6002

--- a/skills/detection/detect-s3-cross-account-copy/src/detect.py
+++ b/skills/detection/detect-s3-cross-account-copy/src/detect.py
@@ -20,7 +20,7 @@ SKILL_NAME = "detect-s3-cross-account-copy"
 CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"

--- a/skills/detection/detect-sensitive-secret-read-k8s/src/detect.py
+++ b/skills/detection/detect-sensitive-secret-read-k8s/src/detect.py
@@ -19,7 +19,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "detect-sensitive-secret-read-k8s"
 OCSF_VERSION = "1.8.0"
@@ -252,7 +259,7 @@ def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
             "uid": native_finding["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "kubernetes", "credential-access", "secret-read"],

--- a/skills/detection/detect-system-prompt-extraction/src/detect.py
+++ b/skills/detection/detect-system-prompt-extraction/src/detect.py
@@ -21,7 +21,8 @@ SKILL_NAME = "detect-system-prompt-extraction"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 INGEST_SKILL = "ingest-mcp-proxy-ocsf"
 

--- a/skills/detection/detect-tool-output-exfiltration-instructions/src/detect.py
+++ b/skills/detection/detect-tool-output-exfiltration-instructions/src/detect.py
@@ -21,7 +21,8 @@ SKILL_NAME = "detect-tool-output-exfiltration-instructions"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 INGEST_SKILL = "ingest-mcp-proxy-ocsf"
 

--- a/skills/detection/detect-tool-output-policy-bypass/src/detect.py
+++ b/skills/detection/detect-tool-output-policy-bypass/src/detect.py
@@ -21,7 +21,8 @@ SKILL_NAME = "detect-tool-output-policy-bypass"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
-REPO_VENDOR = "msaad00/cloud-ai-security-skills"
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
 OUTPUT_FORMATS = ("ocsf", "native")
 INGEST_SKILL = "ingest-mcp-proxy-ocsf"
 

--- a/skills/discovery/discover-cloud-control-evidence/src/discover.py
+++ b/skills/discovery/discover-cloud-control-evidence/src/discover.py
@@ -11,6 +11,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
+
 SKILL_NAME = "discover-cloud-control-evidence"
 SUPPORTED_FRAMEWORKS = ("pci", "soc2", "ai-rmf")
 SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-live-evidence")
@@ -1015,7 +1021,7 @@ def to_ocsf_live_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
             "uid": evidence["evidence_id"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "profiles": ["cloud", "security_control"],

--- a/skills/discovery/discover-control-evidence/src/discover.py
+++ b/skills/discovery/discover-control-evidence/src/discover.py
@@ -11,6 +11,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
+
 SKILL_NAME = "discover-control-evidence"
 SUPPORTED_FRAMEWORKS = ("pci", "soc2")
 SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-live-evidence")
@@ -379,7 +385,7 @@ def to_ocsf_live_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
             "uid": evidence["evidence_id"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "profiles": ["cloud", "security_control"],

--- a/skills/discovery/discover-environment/src/discover.py
+++ b/skills/discovery/discover-environment/src/discover.py
@@ -25,6 +25,12 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
+
 SUPPORTED_OUTPUT_FORMATS = ("native", "ocsf-cloud-resources-inventory")
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -828,7 +834,7 @@ def to_ocsf_cloud_resources_inventory(graph: EnvironmentGraph) -> dict[str, Any]
             "uid": _metadata_uid(graph, inventory_nodes),
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": "discover-environment"},
             },
         },

--- a/skills/ingestion/ingest-azure-activity-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-azure-activity-ocsf/src/ingest.py
@@ -7,7 +7,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-azure-activity-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -263,7 +270,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "azure", "activity-log", "ingest"],

--- a/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-azure-defender-for-cloud-ocsf/src/ingest.py
@@ -7,7 +7,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-azure-defender-for-cloud-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -216,7 +223,7 @@ def _render_ocsf_alert(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "azure", "defender-for-cloud", "ingest", "passthrough"],

--- a/skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "ingest-cloudtrail-ocsf"
@@ -304,7 +305,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "aws", "cloudtrail", "ingest"],

--- a/skills/ingestion/ingest-entra-directory-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-entra-directory-audit-ocsf/src/ingest.py
@@ -16,7 +16,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-entra-directory-audit-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -281,7 +288,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["identity", "entra", "graph", "directory-audit", "ingest"],

--- a/skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-gcp-audit-ocsf/src/ingest.py
@@ -7,7 +7,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-gcp-audit-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -234,7 +241,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "gcp", "audit-log", "ingest"],

--- a/skills/ingestion/ingest-gcp-scc-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-gcp-scc-ocsf/src/ingest.py
@@ -12,7 +12,14 @@ import json
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-gcp-scc-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -166,7 +173,7 @@ def _render_ocsf_finding(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "gcp", "scc", "ingest", "passthrough"],

--- a/skills/ingestion/ingest-google-workspace-login-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-google-workspace-login-ocsf/src/ingest.py
@@ -23,6 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "ingest-google-workspace-login-ocsf"
@@ -310,7 +311,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["identity", "google-workspace", "login-audit", "ingest"],

--- a/skills/ingestion/ingest-guardduty-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-guardduty-ocsf/src/ingest.py
@@ -22,7 +22,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-guardduty-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -397,7 +404,7 @@ def _render_ocsf_finding(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "aws", "guardduty", "ingest", "passthrough"],

--- a/skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py
@@ -23,6 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "ingest-k8s-audit-ocsf"
@@ -369,7 +370,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": canonical["metadata_labels"],

--- a/skills/ingestion/ingest-mcp-proxy-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-mcp-proxy-ocsf/src/ingest.py
@@ -14,7 +14,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-mcp-proxy-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -165,7 +172,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "profiles": [MCP_PROFILE],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "mcp", "ingest"],

--- a/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/src/ingest.py
@@ -7,7 +7,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-nsg-flow-logs-azure-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -231,7 +238,7 @@ def _render_ocsf_record(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "azure", "nsg-flow-logs", "ingest"],

--- a/skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-okta-system-log-ocsf/src/ingest.py
@@ -24,6 +24,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "ingest-okta-system-log-ocsf"
@@ -612,7 +613,7 @@ def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": labels,

--- a/skills/ingestion/ingest-security-hub-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-security-hub-ocsf/src/ingest.py
@@ -23,7 +23,14 @@ import json
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-security-hub-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -417,7 +424,7 @@ def _render_ocsf_finding(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "aws", "security-hub", "asff", "ingest", "passthrough"],

--- a/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/src/ingest.py
@@ -7,7 +7,14 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-vpc-flow-logs-gcp-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -257,7 +264,7 @@ def _render_ocsf_record(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "gcp", "vpc-flow-logs", "ingest"],

--- a/skills/ingestion/ingest-vpc-flow-logs-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-vpc-flow-logs-ocsf/src/ingest.py
@@ -16,7 +16,14 @@ import argparse
 import hashlib
 import json
 import sys
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
 
 SKILL_NAME = "ingest-vpc-flow-logs-ocsf"
 OCSF_VERSION = "1.8.0"
@@ -366,7 +373,7 @@ def _render_ocsf_record(canonical: dict[str, Any]) -> dict[str, Any]:
             "uid": canonical["event_uid"],
             "product": {
                 "name": "cloud-ai-security-skills",
-                "vendor_name": "msaad00/cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
                 "feature": {"name": SKILL_NAME},
             },
             "labels": ["detection-engineering", "aws", "vpc-flow-logs", "ingest"],

--- a/skills/view/convert-ocsf-to-sarif/src/convert.py
+++ b/skills/view/convert-ocsf-to-sarif/src/convert.py
@@ -14,7 +14,14 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import INFORMATION_URI  # noqa: E402
 
 SKILL_NAME = "convert-ocsf-to-sarif"
 SKILL_VERSION = "0.1.0"
@@ -215,7 +222,7 @@ def _build_driver(detectors: set[str], rules: dict[str, dict[str, Any]]) -> dict
     return {
         "name": "cloud-ai-security-skills-detection-engineering",
         "version": SKILL_VERSION,
-        "informationUri": "https://github.com/msaad00/cloud-ai-security-skills",
+        "informationUri": INFORMATION_URI,
         "rules": list(rules.values()),
         "properties": {
             "detectors": sorted(detectors),

--- a/tests/integration/test_shared_identity_env.py
+++ b/tests/integration/test_shared_identity_env.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared import env, identity  # noqa: E402
+
+
+def test_vendor_name_default_matches_constant():
+    assert identity.vendor_name() == identity.DEFAULT_VENDOR_NAME
+    assert identity.VENDOR_NAME == identity.DEFAULT_VENDOR_NAME
+
+
+def test_vendor_name_env_override(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_VENDOR_NAME", "acmecorp/internal-fork")
+    assert identity.vendor_name() == "acmecorp/internal-fork"
+
+
+def test_vendor_name_blank_override_falls_back(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_VENDOR_NAME", "   ")
+    assert identity.vendor_name() == identity.DEFAULT_VENDOR_NAME
+
+
+def test_product_and_information_uri_overrides(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_PRODUCT_NAME", "acme-detections")
+    monkeypatch.setenv("CLOUD_SECURITY_INFORMATION_URI", "https://acme.example/sec")
+    assert identity.product_name() == "acme-detections"
+    assert identity.information_uri() == "https://acme.example/sec"
+
+
+def test_env_int_returns_default_when_unset(monkeypatch):
+    monkeypatch.delenv("WIDGET_THRESHOLD", raising=False)
+    assert env.env_int("WIDGET_THRESHOLD", 7, skill_name="test-skill") == 7
+
+
+def test_env_int_parses_valid(monkeypatch):
+    monkeypatch.setenv("WIDGET_THRESHOLD", "42")
+    assert env.env_int("WIDGET_THRESHOLD", 7, skill_name="test-skill") == 42
+
+
+def test_env_int_warns_on_parse_failure(monkeypatch, capsys):
+    monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+    monkeypatch.setenv("WIDGET_THRESHOLD", "seven")
+    monkeypatch.delenv("CLOUD_SECURITY_STRICT_ENV", raising=False)
+
+    result = env.env_int("WIDGET_THRESHOLD", 7, skill_name="test-skill")
+    assert result == 7
+
+    err = capsys.readouterr().err.strip().splitlines()
+    assert err, "expected stderr telemetry on parse failure"
+    payload = json.loads(err[-1])
+    assert payload["event"] == "env_parse_failed"
+    assert payload["env"] == "WIDGET_THRESHOLD"
+    assert payload["raw"] == "seven"
+    assert payload["default"] == 7
+
+
+def test_env_int_strict_mode_raises(monkeypatch):
+    monkeypatch.setenv("WIDGET_THRESHOLD", "seven")
+    monkeypatch.setenv("CLOUD_SECURITY_STRICT_ENV", "1")
+    try:
+        env.env_int("WIDGET_THRESHOLD", 7, skill_name="test-skill")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError under strict mode")
+
+
+def test_env_float_parses_and_warns(monkeypatch, capsys):
+    monkeypatch.setenv("RATIO", "0.25")
+    assert env.env_float("RATIO", 0.5, skill_name="test-skill") == 0.25
+
+    monkeypatch.setenv("SKILL_LOG_FORMAT", "json")
+    monkeypatch.setenv("RATIO", "half")
+    monkeypatch.delenv("CLOUD_SECURITY_STRICT_ENV", raising=False)
+    assert env.env_float("RATIO", 0.5, skill_name="test-skill") == 0.5
+    payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+    assert payload["event"] == "env_parse_failed"
+
+
+def test_module_constants_resolve_at_import_time():
+    importlib.reload(identity)
+    assert identity.VENDOR_NAME == identity.DEFAULT_VENDOR_NAME
+    assert identity.PRODUCT_NAME == identity.DEFAULT_PRODUCT_NAME


### PR DESCRIPTION
## Summary

Two shared modules + a 47-file sweep, addressing two findings from the 2026-04-28 code-level audit.

### `skills/_shared/identity.py` (#399)
Centralizes `VENDOR_NAME`, `PRODUCT_NAME`, `INFORMATION_URI` with env overrides:

| Env var | Replaces |
|---|---|
| `CLOUD_SECURITY_VENDOR_NAME` | hardcoded \"msaad00/cloud-ai-security-skills\" duplicated across 47 src files |
| `CLOUD_SECURITY_PRODUCT_NAME` | hardcoded \"cloud-ai-security-skills\" |
| `CLOUD_SECURITY_INFORMATION_URI` | hardcoded SARIF `informationUri` GitHub URL |

A fork or org rename now needs to set one env var, not patch every detection / ingestion entrypoint.

### `skills/_shared/env.py` (#401)
`env_int` / `env_float` / `env_ms` fall back to the default *and* emit a structured `env_parse_failed` warning via `runtime_telemetry`. Set `CLOUD_SECURITY_STRICT_ENV=1` to make parse failures fatal for fail-closed deployments. Migrates the three detect skills that hand-rolled their own `_env_int` (`detect-okta-mfa-fatigue`, `detect-credential-stuffing-okta`, `detect-lateral-movement`) while preserving the positive-clamp behavior they relied on.

### Sweep
- 47 src files: `detect-*`, `ingest-*`, `discover-*`, `convert-*` no longer carry the hardcoded vendor literal.
- 17 self-contained ingest/discover/view files gained the standard `REPO_ROOT` `sys.path` injection so they can import from `skills._shared`.
- `ruff --fix` reorganized import blocks where the sweep added new lines.

### Tests
`tests/integration/test_shared_identity_env.py` covers env override precedence, blank-override fallback, parse-failure telemetry payload shape, strict-mode behavior, and module-level constant resolution.

### Note on #405
The audit flagged Azure ingest `except: pass` blocks. On re-review, the 3 azure cases are benign defensive lookups (`parts.index(\"SUBSCRIPTIONS\")` returning `\"\"` when the segment is absent). The only clearly-wrong broad catch is in `discover-environment` and is tracked separately. #405 will be updated with the calibrated finding.

## Test plan

- [x] All 58 per-skill suites pass under per-directory pytest invocation
- [x] `tests/integration/test_shared_identity_env.py` — 10/10 pass
- [x] `ruff check skills/ tests/ mcp-server/ scripts/` — clean
- [x] `bash scripts/run_mypy.sh` — clean
- [x] `validate_skill_contract.py`, `validate_skill_integrity.py`, `validate_dependency_consistency.py`, `validate_safe_skill_bar.py`, `validate_golden_ocsf.py` — all pass
- [x] `grep -rn msaad00 skills/*/*/src/` — empty

Closes #399, #401.