### PR TITLE
feat(coverage): per-framework control coverage — depth, not breadth

### DIFF
--- a/docs/COVERAGE_SNAPSHOT.md
+++ b/docs/COVERAGE_SNAPSHOT.md
@@ -66,18 +66,34 @@ Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF 
 | output | 3 | 3.9% |
 | view | 2 | 2.6% |
 
+## Per-framework control coverage
+
+**Depth, not breadth.** When a skill ships a `checks.py` with explicit `control_id` literals (the CSPM benchmarks today), this table counts the unique controls covered against the framework's published total. Same control covered by two skills counts once.
+
+| Framework | Controls covered | Total | Coverage % |
+|---|---:|---:|---:|
+| CIS AWS v3 | 20 | 58 | 34% |
+| CIS GCP v3 | 10 | 60 | 17% |
+| CIS Azure v2.1 | 6 | 60 | 10% |
+| CIS Controls v8 | 0 | 18 | 0% |
+| CIS Docker | 0 | 17 | 0% |
+| CIS Kubernetes | 0 | 30 | 0% |
+| NIST AI RMF | 0 | 24 | 0% |
+| OWASP LLM Top 10 | 0 | 10 | 0% |
+| OWASP MCP Top 10 | 0 | 10 | 0% |
+
 ## Roadmap progress
 
-Per-track breadth toward the published target. Numbers are **rough** — the framework tag count is a proxy for breadth, not depth. Each track lives under a roadmap issue.
+Per-track breadth toward the published target. The 'Today' column uses **per-control coverage** when the framework has known totals (see table above), else falls back to skill-tag breadth.
 
 | Track | Tag | Issue | Target | Today |
 |---|---|---|---:|---:|
 | MITRE ATT&CK breadth | `mitre-attack-v14` | #253 | 50% | 64% |
 | MITRE ATLAS | `mitre-atlas` | #255 | 40% | 17% |
-| OWASP LLM Top 10 | `owasp-llm-top-10` | #255 | 40% | 11% |
-| OWASP MCP Top 10 | `owasp-mcp-top-10` | #255 | 50% | 9% |
+| OWASP LLM Top 10 | `owasp-llm-top-10` | #255 | 40% | 0% |
+| OWASP MCP Top 10 | `owasp-mcp-top-10` | #255 | 50% | 0% |
 | OWASP Top 10 (web) | `owasp-top-10` | TBD | 30% | 0% |
-| NIST AI RMF | `nist-ai-rmf` | TBD | 30% | 5% |
+| NIST AI RMF | `nist-ai-rmf` | TBD | 30% | 0% |
 
 ## Where the gaps are
 

--- a/scripts/coverage_summary.py
+++ b/scripts/coverage_summary.py
@@ -19,11 +19,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
-
-import re
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 COVERAGE_JSON = REPO_ROOT / "docs" / "framework-coverage.json"

--- a/scripts/coverage_summary.py
+++ b/scripts/coverage_summary.py
@@ -23,9 +23,73 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+import re
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 COVERAGE_JSON = REPO_ROOT / "docs" / "framework-coverage.json"
 SNAPSHOT_MD = REPO_ROOT / "docs" / "COVERAGE_SNAPSHOT.md"
+
+# Total control count per published framework — the denominator for the
+# 'X of Y controls covered' computation. Numbers come from each
+# framework's official enumeration as of the version we tag.
+#
+# When a framework grows or its version bumps, update this table and
+# regenerate. Frameworks not in this map fall back to skill-tag count
+# (the looser proxy).
+FRAMEWORK_TOTAL_CONTROLS: dict[str, int] = {
+    "cis-aws-v3": 58,           # CIS AWS Foundations v3 — numbered controls
+    "cis-gcp-v3": 60,
+    "cis-azure-v2.1": 60,
+    "cis-k8s": 30,              # CIS K8s Benchmark v1.8 — agent-bom-relevant slice
+    "cis-docker": 17,           # CIS Docker Benchmark v1.7 — runtime-relevant slice
+    "cis-controls-v8": 18,      # 18 controls in CIS Controls v8
+    "owasp-top-10": 10,
+    "owasp-llm-top-10": 10,
+    "owasp-mcp-top-10": 10,
+    "nist-ai-rmf": 24,          # AI RMF 1.0 categories (the level outcomes roll up to)
+    # mitre-attack-v14, mitre-atlas, ocsf-1.8, nist-csf-2.0, soc2-tsc,
+    # iso-27001-2022, pci-dss-4.0, cyclonedx-ml-bom intentionally not
+    # enumerated yet — either too coarse-grained or the repo doesn't
+    # claim per-control mapping. Skill-tag count is the proxy.
+}
+
+# Control-ID extractor for evaluation skills that ship a `checks.py`
+# carrying `control_id="x.y"` literals. Returns deduplicated control
+# IDs grouped by framework, derived from the skill's framework tags.
+_CONTROL_ID_PATTERN = re.compile(r'control_id\s*=\s*"([^"]+)"')
+
+
+def _controls_in_skill(skill_path: str) -> set[str]:
+    """Parse `control_id="..."` literals from a skill's `src/checks.py`."""
+    checks = REPO_ROOT / skill_path / "src" / "checks.py"
+    if not checks.is_file():
+        return set()
+    try:
+        text = checks.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return set(_CONTROL_ID_PATTERN.findall(text))
+
+
+def _bucket_controls_by_framework(
+    skills: list[dict],
+) -> dict[str, set[str]]:
+    """For each framework that has a known total, bucket the controls
+    each shipped skill claims to cover. The control IDs themselves come
+    from the skill's checks.py (CSPM-shape skills); the framework
+    binding comes from the skill's `frameworks` tag list.
+
+    Same control ID covered by two skills counts once (the metric is
+    'is the control covered', not 'how many skills cover it')."""
+    by_fw: dict[str, set[str]] = defaultdict(set)
+    for skill in skills:
+        controls = _controls_in_skill(skill["path"])
+        if not controls:
+            continue
+        for fw in skill.get("frameworks", []):
+            if fw in FRAMEWORK_TOTAL_CONTROLS:
+                by_fw[fw].update(controls)
+    return dict(by_fw)
 
 
 def _label_path(path: Path) -> str:
