### PR TITLE
ci: structural validator — fail closed on stale or half-built skill subtrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           packages: pyyaml
       - run: python scripts/validate_skill_contract.py
       - run: python scripts/validate_skill_integrity.py
+      - run: python scripts/validate_skill_structure.py
       - run: python scripts/validate_dependency_consistency.py
       - run: python scripts/validate_framework_coverage.py
       - run: python scripts/validate_ocsf_metadata.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ metadata:
 2. Add or modify skills following the structure above
 3. Ensure tests pass: `pytest skills/<layer>/your-skill/tests/ -v`
 4. Ensure linting passes: `ruff check .`
-5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, `python scripts/validate_dependency_consistency.py`, `python scripts/validate_framework_coverage.py`, and `python scripts/validate_safe_skill_bar.py`
+5. Ensure shared validators pass: `python scripts/validate_skill_contract.py`, `python scripts/validate_skill_integrity.py`, `python scripts/validate_skill_structure.py`, `python scripts/validate_dependency_consistency.py`, `python scripts/validate_framework_coverage.py`, and `python scripts/validate_safe_skill_bar.py`. If `validate_skill_structure.py` flags an empty subtree under `skills/detection-engineering/` (or anywhere else), it usually means stale `__pycache__` from an earlier on-disk layout — run `git clean -fdX skills/detection-engineering/` to drop ignored files only, then re-run the validator.
 6. Open a PR against `main` with a clear description
 7. If the PR is intended for a release cut, follow [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) before tagging
 

