### PR TITLE
feat: Python SDK shim + harness doc (surfaces, scope boundary, Anthropic alignment)

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,0 +1,302 @@
+# Harness — surfaces, customization knobs, scope boundary
+
+One page that answers two questions:
+
+1. **How do operators run, embed, and customize the shipped skills?**
+2. **What does the repo NOT handle, on purpose?**
+
+Read next:
+
+- [`SKILL_CONTRACT.md`](SKILL_CONTRACT.md) — the per-skill bar
+- [`SKILL_COMPOSITION.md`](SKILL_COMPOSITION.md) — workflows + presets
+- [`MCP_AUDIT_CONTRACT.md`](MCP_AUDIT_CONTRACT.md) — audit envelope
+- [`THREAT_MODEL.md`](THREAT_MODEL.md) — adversaries + mitigations
+
+## Five surfaces, one bundle
+
+The same `SKILL.md + src/ + tests/` runs unchanged behind all five
+surfaces. None of them forks the skill model:
+
+| Surface | Where | Use when |
+|---|---|---|
+| **CLI / pipes** | `python skills/<x>/<y>/src/<entry>.py` | quick local triage; CI scripts; ops one-liners |
+| **CI** | `.github/workflows/ci.yml` lanes | gate a PR against a captured fixture |
+| **MCP** | [`mcp-server/src/server.py`](../mcp-server/src/server.py) | any agentic client (Claude Code/Desktop, Cursor, Codex, Cortex, Windsurf, Zed) — stdio JSON-RPC |
+| **Webhook** | [`runners/webhook-receiver/`](../runners/webhook-receiver/) | route a vendor callback / API gateway POST through ingest → sink |
+| **Library SDK** | [`skills/_shared/library.py`](../skills/_shared/library.py) | external Python apps that want to call skills as functions |
+| **Persistent runners** | [`runners/{aws-s3-sqs,gcp-gcs-pubsub,azure-blob-eventgrid}-detect/`](../runners/) | event-driven detection at cloud scale |
+
+## Customization knobs
+
+Five tiers of override. Outer wins:
+
+```
+CLOUD_SECURITY_*  env  >  caller_context  >  preset.json  >  SKILL.md frontmatter  >  defaults
+```
+
+| Knob | Where | What |
+|---|---|---|
+| Tool surface | `CLOUD_SECURITY_MCP_ALLOWED_SKILLS` env | comma-separated allowlist; default = all skills |
+| Per-caller surface | `_caller_context.allowed_skills` JSON field on every call | intersects with the operator allowlist |
+| Workflow surface | [`presets/*.json`](../presets/) | named allowlists tied to a workflow doc |
+| Audit destination | `CLOUD_SECURITY_MCP_AUDIT_LOG` + `CLOUD_SECURITY_AUDIT_HMAC_KEY` | durable JSONL + HMAC chain |
+| Per-call timeout | `mcp_timeout_seconds` in SKILL.md, or `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` env | wall-clock cap |
+| Resource caps | `CLOUD_SECURITY_SKILL_MAX_BYTES` / `MAX_FILE_BYTES` / `MAX_PROCESSES` | RLIMIT enforcement |
+| Retry policy | `CLOUD_SECURITY_RETRY_MAX_ATTEMPTS` / `BASE_SECONDS` / `CAP_SECONDS` / `TOTAL_BUDGET_SECONDS` | bounded by construction |
+| Webhook auth | `WEBHOOK_HMAC_SECRETS` / `WEBHOOK_HMAC_HEADER` / `WEBHOOK_BEARER_TOKEN` | per-skill HMAC + bearer |
+| Webhook routing | `WEBHOOK_ALLOWED_SKILLS` / `WEBHOOK_SINK_TARGETS` | default-deny |
+| Helm | [`runners/webhook-receiver/templates/helm/values.yaml`](../runners/webhook-receiver/templates/helm/values.yaml) | resource limits, security context, audit volume |
+
+## Authentication — what the repo does and doesn't do
+
+**The repo does not authenticate end users.** That's the cloud CLI's
+job and the operator's IDP's job. We never see passwords, never store
+tokens, never cache credentials, never speak SAML / OIDC / SCIM as a
+client.
+
+What the repo does:
+
+1. **Reads the cloud SDK default credential chain.** `boto3` /
+   `google.cloud.*` / `azure-identity` / `snowflake-connector` all
+   look up credentials in the same order they always do — env var,
+   shared file, instance metadata, workload identity, federated SSO
+   token. The skill only calls `boto3.client(...)` and trusts the
+   chain.
+2. **Surfaces a structured `ConfigError` when creds are missing.**
+   The error envelope (`skills/_shared/errors.py`) carries a `hint`
+   field telling the caller exactly what to run (e.g.
+   `aws sso login --profile prod-readonly`). The agent (Claude Code /
+   Cortex / etc.) can pattern-match on the hint and prompt the user.
+3. **Forwards `SKILL_CALLER_*` audit metadata.** The MCP wrapper
+   passes the caller's identity into the skill subprocess so audit
+   logs can attribute actions to a real human, not just to the
+   ambient cred. The actual *authentication* of that human happens
+   upstream of the wrapper.
+
+### Worked example: Snowflake employee, Claude + Cortex, company SSO
+
+```text
+1. Employee runs `snowflake-cli auth login --authenticator externalbrowser`
+   once per shift (their company's SSO flow opens a browser, returns
+   an MFA-stamped token, caches it under ~/.snowflake/).
+2. Employee opens Claude Code (or Cortex) — the agent is configured
+   to load the repo's MCP server.
+3. Agent calls `tools/call source-snowflake-query`. The MCP wrapper
+   invokes the skill subprocess; the skill calls
+   `snowflake.connector.connect()` with no creds in args; the
+   connector reads ~/.snowflake/ and uses the cached SSO token.
+4. If the token has expired, the skill returns:
+     {"event":"skill_error","error_class":"auth","retryable":false,
+      "hint":"snowflake-cli auth login --authenticator externalbrowser"}
+   The agent surfaces the hint to the human, who refreshes once.
+5. Audit log carries `caller_email` from `_caller_context` so the
+   query is attributed to the human, not to the SSO service principal.
+```
+
+The same pattern works for AWS IAM Identity Center, Microsoft Entra,
+GCP Workforce Identity. **The operator's IDP integration is upstream
+of the repo.** We delegate, we don't re-implement.
+
+## Scope boundary — what we handle vs delegate
+
+To stop redundancy creep, we draw the line clearly.
+
+| Concern | Repo's job | Delegated to |
+|---|---|---|
+| Skill contract + lifecycle | ✓ | — |
+| Trust controls (allowlist, dry-run, HITL, audit, RLIMIT, env scrub) | ✓ | — |
+| Wire format (OCSF / native / bridge) | ✓ | — |
+| Per-skill retry / error / log envelope | ✓ | — |
+| **Cloud authentication** | error-fast with hint | cloud CLI / SDK credential chain (`aws sso login`, `gcloud auth login`, etc.) |
+| **Identity federation (SSO)** | propagate `caller_id` | operator's IDP (Okta / Entra / Workforce) |
+| **TLS termination** | speak HTTP behind a WAF | operator's API gateway / WAF |
+| **Multi-tenancy** | one process = one tenant | operator routes per-tenant via separate processes / containers |
+| **Secret management** | read env vars | operator's KMS / Vault / sealed-secrets |
+| **Workflow orchestration** | spec in `examples/workflows/` | operator's SOAR / Step Function / LangGraph |
+| **State persistence (dedupe, checkpoint)** | — | runners own state, skills are stateless |
+| **Rate limiting incoming traffic** | — | operator's API gateway |
+| **Authorization to remediate** | enforce HITL gate | operator's IDP attests `_approval_context` |
+
+### Anti-redundancy rules
+
+These rules exist so a future PR doesn't accidentally re-implement
+something the SDK / IDP / WAF / agent already does:
+
+- **Never store passwords or tokens.** If the repo would need a
+  database table to hold them, that work belongs upstream of the
+  wrapper.
+- **Never speak SAML / OIDC as a client.** The cloud CLI does that.
+- **Never run a workflow engine.** Workflows are markdown specs.
+- **Never proxy traffic to the cloud.** The skill calls the cloud SDK
+  directly; latency, retries, and TLS are the SDK's concern.
+- **Never persist user state between calls.** Skills are pure
+  functions over inputs. State lives in runners or operator
+  databases.
+
+## Surface comparison cheat-sheet
+
+```
+                     CLI    CI    MCP   Webhook   Library
+read-only skills      ✓      ✓     ✓      ✓         ✓
+write skills (HITL)   ✓      ✓     ✓      ✗         ✓
+audit envelope        stderr ✓     ✓      ✓         ✓
+RLIMIT enforced       ✗      ✗     ✓      ✓         ✓
+default-deny routing  n/a    n/a   opt-in opt-in    opt-in
+allowlist tiers       1      1     3      2         1
+```
+
+`MCP` and `Library` go through the registry's gate. `CLI` skips it
+because the local user is trusted; CI skips it because the CI runner
+is trusted. `Webhook` adds an HMAC + default-deny layer because the
+ingress is not trusted.
+
+## Login / privileges / roles — what the best practice actually is
+
+The instinct is to pick one of {standard, customizable, prompted}. The
+right answer is **all three, in layers**, because each solves a
+different problem:
+
+```
+                   identity   privileges   UX
+─────────────────  ────────   ──────────   ──────────────────────────
+Standard           ✓ delegated to IDP
+Customizable                  ✓ via env vars + SKILL.md frontmatter
+Prompted                                   ✓ via agent surfacing hints
+```
+
+### 1. Standard — the always-on baseline
+
+Skills use the cloud SDK's default credential chain. **Don't reimplement
+SSO.** The chain already handles:
+
+- Workload identity (EKS IRSA, GKE Workload Identity, AKS Pod Identity)
+- IDC / SSO-cached tokens (`aws sso login`, `gcloud auth login`,
+  `az login`, `snowflake-cli auth login --authenticator externalbrowser`)
+- Federated tokens (OIDC → STS:AssumeRoleWithWebIdentity, Workforce
+  Federation, Azure App Registration)
+- Static credentials (only when an operator explicitly opts in)
+
+**Best practice:** every shipped skill uses the SDK default chain.
+Zero config in the common case.
+
+### 2. Customizable — pinning an identity per deployment
+
+Operators with multiple cloud accounts / projects / tenants need to
+pin which identity each skill assumes. The repo exposes this via:
+
+- **Env vars** the SDK already honours: `AWS_PROFILE`, `AWS_ROLE_ARN`,
+  `GOOGLE_APPLICATION_CREDENTIALS`, `AZURE_CLIENT_ID`,
+  `SNOWFLAKE_ACCOUNT` / `SNOWFLAKE_USER` / `SNOWFLAKE_AUTHENTICATOR`,
+  `OKTA_DOMAIN` + `OKTA_API_TOKEN`. Pass-through via the wrapper's
+  `CLOUD_SECURITY_*` namespace OR the SDK's own variable name.
+- **SKILL.md frontmatter** declares `caller_roles` + `approver_roles`
+  (vocabulary the operator's IDP attests).
+- **Per-skill IAM policies** under `skills/<x>/<y>/infra/iam_policies/`
+  ship the *minimum* permission set; CI rejects wildcard actions
+  without a `WILDCARD_OK` justification.
+
+**Best practice:** operators pin identity via SDK env vars at
+deployment, not in code. Skills never embed account IDs / role ARNs.
+
+### 3. Prompted — the agent surfaces, the skill detects
+
+Skills are **non-interactive by design**. They never prompt.
+
+When credentials are missing or expired, the skill emits a structured
+error (the `skills/_shared/errors.py` envelope) with three machine-
+readable hooks the agent uses:
+
+- `error_class: "auth"` — the agent knows this is recoverable by user
+  action, not a bug.
+- `retryable: false` — the agent doesn't auto-retry; the user has to
+  do something.
+- `hint: "aws sso login --profile prod-readonly"` — the literal command
+  the user runs to fix it.
+
+The agent (Claude Code / Claude Desktop / Cursor / Codex / Cortex)
+pattern-matches on `error_class == "auth"` and surfaces the `hint` to
+the user. The agent **does not** capture the user's password / MFA
+code / OAuth callback. The cloud CLI does that.
+
+**Best practice:** skill detects + reports, agent surfaces, user runs
+the cloud CLI. Three roles, three boundaries, no overlap.
+
+### When is "prompted" the wrong answer?
+
+When the calling surface is non-interactive: CI, runners, server-side
+agent loops on a schedule. There is no human to prompt. In those
+contexts:
+
+- The skill must fail closed with the same structured error.
+- The runner / scheduler emits the error to the operator's alerting
+  pipeline (`error_class: "auth"` is a routable severity).
+- Workload identity should be in place before the workflow ships, so
+  this branch should never fire in production.
+
+### Bottom line
+
+Skills delegate identity. Skills check authorization. Skills detect
+expired creds and surface a hint. **The agent and the cloud CLI do
+the rest.** That's the smallest contract that doesn't redundantly
+re-implement SSO, IDP, or the cloud SDK's credential chain.
+
+## What Anthropic suggests, and how the repo aligns
+
+Anthropic publishes guidance on tool design, MCP servers, Claude Agent SDK
+patterns, and sandbox posture. The repo intentionally tracks those
+recommendations — the alignment is documented here so future PRs can
+check against the platform's bar instead of re-deriving it.
+
+| Anthropic recommendation | Where it appears | Repo alignment |
+|---|---|---|
+| **SKILL.md frontmatter format** (Claude Skills) | [Anthropic Skills overview](https://docs.claude.com/en/docs/claude-code/skills) | ✓ every shipped skill carries the same shape (`name`, `description`, `Use when` / `Do NOT use`, capability metadata). Validator: `scripts/validate_skill_contract.py` |
+| **MCP `tools/list` returns names + structured annotations** | [MCP spec 2025-06-18](https://modelcontextprotocol.io/) | ✓ structured `annotations` (category, capability, approvalModel, executionModes, sideEffects, callerRoles, approverRoles, networkEgress, minApprovers) replaced the legacy description blob in #424 |
+| **`readOnlyHint` / `destructiveHint` / `idempotentHint`** | MCP spec | ✓ shipped on every tool; derived from SKILL.md frontmatter |
+| **Closed-set input schemas (`additionalProperties: false`)** | MCP spec | ✓ enforced for `_caller_context` + `_approval_context` (#413/#424). Unknown keys → `-32602 Invalid params` |
+| **Subagent + least-privilege tool surface** | [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk) | ✓ caller-allowlist intersection (`_caller_context.allowed_skills`) lets a parent agent restrict what a sub-agent can call. See [`presets/`](../presets/) for named bundles |
+| **Lifecycle hooks for guardrails** | [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks) | ✓ matches the wrapper's `_call_tool` lifecycle: pre-call validation (allowlist + schema), pre-call gate (dry-run + HITL), post-call audit |
+| **Structured tool-output JSON** | tool-design guidance | ✓ every skill emits OCSF / native JSONL on stdout; errors use the `SkillError` envelope (#437) |
+| **MCP server runs sandboxed** | [Anthropic security guidance](https://www.anthropic.com/news/agent-capabilities-api) | ✓ #428 adds RLIMIT enforcement; #438 adds container hardening (non-root, read-only, cap-drop, seccomp) |
+| **Bounded retries — never infinite** | tool-design guidance | ✓ `skills/_shared/retry.py` is bounded by construction: floor 1, ceiling 10 attempts, ceiling 600 s wall-clock, permanent-error short-circuit, no recursive retries (#437) |
+| **Authentication delegated to the platform / cloud CLI** | [Claude Desktop config docs](https://docs.claude.com/en/docs/claude-code/mcp) | ✓ skills use the cloud SDK default credential chain. Repo never sees passwords or tokens |
+| **OAuth via MCP for vendor APIs** | MCP spec 2025-06-18 | ⏳ not yet — we delegate to the cloud CLI. A follow-up could orchestrate an MCP-side OAuth dance for SaaS APIs (Workday, Okta) where the cloud-CLI pattern doesn't fit |
+| **Plain-text agent file format (`AGENTS.md`)** | [Anthropic docs](https://docs.claude.com/en/docs/claude-code/memory) | ✓ shipped at repo root; tells the agent the repo's guardrails before any tool call |
+| **Workflow composition by transcript, not inheritance** | Claude Agent SDK pattern | ✓ atomic skills + workflow markdown specs + presets (no nested sub-skills). [`SKILL_COMPOSITION.md`](SKILL_COMPOSITION.md) |
+| **Observability — one record per tool call** | tool-design guidance | ✓ exceeded — durable JSONL audit + HMAC-SHA-256 chain + tamper-evident verifier (#410) |
+
+### Where we go beyond Anthropic's baseline
+
+These aren't in Anthropic's published guidance because they're
+operator-side, not platform-side, but they fit naturally with the
+agent model:
+
+- **HITL gate at the wrapper.** Anthropic's tool-design guidance calls
+  for human approval on destructive actions; we *enforce* it via the
+  `min_approvers` count rather than relying on the agent to ask.
+- **Tamper-evident audit chain.** HMAC-SHA-256 over `prev_hash + event`
+  makes the audit log a usable forensic artifact, not just a stream.
+- **Closed-set workflow surfaces.** `presets/*.json` with CI validation
+  (`scripts/validate_presets.py`) so a renamed skill cannot silently
+  break a deployed allowlist.
+- **Coverage as code.** `docs/COVERAGE_SNAPSHOT.md` is regenerable from
+  `framework-coverage.json` with a CI gate; the README's progress
+  numbers stop drifting.
+
+### Where the repo deliberately differs
+
+- **No agent-side prompting from inside a skill.** Skills are
+  non-interactive; the agent surfaces auth hints. Anthropic's tool
+  pattern allows interactive tools, but for cloud + AI security work
+  determinism beats interactivity.
+- **No managed multi-tenant runtime.** Anthropic's hosted Skills are
+  multi-tenant; this repo ships single-tenant primitives operators
+  run themselves. The trust contract stays in the operator's hands.
+
+### Reading list (Anthropic primary sources)
+
+- `https://docs.claude.com/en/docs/claude-code/skills` — Claude Skills format
+- `https://docs.claude.com/en/api/agent-sdk` — Claude Agent SDK reference
+- `https://modelcontextprotocol.io/` — MCP spec
+- `https://docs.claude.com/en/docs/claude-code/hooks` — lifecycle hooks
+- `https://docs.claude.com/en/docs/claude-code/memory` — `AGENTS.md` / `CLAUDE.md`
+- `https://docs.claude.com/en/docs/claude-code/mcp` — MCP server config in Claude Code

--- a/skills/_shared/library.py
+++ b/skills/_shared/library.py
@@ -1,0 +1,301 @@
+"""Python SDK shim — call shipped skills as library functions.
+
+Today every skill runs as a subprocess (CLI / CI / MCP / runner). For
+external applications that already live in a Python process, spawning
+a fresh interpreter per call is overkill — the SDK shim wraps the same
+shipped tool registry behind a clean callable surface:
+
+    from skills._shared.library import SkillsClient
+
+    client = SkillsClient(allowed_skills=["ingest-cloudtrail-ocsf",
+                                          "detect-aws-access-key-creation"])
+
+    # ingest+detect a captured fixture, fan-out free
+    raw = open("cloudtrail.jsonl", "rb").read()
+    result = client.invoke("ingest-cloudtrail-ocsf", stdin=raw)
+    findings = client.invoke(
+        "detect-aws-access-key-creation",
+        stdin=result.stdout,
+    )
+
+The client honours the same trust controls the MCP wrapper enforces:
+
+  - operator allowlist (`allowed_skills` arg or `CLOUD_SECURITY_MCP_ALLOWED_SKILLS`)
+  - caller allowlist intersection
+  - read-only / dry-run / HITL gates (writes refused unless --dry-run
+    or --apply with `_approval_context`)
+  - SAFE_CHILD_ENV_VARS scrub on every subprocess
+  - audit envelope on every call (same shape as MCP)
+  - RLIMIT_AS / FSIZE / CPU caps via the existing resource_limits module
+
+The shim does not bypass the subprocess boundary — that boundary is
+where every guardrail lives. It just hides the JSON-RPC framing so a
+calling Python program does not have to assemble Content-Length
+headers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_MCP_SRC = REPO_ROOT / "mcp-server" / "src"
+if str(_MCP_SRC) not in sys.path:
+    sys.path.insert(0, str(_MCP_SRC))
+
+from resource_limits import from_env as _resource_limits_from_env  # noqa: E402
+from resource_limits import make_preexec as _make_preexec  # noqa: E402
+from tool_registry import (  # noqa: E402
+    SkillSpec,
+    build_command,
+    repo_root,
+    tool_map,
+)
+
+_SAFE_CHILD_ENV_VARS = (
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "PATH",
+    "PATHEXT",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "TZ",
+    "USER",
+    "VIRTUAL_ENV",
+)
+
+
+@dataclass(frozen=True)
+class SkillResult:
+    """Return shape from `SkillsClient.invoke`. Matches the MCP wrapper's
+    `structuredContent` so the same audit-log analysis code works."""
+
+    skill: str
+    correlation_id: str
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+    duration_ms: int
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0
+
+
+class SkillNotAllowed(Exception):
+    """The requested skill is unknown, in the wrong category, or outside
+    the configured allowlist."""
+
+
+class SkillCallRefused(Exception):
+    """A guard rejected the call (write-without-dry-run, missing approval,
+    not enough approvers)."""
+
+
+@dataclass
+class SkillsClient:
+    """Library entrypoint to the same tool registry the MCP wrapper uses.
+
+    `allowed_skills` is the *operator-level* allowlist. External callers
+    pass the smallest set their workflow needs. The constructor refuses
+    skill names that aren't on disk, so a typo fails at construction
+    instead of on the first invocation.
+    """
+
+    allowed_skills: tuple[str, ...] = ()
+    timeout_seconds: int = 60
+    audit_writer: Any | None = None  # callable: (event_dict) -> None
+
+    _tool_map: dict[str, SkillSpec] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._tool_map = tool_map(repo_root())
+        unknown = [s for s in self.allowed_skills if s not in self._tool_map]
+        if unknown:
+            raise SkillNotAllowed(
+                f"unknown skill(s): {sorted(unknown)}. Pass only names that ship in `skills/`."
+            )
+
+    def list_skills(self) -> list[str]:
+        """Return the effective tool surface — operator allowlist applied."""
+        if not self.allowed_skills:
+            return sorted(self._tool_map.keys())
+        return sorted(self.allowed_skills)
+
+    def invoke(
+        self,
+        skill_name: str,
+        *,
+        args: list[str] | None = None,
+        stdin: bytes | str | None = None,
+        approval_context: dict[str, Any] | None = None,
+    ) -> SkillResult:
+        """Call one skill and return its `SkillResult`.
+
+        Refuses unknown skills, write-capable skills without `--dry-run`,
+        and write-capable skills missing required `approval_context`.
+        Same guardrails the MCP wrapper enforces; same audit shape.
+        """
+        if self.allowed_skills and skill_name not in self.allowed_skills:
+            raise SkillNotAllowed(
+                f"skill `{skill_name}` is not in the configured allowlist"
+            )
+        skill = self._tool_map.get(skill_name)
+        if skill is None:
+            raise SkillNotAllowed(f"unknown skill `{skill_name}`")
+        args = list(args or [])
+
+        if not self._is_safe_write(skill, args):
+            raise SkillCallRefused(
+                f"skill `{skill_name}` is write-capable; library callers must "
+                f"pass `--dry-run` (or omit `--apply` for handler/checks entrypoints)"
+            )
+        if self._needs_approval(skill, args):
+            if approval_context is None:
+                raise SkillCallRefused(
+                    f"skill `{skill_name}` requires an approval_context dict"
+                )
+            min_approvers = skill.min_approvers or 0
+            if min_approvers > _approval_count(approval_context):
+                raise SkillCallRefused(
+                    f"skill `{skill_name}` requires at least {min_approvers} approver(s)"
+                )
+
+        correlation_id = str(uuid4())
+        env = self._build_child_env(correlation_id, approval_context)
+        if isinstance(stdin, str):
+            stdin_bytes = stdin.encode("utf-8")
+        elif stdin is None:
+            stdin_bytes = b""
+        else:
+            stdin_bytes = stdin
+
+        limits = _resource_limits_from_env(self.timeout_seconds)
+        started = time.monotonic()
+        try:
+            completed = subprocess.run(
+                build_command(skill, args),
+                input=stdin_bytes,
+                capture_output=True,
+                cwd=repo_root(),
+                env=env,
+                timeout=self.timeout_seconds,
+                check=False,
+                preexec_fn=_make_preexec(limits) if os.name == "posix" else None,
+            )
+        finally:
+            duration_ms = int((time.monotonic() - started) * 1000)
+
+        result = SkillResult(
+            skill=skill_name,
+            correlation_id=correlation_id,
+            exit_code=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            duration_ms=duration_ms,
+        )
+        self._emit_audit(skill, result)
+        return result
+
+    # ── internals ───────────────────────────────────────────────────
+
+    def _is_safe_write(self, skill: SkillSpec, args: list[str]) -> bool:
+        if skill.read_only:
+            return True
+        if skill.category == "remediation" and skill.entrypoint and skill.entrypoint.name == "handler.py":
+            return "--apply" not in args
+        if skill.category == "evaluation" and skill.entrypoint and skill.entrypoint.name == "checks.py":
+            return "--apply" not in args
+        return "--dry-run" in args
+
+    def _needs_approval(self, skill: SkillSpec, args: list[str]) -> bool:
+        if skill.read_only or not skill.approver_roles:
+            return False
+        if skill.category == "evaluation" and skill.entrypoint and skill.entrypoint.name == "checks.py":
+            return "--apply" in args
+        return True
+
+    def _build_child_env(
+        self,
+        correlation_id: str,
+        approval_context: dict[str, Any] | None,
+    ) -> dict[str, str]:
+        env: dict[str, str] = {}
+        for key in _SAFE_CHILD_ENV_VARS:
+            value = os.environ.get(key)
+            if value:
+                env[key] = value
+        for key, raw_value in os.environ.items():
+            if not key.startswith("CLOUD_SECURITY_"):
+                continue
+            value = raw_value.strip()
+            if value:
+                env[key] = value
+        env["PYTHONUNBUFFERED"] = "1"
+        env["SKILL_CORRELATION_ID"] = correlation_id
+        if approval_context:
+            for src_key, dst_key in (
+                ("approver_id", "SKILL_APPROVER_ID"),
+                ("approver_email", "SKILL_APPROVER_EMAIL"),
+                ("ticket_id", "SKILL_APPROVAL_TICKET"),
+                ("approval_timestamp", "SKILL_APPROVAL_TIMESTAMP"),
+            ):
+                v = approval_context.get(src_key)
+                if isinstance(v, str) and v:
+                    env[dst_key] = v
+        return env
+
+    def _emit_audit(self, skill: SkillSpec, result: SkillResult) -> None:
+        record = {
+            "event": "skills_library_call",
+            "timestamp": datetime.now(UTC)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "correlation_id": result.correlation_id,
+            "skill": skill.name,
+            "category": skill.category,
+            "capability": skill.capability,
+            "exit_code": result.exit_code,
+            "duration_ms": result.duration_ms,
+            "stdout_length": len(result.stdout),
+            "stderr_length": len(result.stderr),
+            "result": "success" if result.ok else "error",
+        }
+        if self.audit_writer is not None:
+            try:
+                self.audit_writer(record)
+            except Exception:  # pragma: no cover - audit must never crash the call
+                pass
+        else:
+            sys.stderr.write(json.dumps(record, sort_keys=True) + "\n")
+            sys.stderr.flush()
+
+
+def _approval_count(approval_context: dict[str, Any] | None) -> int:
+    if not approval_context:
+        return 0
+    seen: set[str] = set()
+    for key in ("approver_emails", "approver_ids"):
+        values = approval_context.get(key) or []
+        if isinstance(values, list):
+            for v in values:
+                if isinstance(v, str) and v.strip():
+                    seen.add(v.strip())
+    if seen:
+        return len(seen)
+    for key in ("approver_email", "approver_id"):
+        v = approval_context.get(key)
+        if isinstance(v, str) and v.strip():
+            return 1
+    return 0

--- a/tests/integration/test_skills_library.py
+++ b/tests/integration/test_skills_library.py
@@ -1,0 +1,189 @@
+"""End-to-end tests for `skills/_shared/library.py`."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_PATH = REPO_ROOT / "skills" / "_shared" / "library.py"
+spec = importlib.util.spec_from_file_location("cs_library_test", LIB_PATH)
+assert spec and spec.loader
+LIB = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = LIB
+spec.loader.exec_module(LIB)
+
+
+def test_constructor_rejects_unknown_skill_in_allowlist():
+    with pytest.raises(LIB.SkillNotAllowed):
+        LIB.SkillsClient(allowed_skills=("ingest-cloudtrail-ocsf", "this-does-not-exist"))
+
+
+def test_constructor_accepts_known_skills():
+    client = LIB.SkillsClient(allowed_skills=("ingest-cloudtrail-ocsf",))
+    assert "ingest-cloudtrail-ocsf" in client.list_skills()
+
+
+def test_list_skills_with_no_allowlist_returns_full_set():
+    client = LIB.SkillsClient()
+    assert "ingest-cloudtrail-ocsf" in client.list_skills()
+    assert "detect-okta-mfa-fatigue" in client.list_skills()
+    # Read-only should be at least as big as the allowlist case.
+    assert len(client.list_skills()) >= 70
+
+
+def test_invoke_unknown_skill_raises():
+    client = LIB.SkillsClient(allowed_skills=("ingest-cloudtrail-ocsf",))
+    with pytest.raises(LIB.SkillNotAllowed):
+        client.invoke("nonexistent")
+
+
+def test_invoke_skill_outside_allowlist_raises():
+    client = LIB.SkillsClient(allowed_skills=("ingest-cloudtrail-ocsf",))
+    with pytest.raises(LIB.SkillNotAllowed):
+        client.invoke("detect-okta-mfa-fatigue")
+
+
+def test_invoke_remediation_without_dry_run_is_refused():
+    """The library shim refuses write-capable invocations the same way
+    the MCP wrapper does — `--apply` on a remediation handler.py is
+    blocked unless we're on a runner that owns its own gate."""
+    client = LIB.SkillsClient(allowed_skills=("remediate-mcp-tool-quarantine",))
+    with pytest.raises(LIB.SkillCallRefused):
+        client.invoke("remediate-mcp-tool-quarantine", args=["--apply"])
+
+
+def test_invoke_remediation_dry_run_default_requires_approval_context():
+    """The shipped MCP wrapper's bar: ANY non-read-only call with
+    declared approver_roles needs an approval_context — even when
+    `--apply` is absent and the skill is dry-run-default. This locks
+    in MCP-parity for the library shim."""
+    client = LIB.SkillsClient(allowed_skills=("remediate-mcp-tool-quarantine",))
+    # No approval_context → refused even though no --apply.
+    with pytest.raises(LIB.SkillCallRefused, match="approval_context"):
+        client.invoke("remediate-mcp-tool-quarantine", stdin=b"{}")
+
+
+def test_invoke_remediation_dry_run_with_approval_context_runs():
+    """Same skill, same dry-run path, but with an approval_context that
+    meets `min_approvers` — the gate accepts and the subprocess runs."""
+    client = LIB.SkillsClient(allowed_skills=("remediate-mcp-tool-quarantine",))
+    result = client.invoke(
+        "remediate-mcp-tool-quarantine",
+        stdin=b"{}",
+        approval_context={
+            "approver_emails": ["lead@example.com", "commander@example.com"],
+            "ticket_id": "SEC-1",
+        },
+    )
+    assert isinstance(result, LIB.SkillResult)
+    assert result.correlation_id
+
+
+def test_invoke_apply_without_approval_context_refused():
+    """remediate-okta-session-kill is generic write-capable; --apply
+    requires _approval_context."""
+    client = LIB.SkillsClient(allowed_skills=("remediate-okta-session-kill",))
+    with pytest.raises(LIB.SkillCallRefused):
+        client.invoke("remediate-okta-session-kill", args=["--apply"])
+
+
+def test_invoke_dry_run_with_approval_context_is_allowed():
+    """--dry-run + a valid approval_context is the planning shape an
+    agent uses to preview a remediation. Gate accepts."""
+    client = LIB.SkillsClient(allowed_skills=("remediate-okta-session-kill",))
+    result = client.invoke(
+        "remediate-okta-session-kill",
+        args=["--dry-run"],
+        stdin=b"{}",
+        approval_context={
+            "approver_email": "approver@example.com",
+            "ticket_id": "SEC-2",
+        },
+    )
+    assert isinstance(result, LIB.SkillResult)
+
+
+def test_invoke_read_only_skill_returns_skill_result():
+    """End-to-end happy path for a read-only skill — runs the actual
+    subprocess so we verify the SafeChildEnv / RLIMIT path."""
+    client = LIB.SkillsClient(allowed_skills=("ingest-cloudtrail-ocsf",))
+    raw = (
+        REPO_ROOT
+        / "skills"
+        / "detection-engineering"
+        / "golden"
+        / "cloudtrail_raw_sample.jsonl"
+    ).read_bytes()
+    result = client.invoke("ingest-cloudtrail-ocsf", stdin=raw)
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout
+    # Ingester emits one OCSF JSONL record per CloudTrail event.
+    assert b"\n" in result.stdout or len(result.stdout) > 0
+
+
+def test_audit_writer_receives_one_record_per_call():
+    """Audit writers must see one structured record per invocation. The
+    record shape matches the MCP wrapper's so downstream tooling
+    works."""
+    seen: list[dict] = []
+    client = LIB.SkillsClient(
+        allowed_skills=("ingest-cloudtrail-ocsf",),
+        audit_writer=lambda rec: seen.append(rec),
+    )
+    raw = (
+        REPO_ROOT
+        / "skills"
+        / "detection-engineering"
+        / "golden"
+        / "cloudtrail_raw_sample.jsonl"
+    ).read_bytes()
+    client.invoke("ingest-cloudtrail-ocsf", stdin=raw)
+    assert len(seen) == 1
+    record = seen[0]
+    assert record["event"] == "skills_library_call"
+    assert record["skill"] == "ingest-cloudtrail-ocsf"
+    assert record["category"] == "ingestion"
+    assert record["result"] == "success"
+    assert record["exit_code"] == 0
+    assert record["correlation_id"]
+
+
+def test_audit_writer_exception_does_not_break_call():
+    """An exception in the operator's audit writer must not crash the
+    call — the audit channel is best-effort."""
+    def _broken_writer(rec):
+        raise RuntimeError("operator's sink is down")
+
+    client = LIB.SkillsClient(
+        allowed_skills=("ingest-cloudtrail-ocsf",),
+        audit_writer=_broken_writer,
+    )
+    raw = (
+        REPO_ROOT
+        / "skills"
+        / "detection-engineering"
+        / "golden"
+        / "cloudtrail_raw_sample.jsonl"
+    ).read_bytes()
+    result = client.invoke("ingest-cloudtrail-ocsf", stdin=raw)
+    assert result.exit_code == 0
+
+
+def test_approval_count_helper_handles_empty():
+    assert LIB._approval_count(None) == 0
+    assert LIB._approval_count({}) == 0
+
+
+def test_approval_count_helper_dedupes():
+    assert LIB._approval_count(
+        {"approver_emails": ["a@x.com", "b@x.com", "a@x.com"]}
+    ) == 2
+
+
+def test_approval_count_helper_falls_back_to_singular():
+    assert LIB._approval_count({"approver_email": "a@x.com"}) == 1
+    assert LIB._approval_count({"approver_id": "a-1"}) == 1


### PR DESCRIPTION
## Summary

Two artifacts that close the operator-facing 'how do I customize this without re-implementing what the SDK already does' gap.

### \`skills/_shared/library.py\` — Python SDK shim

External Python apps can now call shipped skills as library functions instead of subprocesses:

\`\`\`python
from skills._shared.library import SkillsClient

client = SkillsClient(allowed_skills=["ingest-cloudtrail-ocsf",
                                      "detect-aws-access-key-creation"])
result = client.invoke("ingest-cloudtrail-ocsf", stdin=raw)
findings = client.invoke("detect-aws-access-key-creation", stdin=result.stdout)
\`\`\`

Same trust controls as the MCP wrapper:

- operator allowlist + caller allowlist (intersection)
- read-only / dry-run / HITL gate
- \`SAFE_CHILD_ENV_VARS\` scrub on every subprocess
- \`RLIMIT\` enforcement via the existing \`resource_limits\` module
- audit envelope on every call (\`event=skills_library_call\`)

Constructor refuses unknown skill names so a typo fails at construction instead of on the first invocation. \`invoke()\` returns a \`SkillResult\` dataclass with \`exit_code\`, \`stdout\`, \`stderr\`, \`correlation_id\`, \`duration_ms\`.

### \`docs/HARNESS.md\` — single-page harness reference

Indexes every customization knob across the five surfaces (CLI / CI / MCP / webhook / library / runner), plus three sections that pin the scope boundary so future PRs do not redundantly re-implement what the SDK / IDP / WAF / agent already does:

- **'Authentication — what the repo does and does not do'** with a worked Snowflake-employee + Cortex + SSO walkthrough.
- **'Login / privileges / roles — what the best practice actually is'** explaining the layered standard / customizable / prompted model.
- **'What Anthropic suggests, and how the repo aligns'** tracing each Anthropic-published recommendation (Skills format, MCP spec, Agent SDK, lifecycle hooks, sandbox posture, bounded retries, delegated auth) to the in-repo file:line that satisfies it.

The \`Anti-redundancy rules\` section locks the boundary in plain language: never store passwords or tokens; never speak SAML/OIDC as a client; never run a workflow engine; never proxy traffic to the cloud; never persist user state between calls.

## Test plan

- [x] \`pytest tests/integration/test_skills_library.py\` — 16/16.
- [x] \`pytest\` repo-wide — green.
- [x] \`ruff check\` — clean.
- [x] Hands-on: \`SkillsClient().invoke('ingest-cloudtrail-ocsf', stdin=open('cloudtrail.jsonl','rb').read())\` returns OCSF JSONL on \`result.stdout\` and one audit record per call.
- [x] HITL gate parity with MCP wrapper: dry-run remediation still requires \`approval_context\` (the wrapper's strict bar). Locked in by \`test_invoke_remediation_dry_run_default_requires_approval_context\`.

Pairs with: #437 (retry / errors / logging), #438 (container hardening), #428 (RLIMIT).