@@ -174,19 +238,53 @@ def render(skills: list[dict]) -> str:
     for key in sorted(layers, key=lambda k: -len(layers[k])):
         lines.append(_row(key, len(layers[key]), total))
     lines.append("")
+    lines.append("## Per-framework control coverage")
+    lines.append("")
+    lines.append(
+        "**Depth, not breadth.** When a skill ships a `checks.py` with "
+        "explicit `control_id` literals (the CSPM benchmarks today), this "
+        "table counts the unique controls covered against the framework's "
+        "published total. Same control covered by two skills counts once."
+    )
+    lines.append("")
+    controls_by_fw = _bucket_controls_by_framework(skills)
+    # Only render frameworks the input is actually claiming — either via
+    # a skill tag or via a discovered control. Synthetic inputs (and
+    # smaller deployments) shouldn't see a wall of '0 / N' rows for
+    # frameworks they don't touch.
+    relevant = {k for k in FRAMEWORK_TOTAL_CONTROLS if k in frameworks or controls_by_fw.get(k)}
+    if relevant:
+        lines.append("| Framework | Controls covered | Total | Coverage % |")
+        lines.append("|---|---:|---:|---:|")
+        for fw_key in sorted(relevant, key=lambda k: (-len(controls_by_fw.get(k, set())), k)):
+            covered = len(controls_by_fw.get(fw_key, set()))
+            fw_total = FRAMEWORK_TOTAL_CONTROLS[fw_key]
+            pct = 100 * covered / fw_total if fw_total else 0
+            lines.append(
+                f"| {_label(fw_key, FRAMEWORK_LABEL)} | {covered} | {fw_total} | {pct:.0f}% |"
+            )
+    else:
+        lines.append("_No frameworks in this input have per-control totals defined._")
+    lines.append("")
     lines.append("## Roadmap progress")
     lines.append("")
     lines.append(
-        "Per-track breadth toward the published target. Numbers are "
-        "**rough** — the framework tag count is a proxy for breadth, not "
-        "depth. Each track lives under a roadmap issue."
+        "Per-track breadth toward the published target. The 'Today' column "
+        "uses **per-control coverage** when the framework has known totals "
+        "(see table above), else falls back to skill-tag breadth."
     )
     lines.append("")
     lines.append("| Track | Tag | Issue | Target | Today |")
     lines.append("|---|---|---|---:|---:|")
     for label, issue, key, target in ROADMAP_TARGETS:
-        skill_count = len(frameworks.get(key, set()))
-        pct_today = 100 * skill_count / total if total else 0
+        # Prefer control-coverage % when known; fall back to skill-tag % otherwise.
+        if key in FRAMEWORK_TOTAL_CONTROLS:
+            covered = len(controls_by_fw.get(key, set()))
+            fw_total = FRAMEWORK_TOTAL_CONTROLS[key]
+            pct_today = 100 * covered / fw_total if fw_total else 0
+        else:
+            skill_count = len(frameworks.get(key, set()))
+            pct_today = 100 * skill_count / total if total else 0
         lines.append(
             f"| {label} | `{key}` | {issue} | {target}% | {pct_today:.0f}% |"
         )

--- a/tests/integration/test_coverage_summary.py
+++ b/tests/integration/test_coverage_summary.py
@@ -90,6 +90,54 @@ def test_write_mode_creates_snapshot(tmp_path, monkeypatch):
     assert COV.main(["--check"]) == 0
 
 
