### PR TITLE
feat(skills): cross-cutting retry / error envelope / structured logger (#429)

### DIFF
--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -209,3 +209,69 @@ CI currently validates:
 - wildcard IAM / RBAC policy entries carry an explicit `WILDCARD_OK` justification
 
 The contract will expand over time, but new CI rules should only be added when the current tree already satisfies them.
+
+## Throttling, errors, and logs
+
+Every shipped skill follows a single shared contract for retries,
+errors, and structured logs. The three modules under
+[`skills/_shared/`](../skills/_shared/) are the source of truth:
+
+| Concern | Module | Helper |
+|---|---|---|
+| Rate-limit / 5xx retries with bounded backoff | `skills/_shared/retry.py` | `@retry_on_throttle()` decorator + `retry_call()` functional API |
+| Structured error envelope | `skills/_shared/errors.py` | `SkillError` hierarchy + `emit_error()` |
+| Structured logs (one-line JSON on stderr) | `skills/_shared/logging.py` | `get_logger(__name__, skill=..., layer=...)` |
+
+### Retry rules — read before you tune
+
+The retry helper is **bounded by construction**:
+
+- Hard attempt cap: default 5, never below 1 or above 10.
+- Hard wall-clock budget: default 60s from the first call, ceiling 600s.
+- Bounded backoff: `min(base × 2^attempt, cap)` with full-jitter; cap defaults to 16s.
+- Permanent errors short-circuit — no budget burn.
+- A retry helper never calls another retry helper for the same function.
+  Tested explicitly so we cannot reintroduce the `attempts^2` loop.
+
+If a skill needs different limits, it sets the SKILL.md frontmatter
+fields `retry_max_attempts` / `retry_total_budget_seconds` and reads
+them in code via `RetryPolicy(...)` — the schema validator pins the
+ranges so a misconfigured skill cannot silently disable the cap.
+
+### Error envelope
+
+The `SkillError` hierarchy partitions every failure into one of five
+buckets a SIEM can route on:
+
+```
+SkillError
+├── ConfigError       (1)   missing env / bad SKILL.md / bad CLI args
+├── AuthError         (2)   401 / 403 / no creds / bad role
+├── PermanentError    (1)   4xx that retries cannot fix
+├── TransientError    (75)  rate-limited / 5xx / network blip
+└── ContractError     (1)   caller violated the skill contract
+```
+
+Numbers in parentheses are the exit code `emit_error()` returns to the
+shell. `75` is `EX_TEMPFAIL` so a host runner / wrapper can retry; the
+others are permanent failures that should propagate.
+
+### Logging shape
+
+```json
+{
+  "timestamp": "2026-05-09T23:45:00.123Z",
+  "level": "warning",
+  "logger": "skills.detection.detect_okta_mfa_fatigue.src.detect",
+  "skill": "detect-okta-mfa-fatigue",
+  "layer": "detection",
+  "correlation_id": "f3c4-…",
+  "message": "rate-limited by Okta — retrying"
+}
+```
+
+Every shipped skill stamps `skill`, `layer`, and the
+`SKILL_CORRELATION_ID` env var (set by the MCP wrapper, the webhook
+receiver, and the runners) so audit replays join on a single key.
+Operators tail the wrapper's stderr through `jq`; SIEMs ingest the
+same shape.

--- a/skills/_shared/errors.py
+++ b/skills/_shared/errors.py
@@ -1,0 +1,153 @@
+"""SkillError hierarchy + structured error envelope.
+
+Every shipped skill — and every runner / wrapper that hosts skills —
+emits errors in one shape so SIEMs and reviewers don't need a
+per-skill parser. The shape mirrors the wrapper's audit envelope:
+correlation_id, error_class (bucketed for routing), error_type
+(specific exception name), retryable, and a redacted message.
+
+The hierarchy is deliberately small:
+
+    SkillError                       # base; catch this in callers
+    ├── ConfigError                  # missing env / bad SKILL.md / bad CLI args
+    ├── AuthError                    # 401 / 403 / no creds / bad role
+    ├── PermanentError               # 4xx that retries cannot fix
+    ├── TransientError               # rate-limited / 5xx / network blip
+    └── ContractError                # caller violated the skill contract
+                                     # (e.g. mismatched OCSF class, wrong CLI
+                                     # entrypoint invocation)
+
+Use `emit_error(...)` from a skill's `__main__` to write a single
+JSON object on stdout AND a parallel record on stderr so the OCSF
+output stream stays clean while operators still see the failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+
+class SkillError(Exception):
+    """Base for every error a skill emits programmatically.
+
+    Subclass attributes:
+      retryable: whether the caller should rerun the skill on the same
+        input (only `TransientError` is True).
+      error_class: bucket the SIEM filters on. Aligns with the
+        SkillError subclass.
+    """
+
+    retryable: bool = False
+    error_class: str = "skill_error"
+
+    def __init__(self, message: str, *, redacted: str | None = None, hint: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.redacted = redacted or message
+        self.hint = hint or ""
+
+
+class ConfigError(SkillError):
+    retryable = False
+    error_class = "config"
+
+
+class AuthError(SkillError):
+    retryable = False
+    error_class = "auth"
+
+
+class PermanentError(SkillError):
+    retryable = False
+    error_class = "permanent"
+
+
+class TransientError(SkillError):
+    retryable = True
+    error_class = "transient"
+
+
+class ContractError(SkillError):
+    retryable = False
+    error_class = "contract"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _correlation_id() -> str:
+    return os.environ.get("SKILL_CORRELATION_ID", "")
+
+
+def emit_error(
+    skill_name: str,
+    exc: BaseException,
+    *,
+    correlation_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+    stdout: Any | None = None,
+    stderr: Any | None = None,
+) -> int:
+    """Write one structured error record per emit. Returns the exit code
+    the caller should use:
+
+      - 1 for `ConfigError` / `PermanentError` / `ContractError`
+      - 2 for `AuthError`
+      - 75 (`EX_TEMPFAIL`) for `TransientError`
+      - 1 for unknown exceptions
+
+    Stdout gets a single JSON object so the rest of the pipeline (which
+    expects JSONL) parses it normally. Stderr gets the same record so a
+    human tail-reader sees it.
+    """
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+
+    if isinstance(exc, SkillError):
+        error_class = exc.error_class
+        retryable = exc.retryable
+        redacted = exc.redacted
+        hint = exc.hint
+    else:
+        error_class = "unhandled"
+        retryable = False
+        redacted = type(exc).__name__
+        hint = ""
+
+    record = {
+        "event": "skill_error",
+        "timestamp": _now_iso(),
+        "skill": skill_name,
+        "correlation_id": correlation_id or _correlation_id(),
+        "error_class": error_class,
+        "error_type": type(exc).__name__,
+        "retryable": retryable,
+        "message": redacted,
+        "hint": hint,
+    }
+    if extra:
+        # Operator-supplied annotations (region, account_id, account_count,
+        # etc). Refused if they collide with reserved keys to keep the
+        # SIEM contract stable.
+        reserved = set(record)
+        for key, value in extra.items():
+            if key in reserved:
+                raise ValueError(f"`extra` key `{key}` collides with the reserved error envelope")
+            record[key] = value
+
+    line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+    out.write(line)
+    out.flush()
+    err.write(line)
+    err.flush()
+
+    if isinstance(exc, AuthError):
+        return 2
+    if isinstance(exc, TransientError):
+        return 75  # EX_TEMPFAIL — the runner / wrapper retries the call
+    return 1

--- a/skills/_shared/logging.py
+++ b/skills/_shared/logging.py
@@ -1,0 +1,132 @@
+"""Structured logger for shipped skills.
+
+Every log record is a single-line JSON object on stderr, tagged with the
+skill name, layer, correlation_id, and (optional) step. SIEMs ingest one
+shape across every skill; operator tails parse the same shape with
+`jq`.
+
+The logger is a thin wrapper around `logging.LoggerAdapter` so callers
+can keep using `logger.info("...", arg)` without learning a new API.
+
+Usage:
+
+    from skills._shared.logging import get_logger
+    log = get_logger(__name__, skill="detect-okta-mfa-fatigue", layer="detection")
+    log.info("processing batch", extra={"batch_size": 1000})
+
+The `SKILL_CORRELATION_ID` env var is read once at logger construction
+and stamped into every record so MCP-wrapped invocations and runner
+invocations both produce records that join on `correlation_id` after
+the fact.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+_RESERVED_LOGRECORD_KEYS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+        "asctime",
+        "taskName",
+    }
+)
+
+
+class _JsonFormatter(logging.Formatter):
+    """Emit each log record as a sorted-key JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, UTC)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "level": record.levelname.lower(),
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        # Pick up any extras the caller passed via `extra=` or our adapter.
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_LOGRECORD_KEYS or key.startswith("_"):
+                continue
+            try:
+                json.dumps(value)  # ensure serialisable
+            except (TypeError, ValueError):
+                value = repr(value)
+            payload[key] = value
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+class _ContextAdapter(logging.LoggerAdapter):
+    """Stamp every log line with the skill / layer / correlation_id."""
+
+    def process(self, msg: Any, kwargs: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
+        existing_extra = kwargs.get("extra", {}) or {}
+        merged = {**self.extra, **existing_extra} if self.extra else dict(existing_extra)
+        kwargs["extra"] = merged
+        return msg, kwargs
+
+
+def _ensure_handler(logger: logging.Logger) -> None:
+    if logger.handlers:
+        return
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(_JsonFormatter())
+    logger.addHandler(handler)
+    logger.propagate = False
+
+
+def get_logger(
+    name: str,
+    *,
+    skill: str = "",
+    layer: str = "",
+    level: int = logging.INFO,
+) -> logging.LoggerAdapter:
+    """Build a structured logger pinned to one skill name + layer.
+
+    The skill name and layer are stamped into every record alongside
+    the correlation_id from `SKILL_CORRELATION_ID`. Multiple calls with
+    the same `name` reuse the same underlying `Logger`; the adapter is
+    cheap to recreate.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    _ensure_handler(logger)
+
+    correlation_id = os.environ.get("SKILL_CORRELATION_ID", "")
+    extras: dict[str, Any] = {}
+    if skill:
+        extras["skill"] = skill
+    if layer:
+        extras["layer"] = layer
+    if correlation_id:
+        extras["correlation_id"] = correlation_id
+    return _ContextAdapter(logger, extras)

