### PR TITLE
docs(readme): tighten + restructure to leading-OSS shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,37 +3,18 @@
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
   <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.8.1-0ea5e9"></a>
-  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
-  <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11+-blue.svg"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache_2.0-blue"></a>
+  <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11+-blue"></a>
   <a href="https://schema.ocsf.io/1.8.0"><img alt="OCSF 1.8" src="https://img.shields.io/badge/OCSF-1.8-22d3ee"></a>
-  <a href="https://attack.mitre.org/"><img alt="MITRE ATT&CK" src="https://img.shields.io/badge/MITRE-ATT%26CK-ef4444"></a>
-  <a href="docs/FRAMEWORK_MAPPINGS.md"><img alt="CIS" src="https://img.shields.io/badge/CIS-AWS_%7C_GCP_%7C_Azure-22c55e"></a>
-  <a href="docs/COVERAGE_MODEL.md"><img alt="Coverage Gates" src="https://img.shields.io/badge/coverage-gated-0f766e"></a>
+  <a href="https://attack.mitre.org/"><img alt="MITRE ATT&CK" src="https://img.shields.io/badge/MITRE-ATT%26CK_%2B_ATLAS-ef4444"></a>
+  <a href="docs/FRAMEWORK_MAPPINGS.md"><img alt="OWASP" src="https://img.shields.io/badge/OWASP-Top_10_%2B_LLM-f59e0b"></a>
+  <a href="docs/COVERAGE_SNAPSHOT.md"><img alt="Coverage gated" src="https://img.shields.io/badge/coverage-CI_gated-0f766e"></a>
   <a href="https://github.com/msaad00/agent-bom"><img alt="Scanned by agent-bom" src="https://img.shields.io/badge/scanned_by-agent--bom-164e63"></a>
 </p>
 
+<p align="center"><strong>76 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, runs everywhere the same bundle can.</strong></p>
+
 ---
-
-## What this repo gives you
-
-**76 production-grade skill bundles** for cloud and AI security. Each one normalizes raw cloud, identity, Kubernetes, or MCP signal into a standards-aligned finding — OCSF 1.8 on the wire where it matters, native JSONL where state and audit matter more.
-
-Twelve of those skills are **guarded write paths**: IAM departures across AWS, GCP, and Azure Entra; network revoke on AWS, GCP, and Azure; Okta and Workspace session kill; Entra service-principal credential revoke; Kubernetes quarantine and RBAC revoke; MCP tool quarantine. Every write is dry-run-first, HITL-gated, and dual-audited.
-
-The skill contract is the same everywhere: one `SKILL.md` + `src/` + `tests/` bundle that runs unchanged from the **CLI**, from **CI**, behind an **MCP** wrapper for any agentic client, or inside a **persistent cloud runner**. No fork in behavior, no parallel codepaths, no per-surface drift.
-
-| Layer | Count | Purpose | Output |
-|---|---:|---|---|
-| **Ingest** | 15 | normalize raw source → event stream | native JSONL **or** OCSF 1.8 |
-| **Discover** | 5 | inventory, graph, AI BOM, evidence, IAM departure manifest planning | native / bridge JSON |
-| **Detect** | 29 | deterministic rules with MITRE ATT&CK | OCSF Detection Finding 2004 |
-| **Evaluate** | 7 | 91 posture and benchmark checks | compliance result |
-| **Remediate** | 12 | guarded write paths (IAM departures AWS + GCP + Azure Entra, AWS/GCP/Azure network revoke, Okta session kill, Workspace session kill, K8s quarantine, K8s RBAC revoke, MCP tool quarantine, Entra SP credential revoke) | audited action trail |
-| **View** | 2 | findings → review formats | SARIF · Mermaid |
-| **Output** | 3 | append-only sinks (S3, Snowflake, ClickHouse) | persisted JSONL |
-| **Sources** | 3 | warehouse query adapters (S3 Select, Snowflake, Databricks) | JSONL pass-through |
-
-**Total: 76 shipped skills.**
 
 ## Quickstart
 
@@ -43,7 +24,7 @@ git clone --branch v0.8.1 https://github.com/msaad00/cloud-ai-security-skills.gi
 cd cloud-ai-security-skills
 
 # 2 · Install only the deps the skills you'll run need
-uv sync --group dev --extra aws --extra k8s        # or `--extra gcp`, `--extra azure`, …
+uv sync --group dev --extra aws --extra k8s        # or --extra gcp / --extra azure / ...
 
 # 3 · Run a detection on a captured fixture (no cloud creds needed)
 python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py \
@@ -52,288 +33,118 @@ python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py \
   | python skills/view/convert-ocsf-to-sarif/src/convert.py \
   > findings.sarif
 
