### PR TITLE
ci: tighten coverage floors and add behavioral skill validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
+          packages: >-
+            boto3 defusedxml httpx
+            google-cloud-compute google-cloud-iam google-cloud-resource-manager google-cloud-storage google-api-python-client
+            azure-identity azure-mgmt-network azure-mgmt-resource azure-mgmt-storage
+            clickhouse-connect databricks-sql-connector snowflake-connector-python
       - run: python scripts/validate_skill_contract.py
       - run: python scripts/validate_skill_integrity.py
+      - run: python scripts/validate_skill_runtime.py
       - run: python scripts/validate_dependency_consistency.py
       - run: python scripts/validate_framework_coverage.py
       - run: python scripts/validate_ocsf_metadata.py

--- a/scripts/validate_skill_runtime.py
+++ b/scripts/validate_skill_runtime.py
@@ -1,0 +1,107 @@
+"""Behavioral validator: import every skill entrypoint and check `main()`.
+
+The structural validators (`validate_skill_contract.py`, `validate_skill_integrity.py`,
+etc.) only check files exist and frontmatter parses. They do not catch:
+
+  - syntax errors in entrypoints that no test imports
+  - `ImportError` for a skill module that depends on a freshly-renamed shared util
+  - missing `main()` function that the SKILL.md docs claim exists
+  - top-level side effects that crash on import (rare but they happen)
+
+This validator imports every supported skill entrypoint via `importlib.util`
+with a unique module name (so duplicate `detect`/`ingest` filenames don't
+collide), then verifies the conventional `main()` callable is present.
+
+Run via CI on every PR. Fails closed if anything can't import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+ENTRYPOINT_NAMES = (
+    "ingest.py",
+    "detect.py",
+    "convert.py",
+    "checks.py",
+    "discover.py",
+    "handler.py",
+    "sink.py",
+)
+
+
+def _iter_skill_entrypoints() -> list[Path]:
+    """Yield every `skills/<layer>/<name>/src/<entrypoint>.py` that exists."""
+    paths: list[Path] = []
+    for skill_dir in sorted(SKILLS_DIR.glob("*/*")):
+        src = skill_dir / "src"
+        if not src.is_dir():
+            continue
+        for name in ENTRYPOINT_NAMES:
+            path = src / name
+            if path.is_file():
+                paths.append(path)
+    return paths
+
+
+def _module_name_for(path: Path) -> str:
+    """Generate a unique module name from the skill path so multiple skills
+    can each have their own `detect.py` without colliding in `sys.modules`."""
+    rel = path.relative_to(REPO_ROOT).with_suffix("")
+    return "cloud_security_runtime__" + "_".join(rel.parts)
+
+
+def _import_entrypoint(path: Path) -> tuple[bool, str | None]:
+    name = _module_name_for(path)
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        return False, "could not build importlib spec"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # noqa: BLE001 - any import-time failure is a finding
+        return False, f"{type(exc).__name__}: {exc}"
+
+    if not hasattr(module, "main"):
+        return False, "entrypoint exposes no `main()` function"
+    if not callable(module.main):
+        return False, "`main` exists but is not callable"
+    return True, None
+
+
+def main() -> int:
+    entrypoints = _iter_skill_entrypoints()
+    if not entrypoints:
+        print("Skill runtime validation failed: no entrypoints discovered", file=sys.stderr)
+        return 1
+
+    # Make `from skills._shared.* import ...` resolvable for skills that rely
+    # on it. Mirrors the per-skill `sys.path.insert(REPO_ROOT, ...)` block.
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+
+    failures: list[tuple[Path, str]] = []
+    for path in entrypoints:
+        ok, error = _import_entrypoint(path)
+        if not ok:
+            failures.append((path, error or "unknown"))
+
+    if failures:
+        print("Skill runtime validation failed:", file=sys.stderr)
+        for path, error in failures:
+            rel = path.relative_to(REPO_ROOT)
+            print(f"  - {rel}: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Skill runtime validation passed: imported {len(entrypoints)} entrypoints.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -16,10 +16,19 @@ except ModuleNotFoundError:  # pragma: no cover - exercised when dev deps not in
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_XML = ROOT / "coverage.xml"
-OVERALL_FLOOR = 70.0
+OVERALL_FLOOR = 80.0
+# Per-layer floors set ~5pp below observed coverage on 2026-04-28 so honest
+# refactors have headroom without leaking real regressions. Bump these as
+# coverage climbs; never lower without an issue documenting why.
 LAYER_FLOORS = {
+    "_shared": 90.0,
     "detection": 80.0,
-    "evaluation": 60.0,
+    "discovery": 80.0,
+    "evaluation": 80.0,
+    "ingestion": 80.0,
+    "output": 80.0,
+    "remediation": 70.0,
+    "view": 80.0,
 }
 
 

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -563,71 +563,78 @@ class TestAssumeRoleBoundaryGuardrail:
         assert OCSF_METADATA.main() == 0
 
     def test_test_coverage_validator_passes(self, tmp_path: Path):
+        # Synthetic report: every layer in LAYER_FLOORS gets a class whose hit
+        # rate sits comfortably above its floor (90% for _shared, 70% for
+        # remediation, 80% for the rest). If a future PR adds a new layer
+        # floor, add a corresponding row here so the test keeps reflecting
+        # what a clean run looks like.
         report = tmp_path / "coverage.xml"
         report.write_text(
-            """<?xml version="1.0" ?>
-<coverage line-rate="0.82">
-  <packages>
-    <package name="skills">
-      <classes>
-        <class filename="skills/detection/example/src/detect.py">
-          <lines>
-            <line number="1" hits="1" />
-            <line number="2" hits="1" />
-            <line number="3" hits="1" />
-            <line number="4" hits="1" />
-            <line number="5" hits="0" />
-          </lines>
-        </class>
-        <class filename="skills/evaluation/example/src/checks.py">
-          <lines>
-            <line number="1" hits="1" />
-            <line number="2" hits="1" />
-            <line number="3" hits="1" />
-            <line number="4" hits="0" />
-            <line number="5" hits="0" />
-          </lines>
-        </class>
-      </classes>
-    </package>
-  </packages>
-</coverage>
-""",
+            self._synthetic_coverage_xml(
+                layers={
+                    "_shared": (95, 100),
+                    "detection": (85, 100),
+                    "discovery": (85, 100),
+                    "evaluation": (85, 100),
+                    "ingestion": (85, 100),
+                    "output": (85, 100),
+                    "remediation": (75, 100),
+                    "view": (85, 100),
+                },
+                overall_line_rate=0.86,
+            ),
             encoding="utf-8",
         )
         assert TEST_COVERAGE.main([str(report)]) == 0
 
+    @staticmethod
+    def _synthetic_coverage_xml(
+        *, layers: dict[str, tuple[int, int]], overall_line_rate: float
+    ) -> str:
+        """Build a minimal coverage.xml the validator can parse, with one
+        class per layer whose hit/total ratio matches the provided tuple."""
+        class_blocks: list[str] = []
+        for layer, (hit, total) in layers.items():
+            lines = "\n            ".join(
+                f'<line number="{i + 1}" hits="{1 if i < hit else 0}" />'
+                for i in range(total)
+            )
+            class_blocks.append(
+                f'        <class filename="skills/{layer}/example/src/example.py">\n'
+                f'          <lines>\n            {lines}\n          </lines>\n'
+                f'        </class>'
+            )
+        joined = "\n".join(class_blocks)
+        return (
+            f'<?xml version="1.0" ?>\n'
+            f'<coverage line-rate="{overall_line_rate}">\n'
+            f'  <packages>\n'
+            f'    <package name="skills">\n'
+            f'      <classes>\n{joined}\n      </classes>\n'
+            f'    </package>\n'
+            f'  </packages>\n'
+            f'</coverage>\n'
+        )
+
     def test_test_coverage_validator_fails_low_detection_floor(self, tmp_path: Path):
+        # Same shape as the passing fixture but `detection` drops to 60% —
+        # below its 80% floor. The other layers still pass so we isolate the
+        # failure mode to the floor we're testing.
         report = tmp_path / "coverage-low.xml"
         report.write_text(
-            """<?xml version="1.0" ?>
-<coverage line-rate="0.82">
-  <packages>
-    <package name="skills">
-      <classes>
-        <class filename="skills/detection/example/src/detect.py">
-          <lines>
-            <line number="1" hits="1" />
-            <line number="2" hits="1" />
-            <line number="3" hits="1" />
-            <line number="4" hits="0" />
-            <line number="5" hits="0" />
-          </lines>
-        </class>
-        <class filename="skills/evaluation/example/src/checks.py">
-          <lines>
-            <line number="1" hits="1" />
-            <line number="2" hits="1" />
-            <line number="3" hits="1" />
-            <line number="4" hits="0" />
-            <line number="5" hits="0" />
-          </lines>
-        </class>
-      </classes>
-    </package>
-  </packages>
-</coverage>
-""",
+            self._synthetic_coverage_xml(
+                layers={
+                    "_shared": (95, 100),
+                    "detection": (60, 100),
+                    "discovery": (85, 100),
+                    "evaluation": (85, 100),
+                    "ingestion": (85, 100),
+                    "output": (85, 100),
+                    "remediation": (75, 100),
+                    "view": (85, 100),
+                },
+                overall_line_rate=0.85,
+            ),
             encoding="utf-8",
         )
         assert TEST_COVERAGE.main([str(report)]) == 1


### PR DESCRIPTION
## Summary

Two CI hardening changes from the 2026-04-28 code-level audit.

### #396 — coverage floors
- Raise overall floor 70 → 80% (current: 86.15%).
- Add per-layer floors for the six layers that previously had no enforcement (`_shared`, `discovery`, `ingestion`, `output`, `remediation`, `view`).
- Raise `evaluation` floor 60 → 80% to match the layer's actual 91% coverage.
- Each new floor is set ~5pp below observed coverage on 2026-04-28 so honest refactors have headroom but real regressions trip the gate.

| Layer | Observed | New floor |
|---|---|---|
| `_shared` | 94.77% | 90% |
| `detection` | 87.43% | 80% |
| `discovery` | 88.05% | 80% |
| `evaluation` | 91.74% | 80% |
| `ingestion` | 88.69% | 80% |
| `output` | 91.26% | 80% |
| `remediation` | 79.42% | 70% |
| `view` | 91.61% | 80% |

### #397 — behavioral validator (`scripts/validate_skill_runtime.py`)
The existing CI validators (`validate_skill_contract.py`, `validate_skill_integrity.py`, `validate_ocsf_metadata.py`, etc.) are structural — they check files exist, frontmatter parses, and metadata fields are present. They do not catch:
- Syntax errors in entrypoints that no test imports.
- `ImportError` for a skill module that depends on a freshly-renamed shared util.
- Missing `main()` function that SKILL.md docs claim exists.
- Top-level side effects that crash on import.

The new validator imports every supported skill entrypoint via `importlib.util` with a unique module name (so duplicate `detect`/`ingest` filenames don't collide in `sys.modules`), then verifies the conventional `main()` callable is present. Fails closed.

The `skill-contract` CI job now installs the third-party deps (boto3, google-*, azure-*, snowflake/clickhouse/databricks) the new validator needs to import every skill cleanly.

## Test plan

- [x] `uv run python scripts/validate_test_coverage.py` against fresh `coverage.xml` — 8/8 layer floors pass
- [x] `uv run python scripts/validate_skill_runtime.py` — 73/73 entrypoints import cleanly
- [x] CI matrix expected to remain green; coverage gate now binding

Closes #396, #397.