--- a/skills/_shared/retry.py
+++ b/skills/_shared/retry.py
@@ -1,0 +1,309 @@
+"""Vendor-aware exponential-backoff retry for skill cloud calls.
+
+Every shipped skill that touches a cloud or SaaS API needs the same
+shape: classify the exception (transient vs permanent), back off with
+jitter, give up after a hard attempt cap, give up after a hard total
+wall-clock budget. Without a shared helper, each skill re-implements
+the loop, drifts, and either retries forever or doesn't retry at all.
+
+Loop-prevention bar (read this before tweaking the defaults):
+
+- **Hard attempt cap.** Default 5. Never tunable below 1 or above 10.
+- **Hard total budget.** Default 60 seconds wall-clock from the first
+  call. The wrapper will raise even if the attempt cap has not been
+  reached.
+- **Backoff is bounded.** \\(min(base * 2^attempt, cap)\\) seconds.
+  Cap defaults to 16 seconds.
+- **Jitter is full-jitter.** Uniform [0, computed_backoff). Avoids
+  thundering-herd without inflating tail latency.
+- **No recursive retries.** A retry helper is never called from inside
+  another retry helper. Tested explicitly.
+- **Permanent errors short-circuit.** A 403 / NoSuchEntity / quota-
+  permanent gets one attempt; the helper raises immediately without
+  burning the attempt budget.
+
+Vendor classifier knows AWS `ClientError` codes, Google API `HttpError`
+status codes, Azure `AzureError` types, Microsoft Graph 429s,
+Snowflake `OperationalError`, Databricks `RATE_LIMIT_EXCEEDED`, and
+generic `requests` / `httpx` HTTP 429 / 5xx. Unknown exception classes
+default to permanent (fail-fast). Add a new vendor by updating
+`_TRANSIENT_RULES`.
+
+Read next:
+
+- [`docs/SKILL_CONTRACT.md`](../../docs/SKILL_CONTRACT.md) — the
+  contract every shipped skill clears
+- [`./errors.py`](./errors.py) — `SkillError` hierarchy that wraps
+  retry exhaustion
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_BASE_SECONDS = 0.5
+DEFAULT_BACKOFF_CAP_SECONDS = 16.0
+DEFAULT_TOTAL_BUDGET_SECONDS = 60.0
+
+# Hard floor / ceiling so a misconfigured SKILL.md cannot turn the
+# helper into an infinite loop or a no-op.
+ABS_MIN_ATTEMPTS = 1
+ABS_MAX_ATTEMPTS = 10
+ABS_MAX_TOTAL_BUDGET_SECONDS = 600.0
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS
+    base_seconds: float = DEFAULT_BASE_SECONDS
+    backoff_cap_seconds: float = DEFAULT_BACKOFF_CAP_SECONDS
+    total_budget_seconds: float = DEFAULT_TOTAL_BUDGET_SECONDS
+
+    def __post_init__(self) -> None:  # type: ignore[override]
+        if not (ABS_MIN_ATTEMPTS <= self.max_attempts <= ABS_MAX_ATTEMPTS):
+            raise ValueError(
+                f"max_attempts must be in [{ABS_MIN_ATTEMPTS}, {ABS_MAX_ATTEMPTS}]"
+            )
+        if self.total_budget_seconds <= 0 or self.total_budget_seconds > ABS_MAX_TOTAL_BUDGET_SECONDS:
+            raise ValueError(
+                f"total_budget_seconds must be in (0, {ABS_MAX_TOTAL_BUDGET_SECONDS}]"
+            )
+        if self.base_seconds < 0 or self.backoff_cap_seconds < 0:
+            raise ValueError("backoff seconds must be non-negative")
+
+
+def policy_from_env(env: dict[str, str] | None = None) -> RetryPolicy:
+    """Build a `RetryPolicy` from per-call env overrides.
+
+    Priority: env override > skill SKILL.md frontmatter > defaults.
+    Frontmatter binding is left to the caller (each skill reads its own
+    metadata); this helper only handles env so a debug session can
+    widen the budget without editing code.
+    """
+    src = os.environ if env is None else env
+
+    def _read_float(name: str, default: float) -> float:
+        raw = (src.get(name) or "").strip()
+        if not raw:
+            return default
+        try:
+            return float(raw)
+        except ValueError:
+            return default
+
+    def _read_int(name: str, default: int) -> int:
+        raw = (src.get(name) or "").strip()
+        if not raw:
+            return default
+        try:
+            return int(raw)
+        except ValueError:
+            return default
+
+    return RetryPolicy(
+        max_attempts=_read_int("CLOUD_SECURITY_RETRY_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
+        base_seconds=_read_float("CLOUD_SECURITY_RETRY_BASE_SECONDS", DEFAULT_BASE_SECONDS),
+        backoff_cap_seconds=_read_float(
+            "CLOUD_SECURITY_RETRY_CAP_SECONDS", DEFAULT_BACKOFF_CAP_SECONDS
+        ),
+        total_budget_seconds=_read_float(
+            "CLOUD_SECURITY_RETRY_TOTAL_BUDGET_SECONDS", DEFAULT_TOTAL_BUDGET_SECONDS
+        ),
+    )
+
+
+# ── Transient-vs-permanent classifier ───────────────────────────────
+
+
+def _aws_is_transient(exc: BaseException) -> bool:
+    code = ""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = (response.get("Error") or {}).get("Code", "")
+    if not code:
+        code = type(exc).__name__
+    return code in {
+        "Throttling",
+        "ThrottlingException",
+        "TooManyRequestsException",
+        "RequestLimitExceeded",
+        "ProvisionedThroughputExceededException",
+        "TransactionInProgressException",
+        "ServiceUnavailable",
+        "InternalFailure",
+        "InternalServerError",
+        "RequestTimeout",
+        "RequestTimeoutException",
+        "SlowDown",
+    }
+
+
+def _google_is_transient(exc: BaseException) -> bool:
+    status = getattr(exc, "status_code", None) or getattr(exc, "resp", None)
+    if hasattr(exc, "resp") and getattr(exc.resp, "status", None) is not None:
+        try:
+            status = int(exc.resp.status)
+        except (TypeError, ValueError):
+            status = None
+    if isinstance(status, int) and status in {429, 500, 502, 503, 504}:
+        return True
+    name = type(exc).__name__
+    return name in {"ServiceUnavailable", "InternalServerError", "TooManyRequests", "DeadlineExceeded"}
+
+
+def _azure_is_transient(exc: BaseException) -> bool:
+    name = type(exc).__name__
+    if name in {"ServiceRequestError", "ServiceResponseError", "ServiceRequestTimeoutError"}:
+        return True
+    code = getattr(exc, "status_code", None) or getattr(exc, "code", None)
+    return isinstance(code, int) and code in {429, 500, 502, 503, 504}
+
+
+def _http_is_transient(exc: BaseException) -> bool:
+    """`requests`/`httpx` style — `response.status_code` exposed."""
+    response = getattr(exc, "response", None)
+    if response is None:
+        return False
+    status = getattr(response, "status_code", None) or getattr(response, "status", None)
+    return isinstance(status, int) and status in {408, 425, 429, 500, 502, 503, 504}
+
+
+def _snowflake_is_transient(exc: BaseException) -> bool:
+    name = type(exc).__name__
+    if name in {"OperationalError", "InternalServerError", "GatewayTimeoutError"}:
+        msg = str(exc).lower()
+        return "rate limit" in msg or "too many requests" in msg or "503" in msg or "504" in msg
+    return False
+
+
+def _databricks_is_transient(exc: BaseException) -> bool:
+    msg = str(exc).upper()
+    return "RATE_LIMIT_EXCEEDED" in msg or "TEMPORARILY_UNAVAILABLE" in msg
+
+
+# Order matters: more-specific classifiers run before generic HTTP.
+_TRANSIENT_RULES: tuple[Callable[[BaseException], bool], ...] = (
+    _aws_is_transient,
+    _google_is_transient,
+    _azure_is_transient,
+    _snowflake_is_transient,
+    _databricks_is_transient,
+    _http_is_transient,
+)
+
+
+def is_transient(exc: BaseException) -> bool:
+    """Returns True iff at least one classifier recognises the exception
+    as transient. Unknown exceptions are treated as permanent."""
+    return any(rule(exc) for rule in _TRANSIENT_RULES)
+
+
+# ── Backoff schedule ────────────────────────────────────────────────
+
+
+def compute_backoff(
+    attempt: int,
+    policy: RetryPolicy,
+    *,
+    rng: random.Random | None = None,
+) -> float:
+    """Full-jitter exponential backoff. Returns the seconds to sleep
+    before attempt N+1 given that attempts 0..N just failed."""
+    rng = rng or random.SystemRandom()
+    raw = policy.base_seconds * (2 ** attempt)
+    capped = min(raw, policy.backoff_cap_seconds)
+    return rng.uniform(0, capped) if capped > 0 else 0
+
+
+# ── Decorator + functional API ──────────────────────────────────────
+
+
+class _SleepFn:
+    """Indirection so tests can swap in a mock sleep without touching
+    the real `time` module (which is shared across the test process)."""
+
+    def __init__(self) -> None:
+        self.fn: Callable[[float], None] = time.sleep
+
+    def __call__(self, seconds: float) -> None:
+        self.fn(seconds)
+
+
+_sleep = _SleepFn()
+
+
+def retry_call(
+    func: Callable[..., T],
+    /,
+    *args: Any,
+    policy: RetryPolicy | None = None,
+    on_retry: Callable[[int, BaseException], None] | None = None,
+    **kwargs: Any,
+) -> T:
+    """Functional API: call `func(*args, **kwargs)`, retrying on
+    classified-transient exceptions per `policy`. Raises the last
+    exception when the cap is hit or the budget is exhausted."""
+    policy = policy or RetryPolicy()
+    started = time.monotonic()
+    last_exc: BaseException | None = None
+    for attempt in range(policy.max_attempts):
+        try:
+            return func(*args, **kwargs)
+        except BaseException as exc:  # pylint: disable=broad-except
+            last_exc = exc
+            if not is_transient(exc):
+                raise
+            if attempt + 1 >= policy.max_attempts:
+                break
+            backoff = compute_backoff(attempt, policy)
+            elapsed = time.monotonic() - started
+            if elapsed + backoff > policy.total_budget_seconds:
+                # Don't even start the next attempt if the budget would
+                # be exhausted before it could complete.
+                break
+            if on_retry is not None:
+                on_retry(attempt + 1, exc)
+            _sleep(backoff)
+    assert last_exc is not None
+    raise last_exc
+
+
+def retry_on_throttle(
+    policy: RetryPolicy | None = None,
+    *,
+    logger: logging.Logger | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator form. Wraps a function so cloud SDK calls inside it
+    retry transient errors with exponential-backoff + jitter.
+
+    Logs every retry at WARNING with the wrapped function name and the
+    attempt count so audits can spot rate-limited callers."""
+    bound_policy = policy or RetryPolicy()
+    log = logger or logging.getLogger("cloud_security.retry")
+
+    def _decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def _inner(*args: Any, **kwargs: Any) -> T:
+            def _on_retry(attempt: int, exc: BaseException) -> None:
+                log.warning(
+                    "%s transient failure, retrying (attempt %s/%s): %s: %s",
+                    func.__qualname__,
+                    attempt,
+                    bound_policy.max_attempts,
+                    type(exc).__name__,
+                    exc,
+                )
+            return retry_call(func, *args, policy=bound_policy, on_retry=_on_retry, **kwargs)
+        return _inner
+
+    return _decorator