+def test_per_control_coverage_extracts_real_cspm_ids():
+    """The CSPM benchmark skills ship a checks.py with explicit
+    `control_id` literals. The coverage-summary parser should pull
+    them out and bucket them by framework. Lower bounds — counts may
+    grow but should never shrink without a deliberate change."""
+    aws_controls = COV._controls_in_skill("skills/evaluation/cspm-aws-cis-benchmark")
+    gcp_controls = COV._controls_in_skill("skills/evaluation/cspm-gcp-cis-benchmark")
+    azure_controls = COV._controls_in_skill("skills/evaluation/cspm-azure-cis-benchmark")
+    assert len(aws_controls) >= 15
+    assert len(gcp_controls) >= 5
+    assert len(azure_controls) >= 5
+
+
+def test_per_control_coverage_table_appears_for_real_repo():
+    skills = COV._load()
+    rendered = COV.render(skills)
+    assert "## Per-framework control coverage" in rendered
+    aws = COV._controls_in_skill("skills/evaluation/cspm-aws-cis-benchmark")
+    assert f"| CIS AWS v3 | {len(aws)} | 58 |" in rendered
+
+
+def test_per_control_coverage_omits_frameworks_not_in_input(tmp_path, monkeypatch):
+    """Only render rows for frameworks the input actually claims via
+    `frameworks` or via discovered control IDs — synthetic / smaller
+    deployments do not see a wall of '0/N' rows for frameworks they
+    don't touch."""
+    synthetic = tmp_path / "framework-coverage.json"
+    synthetic.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "path": "skills/evaluation/cspm-aws-cis-benchmark",
+                        "layer": "evaluation",
+                        "providers": ["aws"],
+                        "frameworks": ["cis-aws-v3"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(COV, "COVERAGE_JSON", synthetic)
+    rendered = COV.render(COV._load())
+    assert "CIS AWS v3" in rendered
+    assert "CIS Kubernetes" not in rendered
+
+
 def test_synthetic_skills_render_known_buckets(tmp_path, monkeypatch):
     """Feed a hand-built `framework-coverage.json` so the test does not
     depend on the live repo state. Confirms the bucketing logic."""


### PR DESCRIPTION
## Summary

Closes the loop the user opened in chat: 'does it make sense to set targets in skill counts?'  No. Skill count is a shallow proxy that double-counts skills tagging multiple frameworks and undercounts skills covering many controls (\`cspm-aws-cis-benchmark\` is **one skill** that already covers **20 of 58 CIS AWS v3 controls**). The coverage tool now reports **depth**: per-framework control coverage %, not skill count.

### What ships

- **\`scripts/coverage_summary.py\`**:
  - New \`FRAMEWORK_TOTAL_CONTROLS\` map with the published totals for the frameworks where per-control coverage is meaningful (CIS AWS / GCP / Azure / K8s / Docker / Controls v8, OWASP Top 10 / LLM / MCP, NIST AI RMF).
  - \`_controls_in_skill()\` parses \`control_id="x.y"\` literals from each skill's \`src/checks.py\`. Same control covered by two skills counts once.
  - \`_bucket_controls_by_framework()\` aggregates control IDs per framework via the skill's \`frameworks\` tag list.
  - New 'Per-framework control coverage' section in the rendered snapshot, plus the existing skill-tag table for breadth.
  - Roadmap-progress 'Today' column now uses control coverage % when known, skill-tag % otherwise.
- **\`docs/COVERAGE_SNAPSHOT.md\`** — regenerated with the new section. Today's numbers: CIS AWS 20/58 (34%), CIS GCP 10/60 (17%), CIS Azure 6/60 (10%), others 0% (depth-mapping owed).
- **\`tests/integration/test_coverage_summary.py\`** — 3 new tests on top of the existing 9: real-repo control-ID extraction, real-repo render assertion, synthetic-input row-suppression. **12/12 pass.**

### Why this changes the roadmap

The just-filed gap issues #431–#436 originally proposed targets like 'NIST AI RMF: 4 → 12 skills'. With this PR the right unit is visible: **'NIST AI RMF: 0 / 24 categories → target 8 / 24 (33 %).'** Depth, not breadth. Follow-up: re-phrase those issues against the new metric.

### Render preview

\`\`\`
## Per-framework control coverage

| Framework | Controls covered | Total | Coverage % |
|---|---:|---:|---:|
| CIS AWS v3      | 20 | 58 | 34% |
| CIS GCP v3      | 10 | 60 | 17% |
| CIS Azure v2.1  |  6 | 60 | 10% |
\`\`\`

## Test plan

- [x] \`pytest tests/integration/test_coverage_summary.py\` — 12/12.
- [x] \`pytest\` repo-wide — green.
- [x] \`scripts/coverage_summary.py --check\` — clean (deterministic render after sort tiebreaker added).
- [x] \`scripts/validate_skill_count_consistency.py\` — clean.
- [x] \`ruff check\` — clean.