### PR TITLE
docs(diagrams): three Mermaid sources flagged missing in the audit (#418)

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -12,6 +12,8 @@ Read next:
 - [`MCP_AUDIT_CONTRACT.md`](MCP_AUDIT_CONTRACT.md) — audit envelope
 - [`THREAT_MODEL.md`](THREAT_MODEL.md) — adversaries + mitigations
 
+Visuals: [`diagrams/agent-topology.mmd`](diagrams/agent-topology.mmd) renders the full surface set; [`diagrams/mcp-trust-boundary.mmd`](diagrams/mcp-trust-boundary.mmd) traces the wrapper lifecycle; [`diagrams/pipeline-blast-radius.mmd`](diagrams/pipeline-blast-radius.mmd) colour-codes each layer by capability.
+
 ## Five surfaces, one bundle
 
 The same `SKILL.md + src/ + tests/` runs unchanged behind all five

--- a/docs/MCP_AUDIT_CONTRACT.md
+++ b/docs/MCP_AUDIT_CONTRACT.md
@@ -10,6 +10,8 @@ The goal is to make the wrapper's runtime behavior explicit:
 - failures are still audited
 - secrets and raw stdin are not echoed into the audit trail
 
+Trust boundary at a glance: [`diagrams/mcp-trust-boundary.mmd`](diagrams/mcp-trust-boundary.mmd) — the same lifecycle this doc describes, rendered as a sequence diagram (every guard, every short-circuit, the audit emission point).
+
 Read next:
 
 - [RUNTIME_ISOLATION.md](RUNTIME_ISOLATION.md)

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,32 @@
+# Diagrams
+
+Mermaid sources for the visuals the audit (2026-04-28 / 2026-05-09)
+flagged as missing. Source-controlled here so a regeneration is one
+command:
+
+```bash
+mmdc -i docs/diagrams/<name>.mmd -o docs/images/<name>.svg -t dark -b transparent
+```
+
+(`mmdc` ships with `@mermaid-js/mermaid-cli`.)
+
+## Shipped diagrams
+
+| File | Renders the | Where it's read |
+|---|---|---|
+| [`mcp-trust-boundary.mmd`](mcp-trust-boundary.mmd) | sequence of: agent → MCP wrapper → guards → skill subprocess → audit log; including the dry-run / HITL / `min_approvers` short-circuit branches | `docs/MCP_AUDIT_CONTRACT.md`, `docs/HARNESS.md` |
+| [`agent-topology.mmd`](agent-topology.mmd) | local stdio clients (Claude Code/Desktop, Cursor, Windsurf, Codex, Cortex, Zed) vs remote / HTTP clients (Claude.ai web, runners, GitHub Actions); shared registry behind both surfaces | `docs/HARNESS.md`, `docs/integrations/README.md` |
+| [`pipeline-blast-radius.mmd`](pipeline-blast-radius.mmd) | data flowing left-to-right with each layer colour-coded by capability — read-only ingest/discover/detect/evaluate, HITL-gated remediate, write-only sink — so the trust boundary is visible at a glance | `docs/ARCHITECTURE.md`, `README.md` |
+
+## Authoring rules
+
+- **Each diagram is its own file.** GitHub renders the markdown links
+  natively in `*.md` callsites, and `mmdc` keeps SVG generation
+  deterministic.
+- **Class definitions stay in the diagram** so colours don't drift if
+  the consuming markdown's theme changes.
+- **No external image refs.** Every label is in the diagram source —
+  consistent with the hero-banner rule that text never escapes its
+  container.
+- **Stable node IDs** (`audit_log`, `skill_proc`, `mcp_wrapper`) — so
+  consumers can `grep` source and link section anchors.

--- a/docs/diagrams/agent-topology.mmd
+++ b/docs/diagrams/agent-topology.mmd
@@ -1,0 +1,37 @@
+%% Agent topology — every shipped surface that runs the same
+%% SKILL.md + src/ + tests/ bundle. Local clients use stdio; remote
+%% clients use the webhook receiver or library SDK. Both paths
+%% terminate at the same shipped tool registry.
+flowchart TB
+  classDef local fill:#10b981,stroke:#065f46,color:#ffffff
+  classDef remote fill:#0ea5e9,stroke:#0369a1,color:#ffffff
+  classDef wrap fill:#1e3a8a,stroke:#3b82f6,color:#dbeafe
+  classDef registry fill:#312e81,stroke:#a78bfa,color:#ede9fe
+  classDef skills fill:#0f172a,stroke:#475569,color:#f8fafc
+
+  subgraph Local["Local — stdio JSON-RPC"]
+    direction LR
+    cc["Claude Code"]:::local
+    cd["Claude Desktop"]:::local
+    cur["Cursor"]:::local
+    ws["Windsurf"]:::local
+    cdx["Codex"]:::local
+    ctx["Cortex Code CLI"]:::local
+    zed["Zed"]:::local
+    cont["Continue · Cody · generic MCP"]:::local
+  end
+
+  subgraph Remote["Remote — HTTP / library / event-driven"]
+    direction LR
+    web["Webhook receiver<br/>(HMAC + bearer)"]:::remote
+    lib["Library SDK<br/>(Python in-process)"]:::remote
+    runner["Cloud runners<br/>(S3 / GCS / Blob)"]:::remote
+    ci["GitHub Actions / CI"]:::remote
+  end
+
+  Local --> mcp["mcp-server<br/>stdio wrapper"]:::wrap
+  Remote --> mcp
+
+  mcp --> guards{"Guards<br/>allowlist · dry-run · HITL · RLIMIT · audit"}:::wrap
+  guards --> reg["SkillSpec registry<br/>(SKILL.md frontmatter)"]:::registry
+  reg --> skills["76 shipped skill bundles<br/>(skills/&lt;category&gt;/&lt;name&gt;/)"]:::skills

--- a/docs/diagrams/mcp-trust-boundary.mmd
+++ b/docs/diagrams/mcp-trust-boundary.mmd
@@ -1,0 +1,37 @@
+%% MCP wrapper trust boundary — every guard the wrapper enforces between
+%% the calling agent and the skill subprocess. Read this together with
+%% docs/MCP_AUDIT_CONTRACT.md.
+sequenceDiagram
+  autonumber
+  participant Agent as Agent (Claude / Cursor / Codex / …)
+  participant Wrap as mcp-server (stdio)
+  participant Guards as Guards (allowlist · dry-run · HITL · RLIMIT)
+  participant Skill as skills/&lt;cat&gt;/&lt;name&gt;/src/&lt;entry&gt;.py
+  participant Sink as Audit log (JSONL · HMAC chain)
+
+  Agent->>Wrap: tools/call name, args, _caller_context, _approval_context
+  Note over Wrap: validate args / input / output_format<br/>parse JSON-RPC envelope
+  Wrap->>Guards: intersect operator + caller + preset allowlists
+  alt skill not in effective allowlist
+    Guards-->>Wrap: refuse
+    Wrap-->>Agent: -32601 unknown tool
+    Wrap->>Sink: audit_event result=error
+  else write-capable + no --dry-run
+    Guards-->>Wrap: refuse
+    Wrap-->>Agent: -32602 dry-run / apply violation
+    Wrap->>Sink: audit_event result=error
+  else needs approval + missing _approval_context
+    Guards-->>Wrap: refuse
+    Wrap-->>Agent: -32602 approval required
+    Wrap->>Sink: audit_event result=error
+  else min_approvers &gt; approvals supplied
+    Guards-->>Wrap: refuse
+    Wrap-->>Agent: -32602 N approvers required
+    Wrap->>Sink: audit_event result=error
+  else
+    Guards->>Wrap: pass
+    Wrap->>Skill: subprocess.run<br/>scrubbed env (SAFE_CHILD_ENV_VARS + CLOUD_SECURITY_*)<br/>RLIMIT_AS / FSIZE / CPU<br/>SKILL_CORRELATION_ID, SKILL_CALLER_*, SKILL_APPROVER_*
+    Skill-->>Wrap: stdout JSONL, exit code
+    Wrap->>Sink: audit_event result=success<br/>chain_hash = HMAC-SHA-256(key, prev_hash || event_json)
+    Wrap-->>Agent: result + isError + structuredContent
+  end

--- a/docs/diagrams/pipeline-blast-radius.mmd
+++ b/docs/diagrams/pipeline-blast-radius.mmd
@@ -1,0 +1,54 @@
+%% Pipeline blast radius — every layer colour-coded by capability so
+%% the trust boundary is visible at a glance. Read-only paths are
+%% blue; the HITL gate is orange; the only write paths are red
+%% (remediate) or amber (sink, write-only-storage). Read this with
+%% docs/ARCHITECTURE.md §3 + the SECURITY_BAR.md per-skill matrix.
+flowchart LR
+  classDef raw fill:#0f172a,stroke:#475569,color:#f8fafc
+  classDef readonly fill:#0f1d36,stroke:#3b82f6,color:#dbeafe
+  classDef analyze fill:#0f2a28,stroke:#2dd4bf,color:#d1fae5
+  classDef hitl fill:#2a1708,stroke:#f59e0b,color:#fef3c7
+  classDef write fill:#2a0b1e,stroke:#ef4444,color:#fca5a5
+  classDef sink fill:#1f142e,stroke:#a78bfa,color:#ede9fe
+  classDef view fill:#11202c,stroke:#0ea5e9,color:#bae6fd
+
+  subgraph L0["Source"]
+    raw["raw vendor logs<br/>(CloudTrail · K8s audit · Okta · MCP proxy)"]:::raw
+  end
+  subgraph L1["Ingest · read-only"]
+    ingest["ingest-* / source-*"]:::readonly
+  end
+  subgraph L2["Discover · read-only"]
+    discover["discover-* (inventory · AI BOM · evidence)"]:::readonly
+  end
+  subgraph L3["Detect · read-only"]
+    detect["detect-* (deterministic rules · MITRE ATT&amp;CK / ATLAS / OWASP)"]:::analyze
+  end
+  subgraph L4["Evaluate · read-only"]
+    eval["cspm-*-cis-benchmark · k8s · container · GPU · model-serving"]:::analyze
+  end
+  subgraph L5["Remediate · HITL gated · audit-first"]
+    hitl{"HITL gate<br/>min_approvers + ticket"}:::hitl
+    remediate["remediate-* / iam-departures-*"]:::write
+  end
+  subgraph L6["View · read-only"]
+    view["convert-ocsf-to-sarif · convert-ocsf-to-mermaid"]:::view
+  end
+  subgraph L7["Output · append-only"]
+    sink["sink-s3-jsonl · sink-snowflake-jsonl · sink-clickhouse-jsonl"]:::sink
+  end
+
+  raw --> ingest
+  ingest --> detect
+  ingest --> eval
+  ingest --> sink
+  discover --> eval
+  discover --> hitl
+  detect --> view
+  detect --> sink
+  detect --> hitl
+  eval --> view
+  eval --> sink
+  eval --> hitl
+  hitl --> remediate
+  remediate --> sink


### PR DESCRIPTION
## Summary

Closes #418. Adds the three diagrams the 2026-04-28 / 2026-05-09 audits flagged as missing — source-controlled Mermaid under \`docs/diagrams/\`, rendered inline on GitHub or to SVG via \`mermaid-cli\`.

| File | What it renders |
|---|---|
| [\`mcp-trust-boundary.mmd\`](docs/diagrams/mcp-trust-boundary.mmd) | Sequence: agent → wrapper → guards → skill → audit. Every short-circuit branch (\`-32601\` unknown, \`-32602\` dry-run / approval / approvers, success). Audit emission identical in every branch |
| [\`agent-topology.mmd\`](docs/diagrams/agent-topology.mmd) | Local stdio clients vs remote / event-driven (webhook + library + runners + CI), all terminating at the same shipped registry |
| [\`pipeline-blast-radius.mmd\`](docs/diagrams/pipeline-blast-radius.mmd) | Colour-coded by capability: blue read-only, orange HITL gate, red remediate, amber sink — trust boundary visible at a glance |

Cross-links added:
- \`docs/MCP_AUDIT_CONTRACT.md\` → trust-boundary diagram
- \`docs/HARNESS.md\` → all three

\`docs/diagrams/README.md\` indexes them and pins the authoring rules (per-file, class defs in-diagram, stable node IDs, no external image refs).

## Test plan

- [x] \`pytest\` repo-wide — green.
- [x] \`mmdc -i docs/diagrams/<each>.mmd -o /tmp/test.svg\` — all three render without parse errors.
- [x] GitHub renders Mermaid in \`*.mmd\` markdown blocks natively; the \`.mmd\` files render inline when viewed.