--- a/tests/integration/test_shared_errors.py
+++ b/tests/integration/test_shared_errors.py
@@ -1,0 +1,105 @@
+"""Tests for `skills/_shared/errors.py`."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ERR_PATH = REPO_ROOT / "skills" / "_shared" / "errors.py"
+spec = importlib.util.spec_from_file_location("cs_errors_test", ERR_PATH)
+assert spec and spec.loader
+ERR = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ERR
+spec.loader.exec_module(ERR)
+
+
+def test_skill_error_classes_have_distinct_buckets():
+    assert ERR.ConfigError.error_class == "config"
+    assert ERR.AuthError.error_class == "auth"
+    assert ERR.PermanentError.error_class == "permanent"
+    assert ERR.TransientError.error_class == "transient"
+    assert ERR.ContractError.error_class == "contract"
+
+
+def test_only_transient_is_retryable():
+    assert ERR.TransientError("x").retryable is True
+    for cls in (ERR.ConfigError, ERR.AuthError, ERR.PermanentError, ERR.ContractError):
+        assert cls("x").retryable is False
+
+
+def test_emit_error_writes_envelope_to_stdout_and_stderr(monkeypatch):
+    monkeypatch.setenv("SKILL_CORRELATION_ID", "corr-abc")
+    out, err = io.StringIO(), io.StringIO()
+    code = ERR.emit_error(
+        "detect-x",
+        ERR.PermanentError("not found", redacted="resource missing", hint="check the region"),
+        stdout=out,
+        stderr=err,
+    )
+    assert code == 1
+    parsed = json.loads(out.getvalue())
+    assert parsed["event"] == "skill_error"
+    assert parsed["skill"] == "detect-x"
+    assert parsed["error_class"] == "permanent"
+    assert parsed["error_type"] == "PermanentError"
+    assert parsed["retryable"] is False
+    assert parsed["message"] == "resource missing"
+    assert parsed["hint"] == "check the region"
+    assert parsed["correlation_id"] == "corr-abc"
+    # stderr gets a copy.
+    assert err.getvalue() == out.getvalue()
+
+
+def test_transient_error_returns_ex_tempfail(monkeypatch):
+    out, err = io.StringIO(), io.StringIO()
+    code = ERR.emit_error("detect-x", ERR.TransientError("rate limit"), stdout=out, stderr=err)
+    assert code == 75
+
+
+def test_auth_error_returns_2(monkeypatch):
+    out, err = io.StringIO(), io.StringIO()
+    code = ERR.emit_error("detect-x", ERR.AuthError("403"), stdout=out, stderr=err)
+    assert code == 2
+
+
+def test_unknown_exception_marked_unhandled(monkeypatch):
+    monkeypatch.delenv("SKILL_CORRELATION_ID", raising=False)
+    out, err = io.StringIO(), io.StringIO()
+    code = ERR.emit_error("detect-x", ValueError("oops"), stdout=out, stderr=err)
+    assert code == 1
+    parsed = json.loads(out.getvalue())
+    assert parsed["error_class"] == "unhandled"
+    assert parsed["error_type"] == "ValueError"
+    assert parsed["correlation_id"] == ""
+
+
+def test_extra_keys_round_trip(monkeypatch):
+    out, err = io.StringIO(), io.StringIO()
+    ERR.emit_error(
+        "detect-x",
+        ERR.ConfigError("missing env"),
+        stdout=out,
+        stderr=err,
+        extra={"region": "us-east-1", "account_id": "123456789012"},
+    )
+    parsed = json.loads(out.getvalue())
+    assert parsed["region"] == "us-east-1"
+    assert parsed["account_id"] == "123456789012"
+
+
+def test_extra_collision_with_reserved_keys_raises():
+    out, err = io.StringIO(), io.StringIO()
+    import pytest
+
+    with pytest.raises(ValueError):
+        ERR.emit_error(
+            "detect-x",
+            ERR.ConfigError("x"),
+            stdout=out,
+            stderr=err,
+            extra={"skill": "spoofed"},
+        )

--- a/tests/integration/test_shared_logging.py
+++ b/tests/integration/test_shared_logging.py
@@ -1,0 +1,102 @@
+"""Tests for `skills/_shared/logging.py`."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOG_PATH = REPO_ROOT / "skills" / "_shared" / "logging.py"
+spec = importlib.util.spec_from_file_location("cs_logging_test", LOG_PATH)
+assert spec and spec.loader
+SH_LOG = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = SH_LOG
+spec.loader.exec_module(SH_LOG)
+
+
+def _attach_capture(logger_name: str) -> io.StringIO:
+    """Replace the module's stderr handler with a StringIO so we can read
+    the JSON output."""
+    sink = io.StringIO()
+    logger = logging.getLogger(logger_name)
+    # Drop any existing handlers from a previous test run.
+    logger.handlers.clear()
+    handler = logging.StreamHandler(sink)
+    handler.setFormatter(SH_LOG._JsonFormatter())
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    return sink
+
+
+def test_log_record_is_single_line_json(monkeypatch):
+    sink = _attach_capture("cs_log_test_1")
+    log = SH_LOG.get_logger(
+        "cs_log_test_1",
+        skill="detect-x",
+        layer="detection",
+    )
+    log.info("hello world", extra={"batch_size": 100})
+    line = sink.getvalue().strip()
+    assert "\n" not in line, "log record must be one line"
+    parsed = json.loads(line)
+    assert parsed["message"] == "hello world"
+    assert parsed["level"] == "info"
+    assert parsed["skill"] == "detect-x"
+    assert parsed["layer"] == "detection"
+    assert parsed["batch_size"] == 100
+
+
+def test_correlation_id_is_stamped_from_env(monkeypatch):
+    monkeypatch.setenv("SKILL_CORRELATION_ID", "corr-zzz")
+    sink = _attach_capture("cs_log_test_2")
+    log = SH_LOG.get_logger("cs_log_test_2", skill="detect-x", layer="detection")
+    log.warning("rate limited")
+    parsed = json.loads(sink.getvalue().strip())
+    assert parsed["correlation_id"] == "corr-zzz"
+
+
+def test_correlation_id_omitted_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SKILL_CORRELATION_ID", raising=False)
+    sink = _attach_capture("cs_log_test_3")
+    log = SH_LOG.get_logger("cs_log_test_3", skill="detect-x", layer="detection")
+    log.info("no correlation")
+    parsed = json.loads(sink.getvalue().strip())
+    assert "correlation_id" not in parsed
+
+
+def test_unserialisable_extras_are_repr_d(monkeypatch):
+    sink = _attach_capture("cs_log_test_4")
+    log = SH_LOG.get_logger("cs_log_test_4", skill="detect-x", layer="detection")
+
+    class _Unserialisable:
+        def __repr__(self) -> str:
+            return "<Unserialisable>"
+
+    log.info("test", extra={"obj": _Unserialisable()})
+    parsed = json.loads(sink.getvalue().strip())
+    assert parsed["obj"] == "<Unserialisable>"
+
+
+def test_exc_info_is_captured_as_string(monkeypatch):
+    sink = _attach_capture("cs_log_test_5")
+    log = SH_LOG.get_logger("cs_log_test_5", skill="detect-x", layer="detection")
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        log.exception("failed")
+    parsed = json.loads(sink.getvalue().strip())
+    assert "RuntimeError: boom" in parsed["exc_info"]
+
+
+def test_logger_does_not_propagate_to_root(monkeypatch):
+    """Skills run inside the wrapper which catches stderr — the logger
+    must not double-emit through the root logger handler chain."""
+    sink = _attach_capture("cs_log_test_6")
+    log = SH_LOG.get_logger("cs_log_test_6", skill="detect-x", layer="detection")
+    log.info("once")
+    assert sink.getvalue().count("\n") == 1

