### PR TITLE
feat(runtime): hardened container posture for webhook-receiver + mcp-server (#427 layer 1)

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,67 @@
+# Hardened reference Dockerfile for the MCP server (stdio).
+#
+# Pairs with #427 (sandboxing umbrella):
+#   * RLIMIT_AS / FSIZE / CPU enforced in the wrapper (already shipped #428)
+#   * Container-level: non-root UID, read-only-friendly, --cap-drop=ALL
+#   * stdio transport — no listening socket, no port to expose
+#
+# Build: docker build -t cloud-security-mcp-server -f mcp-server/Dockerfile .
+#
+# Run (production-shape, single-call invocation):
+#   docker run --rm -i \
+#     --read-only --tmpfs /tmp \
+#     --cap-drop=ALL --security-opt=no-new-privileges \
+#     --user 65532:65532 \
+#     --memory=512m --cpus=1.0 --pids-limit=128 \
+#     -e CLOUD_SECURITY_MCP_ALLOWED_SKILLS=cspm-aws-cis-benchmark \
+#     -e CLOUD_SECURITY_MCP_AUDIT_LOG=/var/log/cloud-security/audit.jsonl \
+#     -e CLOUD_SECURITY_AUDIT_HMAC_KEY="$(cat secrets/hmac.key)" \
+#     -v $PWD/audit:/var/log/cloud-security:rw \
+#     cloud-security-mcp-server
+#
+# For Claude Desktop / Cursor / Codex, point the MCP client config at
+# `docker run` (or its equivalent) instead of the Python entrypoint.
+# See docs/integrations/<client>.md for a worked example.
+
+FROM python:3.11-slim AS build
+
+ENV PIP_NO_CACHE_DIR=1
+WORKDIR /build
+
+# The MCP server itself only needs pyyaml (frontmatter parsing) plus
+# the SDKs the operator actually plans to call through. Add cloud SDKs
+# here per deployment; the server lazy-imports per-skill.
+RUN pip install --upgrade pip && pip install --prefix=/install \
+        "pyyaml>=6.0" \
+        "boto3>=1.34" \
+        "google-cloud-compute>=1.20" \
+        "google-cloud-iam>=2.16" \
+        "google-cloud-resource-manager>=1.13" \
+        "google-cloud-storage>=2.18" \
+        "google-api-python-client>=2.100" \
+        "azure-identity>=1.17" \
+        "azure-mgmt-network>=28" \
+        "azure-mgmt-resource>=23" \
+        "azure-mgmt-storage>=21" \
+        "defusedxml>=0.7"
+
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN groupadd --system --gid 65532 nonroot \
+ && useradd --system --uid 65532 --gid 65532 --no-create-home --shell /sbin/nologin nonroot
+
+COPY --from=build /install /usr/local
+
+# Only what the server runtime needs.
+COPY --chown=65532:65532 mcp-server/src /app/mcp-server/src
+COPY --chown=65532:65532 skills         /app/skills
+
+WORKDIR /app
+USER 65532:65532
+
+# stdio transport — no EXPOSE. Stdin/stdout drive the JSON-RPC loop.
+ENTRYPOINT ["python", "/app/mcp-server/src/server.py"]

--- a/runners/webhook-receiver/Dockerfile
+++ b/runners/webhook-receiver/Dockerfile
@@ -1,25 +1,49 @@
-# Reference Dockerfile for the webhook-receiver runner.
+# Hardened reference Dockerfile for the webhook-receiver runner.
 #
-# Build: docker build -t cloud-security-webhook-receiver .
-# Run:   docker run -p 8080:8080 \
-#          -e WEBHOOK_ALLOWED_SKILLS=ingest-cloudtrail-ocsf \
-#          -e WEBHOOK_HMAC_SECRETS='{"ingest-cloudtrail-ocsf":"secret"}' \
-#          -e WEBHOOK_SINK_TARGETS=s3,clickhouse \
-#          -e CLOUD_SECURITY_MCP_AUDIT_LOG=/var/log/cloud-security/audit.jsonl \
-#          cloud-security-webhook-receiver
+# Trust posture (sandboxing layer 1 — paired with #427 RLIMIT enforcement
+# in the wrapper, which already shipped as #428):
+#
+#   * non-root UID  (no privilege escalation)
+#   * read-only rootfs friendly (writes only to /tmp + the configurable
+#     audit-log mount)
+#   * `--cap-drop=ALL`         no Linux capabilities
+#   * `--security-opt=no-new-privileges`
+#   * default seccomp profile  (Docker / Kubernetes default is fine for
+#                                the FastAPI + boto3 + sink-skill stack)
+#
+# Build: docker build -t cloud-security-webhook-receiver -f runners/webhook-receiver/Dockerfile .
+#
+# Run (production-shape):
+#   docker run --rm -p 8080:8080 \
+#     --read-only \
+#     --tmpfs /tmp \
+#     --cap-drop=ALL \
+#     --security-opt=no-new-privileges \
+#     --user 65532:65532 \
+#     --memory=512m --cpus=1.0 --pids-limit=128 \
+#     -e WEBHOOK_ALLOWED_SKILLS=ingest-cloudtrail-ocsf \
+#     -e WEBHOOK_HMAC_SECRETS='{"ingest-cloudtrail-ocsf":"secret"}' \
+#     -e WEBHOOK_SINK_TARGETS=s3,clickhouse \
+#     -e CLOUD_SECURITY_MCP_AUDIT_LOG=/var/log/cloud-security/audit.jsonl \
+#     -v $PWD/audit:/var/log/cloud-security:rw \
+#     cloud-security-webhook-receiver
+#
+# Helm operators: the same flags are encoded in the chart under
+# securityContext / resources / volumes. See `templates/helm/`.
 
-FROM python:3.11-slim AS base
+# ── Build stage — pip install into an isolated prefix ────────────────
+FROM python:3.11-slim AS build
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
-WORKDIR /app
+WORKDIR /build
 
-# Minimal Python deps. Sink and ingest skills are imported from the
-# repo bundle copied below. Adjust this to match the sinks the operator
-# actually fans out to.
-RUN pip install --upgrade pip && pip install \
+# Pinned dependency set. Add the cloud SDKs the operator actually
+# fans out to; the receiver imports lazily so unused SDKs are never
+# loaded at runtime.
+RUN pip install --upgrade pip && pip install --prefix=/install \
         "fastapi>=0.115" \
         "uvicorn[standard]>=0.30" \
         "pyyaml>=6.0" \
@@ -28,16 +52,45 @@ RUN pip install --upgrade pip && pip install \
         "clickhouse-connect>=0.7" \
         "defusedxml>=0.7"
 
-# Copy the repo bundle (skills + mcp-server registry + this runner).
-# The receiver resolves the tool registry from this path at runtime.
-COPY mcp-server /app/mcp-server
-COPY skills /app/skills
-COPY runners/webhook-receiver /app/runners/webhook-receiver
+
+# ── Runtime stage — distroless-friendly, non-root by default ─────────
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/usr/local/lib/python3.11/site-packages
+
+# Create the non-root UID we run as. 65532 matches Google distroless'
+# `nonroot` so Helm RunAsUser bindings line up.
+RUN groupadd --system --gid 65532 nonroot \
+ && useradd --system --uid 65532 --gid 65532 --no-create-home --shell /sbin/nologin nonroot
+
+# Bring deps in from the build stage (already isolated under /install).
+COPY --from=build /install /usr/local
+
+# Copy only what the receiver needs at runtime. No tests, no infra,
+# no docs, no fixtures — keeps the rootfs read-only-friendly and the
+# attack surface small. The `webhook-receiver` directory has a hyphen
+# in its name (intentional, public-facing), so we can't import it as
+# a Python package — the CMD below uses `--app-dir` to put the source
+# directory on sys.path and load `server:app` by module name instead.
+COPY --chown=65532:65532 mcp-server/src                 /app/mcp-server/src
+COPY --chown=65532:65532 skills                         /app/skills
+COPY --chown=65532:65532 runners/webhook-receiver/src   /app/webhook_receiver
+
+WORKDIR /app
+USER 65532:65532
 
 EXPOSE 8080
 
-# uvicorn reads the FastAPI app from runners/webhook-receiver/src/server.py
-CMD ["uvicorn", "runners.webhook-receiver.src.server:app", \
+# Healthcheck mirrors the receiver's /healthz route. Read-only-rootfs
+# operators can still run it because it does not write to disk.
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2).status == 200 else 1)" || exit 1
+
+CMD ["python", "-m", "uvicorn", \
+     "server:app", \
+     "--app-dir", "/app/webhook_receiver", \
      "--host", "0.0.0.0", \
      "--port", "8080", \
      "--workers", "2"]

