### PR TITLE
feat(iam-departures): top-level handler.py shims so MCP sees all 76 skills

### DIFF
--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -66,7 +66,12 @@ class TestMcpServer:
             assert "detect-google-workspace-suspicious-login" in names
             assert "model-serving-security" in names
             assert "remediate-mcp-tool-quarantine" in names
-            assert "iam-departures-aws" not in names
+            # iam-departures-{aws,azure-entra,gcp} are exposed via top-level
+            # src/handler.py shims as of #411. --apply still refuses on
+            # this surface; the destructive path is the deployed runner.
+            assert "iam-departures-aws" in names
+            assert "iam-departures-azure-entra" in names
+            assert "iam-departures-gcp" in names
         finally:
             proc.terminate()
             proc.wait(timeout=5)

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -50,10 +50,17 @@ class TestDiscovery:
             "discover-cloud-control-evidence",
         }
 
-    def test_marks_remediation_skill_without_cli_entrypoint_as_unsupported(self):
+    def test_iam_departures_aws_resolves_top_level_handler_shim(self):
+        """Lock-in for #411: iam-departures-aws ships a top-level
+        src/handler.py shim that re-exports the parser CLI main(). All
+        76 SKILL.md files now resolve to a callable entrypoint."""
         skills = {skill.name: skill for skill in discover_skills(REPO_ROOT)}
-        assert skills["iam-departures-aws"].supported is False
-        assert skills["iam-departures-aws"].capability == "write-remediation"
+        skill = skills["iam-departures-aws"]
+        assert skill.supported is True
+        assert skill.capability == "write-remediation"
+        assert skill.entrypoint is not None
+        assert skill.entrypoint.name == "handler.py"
+        assert skill.entrypoint.parent.name == "src"
 
     def test_supports_standalone_handler_based_remediation_skill(self):
         skills = {skill.name: skill for skill in discover_skills(REPO_ROOT)}
@@ -83,7 +90,14 @@ class TestDiscovery:
         assert "discover-control-evidence" in tools
         assert "discover-cloud-control-evidence" in tools
         assert "remediate-mcp-tool-quarantine" in tools
-        assert "iam-departures-aws" not in tools
+        # iam-departures-{aws,azure-entra,gcp} are MCP-callable as of #411
+        # via top-level src/handler.py shims that delegate to the parser
+        # CLI main(). --apply remains refused at the parser boundary; the
+        # destructive runner pipeline is the only execution surface that
+        # mutates IAM state.
+        assert "iam-departures-aws" in tools
+        assert "iam-departures-azure-entra" in tools
+        assert "iam-departures-gcp" in tools
 
 
 class TestToolDefinition:

--- a/skills/remediation/iam-departures-aws/SKILL.md
+++ b/skills/remediation/iam-departures-aws/SKILL.md
@@ -16,7 +16,7 @@ description: >-
   the audit table by hand. Do NOT use for access provisioning.
 license: Apache-2.0
 approval_model: human_required
-execution_modes: jit, persistent
+execution_modes: jit, ci, mcp, persistent
 side_effects: writes-identity, writes-storage, writes-database, writes-audit
 input_formats: raw, canonical
 output_formats: native

--- a/skills/remediation/iam-departures-aws/src/handler.py
+++ b/skills/remediation/iam-departures-aws/src/handler.py
@@ -14,18 +14,27 @@ silently dropped to 73 callable through MCP.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
-# The parser sub-module owns the actual CLI logic. We append its directory
-# to `sys.path` rather than restructure the package: the Step Function
-# deployment already imports `lambda_parser.handler` by that path, and we
-# do not want to break that.
-_PARSER_DIR = Path(__file__).resolve().parent / "lambda_parser"
-if str(_PARSER_DIR) not in sys.path:
-    sys.path.insert(0, str(_PARSER_DIR))
+# The parser sub-module owns the actual CLI logic. We load it via
+# importlib.util by absolute path rather than restructure the package: the
+# Step Function deployment already imports `lambda_parser.handler` by that
+# path, and we do not want to break that.
+_PARSER_PATH = Path(__file__).resolve().parent / "lambda_parser" / "handler.py"
+_spec = importlib.util.spec_from_file_location(
+    "iam_departures_aws_parser", _PARSER_PATH
+)
+assert _spec and _spec.loader, f"could not load {_PARSER_PATH}"
+_parser_mod = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("iam_departures_aws_parser", _parser_mod)
+_spec.loader.exec_module(_parser_mod)
 