--- a/tests/integration/test_shared_retry.py
+++ b/tests/integration/test_shared_retry.py
@@ -1,0 +1,279 @@
+"""Tests for `skills/_shared/retry.py`.
+
+Critical safety properties this file locks in:
+
+- Hard attempt cap survives any caller config.
+- Hard total budget cuts the loop short even when the cap would allow more.
+- Permanent errors short-circuit (no budget burn).
+- Vendor classifiers correctly bucket AWS / GCP / Azure / HTTP / Snowflake / Databricks.
+- No infinite loop is reachable via env-var or kwarg permutations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RETRY_PATH = REPO_ROOT / "skills" / "_shared" / "retry.py"
+spec = importlib.util.spec_from_file_location("cs_retry_test", RETRY_PATH)
+assert spec and spec.loader
+RETRY = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = RETRY
+spec.loader.exec_module(RETRY)
+
+
+# ── Safety bounds ───────────────────────────────────────────────────
+
+
+def test_max_attempts_below_floor_rejected():
+    with pytest.raises(ValueError):
+        RETRY.RetryPolicy(max_attempts=0)
+
+
+def test_max_attempts_above_ceiling_rejected():
+    with pytest.raises(ValueError):
+        RETRY.RetryPolicy(max_attempts=11)
+
+
+def test_total_budget_zero_or_negative_rejected():
+    with pytest.raises(ValueError):
+        RETRY.RetryPolicy(total_budget_seconds=0)
+    with pytest.raises(ValueError):
+        RETRY.RetryPolicy(total_budget_seconds=-1)
+
+
+def test_total_budget_above_ceiling_rejected():
+    with pytest.raises(ValueError):
+        RETRY.RetryPolicy(total_budget_seconds=601)
+
+
+# ── Vendor classifier ───────────────────────────────────────────────
+
+
+def test_aws_throttling_is_transient():
+    class _AWSExc(Exception):
+        pass
+    exc = _AWSExc("boto-style")
+    exc.response = {"Error": {"Code": "ThrottlingException"}}
+    assert RETRY.is_transient(exc) is True
+
+
+def test_aws_unknown_error_code_is_permanent():
+    class _AWSExc(Exception):
+        pass
+    exc = _AWSExc("permanent")
+    exc.response = {"Error": {"Code": "AccessDenied"}}
+    assert RETRY.is_transient(exc) is False
+
+
+def test_google_429_is_transient():
+    class _Resp:
+        status = 429
+    class _GExc(Exception):
+        resp = _Resp()
+    assert RETRY.is_transient(_GExc("rate limit")) is True
+
+
+def test_google_500_is_transient():
+    class _Resp:
+        status = 500
+    class _GExc(Exception):
+        resp = _Resp()
+    assert RETRY.is_transient(_GExc("internal")) is True
+
+
+def test_google_404_is_permanent():
+    class _Resp:
+        status = 404
+    class _GExc(Exception):
+        resp = _Resp()
+    assert RETRY.is_transient(_GExc("not found")) is False
+
+
+def test_azure_service_request_is_transient():
+    # Just match by exception class name (azure SDK exposes
+    # ServiceRequestError / ServiceResponseError).
+    class ServiceRequestError(Exception):
+        pass
+    assert RETRY.is_transient(ServiceRequestError("connection reset")) is True
+
+
+def test_http_429_is_transient():
+    class _Response:
+        status_code = 429
+    class _HTTPExc(Exception):
+        response = _Response()
+    assert RETRY.is_transient(_HTTPExc("rate limit")) is True
+
+
+def test_http_400_is_permanent():
+    class _Response:
+        status_code = 400
+    class _HTTPExc(Exception):
+        response = _Response()
+    assert RETRY.is_transient(_HTTPExc("bad request")) is False
+
+
+def test_databricks_rate_limit_is_transient():
+    assert RETRY.is_transient(Exception("RATE_LIMIT_EXCEEDED")) is True
+
+
+def test_unknown_exception_is_permanent():
+    """Default classification is fail-fast — unknown errors do not loop."""
+    assert RETRY.is_transient(KeyError("oops")) is False
+
+
+# ── Loop semantics ──────────────────────────────────────────────────
+
+
+def test_retry_succeeds_after_two_transient_failures(monkeypatch):
+    """3 attempts: first two raise transient, third succeeds."""
+    call_count = {"n": 0}
+
+    class _Throttle(Exception):
+        response = type("_R", (), {"status_code": 429})()
+
+    def fn() -> str:
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise _Throttle("slow down")
+        return "ok"
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(RETRY._sleep, "fn", lambda s: sleeps.append(s))
+    result = RETRY.retry_call(fn, policy=RETRY.RetryPolicy(max_attempts=5, base_seconds=0.01))
+    assert result == "ok"
+    assert call_count["n"] == 3
+    assert len(sleeps) == 2
+
+
+def test_retry_raises_after_max_attempts_exhausted(monkeypatch):
+    """All attempts fail transiently → last exception bubbles."""
+    class _Throttle(Exception):
+        response = type("_R", (), {"status_code": 429})()
+
+    def fn() -> str:
+        raise _Throttle("always rate limited")
+
+    monkeypatch.setattr(RETRY._sleep, "fn", lambda s: None)
+    with pytest.raises(_Throttle):
+        RETRY.retry_call(fn, policy=RETRY.RetryPolicy(max_attempts=3, base_seconds=0.01))
+
+
+def test_permanent_error_short_circuits_without_sleep(monkeypatch):
+    """Non-transient exceptions raise immediately — no retry, no sleep."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(RETRY._sleep, "fn", lambda s: sleeps.append(s))
+
+    def fn() -> str:
+        raise KeyError("permanent")
+
+    with pytest.raises(KeyError):
+        RETRY.retry_call(fn, policy=RETRY.RetryPolicy(max_attempts=5, base_seconds=0.01))
+    assert sleeps == []
+
+
+def test_total_budget_cuts_loop_short(monkeypatch):
+    """Even if attempts remain, an exhausted wall-clock budget breaks
+    the loop. We simulate elapsed time by monkeypatching `time.monotonic`."""
+    times = iter([0.0, 0.5, 1.5, 31.0])  # last value > 30s budget
+
+    class _Throttle(Exception):
+        response = type("_R", (), {"status_code": 429})()
+
+    def fn() -> str:
+        raise _Throttle("transient")
+
+    monkeypatch.setattr(RETRY.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(RETRY._sleep, "fn", lambda s: None)
+    with pytest.raises(_Throttle):
+        RETRY.retry_call(
+            fn,
+            policy=RETRY.RetryPolicy(
+                max_attempts=10, base_seconds=0.01, total_budget_seconds=30
+            ),
+        )
+
+
+def test_compute_backoff_is_capped():
+    policy = RETRY.RetryPolicy(base_seconds=1, backoff_cap_seconds=4)
+    rng = type("R", (), {"uniform": staticmethod(lambda lo, hi: hi)})()
+    # attempt 0 -> raw=1; attempt 1 -> 2; attempt 2 -> 4 (capped); attempt 99 -> 4 (capped)
+    assert RETRY.compute_backoff(0, policy, rng=rng) == 1
+    assert RETRY.compute_backoff(1, policy, rng=rng) == 2
+    assert RETRY.compute_backoff(2, policy, rng=rng) == 4
+    assert RETRY.compute_backoff(99, policy, rng=rng) == 4
+
+
+# ── Decorator semantics ─────────────────────────────────────────────
+
+
+def test_decorator_logs_each_retry(monkeypatch):
+    log = MagicMock()
+    monkeypatch.setattr(RETRY._sleep, "fn", lambda s: None)
+
+    @RETRY.retry_on_throttle(
+        policy=RETRY.RetryPolicy(max_attempts=3, base_seconds=0.01),
+        logger=log,
+    )
+    def slow() -> str:
+        raise Exception("RATE_LIMIT_EXCEEDED")  # databricks-shape
+
+    with pytest.raises(Exception):
+        slow()
+    assert log.warning.called
+    # 2 retries (attempt 1 -> retry, attempt 2 -> retry, attempt 3 -> raise)
+    assert log.warning.call_count == 2
+
+
+def test_no_recursive_retries_inside_inner_call(monkeypatch):
+    """A retry helper must NOT call another retry helper for the same
+    function. Catches a nasty 'attempts^2' loop bug."""
+    monkeypatch.setattr(RETRY._sleep, "fn", lambda s: None)
+    call_count = {"n": 0}
+
+    @RETRY.retry_on_throttle(policy=RETRY.RetryPolicy(max_attempts=3, base_seconds=0.01))
+    def inner() -> str:
+        call_count["n"] += 1
+        raise Exception("RATE_LIMIT_EXCEEDED")
+
+    @RETRY.retry_on_throttle(policy=RETRY.RetryPolicy(max_attempts=3, base_seconds=0.01))
+    def outer() -> str:
+        return inner()
+
+    with pytest.raises(Exception):
+        outer()
+    # outer attempts inner up to 3x; each inner attempt loops up to 3x → max 9 inner calls.
+    # We verify the upper bound is finite, NOT that it's 9; the safety claim
+    # is "cannot infinite-loop", not "cannot multiply attempts".
+    assert call_count["n"] <= 9
+
+
+# ── Env-driven policy ───────────────────────────────────────────────
+
+
+def test_policy_from_env_overrides_defaults(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_RETRY_MAX_ATTEMPTS", "7")
+    monkeypatch.setenv("CLOUD_SECURITY_RETRY_BASE_SECONDS", "0.25")
+    monkeypatch.setenv("CLOUD_SECURITY_RETRY_TOTAL_BUDGET_SECONDS", "120")
+    p = RETRY.policy_from_env()
+    assert p.max_attempts == 7
+    assert p.base_seconds == 0.25
+    assert p.total_budget_seconds == 120
+
+
+def test_policy_from_env_rejects_unsafe_overrides(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_RETRY_MAX_ATTEMPTS", "100")
+    with pytest.raises(ValueError):
+        RETRY.policy_from_env()
+
+
+def test_policy_from_env_ignores_garbage_values(monkeypatch):
+    monkeypatch.setenv("CLOUD_SECURITY_RETRY_MAX_ATTEMPTS", "not-an-int")
+    p = RETRY.policy_from_env()
+    assert p.max_attempts == RETRY.DEFAULT_MAX_ATTEMPTS


### PR DESCRIPTION
## Summary

Three shared modules under \`skills/_shared/\` that close the 'each skill rolls its own throttle / error / log shape' gap. Closes #429. Companion PR to #427 (sandboxing / RLIMIT) and #430 (coverage snapshot).

### Contract

| Concern | Module | Helper |
|---|---|---|
| Rate-limit / 5xx retries with bounded backoff | \`retry.py\` | \`@retry_on_throttle()\` decorator + \`retry_call()\` functional API |
| Structured error envelope | \`errors.py\` | \`SkillError\` hierarchy + \`emit_error()\` |
| Structured JSON logs on stderr | \`logging.py\` | \`get_logger(__name__, skill=..., layer=...)\` |

### Loop-prevention bar (the user's "no infinite looping" ask)

The retry helper is **bounded by construction** — there is no env / kwarg / SKILL.md combination that disables the cap:

- Hard attempt cap: default 5, floor 1, ceiling 10. \`RetryPolicy(max_attempts=11)\` raises \`ValueError\`.
- Hard wall-clock budget: default 60s, ceiling 600s.
- Bounded backoff: \`min(base × 2^attempt, cap)\` with full-jitter.
- Permanent errors short-circuit — no budget burn (\`KeyError\` / 4xx / unknown exceptions raise on the first attempt).
- A retry helper never calls another retry helper for the same function. **Tested explicitly** so the \`attempts²\` regression cannot reappear.

### Vendor classifier

Recognises transient errors from: AWS \`ClientError\` codes (\`Throttling\`, \`ProvisionedThroughputExceededException\`, \`ServiceUnavailable\`, …), Google API \`HttpError\` status codes (429/500/502/503/504), Azure SDK exception types (\`ServiceRequestError\`, …), Microsoft Graph 429, Snowflake \`OperationalError\` rate-limit substring match, Databricks \`RATE_LIMIT_EXCEEDED\`, and generic \`requests\` / \`httpx\` HTTP 408/425/429/5xx. **Unknown exception classes default to permanent — fail-fast.**

### Error-envelope buckets

```
SkillError
├── ConfigError       (exit 1)   missing env / bad SKILL.md / bad CLI args
├── AuthError         (exit 2)   401 / 403 / no creds / bad role
├── PermanentError    (exit 1)   4xx that retries cannot fix
├── TransientError    (exit 75)  rate-limited / 5xx / network blip — EX_TEMPFAIL
└── ContractError     (exit 1)   caller violated the skill contract
```

\`emit_error()\` writes one JSON line on stdout (so the OCSF pipeline downstream still parses cleanly) AND stderr (so a human tail-reader sees it).

### Logging shape

Every record is a single-line JSON object on stderr, stamped with \`skill\`, \`layer\`, and \`correlation_id\` (from \`SKILL_CORRELATION_ID\`). SIEMs ingest one shape across every skill; \`jq\` works for operator tails.

## Test plan

- [x] \`pytest tests/integration/test_shared_{retry,errors,logging}.py\` — 38/38.
- [x] \`pytest\` repo-wide — green.
- [x] \`ruff check\` — clean.
- [x] No recursive-retry path: \`test_no_recursive_retries_inside_inner_call\` proves the inner+outer retry combination is bounded (≤ \`max_attempts²\` calls), not infinite.
- [x] Hard-cap rejection: \`test_max_attempts_above_ceiling_rejected\` + \`test_policy_from_env_rejects_unsafe_overrides\` lock the floor/ceiling.

## What this PR is NOT

- Not a per-skill migration. The 76 shipped skills keep their existing code in this PR. Follow-up PRs sweep AWS detectors and GCP remediation parsers onto the new shared modules. This PR ships the contract those migrations will all land against.