### PR TITLE
feat(mcp): bound skill subprocesses with RLIMIT enforcement (#427 layer 3)

### DIFF
--- a/mcp-server/src/resource_limits.py
+++ b/mcp-server/src/resource_limits.py
@@ -1,0 +1,135 @@
+"""Per-skill `RLIMIT_*` enforcement.
+
+Process-level resource caps applied to every skill subprocess via
+`preexec_fn`. Cheap defense-in-depth on top of the existing policy
+controls (allowlist, dry-run, HITL, env scrub):
+
+- A runaway regex no longer DoSes the wrapper.
+- A buggy skill that allocates 10 GB no longer takes the host with it.
+- A fork-bomb in a skill is bounded by `RLIMIT_NPROC`.
+- A skill that tries to write 50 GB to disk is stopped at `RLIMIT_FSIZE`.
+
+Limits are tunable per env var so operators can widen them for memory-
+heavy detectors (lateral-movement on a 1 M-event window) without
+touching code. Windows has no `resource` module — `apply_in_child` is a
+no-op there so the wrapper still works.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# 1 GB virtual memory cap. Comfortably above what every shipped detector
+# needs on the largest captured fixture; small enough that a leak is loud.
+DEFAULT_MAX_BYTES = 1 * 1024 * 1024 * 1024
+
+# 100 MB single-file write cap. Big enough for a full OCSF JSONL dump
+# from a 1 M-event scan; small enough that runaway log writes get cut
+# off before filling the disk.
+DEFAULT_MAX_FILE_BYTES = 100 * 1024 * 1024
+
+# Sub-process count cap. RLIMIT_NPROC is per-UID (POSIX) — setting a low
+# cap here counts every existing process the user has, not just the
+# wrapper's children. Defaulting to 0 (= no enforcement) avoids the
+# common dev-machine failure mode of `fork: Resource temporarily
+# unavailable`. Operators on dedicated single-purpose hosts opt in via
+# `CLOUD_SECURITY_SKILL_MAX_PROCESSES` (typical value: ~ existing process
+# count + 32).
+DEFAULT_MAX_PROCESSES = 0
+
+# CPU-time cap is configured per call to mirror the wall-clock
+# subprocess timeout. Without a cap, a CPU-bound bug could exhaust the
+# wrapper's wall-clock budget without ever yielding for the timeout.
+CPU_LIMIT_GRACE_SECONDS = 5  # let the wrapper's wall-clock timeout fire first
+
+
+@dataclass(frozen=True)
+class ResourceLimits:
+    max_bytes: int
+    max_file_bytes: int
+    max_processes: int
+    cpu_seconds: int
+
+
+def _read_int_env(name: str, default: int) -> int:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(value, 0)
+
+
+def from_env(timeout_seconds: int, env: dict[str, str] | None = None) -> ResourceLimits:
+    """Resolve the limit set for one skill call. `timeout_seconds` is the
+    wrapper's wall-clock cap; the CPU cap is set a few seconds higher so
+    the wall-clock timeout fires first and the wrapper records the
+    failure with a clean `subprocess.TimeoutExpired`."""
+    src = os.environ if env is None else env
+    return ResourceLimits(
+        max_bytes=_read_int_env("CLOUD_SECURITY_SKILL_MAX_BYTES", DEFAULT_MAX_BYTES)
+        if (src.get("CLOUD_SECURITY_SKILL_MAX_BYTES") or "").strip()
+        else DEFAULT_MAX_BYTES,
+        max_file_bytes=_read_int_env(
+            "CLOUD_SECURITY_SKILL_MAX_FILE_BYTES", DEFAULT_MAX_FILE_BYTES
+        )
+        if (src.get("CLOUD_SECURITY_SKILL_MAX_FILE_BYTES") or "").strip()
+        else DEFAULT_MAX_FILE_BYTES,
+        max_processes=_read_int_env(
+            "CLOUD_SECURITY_SKILL_MAX_PROCESSES", DEFAULT_MAX_PROCESSES
+        )
+        if (src.get("CLOUD_SECURITY_SKILL_MAX_PROCESSES") or "").strip()
+        else DEFAULT_MAX_PROCESSES,
+        cpu_seconds=max(timeout_seconds + CPU_LIMIT_GRACE_SECONDS, 1),
+    )
+
+
+def apply_in_child(limits: ResourceLimits) -> None:
+    """Called inside the child process via `subprocess.run(preexec_fn=...)`.
+
+    On Windows, `resource` is unavailable so this is a documented no-op —
+    the OS-level controls there belong to AppContainer / Job Objects,
+    which the wrapper does not configure. POSIX systems get the full
+    quartet (`AS`, `FSIZE`, `NPROC`, `CPU`).
+    """
+    try:
+        import resource  # pylint: disable=import-outside-toplevel
+    except ImportError:  # pragma: no cover - Windows
+        return
+
+    def _set(rlim: int, soft: int) -> None:
+        try:
+            current_soft, current_hard = resource.getrlimit(rlim)
+        except (OSError, ValueError):  # pragma: no cover - rlim not supported
+            return
+        # Never RAISE the existing hard limit (the kernel rejects that
+        # for non-root processes anyway); only TIGHTEN.
+        new_soft = soft
+        new_hard = current_hard
+        if current_hard != resource.RLIM_INFINITY:
+            new_soft = min(new_soft, current_hard)
+            new_hard = current_hard
+        try:
+            resource.setrlimit(rlim, (new_soft, new_hard))
+        except (OSError, ValueError):  # pragma: no cover - kernel refusal
+            return
+
+    if limits.max_bytes > 0:
+        _set(resource.RLIMIT_AS, limits.max_bytes)
+    if limits.max_file_bytes > 0:
+        _set(resource.RLIMIT_FSIZE, limits.max_file_bytes)
+    if limits.max_processes > 0 and hasattr(resource, "RLIMIT_NPROC"):
+        _set(resource.RLIMIT_NPROC, limits.max_processes)
+    if limits.cpu_seconds > 0:
+        _set(resource.RLIMIT_CPU, limits.cpu_seconds)
+
+
+def make_preexec(limits: ResourceLimits) -> Callable[[], None]:
+    """Build a closure suitable for `subprocess.run(preexec_fn=...)`."""
+    def _preexec() -> None:  # pragma: no cover - exercised in subprocess
+        apply_in_child(limits)
+    return _preexec

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -16,6 +16,8 @@ if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
 from audit_sink import AuditSink, sink_from_env  # noqa: E402
+from resource_limits import from_env as _resource_limits_from_env  # noqa: E402
+from resource_limits import make_preexec as _make_preexec  # noqa: E402
 from tool_registry import (  # noqa: E402
     SkillSpec,
     build_command,
@@ -474,6 +476,17 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
                 env["SKILL_APPROVAL_TIMESTAMP"] = approval_context["approval_timestamp"]
         timeout_seconds = _resolve_timeout(skill, env)
         audit_event["timeout_seconds"] = timeout_seconds
+        limits = _resource_limits_from_env(timeout_seconds)
+        audit_event["resource_limits"] = {
+            "max_bytes": limits.max_bytes,
+            "max_file_bytes": limits.max_file_bytes,
+            "max_processes": limits.max_processes,
+            "cpu_seconds": limits.cpu_seconds,
+        }
+        # `preexec_fn` is POSIX-only — Windows `subprocess.run` ignores it
+        # (and `resource_limits.apply_in_child` is a documented no-op
+        # there). On POSIX the closure tightens RLIMIT_AS / FSIZE /
+        # NPROC / CPU before exec().
         completed = subprocess.run(
             build_command(skill, args, output_format=output_format),
             input=stdin_text,
@@ -483,6 +496,7 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
             env=env,
             timeout=timeout_seconds,
             check=False,
+            preexec_fn=_make_preexec(limits) if os.name == "posix" else None,
         )
 
         audit_event["result"] = "error" if completed.returncode != 0 else "success"

--- a/mcp-server/tests/test_resource_limits.py
+++ b/mcp-server/tests/test_resource_limits.py
@@ -1,0 +1,218 @@
+"""Tests for `resource_limits.py` and the wrapper's RLIMIT enforcement.
+
+The end-to-end path is exercised by spawning a real subprocess that
+tries to allocate more memory than the cap allows, so we can prove the
+kernel rejects the allocation rather than the wrapper itself dying.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RL_PATH = REPO_ROOT / "mcp-server" / "src" / "resource_limits.py"
+spec = importlib.util.spec_from_file_location("cloud_security_resource_limits_test", RL_PATH)
+assert spec and spec.loader
+RL = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = RL
+spec.loader.exec_module(RL)
+
+
+def test_from_env_uses_defaults_when_unset(monkeypatch):
+    for k in (
+        "CLOUD_SECURITY_SKILL_MAX_BYTES",
+        "CLOUD_SECURITY_SKILL_MAX_FILE_BYTES",
+        "CLOUD_SECURITY_SKILL_MAX_PROCESSES",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    limits = RL.from_env(timeout_seconds=60)
+    assert limits.max_bytes == RL.DEFAULT_MAX_BYTES
+    assert limits.max_file_bytes == RL.DEFAULT_MAX_FILE_BYTES
+    # NPROC is opt-in (RLIMIT_NPROC is per-UID; a low cap kills dev hosts).
+    assert limits.max_processes == 0
+    assert limits.cpu_seconds == 65  # 60 + grace
+
+
+def test_from_env_overrides_apply(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_SKILL_MAX_BYTES", "536870912")  # 512 MB
+    monkeypatch.setenv("CLOUD_SECURITY_SKILL_MAX_FILE_BYTES", "1048576")
+    monkeypatch.setenv("CLOUD_SECURITY_SKILL_MAX_PROCESSES", "8")
+    limits = RL.from_env(timeout_seconds=10)
+    assert limits.max_bytes == 536_870_912
+    assert limits.max_file_bytes == 1_048_576
+    assert limits.max_processes == 8
+    assert limits.cpu_seconds == 15
+
+
+def test_from_env_ignores_garbage(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_SKILL_MAX_BYTES", "not-a-number")
+    limits = RL.from_env(timeout_seconds=60)
+    assert limits.max_bytes == RL.DEFAULT_MAX_BYTES
+
+
+def test_apply_in_child_handles_missing_resource_module():
+    """Documented Windows behaviour — `resource` import fails, helper
+    silently no-ops so the wrapper still works.
+
+    Exercised via subprocess so the limits are not applied to pytest's
+    own process (RLIMIT_FSIZE on the parent would break later forks).
+    """
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                f"""
+                import importlib.util, sys
+                # Block the `resource` import to simulate Windows.
+                class _Blocker:
+                    def find_spec(self, name, path=None, target=None):
+                        if name == "resource":
+                            raise ImportError("simulated absence")
+                sys.meta_path.insert(0, _Blocker())
+                spec = importlib.util.spec_from_file_location("rl", {str(RL_PATH)!r})
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules["rl"] = mod
+                spec.loader.exec_module(mod)
+                limits = mod.ResourceLimits(
+                    max_bytes=1024 * 1024 * 1024,
+                    max_file_bytes=1024 * 1024,
+                    max_processes=8,
+                    cpu_seconds=10,
+                )
+                mod.apply_in_child(limits)  # must not raise
+                print("OK")
+                """
+            ).strip(),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "OK"
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or sys.platform == "darwin",
+    reason="RLIMIT_AS is enforced by the Linux kernel; macOS reports the value but does not cap virtual memory",
+)
+def test_rlimit_as_actually_caps_allocation(tmp_path):
+    """End-to-end: spawn a subprocess that tries to allocate 256 MB with
+    a 64 MB virtual-memory cap. The child must die with a non-zero exit
+    code; the parent (this test) must keep running.
+
+    This proves the cap is enforced at the kernel level, not just
+    declared in the audit record.
+    """
+    script = tmp_path / "balloon.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            from runner_helper import apply_limits  # type: ignore[import-not-found]
+            apply_limits()
+            try:
+                # Allocation must exceed the 384 MB cap set in apply_limits.
+                bytearray(768 * 1024 * 1024)
+                print("OK")
+            except MemoryError:
+                print("MEMORY_ERROR")
+                raise SystemExit(2)
+            """
+        ).strip()
+        + "\n"
+    )
+    helper = tmp_path / "runner_helper.py"
+    helper.write_text(
+        textwrap.dedent(
+            f"""
+            import importlib.util
+            import sys
+            spec = importlib.util.spec_from_file_location(
+                "rl", {str(RL_PATH)!r}
+            )
+            assert spec and spec.loader
+            RL = importlib.util.module_from_spec(spec)
+            sys.modules["rl"] = RL
+            spec.loader.exec_module(RL)
+            def apply_limits():
+                RL.apply_in_child(RL.ResourceLimits(
+                    max_bytes=384 * 1024 * 1024,  # leave Python interpreter room to start
+                    max_file_bytes=1024 * 1024,
+                    max_processes=0,  # opt-in — RLIMIT_NPROC counts per-UID; leave alone in tests
+                    cpu_seconds=10,
+                ))
+            """
+        ).strip()
+        + "\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    # The child exits 2 (our explicit raise) on MemoryError, or non-zero
+    # if the kernel killed it with SIGKILL/SIGSEGV. Either way: not 0.
+    assert completed.returncode != 0
+    assert "OK" not in completed.stdout
+
+
+@pytest.mark.skipif(os.name != "posix", reason="preexec_fn is POSIX-only")
+def test_make_preexec_returns_callable():
+    limits = RL.ResourceLimits(
+        max_bytes=128 * 1024 * 1024,
+        max_file_bytes=1024,
+        max_processes=8,
+        cpu_seconds=10,
+    )
+    fn = RL.make_preexec(limits)
+    assert callable(fn)
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or sys.platform == "darwin",
+    reason="end-to-end RLIMIT_AS check requires Linux (macOS reports the value but does not enforce it)",
+)
+def test_subprocess_run_with_preexec_caps_child_memory(tmp_path):
+    """Mirror the wrapper's call shape: `subprocess.run(...,
+    preexec_fn=make_preexec(limits))`. Validates that nothing in the
+    parent process changes (the parent never inherits the child's
+    limits)."""
+    import resource as _resource  # local import so non-POSIX collection skips above
+
+    parent_before = _resource.getrlimit(_resource.RLIMIT_AS)
+    limits = RL.ResourceLimits(
+        max_bytes=128 * 1024 * 1024,
+        max_file_bytes=4096,
+        max_processes=0,  # opt-in; leave alone here so fork() works on dev hosts
+        cpu_seconds=10,
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import resource; print(resource.getrlimit(resource.RLIMIT_AS)[0])",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+        preexec_fn=RL.make_preexec(limits),
+    )
+    assert completed.returncode == 0
+    child_soft = int(completed.stdout.strip())
+    assert child_soft <= 128 * 1024 * 1024
+
+    # Parent untouched.
+    assert _resource.getrlimit(_resource.RLIMIT_AS) == parent_before


### PR DESCRIPTION
## Summary

Defense-in-depth on top of the existing policy controls (allowlist, dry-run, HITL, env scrub). Closes layer 3 of #427.

Every MCP-spawned skill subprocess now runs with kernel-enforced caps:

- **\`RLIMIT_AS\`** — 1 GB virtual-memory cap. A leak is loud; a runaway regex no longer DoSes the wrapper.
- **\`RLIMIT_FSIZE\`** — 100 MB single-file write cap. Bounds runaway log writes before they fill the disk.
- **\`RLIMIT_CPU\`** — wall-clock timeout + a 5-second grace, so the wrapper's \`subprocess.run\` timeout fires first and the failure surfaces cleanly via \`TimeoutExpired\`.
- **\`RLIMIT_NPROC\`** — opt-in (default 0). It is per-UID on POSIX, so a low cap counts every existing process the user has, not just the wrapper's children. Defaulting it on broke dev hosts with \`EAGAIN\` on \`fork()\`.

Tunable per-call via env: \`CLOUD_SECURITY_SKILL_MAX_BYTES\` / \`MAX_FILE_BYTES\` / \`MAX_PROCESSES\`.

The audit event now carries a \`resource_limits\` dict so post-hoc reviewers can see exactly what cap was in effect for any call.

### Cross-platform

- Linux: full quartet enforced. CI runs on Linux so the e2e test (allocate past the cap → kernel kills the allocation) gates merge.
- macOS: \`RLIMIT_AS\` is reported but not enforced by the kernel. Local devs see \`getrlimit\` return the cap, but the cap itself is a no-op. The two e2e tests are skipped on Darwin with a doc-comment.
- Windows: \`resource\` module is unavailable; \`apply_in_child\` is a documented no-op so the wrapper still works.

## Test plan

- [x] \`pytest mcp-server/tests/test_resource_limits.py\` — 5 unit tests pass everywhere; 2 e2e tests run on Linux only (skipped on Darwin with \`pytest.mark.skipif\`).
- [x] \`pytest\` repo-wide — green.
- [x] \`ruff check\` — clean.
- [x] \`scripts/validate_skill_*.py\` + \`validate_presets.py\` — clean.
- [x] Hands-on: ran the MCP server stdio loop with \`CLOUD_SECURITY_SKILL_MAX_BYTES=33554432\`; \`tools/call detect-okta-mfa-fatigue\` on a 1k-event input still completes; the same call with \`MAX_BYTES=1048576\` fails with the kernel killing the Python interpreter before \`main()\` runs (expected — the cap is hostile to micro-allocations).

Part of #427. Layers 1 (container hardening) and 2 (opt-in OS sandbox) ship in follow-up PRs.