-# 4 · Wire the skills into any agent over MCP
-# (The repo ships .mcp.json — Claude Code picks it up automatically.
-#  For Claude Desktop, Cursor, Windsurf, Codex, Cortex, Zed, see docs/integrations/.)
+# 4 · Wire into any agent over MCP — repo-shipped .mcp.json works in Claude Code out of the box.
+#     For Claude Desktop, Cursor, Windsurf, Codex, Cortex, Zed: see docs/integrations/.
 ```
 
-Each surface (CLI, CI, MCP, runners) is just a transport — the same `SKILL.md + src/ + tests/` bundle runs unchanged behind it.
+Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent runners**. Same `SKILL.md + src/ + tests/`, no per-surface drift.
 
-<details>
-<summary><b>Why different layers use different formats</b> — OCSF where interop matters, native where state, evidence, and audit matter more</summary>
+## What this repo gives you
 
-OCSF 1.8 is the **SIEM interop wire format** — valuable exactly where events flow to a downstream analyzer. It is not the universal internal format, and this repo is honest about where it fits:
+**76 shipped skill bundles** — atomic, deterministic, single-concern. Twelve are guarded write paths; the other 64 are read-only. Drop one into a pipeline, an agent, a Step Function, or a `python ... | python ...` one-liner.
 
-| Layer | Default emit | Rationale |
-|---|---|---|
-| **Ingest** | OCSF 1.8 (native opt-in) | Raw vendor → OCSF is what OCSF was built for. SIEMs consume it natively |
-| **Detect** | OCSF 1.8 Detection Finding 2004 (native opt-in) | Findings flow to SIEM / SOAR / ticketing — OCSF spares every downstream system from writing a custom parser |
-| **Evaluate / CSPM** | native by default, OCSF Compliance Finding 2003 opt-in | Ops dashboards prefer native; SIEM pipelines can opt into OCSF without losing the native path |
-| **Discover** | native / CycloneDX ML-BOM / bridge | Inventory graphs and AI BOM aren't events. OCSF Inventory Info 5001 is too thin to be worth forcing |
-| **Remediate** | native | Remediation is a state change with an operator-owned audit trail, not a finding |
-| **View** | OCSF **input**, SARIF / Mermaid out | The whole point is rendering OCSF for humans |
-| **Output (sinks)** | pass-through | Sinks write whatever the producer emitted |
+| Layer | Count | Purpose | Output |
+|---|---:|---|---|
+| **Ingest** | 15 | normalize raw cloud / identity / K8s / MCP signal | OCSF 1.8 (native opt-in) |
+| **Discover** | 5 | inventory · graph · AI BOM · evidence · IAM-departure planning | native / bridge JSON |
+| **Detect** | 29 | deterministic rules tagged with MITRE ATT&CK / ATLAS / OWASP | OCSF Detection Finding 2004 |
+| **Evaluate** | 7 | 91 posture and benchmark checks across CIS / NIST / SOC 2 | compliance result |
+| **Remediate** | 12 | guarded write paths — IAM departures × 3 clouds, network revoke × 3, session/credential kill × 4, K8s × 2, MCP tool quarantine | audited action trail |
+| **View** | 2 | findings → review formats | SARIF · Mermaid |
+| **Output** | 3 | append-only sinks | S3 · Snowflake · ClickHouse |
+| **Sources** | 3 | warehouse query adapters | S3 Select · Snowflake · Databricks |
 
-Full discussion: [docs/ARCHITECTURE.md §3 Layer model + §6 Wire contract](docs/ARCHITECTURE.md). The pinned OCSF contract for ingest + detect lives in [skills/detection-engineering/OCSF_CONTRACT.md](skills/detection-engineering/OCSF_CONTRACT.md).
-
-</details>
+**Total: 76 shipped skills.**  Live counts and per-framework coverage in [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) (auto-generated, CI-gated).
 
 ## Architecture
 
-Two intake layers (ingest, discover) → two analyze layers (detect, evaluate) → two act layers (remediate, view) → one persist layer (output). MCP, CLI, CI, and cloud runners all invoke the same skill bundle — the surface is transport, not behavior.
+External signals enter through two intake layers, pass through two analyze layers, exit through two act layers, and persist through one output layer. MCP, CLI, CI, webhook, and runners all invoke the same skill bundle — the surface is transport, not behavior.
 
 ![Clean architecture layers diagram — signals feed intake, analyze, act, and persist stages across the seven shipped skill layers.](docs/images/architecture-layers.svg)
 
 ![Clean runtime surfaces diagram — MCP, CLI, CI, and cloud runners all invoke the same shared skill bundle.](docs/images/runtime-surfaces.svg)
 
-Deeper reads: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) · [docs/SKILL_CONTRACT.md](docs/SKILL_CONTRACT.md) · [docs/COMPLIANCE_EVIDENCE_CAPTURE.md](docs/COMPLIANCE_EVIDENCE_CAPTURE.md).
+Deeper reads: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · [`docs/HARNESS.md`](docs/HARNESS.md) · [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) · [`docs/SKILL_COMPOSITION.md`](docs/SKILL_COMPOSITION.md)
 
-## Agent and runtime integrations
+## Agent integrations
 
-MCP clients go through the repo MCP server; CLI, CI, and cloud runners invoke the skill bundle directly. All four surfaces share the same implementation — see the runtime surfaces diagram above.
+Every agent / IDE goes through the same stdio MCP wrapper. Audit trail, HITL gates, allowlists, RLIMIT enforcement, and timeouts are identical across clients.
 
-- **MCP** · [.mcp.json](.mcp.json) · [mcp-server/README.md](mcp-server/README.md) · [docs/MCP_AUDIT_CONTRACT.md](docs/MCP_AUDIT_CONTRACT.md)
-- **CLI / pipes** · stdin/stdout bundles compose into one-liners
-- **CI** · GitHub Actions publishes SARIF to the Security tab
-- **Runners** · reference runners under [runners/](runners/) for S3/SQS, GCS/PubSub, Blob/EventGrid
+| Client | Doc | Transport |
+|---|---|---|
+| Claude Code (CLI) | repo-root [`.mcp.json`](.mcp.json) — shipped | stdio |
+| Claude Desktop | [`docs/integrations/claude-desktop.md`](docs/integrations/claude-desktop.md) | stdio |
+| Claude.ai (web) | [`docs/integrations/claude-ai-web.md`](docs/integrations/claude-ai-web.md) | n/a — points at desktop / code |
+| Cursor · Windsurf · Codex · Cortex · Zed | [`docs/integrations/`](docs/integrations/) | stdio |
+| Continue · Cody · generic MCP client | [`docs/integrations/ide-agents.md`](docs/integrations/ide-agents.md) | stdio |
+| Anthropic Agent SDK · OpenAI SDK · LangGraph | [`examples/agents/`](examples/agents/) | stdio + Python harness |
+| Webhook (S3 EventBridge / vendor callback / API gateway) | [`runners/webhook-receiver/`](runners/webhook-receiver/) | HTTP, HMAC + bearer |
+| Library (any Python app) | [`skills/_shared/library.py`](skills/_shared/library.py) | in-process subprocess |
 
-### Agent + IDE integrations
+Pre-canned MCP allowlists for the four shipped use-cases live under [`presets/`](presets/) — CSPM-readonly · detection-only · incident-response · AI-runtime. Workflows under [`examples/workflows/`](examples/workflows/).
 
-Per-client setup docs under [`docs/integrations/`](docs/integrations/). Every client goes through the same stdio MCP wrapper, so audit trail, HITL gates, and timeouts are identical across clients.
+## Trust posture
 
-| Client | Doc |
+| Layer | What |
 |---|---|
-| Claude Code (CLI) | repo-root [`.mcp.json`](.mcp.json) (shipped) |
-| Claude Desktop | [`docs/integrations/claude-desktop.md`](docs/integrations/claude-desktop.md) |
-| Claude.ai (web) | [`docs/integrations/claude-ai-web.md`](docs/integrations/claude-ai-web.md) — local MCP not supported; pointers to alternatives |
-| Codex (CLI + IDE) | [`docs/integrations/codex.md`](docs/integrations/codex.md) |
-| Cursor | [`docs/integrations/cursor.md`](docs/integrations/cursor.md) |
-| Windsurf | [`docs/integrations/windsurf.md`](docs/integrations/windsurf.md) |
-| Cortex Code CLI | [`docs/integrations/cortex.md`](docs/integrations/cortex.md) |
-| Zed | [`docs/integrations/zed.md`](docs/integrations/zed.md) |
-| Continue / Cody / generic | [`docs/integrations/ide-agents.md`](docs/integrations/ide-agents.md) |
+| **Audit** | one durable JSONL record per call · HMAC-SHA-256 chain · tamper-evident verifier ([`docs/MCP_AUDIT_CONTRACT.md`](docs/MCP_AUDIT_CONTRACT.md)) |
+| **Allowlist** | operator env ∩ caller_context ∩ workflow preset; default-deny on the webhook surface |
+| **Read-only by default** | category-derived; AST gate refuses cloud-write calls in read-only skills |
+| **Write paths** | dry-run-first · HITL-gated · `min_approvers` enforced before subprocess fires |
+| **RLIMIT** | every subprocess capped: 1 GB virtual memory, 100 MB single-file write, CPU = wrapper timeout + grace |
+| **Container** | non-root UID 65532 · read-only rootfs · `--cap-drop=ALL` · `no-new-privileges` · default seccomp |
+| **Retry** | bounded by construction: ≤ 10 attempts, ≤ 600 s wall-clock budget, no recursive retries ([`skills/_shared/retry.py`](skills/_shared/retry.py)) |
+| **No hardcoded secrets** | CI grep, workload identity only |
 
-Least-privilege scoping across every client via the `CLOUD_SECURITY_MCP_ALLOWED_SKILLS` env var (comma-separated skill names — unlisted skills are not registered as tools). Pre-canned allowlists for the four shipped use-cases live under [`presets/`](presets/) (CSPM-readonly · detection-only · incident-response · AI-runtime); load one and the agent's tool surface is scoped to that workflow's atoms only.
-
-### Skill composition · workflows · presets
-
-Atomic skills compose into runnable security operations through documented **workflows** (markdown specs under [`examples/workflows/`](examples/workflows/)) plus matching **presets** (named MCP allowlists under [`presets/`](presets/)). Each workflow declares its trigger, ordered steps, HITL gate, and audit-chain join key — no hidden state inside a "parent" wrapper, every atom remains independently runnable from CLI / CI / MCP / runner.
-
-Read [`docs/SKILL_COMPOSITION.md`](docs/SKILL_COMPOSITION.md) for the model, including why the repo deliberately avoids nested sub-skill directories.
-
-<details>
-<summary><b>Start here</b> — pick the row that matches the job</summary>
-
-| You have… | Start with | Typical output |
-|---|---|---|
-| a raw log file or stream | [`ingest-*`](skills/ingestion/) → [`detect-*`](skills/detection/) | OCSF Detection Finding |
-| live cloud API access | [`discover-*`](skills/discovery/) or [`evaluation/*`](skills/evaluation/) | graph / benchmark JSON |
-| logs already in your lake (CloudTrail in S3, Okta in Snowflake, Databricks tables) | [`source-*`](skills/ingestion/) → `detect-*` → [`sink-*`](skills/output/) | customer-owned persistence |
-| an AI estate to inventory | [`discover-ai-bom`](skills/discovery/discover-ai-bom/) | CycloneDX-aligned AI BOM + optional AI policy findings |
-| audit evidence to produce | [`discover-control-evidence`](skills/discovery/discover-control-evidence/) | PCI / SOC 2 evidence JSON |
-| OCSF findings to publish | [`view/*`](skills/view/) | SARIF · Mermaid |
-| a departing employee to offboard | [`iam-departures-aws`](skills/remediation/iam-departures-aws/) | dry-run plan or audited action |
-| a suspicious Kubernetes workload to isolate | [`remediate-container-escape-k8s`](skills/remediation/remediate-container-escape-k8s/) | audited quarantine plan / action, with explicit pod-kill and dual-approved node-drain follow-ups |
-
-Full crosswalk: [docs/USE_CASES.md](docs/USE_CASES.md)
-
-</details>
-
-### Closed-loop coverage at a glance
-
-![Closed-loop coverage matrix — 13 of 29 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, GCP service-account-token minting, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
-
-Source of truth for detect↔remediate parity. Tracked at [#155](https://github.com/msaad00/cloud-ai-security-skills/issues/155); design + remaining per-layer SVGs at [#248](https://github.com/msaad00/cloud-ai-security-skills/issues/248).
-
-## Common shipped flows
-
-Three lanes. Same skill bundle contract in every lane — input, output, and control boundary are what change.
-
-Rendered as three separate diagrams so each lane gets its own full-width row — the prior single-diagram layout forced GitHub's mermaid renderer to squeeze the three lanes side-by-side into unreadable thumbnails.
-
-**Lane 1 — Raw log detection and export**
-
-```mermaid
-flowchart LR
-    classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
-    classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
-    classDef detect fill:#047857,stroke:#6ee7b7,color:#ecfdf5
-    classDef sink fill:#6d28d9,stroke:#c4b5fd,color:#f5f3ff
-    classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
-
-    raw["raw payloads<br/>CloudTrail · K8s audit · Okta"]:::source --> ingest["ingest-*"]:::skill --> detect1["detect-*"]:::detect --> view["view/*"]:::sink --> export["SARIF · Mermaid · JSON"]:::output
-```
-
-**Lane 2 — Detection on data already in your lake**
-
-```mermaid
-flowchart LR
-    classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
-    classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
-    classDef detect fill:#047857,stroke:#6ee7b7,color:#ecfdf5
-    classDef sink fill:#6d28d9,stroke:#c4b5fd,color:#f5f3ff
-    classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
-
-    lake["warehouse rows or objects<br/>Snowflake · Databricks · S3"]:::source --> source2["source-*"]:::skill --> detect2["detect-*"]:::detect --> sink["sink-*"]:::sink --> persist["customer-owned persistence"]:::output
-```
-
-**Lane 3 — Live posture and guarded action**
-
-```mermaid
-flowchart LR
-    classDef source fill:#0f172a,stroke:#475569,color:#f8fafc
-    classDef skill fill:#1d4ed8,stroke:#93c5fd,color:#eff6ff
-    classDef remediate fill:#991b1b,stroke:#fca5a5,color:#fef2f2
-    classDef output fill:#0f2942,stroke:#7dd3fc,color:#e0f2fe
-
-    live["live cloud or SaaS state"]:::source --> discover["discover-* / evaluation-*"]:::skill --> native["native outputs"]:::output --> remediate["remediation/*"]:::remediate --> audit["HITL · dual audit · re-verify"]:::output
-```
-
-**Same flow from an MCP agent:**
-
-```text
-tools/call name="ingest-k8s-audit-ocsf" args={"args":["skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl"]}
-tools/call name="detect-privilege-escalation-k8s" args={"input":"<stdout>"}
-tools/call name="convert-ocsf-to-sarif"          args={"input":"<stdout>"}
-```
-
-<details>
-<summary><b>Low-level execution core: the same flow as raw Python entrypoints</b></summary>
-
-```bash
-python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py \
-  skills/detection-engineering/golden/k8s_audit_raw_sample.jsonl \
-  | python skills/detection/detect-privilege-escalation-k8s/src/detect.py \
-  | python skills/view/convert-ocsf-to-sarif/src/convert.py \
-  > findings.sarif
-```
-
-</details>
-
-<details>
-<summary><b>What you get back</b></summary>
-
-Raw audit line (abbreviated):
-```json
-{"kind":"Event","stage":"ResponseComplete","verb":"list","auditID":"k1-list-secrets","user":{"username":"system:serviceaccount:default:builder"}}
-```
-
-OCSF event (abbreviated):
-```json
-{"class_uid":6003,"class_name":"API Activity","metadata":{"uid":"k1-list-secrets"},"api":{"operation":"list"},"resources":[{"type":"secrets","namespace":"default"}]}
-```
-
-OCSF Detection Finding 2004 (abbreviated):
-```json
-{"class_uid":2004,"class_name":"Detection Finding","finding_info":{"title":"Service account enumerated and read a Kubernetes secret","attacks":[{"technique":{"uid":"T1552.007"}}]}}
-```
-
-Native wire format is the same content in a repo-owned envelope — see [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md).
-
-</details>
-
-## Flagship · IAM departures remediation
-
-The flagship shipped write path. Guarded, event-driven, dual-audited — and **one cloud per worker**, never cross-cloud.
-
-![Simplified AWS-only IAM departures workflow. Snowflake, Workday, Databricks, or ClickHouse feed the shared reconciler, which applies rehire, grace-period, and diff logic before writing an S3 manifest. S3 ObjectCreated triggers EventBridge and a Step Function map, which runs parser and worker Lambdas with separate roles. The worker assumes a scoped cross-account role guarded by aws:PrincipalOrgID, executes the IAM cleanup sequence, and dual-audits each action to DynamoDB and KMS-encrypted S3. Audit sinks feed the next reconciler run, and the footer makes clear that other clouds use separate native pipelines.](docs/images/iam-departures-aws.svg)
-
-- **scope first** — rehire and grace-window logic run in the reconciler before the manifest is written
-- **separate principals** — EventBridge, Step Function, parser Lambda, worker Lambda each have their own execution role
-- **one cloud per worker** — the AWS worker only touches AWS IAM via cross-account `AssumeRole` inside the Org. A single worker principal never spans cloud boundaries
-- **dual audit** — DynamoDB + KMS-encrypted S3 for every write; ingest-back so the next run verifies closure
-
-<details>
-<summary><b>Per-cloud service mapping</b> — AWS is shipped; GCP and Azure stack patterns documented (worker library code already exists under <code>src/lambda_worker/clouds/</code>)</summary>
-
-Only the AWS orchestration ships today (under [`infra/`](skills/remediation/iam-departures-aws/infra/)). For Azure and GCP, the **worker library code** lives in [`src/lambda_worker/clouds/`](skills/remediation/iam-departures-aws/src/lambda_worker/clouds/) (`azure_entra.py`, `gcp_iam.py`, `databricks_scim.py`, `snowflake_user.py`); the recommended native orchestration stack per cloud is documented below so operators pick equivalent primitives instead of forcing one stack across all clouds.
-
-| Role | AWS · shipped | GCP · pattern | Azure · pattern |
-|---|---|---|---|
-| Manifest planner | [`iam-departures-reconciler`](skills/discovery/iam-departures-reconciler/) shared read-only skill; emits the canonical manifest body | same shared skill | same shared skill |
-| Event trigger | **EventBridge** rule (S3 `ObjectCreated`) | **Eventarc** trigger (GCS finalize) | **Event Grid** (Blob `Created`) |
-| Orchestration | **Step Functions** (Map state, DLQ, retries) | **Cloud Workflows** (parallel, retries) | **Logic Apps** or **Durable Functions** |
-| Worker compute | **Lambda** (parser + worker) | **Cloud Run Jobs** or **Cloud Functions** | **Azure Functions** or **Container Apps Jobs** |
-| Object store for manifest + evidence | **S3** + **KMS** | **Cloud Storage** + **CMEK** | **Blob Storage** + **CMK** (Key Vault) |
-| Key-value audit | **DynamoDB** (user, ts key) | **Firestore** / **Bigtable** | **Cosmos DB** / **Table Storage** |
-| Identity target | **IAM** (cross-account, `aws:PrincipalOrgID`) | **Cloud IAM** (cross-project, Org policies) | **Entra ID** (tenant scope, Graph API) |
-| DLQ / alerts | **SQS** + **SNS** | **Pub/Sub** + **Cloud Monitoring** | **Service Bus** + **Monitor Alerts** |
-
-Details: [skills/remediation/iam-departures-aws/](skills/remediation/iam-departures-aws/) · [SKILL.md#cross-cloud-workflow-shape](skills/remediation/iam-departures-aws/SKILL.md)
-
-</details>
-
-<details>
-<summary><b>Native vs OCSF</b> — four emit modes and when each is right</summary>
-
-| Mode | When | What it is |
-|---|---|---|
-| `ocsf` | default for ingest and detect streams | OCSF 1.8 JSONL pinned to [`OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md) |
-| `native` | when you want repo fidelity without an envelope | repo-owned external wire format with stable UIDs |
-| `bridge` | when you need both | interoperable fields with native context preserved |
-| `canonical` | internal only | the normalization model between ingest and detect |
-
-The `-ocsf` suffix means OCSF is the default, not the only output. Reference: [docs/NATIVE_VS_OCSF.md](docs/NATIVE_VS_OCSF.md) · [docs/CANONICAL_SCHEMA.md](docs/CANONICAL_SCHEMA.md) · [docs/NORMALIZATION_EXAMPLES.md](docs/NORMALIZATION_EXAMPLES.md)
-
-</details>
-
-## Install and trust
-
-This repo is ready to download and use from GitHub tags or Releases, not as a PyPI package. Operators clone a tagged release or download the signed source tarball, verify the release assets, and install only the dependency groups they need from [`pyproject.toml`](pyproject.toml). `uv.lock` is the ceiling, real installs are narrower.
-
-- [docs/INSTALL.md](docs/INSTALL.md) — download, verify, install, and run
-- [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md) — SBOM, signing, provenance
-- [docs/CREDENTIAL_PROVENANCE.md](docs/CREDENTIAL_PROVENANCE.md) — workload identity first
-- [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md) — release gates
-
-## Security posture
-
-- **Read-only by default.** Write paths are HITL, audited, dry-run-first, and pinned to explicit environment boundaries such as account, project, tenant, org, or cluster allow-lists before `--apply`.
-- **No hardcoded secrets.** Workload identity and short-lived credentials only.
-- **Official SDKs first**, repo-owned code second, canonical OSS only when required.
-- **CI gates** validate skill contracts, integrity, the safe-skill bar, coverage, mypy, and SBOM generation.
-- **Runtime isolation.** Wrappers cannot fork the skill model; they add transport only.
-
-[SECURITY.md](SECURITY.md) · [SECURITY_BAR.md](SECURITY_BAR.md) · [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) · [docs/RUNTIME_ISOLATION.md](docs/RUNTIME_ISOLATION.md)
+Read [`SECURITY.md`](SECURITY.md) · [`SECURITY_BAR.md`](SECURITY_BAR.md) · [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) · [`docs/RUNTIME_ISOLATION.md`](docs/RUNTIME_ISOLATION.md).
 
 ## Compliance frameworks
 
-CIS AWS / GCP / Azure Foundations · CIS Controls v8 · MITRE ATT&CK · MITRE ATLAS · NIST CSF 2.0 · SOC 2 TSC · ISO 27001:2022 · PCI DSS 4.0 · OWASP LLM Top 10 · OWASP MCP Top 10
+OCSF 1.8 · MITRE ATT&CK v14 · MITRE ATLAS · OWASP Top 10 · OWASP LLM Top 10 · OWASP MCP Top 10 · NIST CSF 2.0 · NIST AI RMF · CIS AWS / GCP / Azure / K8s / Containers / Docker / Controls v8 · SOC 2 TSC · ISO 27001:2022 · PCI DSS 4.0 · CycloneDX ML-BOM.
 
-Per-skill framework mapping: [docs/FRAMEWORK_MAPPINGS.md](docs/FRAMEWORK_MAPPINGS.md) · coverage report: [docs/FRAMEWORK_COVERAGE.md](docs/FRAMEWORK_COVERAGE.md) · live counts (auto-generated, CI-gated): **[docs/COVERAGE_SNAPSHOT.md](docs/COVERAGE_SNAPSHOT.md)**
+Live coverage tables (skills × frameworks × clouds × layers): [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md). Per-skill mappings: [`docs/FRAMEWORK_MAPPINGS.md`](docs/FRAMEWORK_MAPPINGS.md).
 
-## Progress snapshot
+<details>
+<summary><b>Why different layers use different formats</b></summary>
 
-Live counts and roadmap progress are auto-generated into [docs/COVERAGE_SNAPSHOT.md](docs/COVERAGE_SNAPSHOT.md) by [`scripts/coverage_summary.py`](scripts/coverage_summary.py); a CI gate refuses any PR where the snapshot has drifted from the on-disk source of truth. The narrative table below is the operator-facing summary:
+OCSF 1.8 is the SIEM interop wire format — valuable exactly where events flow to a downstream analyzer. It is not the universal internal format, and this repo is honest about where it fits:
 
-| Roadmap track | Approx progress | Current shipped state |
-|---|---:|---|
-| **MITRE ATT&CK (`#253`)** | **50%** | AWS/GCP/Azure logging-impairment trio, AWS IAM-user access-key and login-profile slices, the first GCP service-account-key and token-minting slices, AWS discovery burst, and AWS cross-account S3 copy are shipped |
-| **CIS + auto-remediate (`#254`)** | **35%** | 91 checks shipped across AWS/GCP/Azure/K8s/container/GPU/model-serving, with the first guarded AWS `--auto-remediate` slice shipped |
-| **MITRE ATLAS (`#255` umbrella)** | **45%** | AI inventory and evidence, model-serving and GPU posture, MCP prompt injection, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
-| **OWASP LLM Top 10 (`#255` umbrella)** | **45%** | model-serving controls plus MCP prompt injection, credential leak, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and AWS + GCP model-artifact download detection are shipped |
-| **OWASP MCP Top 10 (`#255` umbrella)** | **50%** | MCP prompt injection, tool drift, credential leak, system-prompt extraction, tool-output policy-bypass, tool-output exfiltration-instruction detection, and MCP tool quarantine are shipped |
-
-These are repo-progress estimates, not claims of full framework completion.
-
-## Where things stand
-
-| Area | Shipped today | Planned |
+| Layer | Default | Rationale |
 |---|---|---|
-| **Ingest** | 15 ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources |
-| **Discover** | 5 skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM departures reconciler) | wider SaaS and infra evidence |
-| **Detect** | 29 detectors across MITRE ATT&CK, MITRE ATLAS, OWASP LLM / MCP, and agent-native signals, including the shipped AWS IAM access-key and login-profile slices, the first GCP service-account-key and token-minting slices, the first AWS discovery-burst and cross-account S3-copy slices, the AWS / GCP / Azure logging-impairment trio, the first AWS + GCP model-artifact download slices, and the MCP credential-leak, system-prompt-extraction, plus tool-output-policy-bypass and tool-output-exfiltration-instructions slices | deeper identity pivots, discovery, exfiltration, and more MCP / AI-native patterns |
-| **Evaluate** | 7 benchmarks (91 checks) across CIS AWS/GCP/Azure, K8s, container, GPU, and model serving — native + OCSF 2003 opt-in | 50 % per-platform CIS coverage (#254), broader `--auto-remediate` depth |
-| **Remediate** | 12 guarded write paths across IAM departures, network revoke, session / token kill, K8s containment, and MCP tool quarantine — HITL-gated, dry-run-first, dual audit | broader CSPM and AI-specific remediation families as detection matures |
-| **View** | SARIF, Mermaid attack flow | graph overlay, warehouse-ready converters |
-| **Sinks** | Snowflake, ClickHouse, S3 | Security Lake, BigQuery |
-| **Packs** | `lateral-movement`, `privilege-escalation-k8s` | broader warehouse dialect coverage |
-| **Runners** | AWS S3/SQS, GCP GCS/PubSub, Azure Blob/EventGrid reference | more specialized runners on demand |
+| **Ingest** · **Detect** | OCSF 1.8 | SIEMs consume it natively |
+| **Evaluate** | native (OCSF 2003 opt-in) | Ops dashboards prefer native; SIEMs opt in |
+| **Discover** | native / CycloneDX ML-BOM / bridge | Inventory graphs aren't events |
+| **Remediate** | native | A state change with an operator-owned audit trail |
+| **View** | OCSF in, SARIF / Mermaid out | The whole point is rendering OCSF for humans |
+| **Output (sinks)** | pass-through | Sinks write whatever the producer emitted |
+
+Full discussion: [`docs/ARCHITECTURE.md §3 + §6`](docs/ARCHITECTURE.md). Pinned OCSF contract: [`skills/detection-engineering/OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md).
+
+</details>
+
+<details>
+<summary><b>Closed-loop coverage</b> — which detections have a paired remediation</summary>
+
+![Closed-loop coverage matrix — 13 of 29 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, GCP service-account-token minting, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are detection-first today.](docs/images/coverage-matrix.svg)
+
+</details>
+
+## Install · runtime · trust contract
+
+- [`docs/INSTALL.md`](docs/INSTALL.md) — download, verify, install, run
+- [`docs/HARNESS.md`](docs/HARNESS.md) — five surfaces · customization knobs · scope boundary · Anthropic alignment
+- [`docs/SUPPLY_CHAIN.md`](docs/SUPPLY_CHAIN.md) — SBOM, signing, provenance
+- [`docs/CREDENTIAL_PROVENANCE.md`](docs/CREDENTIAL_PROVENANCE.md) — workload identity first
+- [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) — release gates
+
+## Roadmap
+
+Live: [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) carries the auto-generated framework × cloud × layer coverage. Roadmap tracks live in GitHub Issues — see [`#253`](../../issues/253) (MITRE ATT&CK), [`#254`](../../issues/254) (CIS depth), [`#255`](../../issues/255) (MITRE ATLAS · OWASP LLM · OWASP MCP).
 
 ## Integration with agent-bom
 
-This repo ships the security automations. [agent-bom](https://github.com/msaad00/agent-bom) provides continuous scanning and a unified graph. Use them together for detection + response.
+This repo ships the security automations. [`agent-bom`](https://github.com/msaad00/agent-bom) provides continuous scanning and a unified graph. Use them together for detection plus response.
 
-## License
+## Contributing · License
 
-Apache 2.0. Security research is welcome — see [SECURITY.md](SECURITY.md) for coordinated disclosure.
+PRs welcome — read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the skill bar and [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) for the per-skill checklist. Apache 2.0; coordinated disclosure via [`SECURITY.md`](SECURITY.md).

--- a/scripts/validate_skill_count_consistency.py
+++ b/scripts/validate_skill_count_consistency.py
@@ -40,7 +40,10 @@ CLAIMS: list[Claim] = [
     (REPO_ROOT / "README.md", r"\| \*\*View\*\* \| (\d+) \|", "view"),
     (REPO_ROOT / "README.md", r"\| \*\*Output\*\* \| (\d+) \|", "output"),
     (REPO_ROOT / "README.md", r"\| \*\*Sources\*\* \| (\d+) \|", "sources"),
-    (REPO_ROOT / "README.md", r"\| \*\*Detect\*\* \| (\d+) detectors", "detection"),
+    # The legacy '| **Detect** | N detectors' row was a second copy of
+    # the layer-table count; dropped during the README polish (PR-A
+    # README polish), so the layer-table claim above is now the single
+    # source of truth in README.
     (REPO_ROOT / "README.md", r"Closed-loop coverage matrix — \d+ of (\d+) shipped detections", "detection"),
     # The L3 Detect mermaid claim was removed when both README mermaids were
     # replaced by docs/images/*.svg in #248 phase 1. Count-bearing SVG text and


### PR DESCRIPTION
## Summary

339 lines → 150 lines. The README now follows the Langfuse / ClickHouse / agent-bom shape — hero, one-line tagline, quickstart-first, tight tables instead of paragraphs.

### What changed

- **Quickstart promoted** above 'What this repo gives you' so a reader can copy-paste before scrolling to architecture.
- **Layer-counts table** kept (the validator pins these counts) but the duplicate Detect row is dropped. \`scripts/validate_skill_count_consistency.py\` is updated to drop the obsolete pattern.
- **Architecture** shrunk to two sentences + the two existing diagrams + four doc links (HARNESS, ARCHITECTURE, SKILL_CONTRACT, SKILL_COMPOSITION).
- **Agent integrations** — one table now covers Claude Code / Desktop / web, Cursor / Windsurf / Codex / Cortex / Zed, Continue / Cody / generic, the SDK examples, the webhook receiver, and the library shim.
- **Trust posture** replaces three prose paragraphs with one eight-row table: audit, allowlist, read-only-default, write paths, RLIMIT, container, retry, no-secrets.
- **Compliance frameworks** — one paragraph plus a link to the auto-generated [\`docs/COVERAGE_SNAPSHOT.md\`](docs/COVERAGE_SNAPSHOT.md). The hand-maintained Progress Snapshot table is gone (it was drifting from the JSON source-of-truth).
- **Common shipped flows** three-Mermaid-lane block dropped — that detail lives in \`docs/ARCHITECTURE.md\`.
- **Flagship · IAM departures** detailed section dropped — moved to the skill's own README which already carries the diagram.

### What stayed (the source-of-truth claims)

- Hero banner SVG with the full alt-text
- Per-layer counts table with \`Total: 76 shipped skills\`
- Closed-loop coverage matrix collapse
- 'Why different layers use different formats' details collapse

## Test plan

- [x] \`scripts/validate_skill_count_consistency.py\` — passes after the obsolete-pattern removal.
- [x] \`scripts/validate_skill_contract.py\` — 76/76.
- [x] \`scripts/coverage_summary.py --check\` — clean.
- [x] \`pytest\` repo-wide — green.
- [x] \`wc -l README.md\` — 150 (down from 339).