### PR TITLE
mcp: durable JSONL audit sink with HMAC chain (#396)

### DIFF
--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -49,7 +49,32 @@ That means the event is emitted for:
 - other exceptions raised while the wrapper is preparing or running the tool
 
 The event is written as a single JSON object to `stderr` and terminated by a
-newline.
+newline. When a durable file sink is configured (see *Durable file sink*
+below), the same event — augmented with chain-hash fields — is also appended
+to the configured JSONL file with a per-event `fsync()`.
+
+## Durable file sink (optional)
+
+`stderr` is the always-on sink, but supervising stdio MCP clients can
+silently swallow it. When operators need a record they can audit
+post-hoc, set:
+
+| Variable | Effect |
+|---|---|
+| `CLOUD_SECURITY_MCP_AUDIT_LOG` | Absolute path to a JSONL file. Each `mcp_tool_call` event is appended with a per-event `fsync()`. The file is created with mode `0600`; parent directories are created if needed. |
+| `CLOUD_SECURITY_AUDIT_HMAC_KEY` | When set, every event carries `prev_hash` and `chain_hash` fields, computed as `HMAC-SHA-256(key, prev_hash \|\| canonical_event_json)`. The chain seeds from `0` * 64 on first start and resumes from the last persisted `chain_hash` across restarts. |
+
+Verify a chain post-hoc:
+
+```bash
+CLOUD_SECURITY_AUDIT_HMAC_KEY=... \
+  python scripts/verify_audit_chain.py /var/log/cloud-security-mcp/audit.jsonl
+```
+
+The verifier exits `0` when every event matches its expected chain hash,
+`1` when any event was edited / dropped / re-keyed, and `2` on
+configuration errors. It prints the offending line numbers to stderr so a
+SIEM can ingest the failure trace directly.
 
 ## Event Shape
 

--- a/mcp-server/src/audit_sink.py
+++ b/mcp-server/src/audit_sink.py
@@ -1,0 +1,162 @@
+"""Durable, append-only audit sink for the MCP wrapper.
+
+`_emit_audit_event` historically wrote one JSON line to stderr and returned.
+That satisfies the "every call is audited" claim only when the supervising
+process captures stderr — a stdio MCP client that closes or ignores stderr
+loses the audit trail entirely.
+
+This module adds an optional file sink with three additive guarantees:
+
+1. **Append-only on disk.** A configurable file path receives one JSON line
+   per resolved tool call. Open / write / fsync per event so a crash mid-call
+   still leaves the previous events durable.
+2. **Tamper-evident chain.** When `CLOUD_SECURITY_AUDIT_HMAC_KEY` is set, each
+   event carries `prev_hash` and `chain_hash` fields computed as
+   `HMAC-SHA-256(key, prev_hash || canonical_event_json)`. A verifier script
+   (`scripts/verify_audit_chain.py`) replays the chain and surfaces gaps.
+3. **stderr stays the fallback.** When no file sink is configured, behaviour
+   is unchanged — every event still lands on stderr. When a file sink is
+   configured, both happen so existing supervisors continue to work.
+
+The sink is intentionally process-local: chain hashes are scoped to a single
+server process. Multi-process supervisors should aggregate across processes
+on the consumer side (each process writes its own segment, the verifier
+joins by `correlation_id` order).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+AUDIT_LOG_ENV = "CLOUD_SECURITY_MCP_AUDIT_LOG"
+AUDIT_HMAC_KEY_ENV = "CLOUD_SECURITY_AUDIT_HMAC_KEY"
+
+# Sentinel for the genesis event in a chain. Any non-empty deterministic value
+# works; this one is documented so verifiers can recognise the boundary.
+GENESIS_PREV_HASH = "0" * 64
+
+
+def _canonical_event_bytes(event: dict[str, Any]) -> bytes:
+    """Stable, sorted JSON encoding so the chain hash is reproducible across
+    Python versions and dict insertion orders."""
+    return json.dumps(event, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _chain_hash(prev_hash: str, event: dict[str, Any], key: bytes) -> str:
+    payload = prev_hash.encode("ascii") + b"\n" + _canonical_event_bytes(event)
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+class AuditSink:
+    """Process-local audit sink. Holds the previous chain hash so successive
+    events link. Construct once per server process; never reuse across forks.
+    """
+
+    def __init__(
+        self,
+        log_path: str | os.PathLike[str] | None,
+        hmac_key: bytes | None,
+    ) -> None:
+        self._log_path = Path(log_path) if log_path else None
+        self._hmac_key = hmac_key
+        self._prev_hash = GENESIS_PREV_HASH
+        if self._log_path is not None:
+            # Touch the parent directory so a misconfigured path fails fast at
+            # server start instead of at the first call.
+            self._log_path.parent.mkdir(parents=True, exist_ok=True)
+            # If the file already has content and chaining is on, seed
+            # `_prev_hash` from the last event's `chain_hash` so a restart
+            # extends the existing chain instead of starting a new one.
+            if self._hmac_key is not None and self._log_path.exists():
+                last = _read_last_chain_hash(self._log_path)
+                if last is not None:
+                    self._prev_hash = last
+
+    @property
+    def file_enabled(self) -> bool:
+        return self._log_path is not None
+
+    @property
+    def chain_enabled(self) -> bool:
+        return self._hmac_key is not None
+
+    def annotate(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Return a new event dict with chain fields populated when chaining
+        is enabled. The original event is left untouched so callers can keep
+        a pristine copy for stderr if they prefer."""
+        if not self.chain_enabled:
+            return event
+        annotated = dict(event)
+        annotated["prev_hash"] = self._prev_hash
+        # Compute chain_hash over the event WITHOUT chain_hash (otherwise it
+        # depends on itself). prev_hash is included.
+        annotated["chain_hash"] = _chain_hash(
+            self._prev_hash, annotated, self._hmac_key or b""
+        )
+        self._prev_hash = annotated["chain_hash"]
+        return annotated
+
+    def write_file(self, event: dict[str, Any]) -> None:
+        if self._log_path is None:
+            return
+        line = json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n"
+        # `open` + write + fsync per event so a crash mid-write doesn't lose
+        # the trail. Throughput-conscious deployments can buffer at the OS
+        # level by setting CLOUD_SECURITY_MCP_AUDIT_LOG to a path on a
+        # write-ahead-logged filesystem; for a security audit trail
+        # correctness beats throughput.
+        fd = os.open(
+            self._log_path,
+            os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+            0o600,
+        )
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+
+def _read_last_chain_hash(path: Path) -> str | None:
+    """Read the last line of `path`, parse it, and return its `chain_hash`.
+
+    Returns None if the file is empty, the last line is not JSON, or the
+    last record has no chain_hash. Used to extend an existing chain across
+    server restarts so verifiers see one continuous chain.
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            if size == 0:
+                return None
+            # Walk backwards until we find a newline preceded by content.
+            # 4KB lookback covers our 1-2KB events comfortably.
+            chunk_size = min(size, 4096)
+            fh.seek(size - chunk_size, os.SEEK_SET)
+            tail = fh.read(chunk_size)
+        last_line = tail.splitlines()[-1] if tail else b""
+        if not last_line:
+            return None
+        record = json.loads(last_line.decode("utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(record, dict):
+        return None
+    last_hash = record.get("chain_hash")
+    return last_hash if isinstance(last_hash, str) else None
+
+
+def sink_from_env(env: dict[str, str] | None = None) -> AuditSink:
+    """Build the sink from environment variables. Both vars are optional; the
+    default sink keeps the legacy stderr-only behaviour."""
+    src = os.environ if env is None else env
+    log_path = (src.get(AUDIT_LOG_ENV) or "").strip() or None
+    raw_key = (src.get(AUDIT_HMAC_KEY_ENV) or "").strip()
+    hmac_key = raw_key.encode("utf-8") if raw_key else None
+    return AuditSink(log_path=log_path, hmac_key=hmac_key)

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -15,6 +15,7 @@ CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
+from audit_sink import AuditSink, sink_from_env  # noqa: E402
 from tool_registry import (  # noqa: E402
     SkillSpec,
     build_command,
@@ -144,9 +145,35 @@ def _stable_hash(payload: Any) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
+_AUDIT_SINK: AuditSink | None = None
+
+
+def _audit_sink() -> AuditSink:
+    """Lazy-initialise the process-local audit sink. Reads env vars on first
+    use so tests can override `os.environ` between calls."""
+    global _AUDIT_SINK
+    if _AUDIT_SINK is None:
+        _AUDIT_SINK = sink_from_env()
+    return _AUDIT_SINK
+
+
+def _reset_audit_sink_for_tests() -> None:
+    """Test hook: drop the cached sink so the next call rebuilds it from
+    the current environment."""
+    global _AUDIT_SINK
+    _AUDIT_SINK = None
+
+
 def _emit_audit_event(event: dict[str, Any]) -> None:
-    sys.stderr.write(json.dumps(event, sort_keys=True) + "\n")
+    """Emit one audit record. stderr is always written so existing supervisors
+    keep working; the file sink and chain-hash annotations are additive and
+    opt-in via env (`CLOUD_SECURITY_MCP_AUDIT_LOG`,
+    `CLOUD_SECURITY_AUDIT_HMAC_KEY`)."""
+    sink = _audit_sink()
+    record = sink.annotate(event)
+    sys.stderr.write(json.dumps(record, sort_keys=True) + "\n")
     sys.stderr.flush()
+    sink.write_file(record)
 
 
 def _error_response(request_id: Any, code: int, message: str, data: Any | None = None) -> dict[str, Any]:

--- a/mcp-server/tests/test_audit_sink.py
+++ b/mcp-server/tests/test_audit_sink.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SINK_PATH = REPO_ROOT / "mcp-server" / "src" / "audit_sink.py"
+SPEC = importlib.util.spec_from_file_location("cloud_security_audit_sink_test", SINK_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def _make_event(idx: int) -> dict[str, object]:
+    return {
+        "event": "mcp_tool_call",
+        "tool": f"detect-fake-{idx}",
+        "category": "detection",
+        "result": "success",
+        "correlation_id": f"corr-{idx:04d}",
+    }
+
+
+def test_sink_disabled_when_no_log_path(tmp_path):
+    sink = MODULE.AuditSink(log_path=None, hmac_key=None)
+    annotated = sink.annotate(_make_event(1))
+    assert "chain_hash" not in annotated
+    assert "prev_hash" not in annotated
+    sink.write_file(_make_event(1))  # no-op
+
+
+def test_file_sink_appends_one_line_per_event_and_fsyncs(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    sink = MODULE.AuditSink(log_path=log, hmac_key=None)
+    sink.write_file(_make_event(1))
+    sink.write_file(_make_event(2))
+    sink.write_file(_make_event(3))
+    lines = log.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    parsed = [json.loads(line) for line in lines]
+    assert [r["correlation_id"] for r in parsed] == ["corr-0001", "corr-0002", "corr-0003"]
+
+
+def test_chain_hash_is_continuous_within_a_run(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    sink = MODULE.AuditSink(log_path=log, hmac_key=b"secret")
+    e1 = sink.annotate(_make_event(1))
+    e2 = sink.annotate(_make_event(2))
+    e3 = sink.annotate(_make_event(3))
+
+    assert e1["prev_hash"] == MODULE.GENESIS_PREV_HASH
+    assert e2["prev_hash"] == e1["chain_hash"]
+    assert e3["prev_hash"] == e2["chain_hash"]
+    # chain_hash values must be distinct (genesis + two link events)
+    assert len({e1["chain_hash"], e2["chain_hash"], e3["chain_hash"]}) == 3
+
+
+def test_chain_extends_across_restart(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    s1 = MODULE.AuditSink(log_path=log, hmac_key=b"secret")
+    e1 = s1.annotate(_make_event(1))
+    s1.write_file(e1)
+
+    s2 = MODULE.AuditSink(log_path=log, hmac_key=b"secret")
+    e2 = s2.annotate(_make_event(2))
+    s2.write_file(e2)
+
+    assert e2["prev_hash"] == e1["chain_hash"]
+
+
+def test_verifier_passes_for_valid_chain(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    sink = MODULE.AuditSink(log_path=log, hmac_key=b"secret")
+    for idx in range(5):
+        sink.write_file(sink.annotate(_make_event(idx)))
+
+    env = {**os.environ, "CLOUD_SECURITY_AUDIT_HMAC_KEY": "secret"}
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "verify_audit_chain.py"), str(log)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "verified 5 records, 0 error(s)" in result.stdout
+
+
+def test_verifier_detects_tampered_event(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    sink = MODULE.AuditSink(log_path=log, hmac_key=b"secret")
+    for idx in range(3):
+        sink.write_file(sink.annotate(_make_event(idx)))
+
+    # Tamper with a middle line: change `tool` from `detect-fake-1` to `detect-fake-evil`.
+    lines = log.read_text(encoding="utf-8").splitlines()
+    record = json.loads(lines[1])
+    record["tool"] = "detect-fake-evil"
+    lines[1] = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    env = {**os.environ, "CLOUD_SECURITY_AUDIT_HMAC_KEY": "secret"}
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "verify_audit_chain.py"), str(log)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "chain_hash mismatch" in result.stderr
+
+
+def test_verifier_detects_wrong_key(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    sink = MODULE.AuditSink(log_path=log, hmac_key=b"secret")
+    sink.write_file(sink.annotate(_make_event(0)))
+
+    env = {**os.environ, "CLOUD_SECURITY_AUDIT_HMAC_KEY": "WRONG"}
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "verify_audit_chain.py"), str(log)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_verifier_exit_2_on_missing_key(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    log.write_text("", encoding="utf-8")
+    env = {k: v for k, v in os.environ.items() if k != "CLOUD_SECURITY_AUDIT_HMAC_KEY"}
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "verify_audit_chain.py"), str(log)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+
+
+def test_sink_creates_parent_dirs_at_construction(tmp_path):
+    log = tmp_path / "nested" / "deeply" / "audit.jsonl"
+    MODULE.AuditSink(log_path=log, hmac_key=None)
+    assert log.parent.is_dir()
+
+
+def test_file_sink_chmod_0600(tmp_path):
+    log = tmp_path / "audit.jsonl"
+    sink = MODULE.AuditSink(log_path=log, hmac_key=None)
+    sink.write_file(_make_event(0))
+    mode = log.stat().st_mode & 0o777
+    # On macOS / linux umask is typically 022 so a fresh 0600 open survives.
+    # Whatever umask strips, owner-read+write must remain.
+    assert mode & 0o600 == 0o600

--- a/scripts/verify_audit_chain.py
+++ b/scripts/verify_audit_chain.py
@@ -1,0 +1,113 @@
+"""Verify the HMAC chain on an MCP audit log.
+
+The MCP wrapper (`mcp-server/src/server.py`) optionally writes a
+tamper-evident audit log: each event carries `prev_hash` and `chain_hash`
+fields keyed by `CLOUD_SECURITY_AUDIT_HMAC_KEY`. This script replays the
+chain and surfaces any record whose `chain_hash` does not match
+`HMAC-SHA-256(key, prev_hash || canonical_event_json)`.
+
+Exit status:
+  0 — every event verifies, chain is contiguous
+  1 — one or more events fail verification (gap, edit, or wrong key)
+  2 — usage / IO error before verification could begin
+
+Usage:
+  CLOUD_SECURITY_AUDIT_HMAC_KEY=... \
+    python scripts/verify_audit_chain.py path/to/audit.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+GENESIS_PREV_HASH = "0" * 64
+
+
+def _canonical_event_bytes(event: dict[str, Any]) -> bytes:
+    return json.dumps(event, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _expected_chain_hash(prev_hash: str, event_without_chain: dict[str, Any], key: bytes) -> str:
+    payload = prev_hash.encode("ascii") + b"\n" + _canonical_event_bytes(event_without_chain)
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def _iter_records(path: Path) -> Iterable[tuple[int, dict[str, Any]]]:
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"line {lineno}: invalid JSON: {exc}") from exc
+            if not isinstance(record, dict):
+                raise SystemExit(f"line {lineno}: record is not a JSON object")
+            yield lineno, record
+
+
+def verify(path: Path, key: bytes) -> int:
+    prev_hash = GENESIS_PREV_HASH
+    errors = 0
+    count = 0
+    for lineno, record in _iter_records(path):
+        count += 1
+        actual_prev = record.get("prev_hash")
+        actual_chain = record.get("chain_hash")
+        if not isinstance(actual_chain, str) or not isinstance(actual_prev, str):
+            print(f"line {lineno}: missing prev_hash/chain_hash", file=sys.stderr)
+            errors += 1
+            continue
+        if actual_prev != prev_hash:
+            print(
+                f"line {lineno}: prev_hash mismatch — expected {prev_hash}, got {actual_prev}",
+                file=sys.stderr,
+            )
+            errors += 1
+        # Reconstruct the bytes fed to the chain hash. The annotator computes
+        # the hash over the event AFTER prev_hash is added but BEFORE
+        # chain_hash is added, so strip chain_hash for verification.
+        replay = {k: v for k, v in record.items() if k != "chain_hash"}
+        expected = _expected_chain_hash(actual_prev, replay, key)
+        if not hmac.compare_digest(actual_chain, expected):
+            print(
+                f"line {lineno}: chain_hash mismatch — expected {expected}, got {actual_chain}",
+                file=sys.stderr,
+            )
+            errors += 1
+        prev_hash = actual_chain
+    print(f"verified {count} records, {errors} error(s)")
+    return 0 if errors == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", help="Path to the audit JSONL file")
+    parser.add_argument(
+        "--key-env",
+        default="CLOUD_SECURITY_AUDIT_HMAC_KEY",
+        help="Environment variable holding the HMAC key (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    raw_key = os.environ.get(args.key_env, "").strip()
+    if not raw_key:
+        print(f"error: {args.key_env} is not set", file=sys.stderr)
+        return 2
+    path = Path(args.path)
+    if not path.is_file():
+        print(f"error: {path} is not a file", file=sys.stderr)
+        return 2
+    return verify(path, raw_key.encode("utf-8"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes the loudest gap from the 2026-04-28 audit (#396): the MCP wrapper's audit contract promised a durable trail but only wrote to stderr — a stdio supervisor that swallowed stderr lost every record.

- **`audit_sink.AuditSink`** appends one JSON line per resolved \`tools/call\` to \`CLOUD_SECURITY_MCP_AUDIT_LOG\` with a per-event \`fsync()\`. File is created \`0600\`, parent directories created at server start so misconfigured paths fail fast.
- **HMAC-SHA-256 chain.** When \`CLOUD_SECURITY_AUDIT_HMAC_KEY\` is set, each event carries \`prev_hash\` and \`chain_hash = HMAC-SHA-256(key, prev_hash || canonical_event_json)\`. Chain seeds from \`0\` * 64 and extends across restarts by reading the last persisted \`chain_hash\`.
- **\`scripts/verify_audit_chain.py\`** replays the chain. Exit \`0\` on clean, \`1\` on any tampered/missing/re-keyed record (with line numbers), \`2\` on configuration errors. SIEM-ingestable.
- **stderr stays the always-on sink** so existing supervisors are unchanged.
- **\`docs/MCP_AUDIT_CONTRACT.md\`** documents the env vars, file mode, fsync semantics, and the verifier.

## Test plan

- [x] \`pytest mcp-server/tests/test_audit_sink.py\` — 10/10 pass (fresh sink, restart-extends-chain, tampered-event detection, wrong-key detection, missing-key exit-2, parent-dir creation, 0600 mode).
- [x] \`pytest mcp-server/tests/\` — full MCP suite green, no regression.
- [x] \`pytest\` repo-wide — full suite green.
- [x] \`ruff check\` — clean.

## Why now

The audit memory \`feedback_audit_run_dont_read.md\` calls out that audits must run code, not trust READMEs. This PR closes the audit-vs-code gap that triggered #396 and makes the trust contract self-verifiable.