--- a/scripts/validate_skill_structure.py
+++ b/scripts/validate_skill_structure.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Fail closed on stale or half-built skill subdirectories.
+
+Every directory under `skills/<category>/<name>/` is expected to be a
+shipped skill bundle: it must carry a `SKILL.md`. The 2026-04-28 audit
+surfaced a class of bug where a previous repo reorganization left empty
+sibling directories under `skills/detection-engineering/` that contained
+only `__pycache__/`. Those local-only artefacts confused contributors
+and quietly broke the invariant `count(SKILL.md) == count(<skill dir>)`.
+
+This validator walks the disk and refuses any skill-category subdir that
+either:
+
+  1. Lacks a `SKILL.md`, OR
+  2. Is empty besides cache / dotfiles
+
+…unless the directory matches an explicit allowlist (e.g. shared utils,
+fixture roots, doc-only sibling dirs).
+
+Run in CI next to the other `validate_*.py` scripts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / "skills"
+
+# Categories that follow the standard <category>/<skill>/SKILL.md layout.
+STANDARD_CATEGORIES = (
+    "detection",
+    "discovery",
+    "evaluation",
+    "ingestion",
+    "output",
+    "remediation",
+    "view",
+)
+
+# Sibling directories under `skills/` that are NOT skill-category roots.
+# These hold shared utilities, golden fixtures, or doc indexes.
+SKILL_ROOT_EXCEPTIONS: dict[str, set[str]] = {
+    "_shared": set(),  # shared Python utility module — not a category
+    "detection-engineering": {
+        # Doc-only category alias. Only `golden/` carries real content;
+        # the other historic per-skill subdirs disappeared during the
+        # 2026-Q1 reorg and the index page now points at the
+        # `skills/{ingestion,view}/` siblings.
+        "golden",
+    },
+}
+
+# Sentinel filenames whose presence demonstrates a directory is "real" even
+# if SKILL.md is intentionally absent (e.g. golden fixture roots).
+SENTINEL_NON_SKILL_FILES = ("OCSF_CONTRACT.md", "README.md")
+
+
+def _is_cache_or_dotfile(name: str | Path) -> bool:
+    """Match any path *segment* that is a cache or dotfile."""
+    n = name.name if isinstance(name, Path) else name
+    return n.startswith(".") or n == "__pycache__"
+
+
+def _has_real_content(path: Path) -> bool:
+    """True iff `path` contains any non-cache, non-dot file anywhere in
+    its subtree. A directory whose only files are `*.pyc` under
+    `__pycache__/` is treated as empty — that is the typical shape of
+    a stale subtree left over from a `git mv` that didn't `git clean`."""
+    if not path.exists():
+        return False
+    for child in path.rglob("*"):
+        if child.is_dir():
+            continue
+        if any(_is_cache_or_dotfile(part) for part in child.relative_to(path).parts):
+            continue
+        return True
+    return False
+
+
+def _violations() -> list[str]:
+    errs: list[str] = []
+    for entry in sorted(SKILLS_ROOT.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name in SKILL_ROOT_EXCEPTIONS:
+            allowed = SKILL_ROOT_EXCEPTIONS[entry.name]
+            for child in sorted(entry.iterdir()):
+                if not child.is_dir() or _is_cache_or_dotfile(child):
+                    continue
+                if child.name in allowed:
+                    continue
+                # Anything not allowlisted under an exception root must
+                # either be a real skill (with SKILL.md) or be empty in
+                # the working tree.
+                if (child / "SKILL.md").is_file():
+                    continue
+                if not _has_real_content(child):
+                    errs.append(
+                        f"{child.relative_to(REPO_ROOT)}: empty subdirectory "
+                        f"under exception root `skills/{entry.name}/`. Either "
+                        f"add a SKILL.md, add it to SKILL_ROOT_EXCEPTIONS, or "
+                        f"`git clean -fdX` it locally — it is not a shipped skill."
+                    )
+                else:
+                    errs.append(
+                        f"{child.relative_to(REPO_ROOT)}: subdirectory under "
+                        f"`skills/{entry.name}/` has content but no SKILL.md."
+                    )
+            continue
+        if entry.name in STANDARD_CATEGORIES:
+            for skill_dir in sorted(entry.iterdir()):
+                if not skill_dir.is_dir() or _is_cache_or_dotfile(skill_dir):
+                    continue
+                skill_md = skill_dir / "SKILL.md"
+                if not skill_md.is_file():
+                    if any(
+                        (skill_dir / sentinel).is_file()
+                        for sentinel in SENTINEL_NON_SKILL_FILES
+                    ):
+                        errs.append(
+                            f"{skill_dir.relative_to(REPO_ROOT)}: missing SKILL.md "
+                            f"but has README/contract — looks like a doc-only "
+                            f"sibling. Move it under `docs/` or finish the skill."
+                        )
+                    else:
+                        errs.append(
+                            f"{skill_dir.relative_to(REPO_ROOT)}: missing SKILL.md. "
+                            f"Every directory under `skills/{entry.name}/` must be "
+                            f"a shipped skill bundle."
+                        )
+            continue
+        errs.append(
+            f"{entry.relative_to(REPO_ROOT)}: unknown skill-root entry. Add "
+            f"`{entry.name}` to STANDARD_CATEGORIES or SKILL_ROOT_EXCEPTIONS."
+        )
+    return errs
+
+
+def main() -> int:
+    errs = _violations()
+    if errs:
+        sys.stderr.write("Skill structure validation failed:\n")
+        for line in errs:
+            sys.stderr.write(f"  - {line}\n")
+        return 1
+    print("Skill structure validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_skill_structure_validator.py
+++ b/tests/integration/test_skill_structure_validator.py
@@ -1,0 +1,139 @@
+"""Tests for `scripts/validate_skill_structure.py`.
+
+The validator's job is to refuse half-built or stale skill directories
+before they ship. We exercise it with a synthetic skills tree under
+`tmp_path` so we never depend on the real on-disk layout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_skill_structure.py"
+spec = importlib.util.spec_from_file_location(
+    "cloud_security_skill_structure_validator_test",
+    SCRIPT_PATH,
+)
+assert spec and spec.loader
+MODULE = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = MODULE
+spec.loader.exec_module(MODULE)
+
+
+def _build_tree(root: Path, layout: dict[str, dict | str]) -> None:
+    for name, value in layout.items():
+        target = root / name
+        if isinstance(value, dict):
+            target.mkdir(parents=True, exist_ok=True)
+            _build_tree(target, value)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(value, encoding="utf-8")
+
+
+def _patch_paths(monkeypatch, fake_repo: Path) -> None:
+    monkeypatch.setattr(MODULE, "REPO_ROOT", fake_repo)
+    monkeypatch.setattr(MODULE, "SKILLS_ROOT", fake_repo / "skills")
+
+
+def test_well_formed_repo_passes(tmp_path, monkeypatch):
+    _build_tree(
+        tmp_path,
+        {
+            "skills": {
+                "detection": {
+                    "detect-foo": {"SKILL.md": "frontmatter\n", "src": {"detect.py": ""}},
+                },
+                "_shared": {"identity.py": ""},
+                "detection-engineering": {
+                    "golden": {"some_fixture.jsonl": ""},
+                    "OCSF_CONTRACT.md": "",
+                    "README.md": "",
+                },
+            }
+        },
+    )
+    _patch_paths(monkeypatch, tmp_path)
+    assert MODULE._violations() == []
+
+
+def test_skill_dir_without_skill_md_fails(tmp_path, monkeypatch):
+    _build_tree(
+        tmp_path,
+        {
+            "skills": {
+                "detection": {
+                    "detect-foo": {"src": {"detect.py": ""}},  # no SKILL.md
+                }
+            }
+        },
+    )
+    _patch_paths(monkeypatch, tmp_path)
+    errs = MODULE._violations()
+    assert any("detect-foo: missing SKILL.md" in e for e in errs)
+
+
+def test_pycache_only_subdir_under_exception_root_fails(tmp_path, monkeypatch):
+    _build_tree(
+        tmp_path,
+        {
+            "skills": {
+                "detection-engineering": {
+                    "golden": {"fixture.jsonl": ""},
+                    "ghost": {
+                        "src": {"__pycache__": {"x.cpython-313.pyc": "stale"}},
+                        "tests": {"__pycache__": {"y.cpython-313.pyc": "stale"}},
+                    },
+                }
+            }
+        },
+    )
+    _patch_paths(monkeypatch, tmp_path)
+    errs = MODULE._violations()
+    assert any("ghost" in e and "empty subdirectory" in e for e in errs)
+
+
+def test_doc_only_skill_dir_with_readme_but_no_skill_md_fails(tmp_path, monkeypatch):
+    _build_tree(
+        tmp_path,
+        {
+            "skills": {
+                "detection": {
+                    "halfway-skill": {"README.md": "draft", "src": {}},
+                }
+            }
+        },
+    )
+    _patch_paths(monkeypatch, tmp_path)
+    errs = MODULE._violations()
+    assert any("halfway-skill" in e and "doc-only" in e for e in errs)
+
+
+def test_unknown_skill_root_entry_fails(tmp_path, monkeypatch):
+    _build_tree(
+        tmp_path,
+        {
+            "skills": {
+                "weird-category": {"detect-foo": {"SKILL.md": ""}},
+            }
+        },
+    )
+    _patch_paths(monkeypatch, tmp_path)
+    errs = MODULE._violations()
+    assert any("weird-category" in e for e in errs)
+
+
+def test_repo_state_passes_today(monkeypatch):
+    """Smoke check: the real on-disk repo (after `git clean -fdX`) passes
+    the validator. Run with no monkeypatching so the validator sees the
+    real REPO_ROOT.
+
+    If this fails, a contributor likely needs to either run
+    `git clean -fdX skills/detection-engineering/` to drop stale local
+    pyc-only subtrees, or finish a half-built skill.
+    """
+    errs = MODULE._violations()
+    assert errs == [], "\n".join(errs)


### PR DESCRIPTION
## Summary

Locks in the skill-tree invariant the 2026-04-28 audit surfaced as drift-prone: every directory under \`skills/<category>/<name>/\` must be a shipped skill (carry \`SKILL.md\`). Sibling roots that are not standard categories — \`_shared\`, \`detection-engineering\` — must declare what they allow.

### What broke

A 2026-Q1 reorganization moved per-skill code from \`skills/detection-engineering/<skill>/\` into \`skills/{ingestion,view}/<skill>/\`, but \`__pycache__/\` residue under the old paths was untracked and stayed on local clones. New contributors saw 10 phantom subdirectories with no source files. Today nothing fails CI when this drift accumulates.

### What this PR adds

- **\`scripts/validate_skill_structure.py\`** — recursive structural check. A subdirectory whose only files live under \`__pycache__/\` is treated as empty and reported with a pointer to \`git clean -fdX\`, which is the canonical local cleanup. Skill-category subdirs without \`SKILL.md\` fail with a different message.
- **CI wire-up** in the existing \`skill-contract\` job alongside \`validate_skill_contract.py\` and friends.
- **6 unit tests** under \`tests/integration/\` covering well-formed trees, missing \`SKILL.md\`, pyc-only subtrees, doc-only halfway skills, unknown skill roots, and the current real repo state.
- **CONTRIBUTING.md note** so contributors know how to clean local cruft when the validator fires.

### Why this shape, not bulk \`rm\`

The 10 ghost directories are git-untracked. A tracked deletion would change nothing on disk for anyone who didn't already have the residue. The class of bug — silent drift between disk and \`SKILL.md\` truth — needs a CI gate, not a one-shot delete.

## Test plan

- [x] \`pytest tests/integration/test_skill_structure_validator.py\` — 6/6 pass.
- [x] \`pytest\` repo-wide — full suite green.
- [x] \`ruff check\` — clean.
- [x] \`python scripts/validate_skill_structure.py\` — passes on the cleaned working tree.
- [x] Hands-on: re-introduced a synthetic \`skills/detection-engineering/ghost/src/__pycache__/x.pyc\` and confirmed the validator exits 1 with the expected guidance.