### PR TITLE
feat(detection): migrate 8 detectors onto _shared retry/errors/logging contract

### DIFF
--- a/skills/detection/detect-aws-access-key-creation/src/detect.py
+++ b/skills/detection/detect-aws-access-key-creation/src/detect.py
@@ -21,6 +21,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-aws-access-key-creation"
@@ -28,6 +30,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -203,7 +207,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -271,8 +278,30 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
-        print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.input))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-aws-access-key-creation/tests/test_detect.py
+++ b/skills/detection/detect-aws-access-key-creation/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -104,8 +111,12 @@ def test_accepts_resource_type_user():
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_ct_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-aws-enumeration-burst/src/detect.py
+++ b/skills/detection/detect-aws-enumeration-burst/src/detect.py
@@ -21,6 +21,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-aws-enumeration-burst"
@@ -28,6 +30,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -286,7 +290,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
 
@@ -407,9 +414,31 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv or sys.argv[1:])
-    for finding in detect(_iter_jsonl(args.path), output_format=args.output_format):
-        json.dump(finding, sys.stdout, separators=(",", ":"))
-        sys.stdout.write("\n")
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.path))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            json.dump(finding, sys.stdout, separators=(",", ":"))
+            sys.stdout.write("\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-aws-enumeration-burst/tests/test_detect.py
+++ b/skills/detection/detect-aws-enumeration-burst/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -182,5 +189,9 @@ def test_finding_uid_is_deterministic():
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_ct_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint

--- a/skills/detection/detect-aws-login-profile-creation/src/detect.py
+++ b/skills/detection/detect-aws-login-profile-creation/src/detect.py
@@ -21,6 +21,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-aws-login-profile-creation"
@@ -28,6 +30,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -203,7 +207,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -271,8 +278,30 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
-        print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.input))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-aws-login-profile-creation/tests/test_detect.py
+++ b/skills/detection/detect-aws-login-profile-creation/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -104,8 +111,12 @@ def test_accepts_resource_type_user():
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_ct_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-aws-model-artifact-download/src/detect.py
+++ b/skills/detection/detect-aws-model-artifact-download/src/detect.py
@@ -14,6 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-aws-model-artifact-download"
@@ -21,6 +23,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -322,7 +326,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -401,8 +408,30 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
-        print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.input))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            print(json.dumps(finding, separators=(",", ":"), sort_keys=False))
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-aws-open-security-group/src/detect.py
+++ b/skills/detection/detect-aws-open-security-group/src/detect.py
@@ -41,6 +41,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-aws-open-security-group"
@@ -48,6 +50,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 # OCSF Detection Finding 2004
 FINDING_CLASS_UID = 2004
@@ -371,7 +375,10 @@ def detect(
     risky_ports: Iterable[int] = DEFAULT_RISKY_PORTS,
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
     risky_ports = tuple(sorted(set(risky_ports)))
 
     for event in events:
@@ -452,9 +459,30 @@ def main(argv: list[str] | None = None) -> int:
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
+    findings_emitted = 0
     try:
-        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+        events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-aws-open-security-group/tests/test_detect.py
+++ b/skills/detection/detect-aws-open-security-group/tests/test_detect.py
@@ -4,15 +4,22 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from detect import (  # type: ignore[import-not-found]
+from detect import (  # type: ignore[import-not-found]  # noqa: E402
     ACCEPTED_PRODUCERS,
     DEFAULT_RISKY_PORTS,
     PUBLIC_CIDRS,
     detect,
 )
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 
 def _ct_event(
@@ -219,8 +226,12 @@ def test_mixed_world_and_corp_cidrs_only_emits_for_world():
 
 def test_unsupported_output_format_raises():
     import pytest
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_ct_event(cidrs_v4=["0.0.0.0/0"])], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-cloudtrail-disabled/src/detect.py
+++ b/skills/detection/detect-cloudtrail-disabled/src/detect.py
@@ -25,6 +25,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-cloudtrail-disabled"
@@ -32,6 +34,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -243,7 +247,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -317,9 +324,31 @@ def main(argv: list[str] | None = None) -> int:
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+
+    findings_emitted = 0
     try:
-        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+        events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-cloudtrail-disabled/tests/test_detect.py
+++ b/skills/detection/detect-cloudtrail-disabled/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -112,8 +119,12 @@ def test_skips_missing_trail_identifier(capsys):
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_ct_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/src/detect.py
@@ -14,6 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-gcp-service-account-key-creation"
@@ -21,6 +23,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -247,7 +251,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -319,8 +326,30 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
-        sys.stdout.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.input))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            sys.stdout.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-gcp-audit-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
+++ b/skills/detection/detect-gcp-service-account-key-creation/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -156,8 +163,12 @@ def test_accepts_raw_service_account_resource_name_without_prefix():
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-gcp-service-account-token-minting/src/detect.py
+++ b/skills/detection/detect-gcp-service-account-token-minting/src/detect.py
@@ -14,6 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-gcp-service-account-token-minting"
@@ -21,6 +23,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -233,7 +237,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -302,8 +309,30 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    for finding in detect(_iter_jsonl(args.input), output_format=args.output_format):
-        sys.stdout.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.input))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            sys.stdout.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-gcp-audit-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-gcp-service-account-token-minting/tests/test_detect.py
+++ b/skills/detection/detect-gcp-service-account-token-minting/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -127,8 +134,12 @@ def test_accepts_raw_service_account_resource_name_without_prefix():
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():


### PR DESCRIPTION
Mechanical follow-up to #443 — applies the 5-step migration template to 8 more shipped AWS + GCP detectors.

## Migrated

- detect-aws-access-key-creation
- detect-aws-login-profile-creation
- detect-aws-enumeration-burst
- detect-aws-open-security-group
- detect-aws-model-artifact-download
- detect-gcp-service-account-key-creation
- detect-gcp-service-account-token-minting
- detect-cloudtrail-disabled

## Per-skill changes

- ContractError replaces bare ValueError on unsupported output_format (with hint)
- main() wrapped in try/except SkillError -> emit_error() so the agent / SIEM gets a structured envelope on stdout AND stderr
- get_logger(__name__, skill=..., layer=detection) bound at module top
- Tests updated to assert ContractError shape (error_class=contract, retryable=False, hint contains 'ocsf' / 'native')

## Deliberately not changed

- @retry_on_throttle is NOT added to any of these — every detector here processes events from stdin with zero cloud SDK calls inside detect()
- emit_stderr_event preserved where it exists (load-time vendor telemetry counter, separate audience from the new logger)

## Test plan

- pytest repo-wide: 1866 / 1866 pass
- ruff clean
- validate_skill_runtime: 77 entrypoints import
- coverage_summary --check: in sync