### PR TITLE
mcp: strict context schemas + structured tool annotations (#413, #414)

### DIFF
--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -212,6 +212,32 @@ Operationally, this means:
 - operator-facing diagnostics should stay out of the audit record unless they
   are already safe to publish as metadata
 
+## Tool annotation contract
+
+`tools/list` returns each tool with a short description and a structured
+`annotations` object. Agentic clients should filter on `annotations`
+rather than parse the description.
+
+| Annotation key | Type | Source | Meaning |
+|---|---|---|---|
+| `readOnlyHint` | bool | derived | matches MCP spec — true when the skill never writes |
+| `destructiveHint` | bool | derived | inverse of `readOnlyHint` |
+| `idempotentHint` | bool | derived | matches MCP spec — true when re-running converges |
+| `category` | string | SKILL.md path | one of `ingestion`, `discovery`, `detection`, `evaluation`, `remediation`, `view`, `output` |
+| `capability` | string | frontmatter | `read-only`, `write-remediation`, `write-sink`, `write-runner` |
+| `approvalModel` | string | frontmatter | `none`, `human_required`, etc. |
+| `executionModes` | string[] | frontmatter | `jit`, `ci`, `mcp`, `persistent`, … |
+| `sideEffects` | string[] | frontmatter | `none`, `writes-cloud`, `writes-identity`, `writes-database`, `writes-storage`, `writes-audit` |
+| `inputFormats` / `outputFormats` | string[] | frontmatter | `raw`, `canonical`, `ocsf`, `native`, `bridge` |
+| `networkEgress` | string[] | frontmatter | hostnames or `*.glob.example` patterns the skill is allowed to reach |
+| `callerRoles` / `approverRoles` | string[] | frontmatter | RBAC vocabulary |
+| `minApprovers` | int | frontmatter | 0 when not set; > 0 enforces `_approval_context` |
+
+`additionalProperties: false` on `_caller_context` and `_approval_context`
+in the input schema; the wrapper enforces the same closed key set on
+`tools/call` so a typo on `approver_email` -> `approver_emial` is rejected
+with `-32602` instead of silently dropping into an empty approver list.
+
 ## Reliability Expectations
 
 The wrapper should preserve this audit contract across supported tool calls:

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -239,15 +239,53 @@ def _validate_output_format(raw_output_format: Any) -> str | None:
     return raw_output_format
 
 
+_CALLER_CONTEXT_KEYS = frozenset({
+    "user_id",
+    "email",
+    "session_id",
+    "roles",
+    "allowed_skills",
+})
+
+_APPROVAL_CONTEXT_KEYS = frozenset({
+    "approver_id",
+    "approver_email",
+    "ticket_id",
+    "approval_timestamp",
+    "approver_ids",
+    "approver_emails",
+})
+
+_CONTEXT_ALLOWED_KEYS = {
+    "_caller_context": _CALLER_CONTEXT_KEYS,
+    "_approval_context": _APPROVAL_CONTEXT_KEYS,
+}
+
+
 def _validate_context(raw_context: Any, field_name: str) -> dict[str, Any] | None:
+    """Validate `_caller_context` / `_approval_context` against a closed key
+    set.
+
+    The MCP `inputSchema` for these objects is `additionalProperties: false`,
+    but a permissive client may still send the request — the wrapper must be
+    the second gate. A typo like `approver_emial` was previously accepted,
+    landed in the audit record as an empty approver list, and let the
+    `min_approvers` check incorrectly succeed.
+    """
     if raw_context is None:
         return None
     if not isinstance(raw_context, dict):
         raise ValueError(f"`{field_name}` must be an object")
+    allowed = _CONTEXT_ALLOWED_KEYS.get(field_name)
     validated: dict[str, Any] = {}
     for key, value in raw_context.items():
         if not isinstance(key, str):
             raise ValueError(f"`{field_name}` keys must be strings")
+        if allowed is not None and key not in allowed:
+            raise ValueError(
+                f"`{field_name}.{key}` is not a recognised field; "
+                f"allowed keys are {sorted(allowed)}"
+            )
         if isinstance(value, str):
             validated[key] = value
             continue

--- a/mcp-server/src/tool_registry.py
+++ b/mcp-server/src/tool_registry.py
@@ -225,7 +225,11 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
                     "description": "Optional per-caller skill allowlist; intersects with operator allowlists.",
                 },
             },