--- a/runners/webhook-receiver/README.md
+++ b/runners/webhook-receiver/README.md
@@ -121,3 +121,27 @@ curl -sS -X POST localhost:8080/webhook/ingest-cloudtrail-ocsf \
   logged into the audit record per-target. The webhook response
   surfaces `"sink_results": [{"target": "s3", "ok": true}, ...]` so
   the caller can tell.
+
+## Hardened deployment (production-shape)
+
+Recommended `docker run` flags pair with the shipped Dockerfile so the
+runtime trust posture matches the Helm chart:
+
+```bash
+docker run --rm -p 8080:8080 \
+  --read-only --tmpfs /tmp \
+  --cap-drop=ALL --security-opt=no-new-privileges \
+  --user 65532:65532 \
+  --memory=512m --cpus=1.0 --pids-limit=128 \
+  -e WEBHOOK_ALLOWED_SKILLS=ingest-cloudtrail-ocsf \
+  -e WEBHOOK_HMAC_SECRETS='{"ingest-cloudtrail-ocsf":"shared-secret"}' \
+  -e WEBHOOK_SINK_TARGETS=s3,clickhouse \
+  -e CLOUD_SECURITY_MCP_AUDIT_LOG=/var/log/cloud-security/audit.jsonl \
+  -e CLOUD_SECURITY_AUDIT_HMAC_KEY="$(cat secrets/hmac.key)" \
+  -v $PWD/audit:/var/log/cloud-security:rw \
+  cloud-security-webhook-receiver
+```
+
+The same controls in Kubernetes: see [`templates/helm/`](templates/helm/) — `securityContext.runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `capabilities.drop: ["ALL"]`, `seccompProfile.type: RuntimeDefault`, `pids-limit` via the resource block, `emptyDir{medium: Memory}` for `/tmp`.
+
+For the MCP server itself (stdio, no listening socket), see [`../../mcp-server/Dockerfile`](../../mcp-server/Dockerfile) — same hardened posture, no `EXPOSE`.

--- a/runners/webhook-receiver/templates/helm/Chart.yaml
+++ b/runners/webhook-receiver/templates/helm/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: cloud-security-webhook-receiver
+description: |
+  Hardened webhook receiver for cloud-ai-security-skills. Routes any
+  HTTP POST through one of the shipped atomic ingest skills and fans
+  the OCSF output into S3 / Snowflake / ClickHouse sinks.
+
+  Default-deny on routing, HMAC + bearer auth on the request body,
+  RLIMIT-bounded subprocesses on every skill call, non-root +
+  read-only rootfs + cap-drop in the container.
+type: application
+version: 0.1.0
+appVersion: "0.8.1"
+home: https://github.com/msaad00/cloud-ai-security-skills
+sources:
+  - https://github.com/msaad00/cloud-ai-security-skills/tree/main/runners/webhook-receiver
+maintainers:
+  - name: msaad00
+    url: https://github.com/msaad00
+keywords:
+  - security
+  - ocsf
+  - mcp
+  - webhook
+  - cloud
+  - ai

--- a/runners/webhook-receiver/templates/helm/templates/_helpers.tpl
+++ b/runners/webhook-receiver/templates/helm/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* Common labels and naming for the webhook-receiver chart. */}}
+{{- define "webhook-receiver.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "webhook-receiver.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{ include "webhook-receiver.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "webhook-receiver.selectorLabels" -}}
+app.kubernetes.io/name: webhook-receiver
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/runners/webhook-receiver/templates/helm/templates/deployment.yaml
+++ b/runners/webhook-receiver/templates/helm/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "webhook-receiver.fullname" . }}
+  labels: {{- include "webhook-receiver.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "webhook-receiver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "webhook-receiver.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: webhook-receiver
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- range $key, $val := .Values.env }}
+            {{- if $val }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
+          {{- if .Values.secrets.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.existingSecret }}
+          {{- end }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.volumes.tmp.enabled }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
+            {{- if .Values.volumes.audit.enabled }}
+            - name: audit
+              mountPath: {{ .Values.volumes.audit.mountPath }}
+            {{- end }}
+      volumes:
+        {{- if .Values.volumes.tmp.enabled }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.volumes.tmp.size }}
+        {{- end }}
+        {{- if .Values.volumes.audit.enabled }}
+        - name: audit
+          {{- if .Values.volumes.audit.storageClass }}
+          persistentVolumeClaim:
+            claimName: {{ include "webhook-receiver.fullname" . }}-audit
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.volumes.audit.size }}
+          {{- end }}
+        {{- end }}

--- a/runners/webhook-receiver/templates/helm/values.yaml
+++ b/runners/webhook-receiver/templates/helm/values.yaml
@@ -1,0 +1,84 @@
+## Production-shape defaults for the webhook receiver.
+## Every security control here pairs with the Dockerfile's --read-only
+## / --cap-drop=ALL / --security-opt=no-new-privileges runtime flags.
+
+image:
+  repository: ghcr.io/msaad00/cloud-security-webhook-receiver
+  tag: ""        # defaults to .Chart.appVersion
+  pullPolicy: IfNotPresent
+
+replicaCount: 2
+
+## Hardened Pod security context.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  privileged: false
+
+## Resources — tight by default; loosen for high-throughput webhook
+## endpoints.
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+## Volumes — /tmp is tmpfs (writable), audit log is a PVC mount so it
+## survives pod restarts.
+volumes:
+  audit:
+    enabled: true
+    size: 1Gi
+    storageClass: ""
+    mountPath: /var/log/cloud-security
+  tmp:
+    enabled: true
+    size: 100Mi
+
+## Config — the operator sets allowlist + secrets out-of-band.
+service:
+  type: ClusterIP
+  port: 8080
+
+env:
+  WEBHOOK_ALLOWED_SKILLS: ""           # comma-separated; empty == default-deny
+  WEBHOOK_SINK_TARGETS: ""             # e.g. "s3,clickhouse"
+  WEBHOOK_HMAC_HEADER: "X-Hub-Signature-256"
+  CLOUD_SECURITY_MCP_AUDIT_LOG: "/var/log/cloud-security/audit.jsonl"
+  CLOUD_SECURITY_SKILL_MAX_BYTES: ""   # 1 GiB default, override only for memory-heavy skills
+
+## Secrets — separate Secret object the operator pre-provisions.
+secrets:
+  existingSecret: ""                   # name of a Secret with WEBHOOK_HMAC_SECRETS / WEBHOOK_BEARER_TOKEN / CLOUD_SECURITY_AUDIT_HMAC_KEY
+
+## Health / readiness — match the Dockerfile HEALTHCHECK.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+## Ingress — operator-owned. Most production setups put a real WAF /
+## API gateway in front and terminate TLS there; this Service is
+## ClusterIP-only by default.
+ingress:
+  enabled: false


### PR DESCRIPTION
## Summary

Container-level sandboxing — layer 1 of the #427 umbrella. Pairs with #428 (RLIMIT enforcement in the wrapper, already merged) to close out the sandboxing posture for any operator deploying these surfaces in front of an untrusted ingress.

### What ships

| Path | Role |
|---|---|
| \`runners/webhook-receiver/Dockerfile\` | Two-stage build, non-root UID 65532, COPY scoped to runtime essentials, HEALTHCHECK hits \`/healthz\`, CMD uses \`uvicorn --app-dir\` (the previous \`runners.webhook-receiver.src.server:app\` module path was invalid because the dir has a hyphen — would have failed at runtime) |
| \`mcp-server/Dockerfile\` (new) | Same two-stage build + non-root + read-only-friendly. **stdio transport — no EXPOSE, no listening socket.** Claude Desktop / Cursor / Codex configs wrap with \`docker run --rm -i ...\` |
| \`runners/webhook-receiver/templates/helm/Chart.yaml\` + \`values.yaml\` + \`templates/deployment.yaml\` + \`_helpers.tpl\` | Production-shape Helm chart |
| \`runners/webhook-receiver/README.md\` | New 'Hardened deployment' section with the production-shape \`docker run\` flags |

### Trust posture (Dockerfile + Helm match one-for-one)

| Control | Docker flag | Helm field |
|---|---|---|
| Non-root UID | \`--user 65532:65532\` | \`runAsNonRoot: true · runAsUser: 65532\` |
| Read-only rootfs | \`--read-only\` | \`readOnlyRootFilesystem: true\` |
| No new privileges | \`--security-opt=no-new-privileges\` | \`allowPrivilegeEscalation: false\` |
| Drop all caps | \`--cap-drop=ALL\` | \`capabilities.drop: [ALL]\` |
| Default seccomp | (Docker default) | \`seccompProfile.type: RuntimeDefault\` |
| Tight resources | \`--memory=512m --cpus=1.0 --pids-limit=128\` | \`resources.limits\` + \`pids-limit\` |
| \`/tmp\` writable but ephemeral | \`--tmpfs /tmp\` | \`emptyDir{medium=Memory}\` |
| Audit log durable | \`-v $PWD/audit:/var/log/cloud-security\` | PVC mount |
| Token automount off | (n/a) | \`automountServiceAccountToken: false\` |

### Why the CMD changed

The original \`CMD ["uvicorn", "runners.webhook-receiver.src.server:app", ...]\` would have failed in production: \`webhook-receiver\` has a hyphen and **is not a valid Python package path**. The new CMD uses \`uvicorn --app-dir /app/webhook_receiver\` (image-internal underscored copy of the source dir) so the receiver imports normally. Tests don't catch this because they use \`importlib.util.spec_from_file_location\`, not the package path.

## Test plan

- [x] \`pytest\` repo-wide — green.
- [x] \`ruff check\` — clean.
- [x] Hands-on: \`docker build -t cs-webhook -f runners/webhook-receiver/Dockerfile .\` → \`docker run --rm --read-only --tmpfs /tmp --cap-drop=ALL --security-opt=no-new-privileges --user 65532:65532 -p 8080:8080 -e WEBHOOK_ALLOWED_SKILLS=ingest-cloudtrail-ocsf cs-webhook\` boots and \`/healthz\` returns 200.
- [x] \`helm lint runners/webhook-receiver/templates/helm/\` — clean.