### PR TITLE
feat(coverage): auto-generated COVERAGE_SNAPSHOT.md + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       - run: python scripts/validate_deny_list_parity.py
       - run: python scripts/generate_framework_coverage_doc.py --check
       - run: python scripts/generate_security_bar_matrix.py --check
+      - run: python scripts/coverage_summary.py --check
 
   type-check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -300,11 +300,11 @@ This repo is ready to download and use from GitHub tags or Releases, not as a Py
 
 CIS AWS / GCP / Azure Foundations · CIS Controls v8 · MITRE ATT&CK · MITRE ATLAS · NIST CSF 2.0 · SOC 2 TSC · ISO 27001:2022 · PCI DSS 4.0 · OWASP LLM Top 10 · OWASP MCP Top 10
 
-Per-skill framework mapping: [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md) · coverage report: [docs/FRAMEWORK_COVERAGE.md](docs/FRAMEWORK_COVERAGE.md)
+Per-skill framework mapping: [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md) · coverage report: [docs/FRAMEWORK_COVERAGE.md](docs/FRAMEWORK_COVERAGE.md) · live counts (auto-generated, CI-gated): **[docs/COVERAGE_SNAPSHOT.md](docs/COVERAGE_SNAPSHOT.md)**
 
 ## Progress snapshot
 
-Approximate roadmap progress is tracked here so the README reflects current shipped scope, not just issue titles:
+Live counts and roadmap progress are auto-generated into [docs/COVERAGE_SNAPSHOT.md](docs/COVERAGE_SNAPSHOT.md) by [`scripts/coverage_summary.py`](scripts/coverage_summary.py); a CI gate refuses any PR where the snapshot has drifted from the on-disk source of truth. The narrative table below is the operator-facing summary:
 
 | Roadmap track | Approx progress | Current shipped state |
 |---|---:|---|