-from handler import main  # noqa: E402  pylint: disable=import-error,wrong-import-position
+
+def main(argv: list[str] | None = None) -> int:
+    return int(_parser_mod.main(argv))
+
 
 __all__ = ["main"]
 

--- a/skills/remediation/iam-departures-aws/src/handler.py
+++ b/skills/remediation/iam-departures-aws/src/handler.py
@@ -1,0 +1,34 @@
+"""Top-level CLI / MCP entrypoint for `iam-departures-aws`.
+
+The skill's destructive path lives in the deployed Step Function pipeline
+(`runners/`). This module re-exports the parser's CLI `main()` so the same
+skill is callable from MCP, the CLI, and CI without code changes — but
+only in plan-only / dry-run mode. `--apply` is refused at the parser
+boundary; deletion happens only inside the deployed runner.
+
+Why this shim: `mcp-server/src/tool_registry.ENTRYPOINT_CANDIDATES` resolves
+the first known filename under `src/`; without this top-level handler, the
+registry does not see the skill, and the README's "76 shipped skills"
+silently dropped to 73 callable through MCP.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The parser sub-module owns the actual CLI logic. We append its directory
+# to `sys.path` rather than restructure the package: the Step Function
+# deployment already imports `lambda_parser.handler` by that path, and we
+# do not want to break that.
+_PARSER_DIR = Path(__file__).resolve().parent / "lambda_parser"
+if str(_PARSER_DIR) not in sys.path:
+    sys.path.insert(0, str(_PARSER_DIR))
+
+from handler import main  # noqa: E402  pylint: disable=import-error,wrong-import-position
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skills/remediation/iam-departures-aws/src/lambda_parser/handler.py
+++ b/skills/remediation/iam-departures-aws/src/lambda_parser/handler.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import re
+import sys
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -211,26 +212,29 @@ def _validate_entry(entry: dict) -> dict:
             entry["iam_username"],
         )
 
-    # Confirm IAM user actually exists in the target account
-    account_id = entry["recipient_account_id"]
-    iam_username = entry["iam_username"]
+    # Confirm IAM user actually exists in the target account.
+    # Skipped on the MCP / CLI plan path — that surface lacks per-account
+    # assumed-role credentials. The deployed runner always runs the check.
+    if os.environ.get("IAM_DEPARTURES_AWS_SKIP_EXISTENCE_CHECK", "").strip() not in {"1", "true", "yes", "on"}:
+        account_id = entry["recipient_account_id"]
+        iam_username = entry["iam_username"]
 
-    try:
-        iam_client = _get_iam_client(account_id)
-        iam_client.get_user(UserName=iam_username)
-    except iam_client.exceptions.NoSuchEntityException:
-        return {
-            "action": "skip",
-            "reason": f"IAM user {iam_username} not found in account {account_id}",
-            "entry": entry,
-        }
-    except Exception as exc:
-        # If we can't verify, don't remediate — fail safe
-        return {
-            "action": "skip",
-            "reason": f"Cannot verify IAM user: {exc}",
-            "entry": entry,
-        }
+        try:
+            iam_client = _get_iam_client(account_id)
+            iam_client.get_user(UserName=iam_username)
+        except iam_client.exceptions.NoSuchEntityException:
+            return {
+                "action": "skip",
+                "reason": f"IAM user {iam_username} not found in account {account_id}",
+                "entry": entry,
+            }
+        except Exception as exc:
+            # If we can't verify, don't remediate — fail safe
+            return {
+                "action": "skip",
+                "reason": f"Cannot verify IAM user: {exc}",
+                "entry": entry,
+            }
 
     # All checks passed — remediate
     entry["validation_timestamp"] = datetime.now(timezone.utc).isoformat()
@@ -272,3 +276,121 @@ def _parse_iso(value: str | None) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
         return None
+
+
+# ── CLI entrypoint ──────────────────────────────────────────────────
+
+
+_SAFE_ENTRY_KEYS = (
+    "email",
+    "recipient_account_id",
+    "iam_username",
+    "terminated_at",
+    "iam_deleted",
+    "remediation_status",
+    "is_rehire",
+    "rehire_date",
+    "iam_last_used_at",
+    "iam_created_at",
+    "validation_timestamp",
+)
+
+
+def _redact_entry(entry: dict) -> dict:
+    return {k: v for k, v in entry.items() if k in _SAFE_ENTRY_KEYS}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI / MCP entrypoint: dry-run the parser against a manifest.
+
+    Mirrors the runner's pure pre-flight checks (required fields, account
+    ID format, grace period, rehire decision tree). The IAM-existence call
+    is bypassed via `IAM_DEPARTURES_AWS_SKIP_EXISTENCE_CHECK` because this
+    surface lacks per-account assumed-role credentials. The Step Function
+    pipeline (deployed under runners/) is the only path that actually
+    deletes IAM users.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "iam-departures-aws parser — dry-run a JSONL manifest of "
+            "departed-employee entries against the runner's pre-flight "
+            "policy checks. Read-only at this layer; --apply has no "
+            "effect because deletion happens only in the deployed runner."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        help="Path to a JSONL manifest. Default: read JSONL entries from stdin.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Refused on this surface — the runner pipeline owns the "
+            "destructive path. Use the deployed Step Function to act."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply:
+        sys.stderr.write(
+            json.dumps(
+                {
+                    "event": "apply_refused",
+                    "reason": (
+                        "iam-departures-aws --apply runs only in the deployed Step Function. "
+                        "The MCP/CLI surface stays plan-only; deploy the runner under "
+                        "runners/aws-s3-sqs-detect/ siblings to act."
+                    ),
+                }
+            )
+            + "\n"
+        )
+        return 2
+
+    os.environ.setdefault("IAM_DEPARTURES_AWS_SKIP_EXISTENCE_CHECK", "1")
+
+    if args.manifest:
+        with open(args.manifest, "r", encoding="utf-8") as fh:
+            entries_iter = list(fh)
+    else:
+        entries_iter = list(sys.stdin)
+
+    actions = 0
+    skips = 0
+    for line in entries_iter:
+        line = line.strip()
+        if not line:
+            continue
+        entry = json.loads(line)
+        result = _validate_entry(entry)
+        out = {
+            "action": result["action"],
+            "reason": result.get("reason", ""),
+            "entry": _redact_entry(result["entry"]),
+        }
+        sys.stdout.write(json.dumps(out, sort_keys=True) + "\n")
+        if result["action"] == "remediate":
+            actions += 1
+        else:
+            skips += 1
+
+    sys.stderr.write(
+        json.dumps(
+            {
+                "event": "plan_summary",
+                "actions": actions,
+                "skips": skips,
+                "dry_run": True,
+            }
+        )
+        + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skills/remediation/iam-departures-aws/src/lambda_worker/clouds/gcp_iam.py
+++ b/skills/remediation/iam-departures-aws/src/lambda_worker/clouds/gcp_iam.py
@@ -202,7 +202,7 @@ def _remove_iam_bindings(principal: str, project_ids: list[str], step: int) -> R
             if modified:
                 from google.cloud import resourcemanager_v3
 
-                request = resourcemanager_v3.SetIamPolicyRequest(
+                request = resourcemanager_v3.SetIamPolicyRequest(  # type: ignore[attr-defined]
                     resource=resource,
                     policy=policy,
                 )

--- a/skills/remediation/iam-departures-aws/src/lambda_worker/clouds/gcp_iam.py
+++ b/skills/remediation/iam-departures-aws/src/lambda_worker/clouds/gcp_iam.py
@@ -202,7 +202,7 @@ def _remove_iam_bindings(principal: str, project_ids: list[str], step: int) -> R
             if modified:
                 from google.cloud import resourcemanager_v3
 
-                request = resourcemanager_v3.SetIamPolicyRequest(  # type: ignore[attr-defined]
+                request = resourcemanager_v3.SetIamPolicyRequest(
                     resource=resource,
                     policy=policy,
                 )

--- a/skills/remediation/iam-departures-aws/tests/test_handler_cli.py
+++ b/skills/remediation/iam-departures-aws/tests/test_handler_cli.py
@@ -1,0 +1,128 @@
+"""End-to-end tests for the new top-level CLI / MCP shim
+(`src/handler.py`) and the underlying parser `main()` entrypoint.
+
+The parser already had unit-level tests for `_validate_entry` (see
+`test_parser_lambda.py`); these tests cover the *boundary* the MCP server
+sees: subprocess invocation, stdin manifest, --apply refusal, and exit
+codes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+HANDLER = SKILL_ROOT / "src" / "handler.py"
+
+
+def _well_outside_grace_iso() -> str:
+    """A timestamp well past the 7-day default grace window."""
+    return (datetime.now(timezone.utc) - timedelta(days=180)).isoformat()
+
+
+def _run(stdin: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HANDLER), *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_dry_run_default_emits_plan_for_actionable_entry():
+    entry = {
+        "email": "alice@example.com",
+        "recipient_account_id": "123456789012",
+        "iam_username": "alice",
+        "terminated_at": _well_outside_grace_iso(),
+    }
+    result = _run(json.dumps(entry) + "\n")
+    assert result.returncode == 0, result.stderr
+
+    plan = json.loads(result.stdout.strip().splitlines()[0])
+    assert plan["action"] == "remediate"
+    assert plan["entry"]["iam_username"] == "alice"
+
+    summary = json.loads(result.stderr.strip().splitlines()[-1])
+    assert summary == {
+        "event": "plan_summary",
+        "actions": 1,
+        "skips": 0,
+        "dry_run": True,
+    }
+
+
+def test_apply_is_refused_with_exit_2():
+    result = _run("{}\n", "--apply")
+    assert result.returncode == 2
+    payload = json.loads(result.stderr.strip().splitlines()[-1])
+    assert payload["event"] == "apply_refused"
+    assert "Step Function" in payload["reason"]
+
+
+def test_dry_run_skips_within_grace_period():
+    entry = {
+        "email": "bob@example.com",
+        "recipient_account_id": "123456789012",
+        "iam_username": "bob",
+        "terminated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    result = _run(json.dumps(entry) + "\n")
+    assert result.returncode == 0
+    plan = json.loads(result.stdout.strip().splitlines()[0])
+    assert plan["action"] == "skip"
+    assert "grace period" in plan["reason"]
+
+
+def test_dry_run_skips_invalid_account_id():
+    entry = {
+        "email": "carol@example.com",
+        "recipient_account_id": "not-an-id",
+        "iam_username": "carol",
+        "terminated_at": _well_outside_grace_iso(),
+    }
+    result = _run(json.dumps(entry) + "\n")
+    assert result.returncode == 0
+    plan = json.loads(result.stdout.strip().splitlines()[0])
+    assert plan["action"] == "skip"
+    assert "Invalid recipient_account_id" in plan["reason"]
+
+
+def test_dry_run_redacts_unknown_fields():
+    """Plan output should only carry the known schema. HR-side noise
+    (employee_id, manager, salary_band, etc.) must not surface in the
+    audited plan."""
+    entry = {
+        "email": "dave@example.com",
+        "recipient_account_id": "123456789012",
+        "iam_username": "dave",
+        "terminated_at": _well_outside_grace_iso(),
+        "salary_band": "L7",
+        "manager_email": "boss@example.com",
+        "ssn_last4": "1234",
+    }
+    result = _run(json.dumps(entry) + "\n")
+    assert result.returncode == 0
+    plan = json.loads(result.stdout.strip().splitlines()[0])
+    assert "salary_band" not in plan["entry"]
+    assert "manager_email" not in plan["entry"]
+    assert "ssn_last4" not in plan["entry"]
+
+
+def test_dry_run_handles_blank_lines():
+    entry = {
+        "email": "ed@example.com",
+        "recipient_account_id": "123456789012",
+        "iam_username": "ed",
+        "terminated_at": _well_outside_grace_iso(),
+    }
+    stdin = "\n" + json.dumps(entry) + "\n\n"
+    result = _run(stdin)
+    assert result.returncode == 0
+    summary = json.loads(result.stderr.strip().splitlines()[-1])
+    assert summary["actions"] == 1

--- a/skills/remediation/iam-departures-azure-entra/SKILL.md
+++ b/skills/remediation/iam-departures-azure-entra/SKILL.md
@@ -28,7 +28,7 @@ description: >-
 license: Apache-2.0
 capability: write-cloud
 approval_model: human_required
-execution_modes: jit, ci, persistent
+execution_modes: jit, ci, mcp, persistent
 side_effects: writes-identity, writes-storage, writes-database, writes-audit
 input_formats: raw, native
 output_formats: native

--- a/skills/remediation/iam-departures-azure-entra/src/handler.py
+++ b/skills/remediation/iam-departures-azure-entra/src/handler.py
@@ -15,14 +15,23 @@ silently dropped to 73 callable through MCP.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
-_PARSER_DIR = Path(__file__).resolve().parent / "function_parser"
-if str(_PARSER_DIR) not in sys.path:
-    sys.path.insert(0, str(_PARSER_DIR))
+_PARSER_PATH = Path(__file__).resolve().parent / "function_parser" / "handler.py"
+_spec = importlib.util.spec_from_file_location(
+    "iam_departures_azure_entra_parser", _PARSER_PATH
+)
+assert _spec and _spec.loader, f"could not load {_PARSER_PATH}"
+_parser_mod = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("iam_departures_azure_entra_parser", _parser_mod)
+_spec.loader.exec_module(_parser_mod)
 
-from handler import main  # noqa: E402  pylint: disable=import-error,wrong-import-position
+
+def main(argv: list[str] | None = None) -> int:
+    return int(_parser_mod.main(argv))
+
 
 __all__ = ["main"]
 

--- a/skills/remediation/iam-departures-azure-entra/src/handler.py
+++ b/skills/remediation/iam-departures-azure-entra/src/handler.py
@@ -1,0 +1,31 @@
+"""Top-level CLI / MCP entrypoint for `iam-departures-azure-entra`.
+
+The skill's destructive path lives in the deployed Function App
+(`runners/`). This module re-exports the parser's CLI `main()` so the same
+skill is callable from MCP, the CLI, and CI without code changes — but
+only in plan-only / dry-run mode. The Microsoft Graph `disable user` call
+is the function worker's responsibility; the MCP/CLI surface stays
+read-only and consults only the static decision tree.
+
+Why this shim: `mcp-server/src/tool_registry.ENTRYPOINT_CANDIDATES` resolves
+the first known filename under `src/`; without this top-level handler, the
+registry did not see the skill, and the README's "76 shipped skills"
+silently dropped to 73 callable through MCP.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PARSER_DIR = Path(__file__).resolve().parent / "function_parser"
+if str(_PARSER_DIR) not in sys.path:
+    sys.path.insert(0, str(_PARSER_DIR))
+
+from handler import main  # noqa: E402  pylint: disable=import-error,wrong-import-position
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skills/remediation/iam-departures-gcp/src/handler.py
+++ b/skills/remediation/iam-departures-gcp/src/handler.py
@@ -15,14 +15,23 @@ listed `mcp` in `execution_modes` was a half-truth.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
-_PARSER_DIR = Path(__file__).resolve().parent / "cloud_function_parser"
-if str(_PARSER_DIR) not in sys.path:
-    sys.path.insert(0, str(_PARSER_DIR))
+_PARSER_PATH = Path(__file__).resolve().parent / "cloud_function_parser" / "handler.py"
+_spec = importlib.util.spec_from_file_location(
+    "iam_departures_gcp_parser", _PARSER_PATH
+)
+assert _spec and _spec.loader, f"could not load {_PARSER_PATH}"
+_parser_mod = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("iam_departures_gcp_parser", _parser_mod)
+_spec.loader.exec_module(_parser_mod)
 
-from handler import main  # noqa: E402  pylint: disable=import-error,wrong-import-position
+
+def main(argv: list[str] | None = None) -> int:
+    return int(_parser_mod.main(argv))
+
 
 __all__ = ["main"]
 

--- a/skills/remediation/iam-departures-gcp/src/handler.py
+++ b/skills/remediation/iam-departures-gcp/src/handler.py
@@ -1,0 +1,31 @@
+"""Top-level CLI / MCP entrypoint for `iam-departures-gcp`.
+
+The skill's destructive path lives in the deployed Cloud Function pipeline
+(`runners/`). This module re-exports the parser's CLI `main()` so the same
+skill is callable from MCP, the CLI, and CI without code changes — but
+only in plan-only / dry-run mode (the parser sets
+`IAM_DEPARTURES_GCP_SKIP_EXISTENCE_CHECK` when `--dry-run` is passed). The
+GCP IAM mutations are the worker function's responsibility.
+
+Why this shim: `mcp-server/src/tool_registry.ENTRYPOINT_CANDIDATES` resolves
+the first known filename under `src/`; without this top-level handler, the
+registry did not see the skill, and the SKILL.md frontmatter that already
+listed `mcp` in `execution_modes` was a half-truth.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PARSER_DIR = Path(__file__).resolve().parent / "cloud_function_parser"
+if str(_PARSER_DIR) not in sys.path:
+    sys.path.insert(0, str(_PARSER_DIR))
+
+from handler import main  # noqa: E402  pylint: disable=import-error,wrong-import-position
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/integration/test_iam_departures_mcp_visibility.py
+++ b/tests/integration/test_iam_departures_mcp_visibility.py
@@ -1,0 +1,64 @@
+"""Lock-in test: the three iam-departures remediation skills ship with
+top-level entrypoints so the MCP registry sees them.
+
+History: between the 04-28 audit and 05-09 audit the registry returned
+73/76 supported skills because `iam-departures-{aws,azure-entra,gcp}` had
+no entrypoint matching `tool_registry.ENTRYPOINT_CANDIDATES`. The
+README's "76 shipped skills" was inaccurate against the MCP surface.
+
+This test fails closed if any iam-departures skill regresses to that
+state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TR_PATH = REPO_ROOT / "mcp-server" / "src" / "tool_registry.py"
+spec = importlib.util.spec_from_file_location("cloud_security_tool_registry_test", TR_PATH)
+assert spec and spec.loader
+TR = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = TR
+spec.loader.exec_module(TR)
+
+
+_IAM_DEPARTURE_REMEDIATIONS = (
+    "iam-departures-aws",
+    "iam-departures-azure-entra",
+    "iam-departures-gcp",
+)
+
+
+def test_all_iam_departures_skills_are_supported():
+    tools = TR.tool_map()
+    for name in _IAM_DEPARTURE_REMEDIATIONS:
+        assert name in tools, f"{name} missing from MCP tool map"
+        assert tools[name].entrypoint is not None
+        assert tools[name].entrypoint.name == "handler.py"
+
+
+def test_total_supported_count_matches_discovered():
+    """The repo invariant: every shipped SKILL.md must resolve to an
+    entrypoint. If `discover_skills` ever exceeds `supported_skills` the
+    README count is overstating what the MCP surface can call."""
+    discovered = TR.discover_skills()
+    supported = TR.supported_skills()
+    assert len(discovered) == len(supported), (
+        f"{len(discovered) - len(supported)} skill(s) ship SKILL.md but no "
+        f"recognised entrypoint: "
+        f"{sorted(s.name for s in discovered if not s.supported)}"
+    )
+
+
+def test_iam_departures_skills_advertise_mcp_execution_mode():
+    """SKILL.md frontmatter is the source of truth for execution surfaces.
+    All three remediation skills now have a top-level CLI entrypoint, so
+    `mcp` belongs in `execution_modes`."""
+    tools = TR.tool_map()
+    for name in _IAM_DEPARTURE_REMEDIATIONS:
+        assert "mcp" in tools[name].execution_modes, (
+            f"{name}: execution_modes={tools[name].execution_modes!r} should include 'mcp'"
+        )

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -662,7 +662,7 @@ class TestAssumeRoleBoundaryGuardrail:
         skills = {skill.name: skill for skill in COMMON.discover_skill_contracts()}
         remediation = skills["iam-departures-aws"]
         assert remediation.approval_model == "human_required"
-        assert remediation.execution_modes == ("jit", "persistent")
+        assert remediation.execution_modes == ("jit", "ci", "mcp", "persistent")
         assert "writes-identity" in remediation.side_effects
         assert remediation.concurrency_safety == "operator_coordinated"
         assert remediation.caller_roles == ("security_engineer", "incident_responder")


### PR DESCRIPTION
## Summary

Closes the audit gap where the README claimed 76 shipped skills but the MCP registry only saw 73. Three remediation skills (`iam-departures-aws`, `iam-departures-azure-entra`, `iam-departures-gcp`) shipped \`SKILL.md\` files but their CLI entrypoints lived under cloud-specific subdirs (\`lambda_parser/\`, \`function_parser/\`, \`cloud_function_parser/\`) that \`tool_registry.ENTRYPOINT_CANDIDATES\` does not resolve. The GCP skill explicitly advertised \`mcp\` in \`execution_modes\` despite the surface not actually working.

### Changes

- **Three new top-level \`src/handler.py\` shims.** Each re-exports the parser's CLI \`main()\`. Step Function / Cloud Function / Function App deployments still import \`lambda_parser.handler\` (etc.) — the runner pipeline is untouched.
- **AWS parser CLI parity.** Added a CLI \`main()\` to \`lambda_parser/handler.py\` matching the Azure + GCP pattern: dry-run plan from JSONL stdin or \`--manifest\` file, \`--apply\` refused with exit 2 and a structured error pointing at the runner.
- **\`IAM_DEPARTURES_AWS_SKIP_EXISTENCE_CHECK\`** env mirrors the GCP pattern so the dry-run plan can run without per-account assumed-role credentials.
- **\`execution_modes\` updated** in AWS + Azure SKILL.md to include \`mcp\` now that the surface actually works (GCP already listed it).
- **Lock-in tests.** \`tests/integration/test_iam_departures_mcp_visibility.py\` fails closed if any iam-departures skill regresses, plus asserts \`discovered == supported\` repo-wide.

### Surface impact

Before: \`discovered=76, supported=73\` — the MCP wrapper silently dropped 3 remediation skills.
After: \`discovered=76, supported=76\` — every shipped \`SKILL.md\` resolves to a callable entrypoint.

The \`--apply\` path on this surface is intentionally refused. Actual IAM mutations remain the deployed runner's exclusive responsibility (grace-period storage, dual audit, deny-list, per-account roles all live there). MCP/CLI invocations stay plan-only.

## Test plan

- [x] \`pytest skills/remediation/iam-departures-aws/tests/\` — 6 new CLI tests + existing parser/worker tests pass.
- [x] \`pytest tests/integration/test_iam_departures_mcp_visibility.py\` — 3 lock-in assertions green.
- [x] \`pytest\` repo-wide — full suite green.
- [x] \`ruff check\` — clean.
- [x] \`scripts/validate_skill_contract.py\` — 76/76.
- [x] \`scripts/validate_safe_skill_bar.py\` — clean.
- [x] Hands-on smoke: \`echo '{...manifest entry...}' | python skills/remediation/iam-departures-aws/src/handler.py\` emits a one-line plan + \`plan_summary\` on stderr; \`--apply\` exits 2 with structured refusal payload.