-            "additionalProperties": True,
+            # Strict: a typo on `approver_email` -> `approver_emial` lands in
+            # the audit event as an empty approver list and the wrapper still
+            # computes min_approvers against the typo'd field. Reject unknown
+            # keys at the schema boundary instead.
+            "additionalProperties": False,
         },
         "_approval_context": {
             "type": "object",
@@ -242,7 +246,7 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
                 "approver_ids": {"type": "array", "items": {"type": "string"}},
                 "approver_emails": {"type": "array", "items": {"type": "string"}},
             },
-            "additionalProperties": True,
+            "additionalProperties": False,
         },
     }
     if skill.output_formats:
@@ -259,26 +263,45 @@ def tool_input_schema(skill: SkillSpec) -> dict[str, object]:
 
 
 def tool_definition(skill: SkillSpec) -> dict[str, object]:
-    mode_list = ", ".join(skill.execution_modes) if skill.execution_modes else "unspecified"
-    effect_list = ", ".join(skill.side_effects) if skill.side_effects else "unspecified"
-    egress_list = ", ".join(skill.network_egress) if skill.network_egress else "none"
-    caller_roles = ", ".join(skill.caller_roles) if skill.caller_roles else "unspecified"
-    approver_roles = ", ".join(skill.approver_roles) if skill.approver_roles else "unspecified"
-    min_approvers = skill.min_approvers if skill.min_approvers is not None else "unspecified"
+    """Build a tool definition for `tools/list`.
+
+    The MCP spec lets servers attach arbitrary keys under `annotations`. The
+    SKILL.md frontmatter carries structured fields (approval model, execution
+    modes, side effects, network egress, caller / approver roles, min
+    approvers) that an agent should be able to filter on programmatically
+    rather than parse out of a free-text description. Those fields live in
+    `annotations` from this PR forward; the description stays short. Legacy
+    `readOnlyHint` / `destructiveHint` / `idempotentHint` are kept for
+    spec-compliant clients that already read them.
+    """
+    description = (
+        skill.description.strip()
+        if skill.description
+        else f"Skill `{skill.name}` ({skill.category} layer)."
+    )
     tool: dict[str, object] = {
         "name": skill.name,
-        "description": (
-            f"{skill.description} Approval model: {skill.approval_model or 'unspecified'}. "
-            f"Execution modes: {mode_list}. Side effects: {effect_list}. "
-            f"Network egress: {egress_list}. "
-            f"Caller roles: {caller_roles}. Approver roles: {approver_roles}. "
-            f"Min approvers: {min_approvers}."
-        ),
+        "description": description,
         "inputSchema": tool_input_schema(skill),
         "annotations": {
+            # Spec-defined hints — kept for clients that already filter on them.
             "readOnlyHint": skill.read_only,
             "destructiveHint": not skill.read_only,
             "idempotentHint": skill.read_only,
+            # Repo-defined structured metadata. Documented in
+            # docs/MCP_AUDIT_CONTRACT.md so tool-using clients can filter
+            # without reading prose.
+            "category": skill.category,
+            "capability": skill.capability,
+            "approvalModel": skill.approval_model or "none",
+            "executionModes": list(skill.execution_modes),
+            "sideEffects": list(skill.side_effects),
+            "inputFormats": list(skill.input_formats),
+            "outputFormats": list(skill.output_formats),
+            "networkEgress": list(skill.network_egress),
+            "callerRoles": list(skill.caller_roles),
+            "approverRoles": list(skill.approver_roles),
+            "minApprovers": skill.min_approvers if skill.min_approvers is not None else 0,
         },
     }
     return tool

--- a/mcp-server/tests/test_server_unit.py
+++ b/mcp-server/tests/test_server_unit.py
@@ -54,6 +54,7 @@ class _FakeSkill:
         self.min_approvers = min_approvers
         self.mcp_timeout_seconds = mcp_timeout_seconds
         self.entrypoint = None if entrypoint_name is None else Path(entrypoint_name)
+        self.input_formats = ()
         self.output_formats = ()
 
 

--- a/mcp-server/tests/test_tool_registry.py
+++ b/mcp-server/tests/test_tool_registry.py
@@ -106,16 +106,26 @@ class TestToolDefinition:
         tool = tool_definition(skill)
         assert tool["name"] == "ingest-cloudtrail-ocsf"
         assert "CloudTrail" in tool["description"]
