### PR TITLE
fix(hero-banner): wordmark + tagline must not overflow their containers

### DIFF
--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -48,17 +48,18 @@
     <rect x="56" y="84" width="772" height="380" rx="22" fill="#0b1628" stroke="#22314d"/>
     <rect x="856" y="84" width="488" height="380" rx="22" fill="#0b1628" stroke="#22314d"/>
 
-    <!-- Wordmark container -->
+    <!-- Wordmark container — sized so the text stays comfortably inside the 724px panel width -->
     <g transform="translate(80,108)">
-      <rect x="0" y="0" width="724" height="76" rx="16" fill="#0a1326" stroke="#1e3a8a"/>
-      <text x="20" y="56" font-size="44" font-weight="900" fill="url(#wordmark)" letter-spacing="-0.8">agentic security skills for cloud and AI</text>
+      <rect x="0" y="0" width="724" height="72" rx="16" fill="#0a1326" stroke="#1e3a8a"/>
+      <text x="20" y="50" font-size="34" font-weight="900" fill="url(#wordmark)" letter-spacing="-0.4">agentic security skills for cloud and AI</text>
     </g>
 
-    <!-- Tagline container -->
-    <g transform="translate(80,196)">
-      <rect x="0" y="0" width="724" height="62" rx="14" fill="#0a1326" stroke="#1e293b"/>
-      <text x="20" y="26" fill="#e5eefb" font-size="15" font-weight="700">Production-grade security skills for cloud and AI systems.</text>
-      <text x="20" y="48" fill="#94a3b8" font-size="13">Same skill bundle contract across CLI, CI, MCP, and persistent runners. OCSF where interop matters; native where state, evidence, and audit matter more.</text>
+    <!-- Tagline container — three short lines, every one comfortably inside the panel -->
+    <g transform="translate(80,192)">
+      <rect x="0" y="0" width="724" height="68" rx="14" fill="#0a1326" stroke="#1e293b"/>
+      <text x="20" y="22" fill="#e5eefb" font-size="14" font-weight="700">Production-grade security skills for cloud and AI systems.</text>
+      <text x="20" y="42" fill="#94a3b8" font-size="12">One bundle, four surfaces — CLI, CI, MCP, and persistent runners share the same skill contract.</text>
+      <text x="20" y="60" fill="#94a3b8" font-size="12">OCSF where interop matters; native where state, evidence, and audit matter more.</text>
     </g>
 
     <!-- Capability pills row 1: counts -->
@@ -112,7 +113,7 @@
         <text x="50" y="23" fill="#dbe4f0" font-size="13" font-weight="700">dual-audited writes</text>
       </g>
       <g transform="translate(450,0)">
-        <rect x="0" y="0" width="202" height="36" rx="12" fill="#11202c" stroke="#0ea5e9"/>
+        <rect x="0" y="0" width="232" height="36" rx="12" fill="#11202c" stroke="#0ea5e9"/>
         <text x="14" y="23" fill="#7dd3fc" font-size="13" font-weight="900">CIS · NIST CSF · SOC 2</text>
       </g>
     </g>


### PR DESCRIPTION
## Summary

Follow-up to #421 — the merged version still showed the wordmark and the tagline overflowing their rounded-rect borders in renders. \`#421\` was auto-merged before this overflow fix landed on the branch.

### Cause

The new wordmark text (\"agentic security skills for cloud and AI\", 39 chars) was set at 44px, which renders ~860px wide — wider than the 724px container. The tagline second line was a 155-char paragraph at 13px that also exceeded the inner width. The Row-3 \`CIS · NIST CSF · SOC 2\` pill was 202px wide; the framework list rendered ~209px and clipped the right edge.

### Fix

- Wordmark font 44 → 34, letter-spacing -0.8 → -0.4. Text now renders ~660px wide; container inner width is 704px.
- Tagline restructured to **three short lines**, each comfortably inside the panel. Container height grew 62 → 68 to fit.
- Row-3 pill widened 202 → 232 so the framework list no longer clips.

### Verification

\`rsvg-convert\` preview confirms every label sits inside its container with breathing room. \`scripts/validate_skill_count_consistency.py\` still passes (the regex patterns over the SVG \`<desc>\` accessibility text are unchanged).

## Test plan

- [x] \`scripts/validate_skill_count_consistency.py\` — 76, 29, 12, 7.
- [x] \`scripts/validate_skill_contract.py\` — 76/76.
- [x] \`scripts/validate_presets.py\` — 4/4.
- [x] Hands-on render: \`rsvg-convert -w 1400 docs/images/hero-banner.svg\` — every text element stays inside its parent container.