### PR TITLE
docs: hero banner refresh + README quickstart + framework breadth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cloud-ai-security-skills — production-grade security skills for cloud and AI systems. 76 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. MITRE ATT&CK tagged detections. MCP audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![Agentic security skills for cloud and AI — 76 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -16,7 +16,11 @@
 
 ## What this repo gives you
 
-**76 shipped skill bundles** that turn raw cloud, identity, Kubernetes, and MCP signals into stable, standards-aligned findings — plus twelve guarded write paths spanning AWS/GCP/Azure IAM departures, AWS/GCP/Azure network revoke, Okta, Workspace, Entra SP, K8s quarantine, K8s RBAC, and MCP tools. Each skill is a self-contained `SKILL.md + src/ + tests/` bundle that runs unchanged from the CLI, CI, MCP, or a persistent cloud runner.
+**76 production-grade skill bundles** for cloud and AI security. Each one normalizes raw cloud, identity, Kubernetes, or MCP signal into a standards-aligned finding — OCSF 1.8 on the wire where it matters, native JSONL where state and audit matter more.
+
+Twelve of those skills are **guarded write paths**: IAM departures across AWS, GCP, and Azure Entra; network revoke on AWS, GCP, and Azure; Okta and Workspace session kill; Entra service-principal credential revoke; Kubernetes quarantine and RBAC revoke; MCP tool quarantine. Every write is dry-run-first, HITL-gated, and dual-audited.
+
+The skill contract is the same everywhere: one `SKILL.md` + `src/` + `tests/` bundle that runs unchanged from the **CLI**, from **CI**, behind an **MCP** wrapper for any agentic client, or inside a **persistent cloud runner**. No fork in behavior, no parallel codepaths, no per-surface drift.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
@@ -30,6 +34,30 @@
 | **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
 
 **Total: 76 shipped skills.**
+
+## Quickstart
+
+```bash
+# 1 · Clone a tagged release
+git clone --branch v0.8.1 https://github.com/msaad00/cloud-ai-security-skills.git
+cd cloud-ai-security-skills
+
+# 2 · Install only the deps the skills you'll run need
+uv sync --group dev --extra aws --extra k8s        # or `--extra gcp`, `--extra azure`, …
+
+# 3 · Run a detection on a captured fixture (no cloud creds needed)
+python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py \
+       skills/detection-engineering/golden/cloudtrail_raw_sample.jsonl \
+  | python skills/detection/detect-aws-access-key-creation/src/detect.py \
+  | python skills/view/convert-ocsf-to-sarif/src/convert.py \
+  > findings.sarif
+
+# 4 · Wire the skills into any agent over MCP
+# (The repo ships .mcp.json — Claude Code picks it up automatically.
+#  For Claude Desktop, Cursor, Windsurf, Codex, Cortex, Zed, see docs/integrations/.)
+```
+
+Each surface (CLI, CI, MCP, runners) is just a transport — the same `SKILL.md + src/ + tests/` bundle runs unchanged behind it.
 
 <details>
 <summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
@@ -52,15 +80,13 @@ Full discussion: [docs/ARCHITECTURE.md §3 Layer model + §6 Wire contract](docs
 
 ## Architecture
 
-External signals enter through two intake layers, pass through two analyze layers, and exit through two act layers, persisting through one output layer. The README now splits the picture into two simpler visuals so the layer flow and runtime story stay readable on GitHub.
+Two intake layers (ingest, discover) → two analyze layers (detect, evaluate) → two act layers (remediate, view) → one persist layer (output). MCP, CLI, CI, and cloud runners all invoke the same skill bundle — the surface is transport, not behavior.
 
 ![Clean architecture layers diagram — signals feed intake, analyze, act, and persist stages across the seven shipped skill layers.](docs/images/architecture-layers.svg)
 
 ![Clean runtime surfaces diagram — MCP, CLI, CI, and cloud runners all invoke the same shared skill bundle.](docs/images/runtime-surfaces.svg)
 
-Full contract: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
-
-For UI-only audit evidence and screenshot-backed control capture, see the design note in [docs/COMPLIANCE_EVIDENCE_CAPTURE.md](docs/COMPLIANCE_EVIDENCE_CAPTURE.md). The repo direction there is export-first, screenshot-when-necessary.
+Deeper reads: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) · [docs/SKILL_CONTRACT.md](docs/SKILL_CONTRACT.md) · [docs/COMPLIANCE_EVIDENCE_CAPTURE.md](docs/COMPLIANCE_EVIDENCE_CAPTURE.md).
 
 ## Agent and runtime integrations
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="500" viewBox="0 0 1400 500" role="img" aria-labelledby="title desc">
-  <title id="title">cloud-ai-security-skills — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the cloud-ai-security-skills repository. Left panel shows the wordmark, tagline, and six capability pills for 76 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 29 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="540" viewBox="0 0 1400 540" role="img" aria-labelledby="title desc">
+  <title id="title">agentic security skills for cloud and AI — production-grade security skills for cloud and AI systems</title>
+  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 76 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 29 detect, 7 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -23,38 +23,46 @@
     <symbol id="aws" viewBox="0 0 24 24"><path fill="#f59e0b" d="M6.763 10.036c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 0 1-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 0 1-.287-.375 6.18 6.18 0 0 1-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.391-.384-.59-.894-.59-1.533 0-.678.239-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.287 2.287 0 0 1-.28.104.488.488 0 0 1-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 0 1 .224-.167c.279-.144.614-.264 1.005-.36a4.84 4.84 0 0 1 1.246-.151c.95 0 1.644.216 2.091.647.439.43.662 1.085.662 1.963v2.586zm-3.24 1.214c.263 0 .534-.048.822-.144.287-.096.543-.271.758-.51.128-.152.224-.32.272-.512.047-.191.08-.423.08-.694v-.335a6.66 6.66 0 0 0-.735-.136 6.02 6.02 0 0 0-.75-.048c-.535 0-.926.104-1.19.32-.263.215-.39.518-.39.917 0 .375.095.655.295.846.191.2.47.296.838.296zM21.698 16.207c-2.626 1.94-6.442 2.969-9.722 2.969-4.598 0-8.74-1.7-11.87-4.526-.247-.223-.024-.527.272-.351 3.384 1.963 7.559 3.153 11.877 3.153 2.914 0 6.114-.607 9.06-1.852.439-.2.814.287.383.607zM22.792 14.961c-.336-.43-2.22-.207-3.074-.103-.255.032-.295-.192-.063-.36 1.5-1.053 3.967-.75 4.254-.399.287.36-.08 2.826-1.485 4.007-.215.184-.423.088-.327-.151.32-.79 1.03-2.57.695-2.994z"/></symbol>
     <symbol id="gcp" viewBox="0 0 24 24"><path fill="#60a5fa" d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38zm-.358 4.146c1.244-.04 2.518.368 3.486 1.15a5.186 5.186 0 0 1 1.862 4.078v.518c3.53-.07 3.53 5.262 0 5.193h-5.193l-.008.009v-.04H6.785a2.59 2.59 0 0 1-1.067-.23h.001a2.597 2.597 0 1 1 3.437-3.437l3.013-3.012A6.747 6.747 0 0 0 8.11 8.24c.018-.01.04-.026.054-.023a5.186 5.186 0 0 1 3.67-1.69z"/></symbol>
     <symbol id="azure" viewBox="0 0 24 24"><path fill="#38bdf8" d="M22.379 23.343a1.62 1.62 0 0 0 1.536-2.14v.002L17.35 1.76A1.62 1.62 0 0 0 15.816.657H8.184A1.62 1.62 0 0 0 6.65 1.76L.086 21.204a1.62 1.62 0 0 0 1.536 2.139h4.741a1.62 1.62 0 0 0 1.535-1.103l.977-2.892 4.947 3.675c.28.208.618.32.966.32m-3.084-12.531 3.624 10.739a.54.54 0 0 1-.51.713v-.001h-.03a.54.54 0 0 1-.322-.106l-9.287-6.9h4.853m6.313 7.006c.116-.326.13-.694.007-1.058L9.79 1.76a1.722 1.722 0 0 0-.007-.02h6.034a.54.54 0 0 1 .512.366l6.562 19.445a.54.54 0 0 1-.338.684"/></symbol>
-    <symbol id="k8s" viewBox="0 0 24 24"><path fill="#93c5fd" d="M10.204 14.35l.007.01-.999 2.413a5.171 5.171 0 0 1-2.075-2.597l2.578-.437.004.005a.44.44 0 0 1 .484.606zm-.833-2.129a.44.44 0 0 0 .173-.756l.002-.011L7.585 9.7a5.143 5.143 0 0 0-.73 3.255l2.514-.725.002-.009zm1.145-1.98a.44.44 0 0 0 .699-.337l.01-.005.15-2.62a5.144 5.144 0 0 0-3.01 1.442l2.147 1.523.004-.002zm.76 2.75l.723.349.722-.347.18-.78-.5-.623h-.804l-.5.623.179.779zm1.5-3.095a.44.44 0 0 0 .7.336l.008.003 2.134-1.513a5.188 5.188 0 0 0-2.992-1.442l.148 2.615.002.001zm10.876 5.97l-5.773 7.181a1.6 1.6 0 0 1-1.248.594l-9.261.003a1.6 1.6 0 0 1-1.247-.596l-5.776-7.18a1.583 1.583 0 0 1-.307-1.34L2.1 5.573c.108-.47.425-.864.863-1.073L11.305.513a1.606 1.606 0 0 1 1.385 0l8.345 3.985c.438.209.755.604.863 1.073l2.062 8.955c.108.47-.005.963-.308 1.34zm-3.289-2.057c-.042-.01-.103-.026-.145-.034-.174-.033-.315-.025-.479-.038-.35-.037-.638-.067-.895-.148-.105-.04-.18-.165-.216-.216l-.201-.059a6.45 6.45 0 0 0-.105-2.332 6.465 6.465 0 0 0-.936-2.163c.052-.047.15-.133.177-.159.008-.09.001-.183.094-.282.197-.185.444-.338.743-.522.142-.084.273-.137.415-.242.032-.024.076-.062.11-.089.24-.191.295-.52.123-.736-.172-.216-.506-.236-.745-.045-.034.027-.08.062-.111.088-.134.116-.217.23-.33.35-.246.25-.45.458-.673.609-.097.056-.239.037-.303.033l-.19.135a6.545 6.545 0 0 0-4.146-2.003l-.012-.223c-.065-.062-.143-.115-.163-.25-.022-.268.015-.557.057-.905.023-.163.061-.298.068-.475.001-.04-.001-.099-.001-.142 0-.306-.224-.555-.5-.555-.275 0-.499.249-.499.555l.001.014c0 .041-.002.092 0 .128.006.177.044.312.067.475.042.348.078.637.056.906a.545.545 0 0 1-.162.258l-.012.211a6.424 6.424 0 0 0-4.166 2.003 8.373 8.373 0 0 1-.18-.128c-.09.012-.18.04-.297-.029-.223-.15-.427-.358-.673-.608-.113-.12-.195-.234-.329-.349-.03-.026-.077-.062-.111-.088a.594.594 0 0 0-.348-.132.481.481 0 0 0-.398.176c-.172.216-.117.546.123.737l.007.005.104.083c.142.105.272.159.414.242.299.185.546.338.743.522.076.082.09.226.1.288l.16.143a6.462 6.462 0 0 0-1.02 4.506l-.208.06c-.055.072-.133.184-.215.217-.257.081-.546.11-.895.147-.164.014-.305.006-.48.039-.037.007-.09.02-.133.03l-.004.002-.007.002c-.295.071-.484.342-.423.608.061.267.349.429.645.365l.007-.001.01-.003.129-.029c.17-.046.294-.113.448-.172.33-.118.604-.217.87-.256.112-.009.23.069.288.101l.217-.037a6.5 6.5 0 0 0 2.88 3.596l-.09.218c.033.084.069.199.044.282-.097.252-.263.517-.452.813-.091.136-.185.242-.268.399-.02.037-.045.095-.064.134-.128.275-.034.591.213.71.248.12.556-.007.69-.282v-.002c.02-.039.046-.09.062-.127.07-.162.094-.301.144-.458.132-.332.205-.68.387-.897.05-.06.13-.082.215-.105l.113-.205a6.453 6.453 0 0 0 4.609.012l.106.192c.086.028.18.042.256.155.136.232.229.507.342.84.05.156.074.295.145.457.016.037.043.09.062.129.133.276.442.402.69.282.247-.118.341-.435.213-.71-.02-.039-.045-.096-.065-.134-.083-.156-.177-.261-.268-.398-.19-.296-.346-.541-.443-.793-.04-.13.007-.21.038-.294-.018-.022-.059-.144-.083-.202a6.499 6.499 0 0 0 2.88-3.622c.064.01.176.03.213.038.075-.05.144-.114.28-.104.266.039.54.138.87.256.154.06.277.128.448.173.036.01.088.019.13.028l.009.003.007.001c.297.064.584-.098.645-.365.06-.266-.128-.537-.423-.608zM16.4 9.701l-1.95 1.746v.005a.44.44 0 0 0 .173.757l.003.01 2.526.728a5.199 5.199 0 0 0-.108-1.674A5.208 5.208 0 0 0 16.4 9.7zm-4.013 5.325a.437.437 0 0 0-.404-.232.44.44 0 0 0-.372.233h-.002l-1.268 2.292a5.164 5.164 0 0 0 3.326.003l-1.27-2.296h-.01zm1.888-1.293a.44.44 0 0 0-.27.036.44.44 0 0 0-.214.572l-.003.004 1.01 2.438a5.15 5.15 0 0 0 2.081-2.615l-2.6-.44-.004.005z"/></symbol>
+    <symbol id="k8s" viewBox="0 0 24 24"><path fill="#93c5fd" d="M12 0L1.6 6v12L12 24l10.4-6V6L12 0zm0 4.4L18 8v8L12 19.6 6 16V8l6-3.6z"/></symbol>
     <symbol id="okta" viewBox="0 0 24 24"><path fill="#3b82f6" d="M12 0C5.389 0 0 5.35 0 12s5.35 12 12 12 12-5.35 12-12S18.611 0 12 0zm0 18c-3.325 0-6-2.675-6-6s2.675-6 6-6 6 2.675 6 6-2.675 6-6 6z"/></symbol>
     <symbol id="entra" viewBox="0 0 24 24"><path fill="#60a5fa" d="M0 0v11.408h11.408V0zm12.594 0v11.408H24V0zM0 12.594V24h11.408V12.594zm12.594 0V24H24V12.594z"/></symbol>
     <symbol id="google" viewBox="0 0 24 24"><path fill="#fca5a5" d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></symbol>
-    <symbol id="snowflake" viewBox="0 0 24 24"><path fill="#7dd3fc" d="M7.602 12.4c.038-.151.076-.304.076-.456 0-.114-.038-.228-.038-.342-.114-.343-.304-.647-.646-.838l-4.87-2.777c-.685-.38-1.56-.152-1.94.533-.381.685-.153 1.56.532 1.94l2.701 1.56-2.701 1.56c-.685.38-.913 1.256-.533 1.94.38.685 1.256.914 1.94.533l4.832-2.777c.343-.267.571-.533.647-.876zm1.332 2.626c-.266-.038-.57.038-.837.19l-4.832 2.777c-.685.38-.913 1.256-.532 1.94.38.686 1.255.914 1.94.533l2.701-1.56v3.12c0 .8.647 1.408 1.446 1.408.799 0 1.407-.647 1.407-1.408v-5.592c0-.761-.57-1.37-1.293-1.408zm4.946-6.088c.266.038.57-.038.837-.19l4.832-2.777c.685-.38.913-1.256.532-1.94-.38-.686-1.255-.914-1.94-.533l-2.701 1.56V1.975c0-.799-.647-1.408-1.446-1.408-.799 0-1.446.609-1.446 1.408V7.53c0 .76.609 1.37 1.332 1.407zM3.265 5.97l4.832 2.777c.266.152.533.19.837.19.723-.038 1.331-.684 1.331-1.407V1.975c0-.799-.646-1.408-1.407-1.408-.799 0-1.446.647-1.446 1.408v3.12l-2.701-1.56c-.685-.38-1.56-.152-1.94.533-.419.646-.19 1.521.494 1.902zm18.22 8.184l-2.701 1.56 2.7 1.56c.686.38.914 1.256.533 1.94-.38.685-1.255.913-1.94.533l-4.832-2.778a1.644 1.644 0 01-.647-.798c-.037-.153-.076-.305-.076-.457 0-.114.039-.228.039-.342.114-.343.342-.647.646-.837l4.832-2.778c.685-.38 1.56-.152 1.94.533.457.609.19 1.484-.494 1.864z"/></symbol>
+    <symbol id="snowflake" viewBox="0 0 24 24"><path fill="#7dd3fc" d="M12 2v20M5 5l14 14M19 5L5 19M2 12h20"/></symbol>
     <symbol id="databricks" viewBox="0 0 24 24"><path fill="#f97316" d="M.95 14.184L12 20.403l9.919-5.55v2.21L12 22.662l-10.484-5.96-.565.308v.77L12 24l11.05-6.218v-4.317l-.515-.309L12 19.118l-9.867-5.653v-2.21L12 16.805l11.05-6.218V6.32l-.515-.308L12 11.974 2.647 6.681 12 1.388l7.76 4.368.668-.411v-.566L12 0 .95 6.27v.72L12 13.207l9.919-5.55v2.26L12 15.52 1.516 9.56l-.565.308Z"/></symbol>
     <symbol id="clickhouse" viewBox="0 0 24 24"><path fill="#fbbf24" d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z"/></symbol>
   </defs>
 
-  <rect width="1400" height="420" fill="url(#bg)"/>
-  <rect width="1400" height="420" fill="url(#grid)"/>
-  <rect width="1400" height="420" fill="url(#glow)"/>
+  <rect width="1400" height="540" fill="url(#bg)"/>
+  <rect width="1400" height="540" fill="url(#grid)"/>
+  <rect width="1400" height="540" fill="url(#glow)"/>
 
   <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
-    <!-- Eyebrow -->
+    <!-- Eyebrow pill -->
     <g transform="translate(72,40)">
-      <rect x="0" y="0" width="206" height="28" rx="14" fill="#0b1628" stroke="#334155"/>
+      <rect x="0" y="0" width="220" height="28" rx="14" fill="#0b1628" stroke="#334155"/>
       <circle cx="18" cy="14" r="3.5" fill="#22d3ee"/>
       <text x="32" y="19" fill="#c7d2fe" font-size="11" font-weight="800" letter-spacing="1.6">OSS · APACHE 2.0 · OCSF 1.8</text>
     </g>
 
     <!-- Main panels -->
-    <rect x="56" y="84" width="772" height="300" rx="22" fill="#0b1628" stroke="#22314d"/>
-    <rect x="856" y="84" width="488" height="300" rx="22" fill="#0b1628" stroke="#22314d"/>
+    <rect x="56" y="84" width="772" height="380" rx="22" fill="#0b1628" stroke="#22314d"/>
+    <rect x="856" y="84" width="488" height="380" rx="22" fill="#0b1628" stroke="#22314d"/>
 
-    <!-- Left panel -->
-    <text x="88" y="142" font-size="58" font-weight="900" fill="url(#wordmark)" letter-spacing="-1.2">cloud-ai-security-skills</text>
-    <text x="90" y="176" fill="#e5eefb" font-size="18" font-weight="600">Production-grade security skills for cloud and AI systems.</text>
-    <text x="90" y="202" fill="#94a3b8" font-size="16">Same skill bundle contract across CLI, CI, MCP, and persistent runners.</text>
-    <text x="90" y="228" fill="#94a3b8" font-size="16">OCSF where interop matters. Native where state, evidence, and audit matter more.</text>
+    <!-- Wordmark container -->
+    <g transform="translate(80,108)">
+      <rect x="0" y="0" width="724" height="76" rx="16" fill="#0a1326" stroke="#1e3a8a"/>
+      <text x="20" y="56" font-size="44" font-weight="900" fill="url(#wordmark)" letter-spacing="-0.8">agentic security skills for cloud and AI</text>
+    </g>
 
-    <g transform="translate(88,252)">
+    <!-- Tagline container -->
+    <g transform="translate(80,196)">
+      <rect x="0" y="0" width="724" height="62" rx="14" fill="#0a1326" stroke="#1e293b"/>
+      <text x="20" y="26" fill="#e5eefb" font-size="15" font-weight="700">Production-grade security skills for cloud and AI systems.</text>
+      <text x="20" y="48" fill="#94a3b8" font-size="13">Same skill bundle contract across CLI, CI, MCP, and persistent runners. OCSF where interop matters; native where state, evidence, and audit matter more.</text>
+    </g>
+
+    <!-- Capability pills row 1: counts -->
+    <g transform="translate(80,272)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
         <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">76</text>
@@ -65,110 +73,145 @@
         <text x="16" y="23" fill="#67e8f9" font-size="14" font-weight="900">OCSF 1.8</text>
       </g>
       <g transform="translate(328,0)">
-        <rect x="0" y="0" width="186" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
+        <rect x="0" y="0" width="200" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">91</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">benchmark checks</text>
       </g>
     </g>
-    <g transform="translate(88,298)">
+
+    <!-- Capability pills row 2: framework coverage -->
+    <g transform="translate(80,318)">
       <g>
-        <rect x="0" y="0" width="204" height="36" rx="12" fill="#2a0b1e" stroke="#ef4444"/>
-        <text x="16" y="23" fill="#fca5a5" font-size="13" font-weight="900">MITRE ATT&amp;CK</text>
-        <text x="126" y="23" fill="#dbe4f0" font-size="13" font-weight="700">tagged</text>
+        <rect x="0" y="0" width="172" height="36" rx="12" fill="#2a0b1e" stroke="#ef4444"/>
+        <text x="14" y="23" fill="#fca5a5" font-size="13" font-weight="900">MITRE ATT&amp;CK</text>
       </g>
-      <g transform="translate(216,0)">
-        <rect x="0" y="0" width="212" height="36" rx="12" fill="#1f142e" stroke="#a78bfa"/>
-        <text x="16" y="23" fill="#c4b5fd" font-size="13" font-weight="900">MCP</text>
-        <text x="56" y="23" fill="#dbe4f0" font-size="13" font-weight="700">audited tool calls</text>
+      <g transform="translate(184,0)">
+        <rect x="0" y="0" width="156" height="36" rx="12" fill="#2a0b1e" stroke="#f43f5e"/>
+        <text x="14" y="23" fill="#fda4af" font-size="13" font-weight="900">MITRE ATLAS</text>
       </g>
-      <g transform="translate(440,0)">
-        <rect x="0" y="0" width="180" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
-        <text x="16" y="23" fill="#fbbf24" font-size="13" font-weight="900">HITL</text>
-        <text x="54" y="23" fill="#dbe4f0" font-size="13" font-weight="700">dual-audited writes</text>
+      <g transform="translate(352,0)">
+        <rect x="0" y="0" width="160" height="36" rx="12" fill="#2a1708" stroke="#f97316"/>
+        <text x="14" y="23" fill="#fdba74" font-size="13" font-weight="900">OWASP Top 10</text>
+      </g>
+      <g transform="translate(524,0)">
+        <rect x="0" y="0" width="180" height="36" rx="12" fill="#2a1708" stroke="#fbbf24"/>
+        <text x="14" y="23" fill="#fcd34d" font-size="13" font-weight="900">OWASP LLM Top 10</text>
+      </g>
+    </g>
+
+    <!-- Capability pills row 3: trust + audit -->
+    <g transform="translate(80,364)">
+      <g>
+        <rect x="0" y="0" width="220" height="36" rx="12" fill="#1f142e" stroke="#a78bfa"/>
+        <text x="14" y="23" fill="#c4b5fd" font-size="13" font-weight="900">MCP</text>
+        <text x="54" y="23" fill="#dbe4f0" font-size="13" font-weight="700">audited tool calls</text>
+      </g>
+      <g transform="translate(232,0)">
+        <rect x="0" y="0" width="206" height="36" rx="12" fill="#0f1f0b" stroke="#22c55e"/>
+        <text x="14" y="23" fill="#86efac" font-size="13" font-weight="900">HITL</text>
+        <text x="50" y="23" fill="#dbe4f0" font-size="13" font-weight="700">dual-audited writes</text>
+      </g>
+      <g transform="translate(450,0)">
+        <rect x="0" y="0" width="202" height="36" rx="12" fill="#11202c" stroke="#0ea5e9"/>
+        <text x="14" y="23" fill="#7dd3fc" font-size="13" font-weight="900">CIS · NIST CSF · SOC 2</text>
       </g>
     </g>
 
     <!-- Right panel: shipped layer map -->
-    <text x="888" y="120" fill="#93c5fd" font-size="12" font-weight="800" letter-spacing="1.6">CURRENT SHIPPED SURFACE</text>
-    <text x="888" y="146" fill="#f8fafc" font-size="28" font-weight="900">Seven core layers plus edges</text>
-    <text x="888" y="168" fill="#94a3b8" font-size="14">Counts below match the current repo and README routing surface.</text>
+    <!-- Header pill -->
+    <g transform="translate(880,108)">
+      <rect x="0" y="0" width="240" height="28" rx="14" fill="#0a1326" stroke="#1e293b"/>
+      <text x="14" y="19" fill="#93c5fd" font-size="11" font-weight="800" letter-spacing="1.6">CURRENT SHIPPED SURFACE</text>
+    </g>
+    <!-- Subtitle pill -->
+    <g transform="translate(880,144)">
+      <rect x="0" y="0" width="440" height="44" rx="12" fill="#0a1326" stroke="#1e293b"/>
+      <text x="16" y="22" fill="#f8fafc" font-size="20" font-weight="900">Seven core layers plus edges</text>
+      <text x="16" y="38" fill="#94a3b8" font-size="11">Counts match the current repo and README routing surface.</text>
+    </g>
 
-    <g transform="translate(888,190)">
+    <g transform="translate(880,200)">
       <g>
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
         <text x="14" y="23" fill="#dbeafe" font-size="13" font-weight="800">L1 Ingest</text>
-        <text x="182" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">15</text>
+        <text x="194" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">15</text>
       </g>
       <g transform="translate(222,0)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
         <text x="14" y="23" fill="#dbeafe" font-size="13" font-weight="800">L2 Discover</text>
-        <text x="182" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">5</text>
+        <text x="194" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">5</text>
       </g>
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">29</text>
+        <text x="194" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">29</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L4 Evaluate</text>
-        <text x="182" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">7</text>
+        <text x="194" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">7</text>
       </g>
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
         <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L5 Remediate</text>
-        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">12</text>
+        <text x="194" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">12</text>
       </g>
       <g transform="translate(222,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>
         <text x="14" y="23" fill="#fef3c7" font-size="13" font-weight="800">L6 View</text>
-        <text x="182" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">2</text>
+        <text x="194" y="23" text-anchor="end" fill="#fbbf24" font-size="13" font-weight="900">2</text>
       </g>
       <g transform="translate(0,144)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#12112e" stroke="#a78bfa"/>
         <text x="14" y="23" fill="#ede9fe" font-size="13" font-weight="800">L7 Output</text>
-        <text x="182" y="23" text-anchor="end" fill="#c4b5fd" font-size="13" font-weight="900">3</text>
+        <text x="194" y="23" text-anchor="end" fill="#c4b5fd" font-size="13" font-weight="900">3</text>
       </g>
       <g transform="translate(222,144)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#12112e" stroke="#a78bfa"/>
         <text x="14" y="23" fill="#ede9fe" font-size="13" font-weight="800">L0 Source adapters</text>
-        <text x="182" y="23" text-anchor="end" fill="#c4b5fd" font-size="13" font-weight="900">3</text>
+        <text x="194" y="23" text-anchor="end" fill="#c4b5fd" font-size="13" font-weight="900">3</text>
       </g>
     </g>
 
-    <!-- Footer divider — pushed below the L7/L0 panel row (which ends at y=370) -->
-    <line x1="56" y1="408" x2="1344" y2="408" stroke="#1e293b" stroke-width="1"/>
+    <!-- Footer divider -->
+    <line x1="56" y1="488" x2="1344" y2="488" stroke="#1e293b" stroke-width="1"/>
 
-    <!-- Left: vendor strip -->
-    <text x="72" y="432" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">RUNS AGAINST</text>
-    <g transform="translate(72,442)">
-      <g><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#aws" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(44,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#gcp" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(88,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#azure" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(132,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#k8s" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(176,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#okta" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(220,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#entra" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(264,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#google" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(308,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#snowflake" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(352,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#databricks" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(396,0)"><rect x="0" y="0" width="36" height="36" rx="8" fill="#0b1628" stroke="#1f2937"/><use href="#clickhouse" x="8" y="8" width="20" height="20"/></g>
-      <g transform="translate(440,0)">
-        <rect x="0" y="0" width="60" height="36" rx="8" fill="#1b1235" stroke="#a78bfa"/>
-        <text x="30" y="23" text-anchor="middle" fill="#c4b5fd" font-size="12" font-weight="800">MCP</text>
+    <!-- Vendor strip — label inside its own pill -->
+    <g transform="translate(72,500)">
+      <rect x="0" y="0" width="120" height="28" rx="14" fill="#0a1326" stroke="#1e293b"/>
+      <text x="14" y="19" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">RUNS AGAINST</text>
+    </g>
+    <g transform="translate(204,500)">
+      <g><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#aws" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(36,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#gcp" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(72,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#azure" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(108,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#k8s" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(144,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#okta" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(180,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#entra" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(216,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#google" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(252,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#snowflake" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(288,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#databricks" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(324,0)"><rect x="0" y="0" width="28" height="28" rx="7" fill="#0b1628" stroke="#1f2937"/><use href="#clickhouse" x="6" y="6" width="16" height="16"/></g>
+      <g transform="translate(360,0)">
+        <rect x="0" y="0" width="56" height="28" rx="7" fill="#1b1235" stroke="#a78bfa"/>
+        <text x="28" y="19" text-anchor="middle" fill="#c4b5fd" font-size="11" font-weight="800">MCP</text>
       </g>
     </g>
 
-    <!-- Right: access surfaces — y-aligned with RUNS AGAINST at new footer position -->
-    <text x="1328" y="432" text-anchor="end" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">ACCESS SURFACES</text>
-    <g transform="translate(1012,442)" font-size="12" font-weight="700" fill="#cbd5e1">
-      <rect x="0" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>
-      <text x="36" y="22" text-anchor="middle">CLI</text>
-      <rect x="80" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>
-      <text x="116" y="22" text-anchor="middle">CI</text>
-      <rect x="160" y="0" width="72" height="36" rx="9" fill="#0b1628" stroke="#334155"/>
-      <text x="196" y="22" text-anchor="middle">MCP</text>
-      <rect x="240" y="0" width="76" height="36" rx="9" fill="#0b1628" stroke="#334155"/>
-      <text x="278" y="22" text-anchor="middle">runners</text>
+    <!-- Access surfaces — label inside its own pill -->
+    <g transform="translate(872,500)">
+      <rect x="0" y="0" width="148" height="28" rx="14" fill="#0a1326" stroke="#1e293b"/>
+      <text x="14" y="19" fill="#64748b" font-size="10" font-weight="800" letter-spacing="1.6">ACCESS SURFACES</text>
+    </g>
+    <g transform="translate(1032,500)">
+      <rect x="0" y="0" width="68" height="28" rx="9" fill="#0b1628" stroke="#334155"/>
+      <text x="34" y="19" text-anchor="middle" fill="#cbd5e1" font-size="12" font-weight="700">CLI</text>
+      <rect x="76" y="0" width="68" height="28" rx="9" fill="#0b1628" stroke="#334155"/>
+      <text x="110" y="19" text-anchor="middle" fill="#cbd5e1" font-size="12" font-weight="700">CI</text>
+      <rect x="152" y="0" width="68" height="28" rx="9" fill="#0b1628" stroke="#334155"/>
+      <text x="186" y="19" text-anchor="middle" fill="#cbd5e1" font-size="12" font-weight="700">MCP</text>
+      <rect x="228" y="0" width="80" height="28" rx="9" fill="#0b1628" stroke="#334155"/>
+      <text x="268" y="19" text-anchor="middle" fill="#cbd5e1" font-size="12" font-weight="700">runners</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

Three polish changes responding to product feedback that the repo's first impression was muddled, the framework story understated breadth, and a new reader couldn't see how to actually run a skill before scrolling past architecture diagrams.

### Hero banner (\`docs/images/hero-banner.svg\`)

- **New wordmark** — 'agentic security skills for cloud and AI'. The previous wordmark was the repo slug; the new one names what the repo does.
- **No text outside containers.** Every visible label is now wrapped in a rect / pill / panel. The eyebrow row, the wordmark, the tagline, every framework pill, every layer card, and the two footer labels (RUNS AGAINST, ACCESS SURFACES) live inside their own containers.
- **Framework pills broadened** — MITRE ATT&CK, **MITRE ATLAS**, **OWASP Top 10**, **OWASP LLM Top 10**, plus a third row pill summarizing CIS / NIST CSF / SOC 2. Matches the actual SKILL.md frontmatter coverage instead of the legacy ATT&CK-only callout.
- Canvas height 500 → 540px so the new pill row doesn't crowd the layer map.

### README (\`README.md\`)

- **'What this repo gives you'** rewritten as three concrete paragraphs (what it produces · the twelve guarded write paths · same-bundle-everywhere contract).
- **New 'Quickstart' section** — 4 steps to clone, install only the deps you need, run a detection on a captured fixture, and point any agent at the shipped \`.mcp.json\`. Ease-of-use path now precedes architecture.
- **Architecture intro** tightened to one sentence; the two existing diagrams carry the visual weight.

## Test plan

- [x] \`scripts/validate_skill_count_consistency.py\` — clean (validator's regex patterns over the SVG \`<desc>\` and README count claims still match).
- [x] \`scripts/validate_skill_contract.py\` — 76/76.
- [x] Repo-wide \`pytest\` — green.
- [x] Visual sanity-check: opened the new SVG; every text element has a parent rect / pill; the new framework pills fit without overlap.