### PR TITLE
feat(mcp): opt-in OS sandbox — bwrap (Linux) / sandbox-exec (macOS) [closes #427]

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -44,6 +44,7 @@ CLOUD_SECURITY_*  env  >  caller_context  >  preset.json  >  SKILL.md frontmatte
 | Audit destination | `CLOUD_SECURITY_MCP_AUDIT_LOG` + `CLOUD_SECURITY_AUDIT_HMAC_KEY` | durable JSONL + HMAC chain |
 | Per-call timeout | `mcp_timeout_seconds` in SKILL.md, or `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` env | wall-clock cap |
 | Resource caps | `CLOUD_SECURITY_SKILL_MAX_BYTES` / `MAX_FILE_BYTES` / `MAX_PROCESSES` | RLIMIT enforcement |
+| OS sandbox (opt-in) | `CLOUD_SECURITY_MCP_SANDBOX=on` | wrap each skill subprocess under `bwrap` (Linux) / `sandbox-exec` (macOS); fs/pid/ipc isolation; network dropped only when `network_egress: []` declared; no-op fallback if wrapper binary absent |
 | Retry policy | `CLOUD_SECURITY_RETRY_MAX_ATTEMPTS` / `BASE_SECONDS` / `CAP_SECONDS` / `TOTAL_BUDGET_SECONDS` | bounded by construction |
 | Webhook auth | `WEBHOOK_HMAC_SECRETS` / `WEBHOOK_HMAC_HEADER` / `WEBHOOK_BEARER_TOKEN` | per-skill HMAC + bearer |
 | Webhook routing | `WEBHOOK_ALLOWED_SKILLS` / `WEBHOOK_SINK_TARGETS` | default-deny |

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -35,6 +35,59 @@ Persistent mode should be read as:
 - a separate runner or serverless wrapper owns checkpoints, retries, queue offsets, and sink writes
 - operators still need to provide the surrounding runtime unless the skill explicitly ships one
 
+## Sandboxing layers
+
+The MCP wrapper and the Python SDK shim spawn every skill in a child
+subprocess. Three layers of isolation can stack on that boundary; the
+operator opts in to as many as their host supports.
+
+### Layer 1 — container hardening (default in shipped image)
+
+The shipped image runs as non-root, with a read-only root filesystem,
+`no-new-privileges`, dropped Linux capabilities, and a writable
+`/tmp` tmpfs. Operators who run the wrapper outside the image are
+responsible for re-creating equivalent controls.
+
+### Layer 2 — opt-in OS sandbox (this layer)
+
+Operators set `CLOUD_SECURITY_MCP_SANDBOX=on` to wrap each skill
+subprocess under the platform's namespace / sandbox tooling:
+
+- **Linux (`bwrap`)** — read-only binds for `/usr`, `/etc`, `/lib`,
+  `/lib64`; the repo bound at its real path so the cwd keeps working;
+  `--tmpfs /tmp`; `--proc /proc`; `--dev /dev`; `--unshare-all` to
+  drop pid / ipc / mount / uts / cgroup namespaces; `--die-with-parent`
+  so the child exits when the wrapper does. Network stays on by
+  default (cloud SDKs need it) — only skills whose `SKILL.md`
+  declares `network_egress: []` get `--unshare-net`.
+- **macOS (`sandbox-exec`)** — the wrapper writes a per-call deny-by-
+  default `.sb` profile to `/tmp/`, allowing `file-read*`,
+  `file-write*` under `/tmp/` and the repo root, `process*`, and
+  `network*` (toggled to `(deny network*)` when `network_egress: []`).
+- **Other platforms** — no-op fallback. The wrapper logs a one-shot
+  stderr warning and proceeds unwrapped.
+
+Off by default; off behaviour is byte-identical to pre-layer-2. When
+the env var is on but the wrapper binary (`bwrap` / `sandbox-exec`)
+isn't installed, the wrapper falls back to the unsandboxed command
+and emits an `mcp_sandbox_fallback` event on stderr so the operator
+notices their opt-in didn't take. The audit envelope carries a new
+`sandboxed: bool` field on every call, so SOC tooling can prove
+which calls actually ran wrapped.
+
+Network policy is binary, not per-host, in this layer. The repo's
+`network_egress` field is advisory and may list hostnames; layer 2
+only enforces "all or nothing" — per-host iptables / pf rules are
+out of scope until a future PR.
+
+### Layer 3 — `RLIMIT_*` enforcement (always on, POSIX)
+
+`mcp-server/src/resource_limits.py` clamps `RLIMIT_AS`, `RLIMIT_FSIZE`,
+optionally `RLIMIT_NPROC`, and `RLIMIT_CPU` in a `preexec_fn` before
+`exec()`. Tunable via `CLOUD_SECURITY_SKILL_MAX_BYTES` /
+`MAX_FILE_BYTES` / `MAX_PROCESSES`. Windows has no `resource` module;
+this layer is a documented no-op there.
+
 ## Read-only skills
 
 These layers should stay read-only unless the skill contract says otherwise:

--- a/mcp-server/src/sandbox.py
+++ b/mcp-server/src/sandbox.py
@@ -1,0 +1,185 @@
+"""Layer 2 — opt-in OS-level sandbox for skill subprocesses.
+
+Layer 1 of the sandboxing umbrella (#427) hardened the container image
+(non-root, read-only fs, no-new-privileges, dropped caps). Layer 3
+clamped per-process kernel resources via `RLIMIT_AS / FSIZE / CPU` in a
+`preexec_fn`. Layer 2 (this module) is the optional middle layer:
+operators who want filesystem / pid / ipc / mount-namespace isolation
+opt in by setting `CLOUD_SECURITY_MCP_SANDBOX=on`, and the wrapper then
+spawns each skill under `bwrap` (Linux) or `sandbox-exec` (macOS) with
+a per-skill profile derived from the skill's `network_egress`
+declaration in `SKILL.md` frontmatter.
+
+Design constraints:
+
+- **Off by default.** No behaviour change for any current operator
+  unless they flip the env var.
+- **No new Python deps.** `bwrap` and `sandbox-exec` are OS-installed
+  binaries — the module shells out to whichever is present.
+- **No-op fallback.** If the wrapper binary is missing, the platform
+  isn't supported, or the env var is unset, `wrap_command` returns the
+  original `cmd` unchanged. We log a warning to stderr the first time
+  we have to fall back so operators notice their opt-in didn't take.
+- **Network policy is binary, not per-host.** The repo's
+  `network_egress` field is advisory and may list hostnames; layer 2
+  enforces "all or nothing" — only `network_egress: ()` (declared
+  empty) drops the network. Future PRs can add per-host iptables / pf
+  rules when we're ready to own that complexity.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
+    from tool_registry import SkillSpec
+
+SANDBOX_ENV = "CLOUD_SECURITY_MCP_SANDBOX"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+_FALLBACK_WARNED: set[str] = set()
+
+
+def is_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return True when `CLOUD_SECURITY_MCP_SANDBOX` is truthy.
+
+    Truthy values match the rest of the wrapper: `1`, `true`, `yes`,
+    `on` (case-insensitive). Anything else — including missing — is
+    treated as off.
+    """
+    src = os.environ if env is None else env
+    return src.get(SANDBOX_ENV, "").strip().lower() in _TRUTHY
+
+
+def _platform() -> str:
+    """Return `linux`, `darwin`, or `unsupported`. Split out so tests
+    can monkeypatch `sys.platform`."""
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "unsupported"
+
+
+def _network_locked_down(skill: SkillSpec) -> bool:
+    """A skill drops the network only when it explicitly declared
+    `network_egress: []` (an empty tuple after parsing). Any declared
+    hostnames — or no declaration at all — keep the network on, because
+    cloud SDKs need it."""
+    return skill.network_egress == ()
+
+
+def _warn_fallback(reason: str) -> None:
+    """Log once-per-reason so operators notice their opt-in didn't
+    take, without spamming stderr on every call."""
+    if reason in _FALLBACK_WARNED:
+        return
+    _FALLBACK_WARNED.add(reason)
+    sys.stderr.write(
+        f'{{"event":"mcp_sandbox_fallback","reason":"{reason}"}}\n'
+    )
+    sys.stderr.flush()
+
+
+def _bwrap_command(cmd: list[str], skill: SkillSpec, repo: Path) -> list[str]:
+    """Build a `bwrap`-prefixed command line.
+
+    Read-only binds for the OS roots; bind the repo at its real path so
+    the skill keeps working cwd. Tmpfs `/tmp`, fresh `/proc` and `/dev`,
+    and `--unshare-all` to drop pid / ipc / mount / uts / cgroup
+    namespaces. Keep network on by default (cloud SDKs need it); drop
+    it when `network_egress: []` was declared.
+    """
+    repo_str = str(repo)
+    args = ["bwrap"]
+    for ro in ("/usr", "/etc", "/lib", "/lib64"):
+        if Path(ro).exists():
+            args += ["--ro-bind", ro, ro]
+    args += [
+        "--bind", repo_str, repo_str,
+        "--tmpfs", "/tmp",
+        "--proc", "/proc",
+        "--dev", "/dev",
+        "--unshare-all",
+    ]
+    args += ["--unshare-net"] if _network_locked_down(skill) else ["--share-net"]
+    args += ["--die-with-parent"]
+    args += ["--", *cmd]
+    return args
+
+
+def _sandbox_exec_command(cmd: list[str], skill: SkillSpec, repo: Path) -> list[str]:
+    """Build a `sandbox-exec`-prefixed command line.
+
+    Emits a deny-by-default `.sb` profile to a temp file, then invokes
+    `sandbox-exec -f <profile> <cmd...>`. Allows file I/O under `/tmp`
+    and the repo, plus process spawning; toggles `network*` based on
+    `network_egress`.
+    """
+    repo_str = str(repo)
+    network_clause = "(deny network*)" if _network_locked_down(skill) else "(allow network*)"
+    profile = f"""(version 1)
+(deny default)
+(allow process*)
+(allow signal (target self))
+(allow sysctl-read)
+(allow file-read*)
+(allow file-write* (subpath "/tmp"))
+(allow file-write* (subpath "/private/tmp"))
+(allow file-write* (subpath "/private/var/folders"))
+(allow file-write* (subpath {repo_str!r}))
+(allow ipc-posix-shm)
+(allow mach-lookup)
+{network_clause}
+"""
+    fd, path = tempfile.mkstemp(prefix="mcp-sandbox-", suffix=".sb")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(profile)
+    except Exception:  # pragma: no cover - tmp write failure
+        os.close(fd)
+        raise
+    return ["sandbox-exec", "-f", path, *cmd]
+
+
+def wrap_command(
+    cmd: list[str],
+    skill: SkillSpec,
+    *,
+    env: dict[str, str] | None = None,
+    repo_root: Path | None = None,
+) -> list[str]:
+    """Return `cmd` with the platform's sandbox wrapper prepended.
+
+    Falls back to the unwrapped command (logging a one-shot stderr
+    warning) when:
+
+    - `CLOUD_SECURITY_MCP_SANDBOX` is unset / falsy
+    - the platform is not Linux or macOS
+    - the platform's wrapper binary (`bwrap` / `sandbox-exec`) isn't
+      installed
+
+    The fallback is intentional — we never crash the wrapper just
+    because the operator hasn't installed bwrap yet.
+    """
+    if not is_enabled(env):
+        return cmd
+    repo = repo_root or Path(__file__).resolve().parents[2]
+    platform = _platform()
+    if platform == "linux":
+        if shutil.which("bwrap") is None:
+            _warn_fallback("bwrap_not_installed")
+            return cmd
+        return _bwrap_command(cmd, skill, repo)
+    if platform == "darwin":
+        if shutil.which("sandbox-exec") is None:
+            _warn_fallback("sandbox_exec_not_installed")
+            return cmd
+        return _sandbox_exec_command(cmd, skill, repo)
+    _warn_fallback(f"unsupported_platform_{sys.platform}")
+    return cmd

--- a/mcp-server/src/sandbox.py
+++ b/mcp-server/src/sandbox.py
@@ -100,9 +100,13 @@ def _bwrap_command(cmd: list[str], skill: SkillSpec, repo: Path) -> list[str]:
     for ro in ("/usr", "/etc", "/lib", "/lib64"):
         if Path(ro).exists():
             args += ["--ro-bind", ro, ro]
+    # `/tmp`, `/proc`, `/dev` here are bwrap mount-target paths inside
+    # the sandboxed namespace, NOT a Python tempfile path. Bandit's
+    # B108 hardcoded-tmp-directory check is a false positive on this
+    # well-known bwrap argument shape.
     args += [
         "--bind", repo_str, repo_str,
-        "--tmpfs", "/tmp",
+        "--tmpfs", "/tmp",  # nosec B108
         "--proc", "/proc",
         "--dev", "/dev",
         "--unshare-all",

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -15,6 +15,7 @@ CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
+import sandbox  # noqa: E402
 from audit_sink import AuditSink, sink_from_env  # noqa: E402
 from resource_limits import from_env as _resource_limits_from_env  # noqa: E402
 from resource_limits import make_preexec as _make_preexec  # noqa: E402
@@ -487,8 +488,15 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
         # (and `resource_limits.apply_in_child` is a documented no-op
         # there). On POSIX the closure tightens RLIMIT_AS / FSIZE /
         # NPROC / CPU before exec().
+        command = build_command(skill, args, output_format=output_format)
+        sandbox_active = sandbox.is_enabled()
+        if sandbox_active:
+            command = sandbox.wrap_command(command, skill)
+        audit_event["sandboxed"] = bool(
+            sandbox_active and command and command[0] in {"bwrap", "sandbox-exec"}
+        )
         completed = subprocess.run(
-            build_command(skill, args, output_format=output_format),
+            command,
             input=stdin_text,
             text=True,
             capture_output=True,

--- a/mcp-server/tests/test_sandbox.py
+++ b/mcp-server/tests/test_sandbox.py
@@ -1,0 +1,185 @@
+"""Tests for `sandbox.py` — the opt-in OS-level sandbox wrapper.
+
+These tests don't actually exec sandboxed subprocesses. We
+monkeypatch `shutil.which`, `sys.platform`, and the env so the unit
+tests stay fast and host-independent. The real bwrap / sandbox-exec
+invocations get exercised by the operator hands-on smoke (and by
+release pipelines on the supported platforms).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SB_PATH = REPO_ROOT / "mcp-server" / "src" / "sandbox.py"
+spec = importlib.util.spec_from_file_location("cloud_security_sandbox_test", SB_PATH)
+assert spec and spec.loader
+SB = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = SB
+spec.loader.exec_module(SB)
+
+
+class _FakeSkill:
+    """Stand-in for `SkillSpec`; only the fields sandbox.py reads."""
+
+    def __init__(self, name: str = "fake-skill", network_egress: tuple[str, ...] = ()):
+        self.name = name
+        self.network_egress = network_egress
+
+
+@pytest.fixture(autouse=True)
+def _clear_warning_cache():
+    SB._FALLBACK_WARNED.clear()
+    yield
+    SB._FALLBACK_WARNED.clear()
+
+
+# ── is_enabled() truthy parsing ─────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "YES", "on", "On"])
+def test_is_enabled_truthy(monkeypatch, value):
+    monkeypatch.setenv(SB.SANDBOX_ENV, value)
+    assert SB.is_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_is_enabled_falsy(monkeypatch, value):
+    monkeypatch.setenv(SB.SANDBOX_ENV, value)
+    assert SB.is_enabled() is False
+
+
+def test_is_enabled_default_off(monkeypatch):
+    monkeypatch.delenv(SB.SANDBOX_ENV, raising=False)
+    assert SB.is_enabled() is False
+
+
+def test_is_enabled_accepts_explicit_env_dict():
+    assert SB.is_enabled({SB.SANDBOX_ENV: "yes"}) is True
+    assert SB.is_enabled({SB.SANDBOX_ENV: "no"}) is False
+    assert SB.is_enabled({}) is False
+
+
+# ── wrap_command no-op paths ────────────────────────────────────────
+
+
+def test_wrap_command_returns_input_when_disabled(monkeypatch):
+    monkeypatch.delenv(SB.SANDBOX_ENV, raising=False)
+    cmd = ["python", "src/detect.py"]
+    assert SB.wrap_command(cmd, _FakeSkill()) == cmd
+
+
+def test_wrap_command_no_op_on_unsupported_platform(monkeypatch):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "on")
+    monkeypatch.setattr(SB.sys, "platform", "win32")
+    cmd = ["python", "src/detect.py"]
+    assert SB.wrap_command(cmd, _FakeSkill()) == cmd
+
+
+def test_wrap_command_no_op_when_bwrap_missing(monkeypatch, capsys):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "1")
+    monkeypatch.setattr(SB.sys, "platform", "linux")
+    monkeypatch.setattr(SB.shutil, "which", lambda _name: None)
+    cmd = ["python", "src/detect.py"]
+    assert SB.wrap_command(cmd, _FakeSkill()) == cmd
+    captured = capsys.readouterr()
+    assert "bwrap_not_installed" in captured.err
+
+
+def test_wrap_command_no_op_when_sandbox_exec_missing(monkeypatch, capsys):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "1")
+    monkeypatch.setattr(SB.sys, "platform", "darwin")
+    monkeypatch.setattr(SB.shutil, "which", lambda _name: None)
+    cmd = ["python", "src/detect.py"]
+    assert SB.wrap_command(cmd, _FakeSkill()) == cmd
+    captured = capsys.readouterr()
+    assert "sandbox_exec_not_installed" in captured.err
+
+
+def test_fallback_warning_emitted_once_per_reason(monkeypatch, capsys):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "1")
+    monkeypatch.setattr(SB.sys, "platform", "linux")
+    monkeypatch.setattr(SB.shutil, "which", lambda _name: None)
+    SB.wrap_command(["x"], _FakeSkill())
+    SB.wrap_command(["x"], _FakeSkill())
+    captured = capsys.readouterr()
+    assert captured.err.count("bwrap_not_installed") == 1
+
+
+# ── Linux (bwrap) ───────────────────────────────────────────────────
+
+
+def test_bwrap_prefix_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "1")
+    monkeypatch.setattr(SB.sys, "platform", "linux")
+    monkeypatch.setattr(SB.shutil, "which", lambda name: f"/usr/bin/{name}" if name == "bwrap" else None)
+    skill = _FakeSkill(network_egress=("api.example.com",))
+    cmd = ["python", "skills/foo/src/detect.py"]
+    wrapped = SB.wrap_command(cmd, skill, repo_root=tmp_path)
+    assert wrapped[0] == "bwrap"
+    # Network kept on for declared egress.
+    assert "--share-net" in wrapped
+    assert "--unshare-net" not in wrapped
+    # Original command lives after the `--` terminator.
+    assert wrapped[-len(cmd):] == cmd
+    assert wrapped[-len(cmd) - 1] == "--"
+    # Repo binding present.
+    assert "--bind" in wrapped
+    assert str(tmp_path) in wrapped
+
+
+def test_bwrap_unshare_net_when_egress_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "on")
+    monkeypatch.setattr(SB.sys, "platform", "linux")
+    monkeypatch.setattr(SB.shutil, "which", lambda name: f"/usr/bin/{name}" if name == "bwrap" else None)
+    skill = _FakeSkill(network_egress=())
+    wrapped = SB.wrap_command(["python", "src/x.py"], skill, repo_root=tmp_path)
+    assert "--unshare-net" in wrapped
+    assert "--share-net" not in wrapped
+
+
+# ── macOS (sandbox-exec) ────────────────────────────────────────────
+
+
+def test_sandbox_exec_prefix_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "yes")
+    monkeypatch.setattr(SB.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        SB.shutil, "which",
+        lambda name: f"/usr/bin/{name}" if name == "sandbox-exec" else None,
+    )
+    skill = _FakeSkill(network_egress=("login.microsoftonline.com",))
+    cmd = ["python", "skills/foo/src/detect.py"]
+    wrapped = SB.wrap_command(cmd, skill, repo_root=tmp_path)
+    assert wrapped[0] == "sandbox-exec"
+    assert wrapped[1] == "-f"
+    profile_path = Path(wrapped[2])
+    assert profile_path.exists()
+    profile = profile_path.read_text(encoding="utf-8")
+    assert "(deny default)" in profile
+    assert "(allow network*)" in profile
+    assert "(deny network*)" not in profile
+    assert str(tmp_path) in profile
+    assert wrapped[3:] == cmd
+    profile_path.unlink()
+
+
+def test_sandbox_exec_denies_network_when_egress_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv(SB.SANDBOX_ENV, "on")
+    monkeypatch.setattr(SB.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        SB.shutil, "which",
+        lambda name: f"/usr/bin/{name}" if name == "sandbox-exec" else None,
+    )
+    skill = _FakeSkill(network_egress=())
+    wrapped = SB.wrap_command(["python", "src/x.py"], skill, repo_root=tmp_path)
+    profile_path = Path(wrapped[2])
+    profile = profile_path.read_text(encoding="utf-8")
+    assert "(deny network*)" in profile
+    assert "(allow network*)" not in profile
+    profile_path.unlink()

--- a/skills/_shared/library.py
+++ b/skills/_shared/library.py
@@ -52,6 +52,7 @@ _MCP_SRC = REPO_ROOT / "mcp-server" / "src"
 if str(_MCP_SRC) not in sys.path:
     sys.path.insert(0, str(_MCP_SRC))
 
+import sandbox as _sandbox  # noqa: E402
 from resource_limits import from_env as _resource_limits_from_env  # noqa: E402
 from resource_limits import make_preexec as _make_preexec  # noqa: E402
 from tool_registry import (  # noqa: E402
@@ -182,10 +183,17 @@ class SkillsClient:
             stdin_bytes = stdin
 
         limits = _resource_limits_from_env(self.timeout_seconds)
+        command = build_command(skill, args)
+        sandbox_active = _sandbox.is_enabled()
+        if sandbox_active:
+            command = _sandbox.wrap_command(command, skill)
+        sandboxed = bool(
+            sandbox_active and command and command[0] in {"bwrap", "sandbox-exec"}
+        )
         started = time.monotonic()
         try:
             completed = subprocess.run(
-                build_command(skill, args),
+                command,
                 input=stdin_bytes,
                 capture_output=True,
                 cwd=repo_root(),
@@ -205,7 +213,7 @@ class SkillsClient:
             stderr=completed.stderr,
             duration_ms=duration_ms,
         )
-        self._emit_audit(skill, result)
+        self._emit_audit(skill, result, sandboxed=sandboxed)
         return result
 
     # ── internals ───────────────────────────────────────────────────
@@ -256,7 +264,7 @@ class SkillsClient:
                     env[dst_key] = v
         return env
 
-    def _emit_audit(self, skill: SkillSpec, result: SkillResult) -> None:
+    def _emit_audit(self, skill: SkillSpec, result: SkillResult, *, sandboxed: bool = False) -> None:
         record = {
             "event": "skills_library_call",
             "timestamp": datetime.now(UTC)
@@ -271,6 +279,7 @@ class SkillsClient:
             "stdout_length": len(result.stdout),
             "stderr_length": len(result.stderr),
             "result": "success" if result.ok else "error",
+            "sandboxed": sandboxed,
         }
         if self.audit_writer is not None:
             try:


### PR DESCRIPTION
Final layer of the sandboxing umbrella #427. Layers 1 + 3 already shipped (#438 container hardening · #428 RLIMIT enforcement). This PR adds **opt-in OS-level isolation** via `bwrap` on Linux or `sandbox-exec` on macOS.

## Summary

- **Off by default.** Operators opt in via `CLOUD_SECURITY_MCP_SANDBOX=on`. Existing deployments are unaffected.
- **Per-platform wrapper.**
  - Linux → `bwrap` with `--ro-bind /usr /etc /lib /lib64 --bind <repo-root> --tmpfs /tmp --proc /proc --dev /dev --unshare-all --share-net`. Skills with `network_egress: none` in SKILL.md frontmatter additionally get `--unshare-net`.
  - macOS → `sandbox-exec` with a generated `.sb` profile: deny-by-default, allow `file-read*` / `file-write*` to /tmp + repo-root, allow `process*`, allow `network*` (or deny when frontmatter says `network_egress: none`).
- **Graceful no-op fallback.** If the wrapper binary is missing or the platform is unsupported (Windows, etc.), the call runs unwrapped and a one-line warning lands on stderr — no crash.
- **Audit envelope picks up a `sandboxed: bool`** field so post-hoc reviewers can see exactly which calls ran inside the sandbox.

## Wired into

- `mcp-server/src/server.py` — every `tools/call` resolved subprocess
- `skills/_shared/library.py` — the Python SDK shim's same path

## Files

- New: `mcp-server/src/sandbox.py` (platform detection, env read, bwrap/sandbox-exec command builder, network-egress policy, fallback)
- New: `mcp-server/tests/test_sandbox.py` — **24 unit tests**, all monkeypatched (no real subprocess exec)
- Modified: `mcp-server/src/server.py`, `skills/_shared/library.py` (wire-through + audit field)
- Modified: `docs/RUNTIME_ISOLATION.md` (new 'Sandboxing layers' section covering all three)
- Modified: `docs/HARNESS.md` (new `CLOUD_SECURITY_MCP_SANDBOX` row in the customization-knobs table)

## Test plan

- [x] `pytest mcp-server/tests/test_sandbox.py` — 24/24 pass
- [x] `pytest mcp-server/tests/` — full MCP suite green (~106 tests)
- [x] `pytest` repo-wide — green
- [x] `ruff check` clean on touched files
- [x] `bash scripts/run_mypy.sh` clean
- [x] **macOS hands-on**: `CLOUD_SECURITY_MCP_SANDBOX=on python mcp-server/src/server.py < /dev/null` boots cleanly with `sandbox-exec` at /usr/bin/sandbox-exec
- [ ] **Linux hands-on with real `bwrap`** — the bwrap command builder is covered by unit tests with monkeypatched `shutil.which` / `sys.platform`, but real exec wasn't validated locally (host is Darwin). CI runs on Linux so that path is gated by the test matrix.

## Constraints respected

- No new Python dependencies. `bwrap` / `sandbox-exec` are OS-installed binaries.
- No behaviour change for any existing operator until they explicitly opt in.
- Network policy is binary (all-or-nothing) for now; per-host iptables/pf enforcement is a follow-up.