-        assert tool["annotations"]["readOnlyHint"] is True
         assert tool["inputSchema"]["properties"]["args"]["type"] == "array"
         assert tool["inputSchema"]["properties"]["output_format"]["enum"] == ["ocsf", "native"]
-        assert "Approval model: none." in tool["description"]
-        assert "Execution modes: jit, ci, mcp, persistent." in tool["description"]
-        assert "Side effects: none." in tool["description"]
-        assert "Network egress: none." in tool["description"]
-        assert "Caller roles: unspecified." in tool["description"]
-        assert "Approver roles: unspecified." in tool["description"]
-        assert "Min approvers: unspecified." in tool["description"]
+        # Spec-defined hints stay as before for clients that already filter on them.
+        assert tool["annotations"]["readOnlyHint"] is True
+        assert tool["annotations"]["destructiveHint"] is False
+        assert tool["annotations"]["idempotentHint"] is True
+        # Repo-defined structured metadata replaces the legacy description blob.
+        ann = tool["annotations"]
+        assert ann["category"] == "ingestion"
+        assert ann["capability"] == "read-only"
+        assert ann["approvalModel"] == "none"
+        assert ann["executionModes"] == ["jit", "ci", "mcp", "persistent"]
+        assert ann["sideEffects"] == ["none"]
+        assert ann["inputFormats"] == ["raw"]
+        assert ann["outputFormats"] == ["ocsf", "native"]
+        assert ann["networkEgress"] == []
+        assert ann["callerRoles"] == []
+        assert ann["approverRoles"] == []
+        assert ann["minApprovers"] == 0
+        # SkillSpec invariants unchanged.
         assert skill.input_formats == ("raw",)
         assert skill.output_formats == ("ocsf", "native")
         assert skill.approval_model == "none"


### PR DESCRIPTION
## Summary

Two paired wrapper-only hardenings the audit flagged as DX/security gaps. Both close shipped issues and tighten the MCP contract for agentic clients.

### #413 — \`additionalProperties: false\` on context objects

Typos like \`approver_email\` → \`approver_emial\` previously dropped into an empty \`_approval_context\`, let the \`min_approvers\` gate succeed with zero approvers, and showed up that way in the audit record. The fix is paired so a permissive client cannot bypass the wrapper:

- Input schema flips to \`additionalProperties: false\` on \`_caller_context\` and \`_approval_context\`.
- \`_validate_context()\` enforces the same closed key set on every \`tools/call\`. Unknown keys raise \`-32602 Invalid params\`.

### #414 — Structured \`annotations\` instead of description prose

Agentic clients had to parse free-text \`Approval model: human_required. Execution modes: jit, ci, mcp.\` to filter the tool list. Promote the SKILL.md frontmatter into MCP \`annotations\`:

| key | meaning |
|---|---|
| \`category\` / \`capability\` | layer + write-class |
| \`approvalModel\` / \`minApprovers\` | HITL gate |
| \`executionModes\` / \`sideEffects\` | runtime model |
| \`inputFormats\` / \`outputFormats\` | wire compatibility |
| \`networkEgress\` / \`callerRoles\` / \`approverRoles\` | RBAC + egress envelope |

Spec-defined hints (\`readOnlyHint\`, \`destructiveHint\`, \`idempotentHint\`) are unchanged. Description shrinks back to the SKILL.md description text only.

Both changes are wrapper-only — atomic skills are untouched.

## Test plan

- [x] \`pytest mcp-server/tests/\` — \`test_tool_definition_comes_from_skill_metadata\` rewritten to assert the new annotations; \`_FakeSkill\` extended with \`input_formats\`. All MCP tests pass.
- [x] \`pytest\` repo-wide — green.
- [x] \`ruff check\` — clean.
- [x] \`scripts/validate_skill_contract.py\` — 76/76.
- [x] Hands-on: ran the MCP server stdio loop locally; \`tools/list\` returns annotations including \`approvalModel: human_required\` for remediation skills and \`approvalModel: none\` for read-only ones; sending \`_approval_context: {"approver_emial": "x"}\` is now rejected with \`-32602\`.

Closes #413, #414.