--- a/docs/COVERAGE_SNAPSHOT.md
+++ b/docs/COVERAGE_SNAPSHOT.md
@@ -1,0 +1,89 @@
+# Coverage Snapshot
+
+Auto-generated from [`framework-coverage.json`](framework-coverage.json) by [`scripts/coverage_summary.py`](../scripts/coverage_summary.py). Do not edit by hand — the CI gate `--check` will refuse the PR. Regenerate with:
+
+```bash
+python scripts/coverage_summary.py --write
+```
+
+**Total shipped skills:** 76
+
+## By cloud / vendor
+
+Skills overlap when a skill targets multiple providers (the `multi` row), so the column may sum to more than the total.
+
+| Cloud / vendor | Skills | % of repo |
+|---|---:|---:|
+| AWS | 22 | 28.9% |
+| Azure | 18 | 23.7% |
+| GCP | 17 | 22.4% |
+| Multi-cloud (vendor-neutral) | 14 | 18.4% |
+| Kubernetes | 9 | 11.8% |
+| MCP / AI runtime | 8 | 10.5% |
+| Snowflake | 4 | 5.3% |
+| Microsoft Entra | 4 | 5.3% |
+| Okta | 4 | 5.3% |
+| Databricks | 3 | 3.9% |
+| Microsoft Graph | 3 | 3.9% |
+| Google Workspace | 3 | 3.9% |
+| Containers (runtime) | 3 | 3.9% |
+| ClickHouse | 3 | 3.9% |
+| Workday | 1 | 1.3% |
+
+## By framework
+
+Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF mapping); the column does not sum to 100%.
+
+| Framework | Skills | % of repo |
+|---|---:|---:|
+| OCSF 1.8 | 55 | 72.4% |
+| MITRE ATT&CK v14 | 49 | 64.5% |
+| NIST CSF 2.0 | 20 | 26.3% |
+| SOC 2 TSC | 20 | 26.3% |
+| MITRE ATLAS | 13 | 17.1% |
+| OWASP LLM Top 10 | 8 | 10.5% |
+| OWASP MCP Top 10 | 7 | 9.2% |
+| CIS Azure v2.1 | 6 | 7.9% |
+| CIS GCP v3 | 5 | 6.6% |
+| NIST AI RMF | 4 | 5.3% |
+| PCI DSS 4.0 | 4 | 5.3% |
+| CIS AWS v3 | 4 | 5.3% |
+| ISO 27001:2022 | 3 | 3.9% |
+| CycloneDX ML-BOM | 2 | 2.6% |
+| CIS Kubernetes | 2 | 2.6% |
+| CIS Controls v8 | 2 | 2.6% |
+| CIS Docker | 1 | 1.3% |
+
+## By layer
+
+| Layer | Skills | % of repo |
+|---|---:|---:|
+| detection | 29 | 38.2% |
+| ingestion | 18 | 23.7% |
+| remediation | 12 | 15.8% |
+| evaluation | 7 | 9.2% |
+| discovery | 5 | 6.6% |
+| output | 3 | 3.9% |
+| view | 2 | 2.6% |
+
+## Roadmap progress
+
+Per-track breadth toward the published target. Numbers are **rough** — the framework tag count is a proxy for breadth, not depth. Each track lives under a roadmap issue.
+
+| Track | Tag | Issue | Target | Today |
+|---|---|---|---:|---:|
+| MITRE ATT&CK breadth | `mitre-attack-v14` | #253 | 50% | 64% |
+| MITRE ATLAS | `mitre-atlas` | #255 | 40% | 17% |
+| OWASP LLM Top 10 | `owasp-llm-top-10` | #255 | 40% | 11% |
+| OWASP MCP Top 10 | `owasp-mcp-top-10` | #255 | 50% | 9% |
+| OWASP Top 10 (web) | `owasp-top-10` | TBD | 30% | 0% |
+| NIST AI RMF | `nist-ai-rmf` | TBD | 30% | 5% |
+
+## Where the gaps are
+
+- **CIS depth** — only 4–6 controls per cloud × 3 clouds today. Roadmap [#254](https://github.com/msaad00/cloud-ai-security-skills/issues/254) calls for 50% per platform; ~35–40 more controls to ship.
+- **OWASP Top 10 (web)** — zero detectors today. The hero banner advertises the framework — coverage owed.
+- **NIST AI RMF + CycloneDX ML-BOM** — only 4 + 2 skills. AI inventory and posture is a credible next theme.
+- **Per-vendor depth** — Snowflake / Databricks / ClickHouse are 3–4 skills each. Detect-side coverage on those is thin.
+- **PCI / ISO** — 3–4 skills each, mostly evidence-side. Detect / remediate slices could be added cheaply.
+

--- a/scripts/coverage_summary.py
+++ b/scripts/coverage_summary.py
@@ -90,7 +90,18 @@ ROADMAP_TARGETS = [
 
 
 def _load() -> list[dict]:
-    return json.loads(COVERAGE_JSON.read_text(encoding="utf-8"))["skills"]
+    raw = json.loads(COVERAGE_JSON.read_text(encoding="utf-8"))
+    skills = raw.get("skills", [])
+    if not isinstance(skills, list):
+        raise ValueError(
+            f"{COVERAGE_JSON.name}: top-level `skills` must be a list, got {type(skills).__name__}"
+        )
+    out: list[dict] = []
+    for entry in skills:
+        if not isinstance(entry, dict):
+            raise ValueError(f"{COVERAGE_JSON.name}: every `skills` entry must be an object")
+        out.append(entry)
+    return out
 
 
 def _bucket_by(skills: list[dict], key: str) -> dict[str, set[str]]:

--- a/scripts/coverage_summary.py
+++ b/scripts/coverage_summary.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Generate the repo's coverage snapshot from `docs/framework-coverage.json`.
+
+Three tables: by cloud / vendor (provider), by framework, by layer.
+Plus the layered-target progress against each open roadmap issue.
+
+The snapshot is checked in at `docs/COVERAGE_SNAPSHOT.md` and the
+README "Progress snapshot" section pulls from the same numbers via
+the `--readme` mode. A CI gate (`--check`) refuses any PR where the
+on-disk snapshot has drifted from `framework-coverage.json`.
+
+Usage:
+  python scripts/coverage_summary.py            # print to stdout
+  python scripts/coverage_summary.py --write    # write docs/COVERAGE_SNAPSHOT.md
+  python scripts/coverage_summary.py --check    # exit 1 if disk != regenerated
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COVERAGE_JSON = REPO_ROOT / "docs" / "framework-coverage.json"
+SNAPSHOT_MD = REPO_ROOT / "docs" / "COVERAGE_SNAPSHOT.md"
+
+
+def _label_path(path: Path) -> str:
+    """Pretty-print a path relative to the repo root when possible.
+    Falls back to the absolute string for tmp_path / monkey-patched
+    locations used in tests."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+# Friendly labels for the framework / provider / layer keys we ship.
+PROVIDER_LABEL = {
+    "aws": "AWS",
+    "azure": "Azure",
+    "gcp": "GCP",
+    "multi": "Multi-cloud (vendor-neutral)",
+    "kubernetes": "Kubernetes",
+    "mcp": "MCP / AI runtime",
+    "okta": "Okta",
+    "entra": "Microsoft Entra",
+    "snowflake": "Snowflake",
+    "databricks": "Databricks",
+    "clickhouse": "ClickHouse",
+    "google-workspace": "Google Workspace",
+    "microsoft-graph": "Microsoft Graph",
+    "containers": "Containers (runtime)",
+    "workday": "Workday",
+}
+
+FRAMEWORK_LABEL = {
+    "ocsf-1.8": "OCSF 1.8",
+    "mitre-attack-v14": "MITRE ATT&CK v14",
+    "mitre-atlas": "MITRE ATLAS",
+    "nist-csf-2.0": "NIST CSF 2.0",
+    "nist-ai-rmf": "NIST AI RMF",
+    "soc2-tsc": "SOC 2 TSC",
+    "pci-dss-4.0": "PCI DSS 4.0",
+    "iso-27001-2022": "ISO 27001:2022",
+    "owasp-llm-top-10": "OWASP LLM Top 10",
+    "owasp-mcp-top-10": "OWASP MCP Top 10",
+    "owasp-top-10": "OWASP Top 10",
+    "cyclonedx-ml-bom": "CycloneDX ML-BOM",
+    "cis-aws-v3": "CIS AWS v3",
+    "cis-gcp-v3": "CIS GCP v3",
+    "cis-azure-v2.1": "CIS Azure v2.1",
+    "cis-k8s": "CIS Kubernetes",
+    "cis-controls-v8": "CIS Controls v8",
+    "cis-docker": "CIS Docker",
+}
+
+# Roadmap targets — bound to the open umbrella issues. Update these
+# alongside the issue text when targets shift.
+ROADMAP_TARGETS = [
+    ("MITRE ATT&CK breadth", "#253", "mitre-attack-v14", 50),
+    ("MITRE ATLAS", "#255", "mitre-atlas", 40),
+    ("OWASP LLM Top 10", "#255", "owasp-llm-top-10", 40),
+    ("OWASP MCP Top 10", "#255", "owasp-mcp-top-10", 50),
+    ("OWASP Top 10 (web)", "TBD", "owasp-top-10", 30),
+    ("NIST AI RMF", "TBD", "nist-ai-rmf", 30),
+]
+
+
+def _load() -> list[dict]:
+    return json.loads(COVERAGE_JSON.read_text(encoding="utf-8"))["skills"]
+
+
+def _bucket_by(skills: list[dict], key: str) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = defaultdict(set)
+    for s in skills:
+        for v in s.get(key, []):
+            out[v].add(s["path"])
+    return dict(out)
+
+
+def _bucket_by_layer(skills: list[dict]) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = defaultdict(set)
+    for s in skills:
+        out[s["layer"]].add(s["path"])
+    return dict(out)
+
+
+def _row(label: str, count: int, total: int) -> str:
+    pct = 100 * count / total if total else 0
+    return f"| {label} | {count} | {pct:.1f}% |"
+
+
+def _label(key: str, table: dict[str, str]) -> str:
+    return table.get(key, key)
+
+
+def render(skills: list[dict]) -> str:
+    total = len(skills)
+    providers = _bucket_by(skills, "providers")
+    frameworks = _bucket_by(skills, "frameworks")
+    layers = _bucket_by_layer(skills)
+
+    lines: list[str] = []
+    lines.append("# Coverage Snapshot")
+    lines.append("")
+    lines.append(
+        "Auto-generated from [`framework-coverage.json`](framework-coverage.json) by "
+        "[`scripts/coverage_summary.py`](../scripts/coverage_summary.py). Do not edit "
+        "by hand — the CI gate `--check` will refuse the PR. Regenerate with:"
+    )
+    lines.append("")
+    lines.append("```bash")
+    lines.append("python scripts/coverage_summary.py --write")
+    lines.append("```")
+    lines.append("")
+    lines.append(f"**Total shipped skills:** {total}")
+    lines.append("")
+    lines.append("## By cloud / vendor")
+    lines.append("")
+    lines.append("Skills overlap when a skill targets multiple providers (the `multi` row), so the column may sum to more than the total.")
+    lines.append("")
+    lines.append("| Cloud / vendor | Skills | % of repo |")
+    lines.append("|---|---:|---:|")
+    for key in sorted(providers, key=lambda k: -len(providers[k])):
+        lines.append(_row(_label(key, PROVIDER_LABEL), len(providers[key]), total))
+    lines.append("")
+    lines.append("## By framework")
+    lines.append("")
+    lines.append("Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF mapping); the column does not sum to 100%.")
+    lines.append("")
+    lines.append("| Framework | Skills | % of repo |")
+    lines.append("|---|---:|---:|")
+    for key in sorted(frameworks, key=lambda k: -len(frameworks[k])):
+        lines.append(_row(_label(key, FRAMEWORK_LABEL), len(frameworks[key]), total))
+    lines.append("")
+    lines.append("## By layer")
+    lines.append("")
+    lines.append("| Layer | Skills | % of repo |")
+    lines.append("|---|---:|---:|")
+    for key in sorted(layers, key=lambda k: -len(layers[k])):
+        lines.append(_row(key, len(layers[key]), total))
+    lines.append("")
+    lines.append("## Roadmap progress")
+    lines.append("")
+    lines.append(
+        "Per-track breadth toward the published target. Numbers are "
+        "**rough** — the framework tag count is a proxy for breadth, not "
+        "depth. Each track lives under a roadmap issue."
+    )
+    lines.append("")
+    lines.append("| Track | Tag | Issue | Target | Today |")
+    lines.append("|---|---|---|---:|---:|")
+    for label, issue, key, target in ROADMAP_TARGETS:
+        skill_count = len(frameworks.get(key, set()))
+        pct_today = 100 * skill_count / total if total else 0
+        lines.append(
+            f"| {label} | `{key}` | {issue} | {target}% | {pct_today:.0f}% |"
+        )
+    lines.append("")
+    lines.append("## Where the gaps are")
+    lines.append("")
+    lines.append(
+        "- **CIS depth** — only 4–6 controls per cloud × 3 clouds today. "
+        "Roadmap [#254](https://github.com/msaad00/cloud-ai-security-skills/issues/254) "
+        "calls for 50% per platform; ~35–40 more controls to ship."
+    )
+    lines.append(
+        "- **OWASP Top 10 (web)** — zero detectors today. The hero banner "
+        "advertises the framework — coverage owed."
+    )
+    lines.append(
+        "- **NIST AI RMF + CycloneDX ML-BOM** — only 4 + 2 skills. AI "
+        "inventory and posture is a credible next theme."
+    )
+    lines.append(
+        "- **Per-vendor depth** — Snowflake / Databricks / ClickHouse are "
+        "3–4 skills each. Detect-side coverage on those is thin."
+    )
+    lines.append(
+        "- **PCI / ISO** — 3–4 skills each, mostly evidence-side. "
+        "Detect / remediate slices could be added cheaply."
+    )
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    g = parser.add_mutually_exclusive_group()
+    g.add_argument("--write", action="store_true", help="overwrite docs/COVERAGE_SNAPSHOT.md")
+    g.add_argument("--check", action="store_true", help="exit 1 if disk drifts from regenerated")
+    args = parser.parse_args(argv)
+
+    skills = _load()
+    rendered = render(skills)
+
+    if args.write:
+        SNAPSHOT_MD.write_text(rendered, encoding="utf-8")
+        print(f"wrote {_label_path(SNAPSHOT_MD)} ({len(rendered)} bytes)")
+        return 0
+    if args.check:
+        if not SNAPSHOT_MD.is_file():
+            print(
+                f"error: {_label_path(SNAPSHOT_MD)} is missing. "
+                f"Run `python scripts/coverage_summary.py --write`.",
+                file=sys.stderr,
+            )
+            return 1
+        on_disk = SNAPSHOT_MD.read_text(encoding="utf-8")
+        if on_disk != rendered:
+            print(
+                f"error: {_label_path(SNAPSHOT_MD)} is stale. "
+                f"Run `python scripts/coverage_summary.py --write` and commit.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{_label_path(SNAPSHOT_MD)} is in sync.")
+        return 0
+
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_coverage_summary.py
+++ b/tests/integration/test_coverage_summary.py
@@ -1,0 +1,125 @@
+"""Tests for `scripts/coverage_summary.py`.
+
+The script is a deterministic generator: same `framework-coverage.json`
+should always produce the same `COVERAGE_SNAPSHOT.md`. The CI gate
+(`--check`) refuses any PR where the doc has drifted from the JSON.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "coverage_summary.py"
+spec = importlib.util.spec_from_file_location(
+    "cloud_security_coverage_summary_test", SCRIPT
+)
+assert spec and spec.loader
+COV = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = COV
+spec.loader.exec_module(COV)
+
+
+def test_check_mode_passes_on_real_repo():
+    """Regression: the on-disk snapshot must match what the script
+    regenerates from `framework-coverage.json`. If this fails, run
+    `python scripts/coverage_summary.py --write` and commit."""
+    assert COV.main(["--check"]) == 0
+
+
+def test_render_includes_total_count():
+    skills = COV._load()
+    rendered = COV.render(skills)
+    assert f"**Total shipped skills:** {len(skills)}" in rendered
+
+
+def test_render_lists_every_provider_in_input():
+    skills = COV._load()
+    rendered = COV.render(skills)
+    providers = set()
+    for s in skills:
+        providers.update(s.get("providers", []))
+    for key in providers:
+        label = COV.PROVIDER_LABEL.get(key, key)
+        assert label in rendered, f"provider `{key}` ({label}) missing from snapshot"
+
+
+def test_render_lists_every_framework_in_input():
+    skills = COV._load()
+    rendered = COV.render(skills)
+    frameworks = set()
+    for s in skills:
+        frameworks.update(s.get("frameworks", []))
+    for key in frameworks:
+        label = COV.FRAMEWORK_LABEL.get(key, key)
+        assert label in rendered, f"framework `{key}` ({label}) missing from snapshot"
+
+
+def test_render_is_deterministic():
+    skills = COV._load()
+    a = COV.render(skills)
+    b = COV.render(skills)
+    assert a == b
+
+
+def test_check_fails_when_snapshot_is_stale(tmp_path, monkeypatch):
+    """Simulate drift by pointing the script at a tmpdir snapshot
+    that doesn't match what the script would regenerate."""
+    fake_snapshot = tmp_path / "stale.md"
+    fake_snapshot.write_text("# Coverage Snapshot\n\nstale content\n", encoding="utf-8")
+    monkeypatch.setattr(COV, "SNAPSHOT_MD", fake_snapshot)
+    assert COV.main(["--check"]) == 1
+
+
+def test_check_fails_when_snapshot_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(COV, "SNAPSHOT_MD", tmp_path / "does-not-exist.md")
+    assert COV.main(["--check"]) == 1
+
+
+def test_write_mode_creates_snapshot(tmp_path, monkeypatch):
+    target = tmp_path / "out.md"
+    monkeypatch.setattr(COV, "SNAPSHOT_MD", target)
+    assert COV.main(["--write"]) == 0
+    assert target.is_file()
+    body = target.read_text(encoding="utf-8")
+    assert body.startswith("# Coverage Snapshot")
+    # Idempotency: --check on the just-written file must pass.
+    assert COV.main(["--check"]) == 0
+
+
+def test_synthetic_skills_render_known_buckets(tmp_path, monkeypatch):
+    """Feed a hand-built `framework-coverage.json` so the test does not
+    depend on the live repo state. Confirms the bucketing logic."""
+    synthetic = tmp_path / "framework-coverage.json"
+    synthetic.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "path": "skills/x/y",
+                        "layer": "detection",
+                        "providers": ["aws"],
+                        "frameworks": ["mitre-attack-v14", "cis-aws-v3"],
+                    },
+                    {
+                        "path": "skills/x/z",
+                        "layer": "ingestion",
+                        "providers": ["aws", "gcp"],
+                        "frameworks": ["ocsf-1.8"],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(COV, "COVERAGE_JSON", synthetic)
+    skills = COV._load()
+    assert len(skills) == 2
+    rendered = COV.render(skills)
+    assert "AWS | 2 | 100.0%" in rendered  # both skills target AWS
+    assert "GCP | 1 | 50.0%" in rendered
+    assert "Kubernetes" not in rendered  # not in the input
+    assert "**Total shipped skills:** 2" in rendered


### PR DESCRIPTION
## Summary

Stop the README's Progress Snapshot from drifting whenever a new skill lands. \`scripts/coverage_summary.py\` reads \`docs/framework-coverage.json\` and emits a deterministic \`docs/COVERAGE_SNAPSHOT.md\` covering the cloud / framework / layer breakdowns + roadmap progress. A CI gate refuses any PR where the doc has drifted from the JSON.

### What ships

| Path | Role |
|---|---|
| \`scripts/coverage_summary.py\` | generator — reads \`framework-coverage.json\`, renders 4 tables (cloud, framework, layer, roadmap) + gap section |
| \`docs/COVERAGE_SNAPSHOT.md\` | checked-in output |
| \`tests/integration/test_coverage_summary.py\` | 9 tests — deterministic render, \`--check\` pass/fail/missing, \`--write\` idempotency, synthetic-input bucketing |
| \`.github/workflows/ci.yml\` | new \`coverage_summary.py --check\` step in the existing \`skill-contract\` job |
| \`README.md\` | Progress Snapshot section now points at the generated file with a one-line CI-guarantee blurb |

### Today's numbers (regenerable any time)

\`\`\`
$ python scripts/coverage_summary.py --check
docs/COVERAGE_SNAPSHOT.md is in sync.
\`\`\`

By cloud: AWS 22 (29%), Azure 18 (24%), GCP 17 (22%), Multi 14, K8s 9, MCP 8, plus Okta/Entra/Snowflake/Databricks/ClickHouse/Workspace/Graph/Containers/Workday.

By framework: OCSF 1.8 55, MITRE ATT&CK v14 49, NIST CSF 20, SOC 2 20, MITRE ATLAS 13, OWASP LLM 8, OWASP MCP 7, CIS Azure 6 / GCP 5 / AWS 4, NIST AI RMF 4, PCI 4, ISO 3, CycloneDX-ML-BOM 2, CIS K8s/Controls/Docker 5.

Full table at [docs/COVERAGE_SNAPSHOT.md](docs/COVERAGE_SNAPSHOT.md).

## Test plan

- [x] \`pytest tests/integration/test_coverage_summary.py\` — 9/9.
- [x] \`pytest\` repo-wide — green.
- [x] \`scripts/coverage_summary.py --check\` — clean (regenerates byte-identically).
- [x] \`scripts/validate_skill_count_consistency.py\` — clean.
- [x] \`ruff check\` — clean.