### PR TITLE
feat(cspm-gcp): CIS GCP v3 depth ramp 10 → 30 controls (closes #434)

### DIFF
--- a/docs/COVERAGE_SNAPSHOT.md
+++ b/docs/COVERAGE_SNAPSHOT.md
@@ -73,9 +73,9 @@ Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF 
 
 | Framework | Controls covered | Total | Coverage % |
 |---|---:|---:|---:|
+| CIS Azure v2.1 | 32 | 60 | 53% |
+| CIS GCP v3 | 30 | 60 | 50% |
 | CIS AWS v3 | 29 | 58 | 50% |
-| CIS GCP v3 | 10 | 60 | 17% |
-| CIS Azure v2.1 | 6 | 60 | 10% |
 | CIS Controls v8 | 0 | 18 | 0% |
 | CIS Docker | 0 | 17 | 0% |
 | CIS Kubernetes | 0 | 30 | 0% |

--- a/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/SKILL.md
@@ -2,13 +2,14 @@
 name: cspm-gcp-cis-benchmark
 description: >-
   Assess GCP projects against a curated subset of CIS GCP Foundations Benchmark v3.0
-  controls. Automates 10 high-impact read-only checks across IAM, Cloud Storage,
-  logging, and VPC networking. Use when the user mentions GCP CIS benchmark, GCP
-  security posture, service account key audit, audit logging coverage, or public
-  bucket detection. Do NOT use for AWS or Azure;
-  do NOT use to remediate findings (assessment-only, zero write permissions); do NOT
-  claim full CIS GCP coverage — only 10 controls are implemented, see the Roadmap
-  section in this file for the gap.
+  controls. Automates 30 high-impact read-only checks across IAM, Cloud Storage,
+  logging/monitoring, VPC networking, Compute Engine, Cloud SQL, and BigQuery. Use
+  when the user mentions GCP CIS benchmark, GCP security posture, service account
+  key audit, audit logging coverage, public bucket detection, Cloud SQL exposure,
+  or BigQuery data protection. Do NOT use for AWS or Azure; do NOT use to remediate
+  findings (assessment-only, zero write permissions); do NOT claim full CIS GCP
+  coverage — 30 of ~60 numbered controls are implemented, see the Roadmap section
+  for the remaining gap.
 license: Apache-2.0
 approval_model: none
 execution_modes: jit, ci, mcp, persistent
@@ -35,9 +36,9 @@ metadata:
 # CSPM — GCP CIS Foundations Benchmark v3.0 (subset)
 
 Automated assessment of GCP projects against a curated subset of CIS GCP
-Foundations Benchmark v3.0. The full benchmark has 80+ controls; this skill
-implements **10 high-impact checks** that cover the most common findings on
-real GCP projects. Each check is mapped to NIST CSF 2.0.
+Foundations Benchmark v3.0. The full benchmark has 60+ numbered controls;
+this skill implements **30 high-impact checks** that cover the most common
+findings on real GCP projects. Each check is mapped to NIST CSF 2.0.
 
 > **Honest scope:** the table below lists *only* what `src/checks.py` actually
 > implements. See the **Roadmap** at the bottom for controls that are documented
@@ -59,18 +60,21 @@ Closed loop: scan → finding → fix (PR or console) → re-scan to verify the 
 ```mermaid
 flowchart LR
     subgraph GCP["GCP Project — read-only"]
-        IAM["IAM & Service Accounts<br/>3 checks"]
+        IAM["IAM & Service Accounts<br/>9 checks"]
         GCS["Cloud Storage<br/>2 checks"]
-        LOG["Audit Logging<br/>1 check"]
-        NET["VPC / Firewall<br/>4 checks"]
+        LOG["Logging & Monitoring<br/>6 checks"]
+        NET["VPC / Firewall / DNS<br/>5 checks"]
+        VM["Compute Engine<br/>4 checks"]
+        SQL["Cloud SQL<br/>2 checks"]
+        BQ["BigQuery<br/>2 checks"]
     end
 
-    CHK["checks.py<br/>10 CIS v3.0 controls<br/>roles/viewer + iam.securityReviewer"]
+    CHK["checks.py<br/>30 CIS v3.0 controls<br/>roles/viewer + iam.securityReviewer"]
     OUT["Findings<br/>JSON · Console"]
     FIX["Remediation<br/>IaC PR · console fix<br/>or exception with TTL"]
     VERIFY["Re-scan<br/>control_id == pass"]
 
-    IAM & GCS & LOG & NET --> CHK --> OUT --> FIX --> VERIFY
+    IAM & GCS & LOG & NET & VM & SQL & BQ --> CHK --> OUT --> FIX --> VERIFY
     VERIFY -. drift detected .-> CHK
 
     style GCP fill:#1e293b,stroke:#475569,color:#e2e8f0
@@ -88,17 +92,23 @@ flowchart LR
 - **Least privilege**: reads project IAM policy, bucket posture, VPC networks, and subnet attributes only.
 - **Idempotent**: Run as often as needed with no side effects.
 
-## Implemented Controls (10)
+## Implemented Controls (30)
 
 Each row maps to one function in `src/checks.py`. If it's not in this table, it's not implemented.
 
-### Section 1 — IAM (3 checks)
+### Section 1 — IAM (9 checks)
 
 | # | CIS Control | Function | Severity | NIST CSF 2.0 |
 |---|------------|----------|----------|--------------|
 | 1.1 | Corporate credentials only (no personal Gmail) | `check_1_1_no_gmail_accounts` | HIGH | PR.AC-1 |
 | 1.3 | No user-managed service account keys | `check_1_3_no_sa_keys` | HIGH | PR.AC-1 |
 | 1.4 | Service account key rotation (90 days) | `check_1_4_sa_key_rotation` | MEDIUM | PR.AC-1 |
+| 1.5 | Separation of duties — no principal holds both `serviceAccountAdmin` and `serviceAccountUser` | `check_1_5_separation_sa_admin` | MEDIUM | PR.AC-4 |
+| 1.6 | Org policy `iam.disableServiceAccountKeyCreation` enforced | `check_1_6_disable_sa_key_creation` | MEDIUM | PR.AC-1 |
+| 1.11 | Separation of duties on KMS roles (admin vs crypto-key) | `check_1_11_separation_kms` | MEDIUM | PR.AC-4 |
+| 1.12 | KMS keys not exposed to `allUsers`/`allAuthenticatedUsers` | `check_1_12_kms_keys_not_public` | CRITICAL | PR.AC-3 |
+| 1.13 | API keys carry application + API restrictions | `check_1_13_api_keys_restricted` | MEDIUM | PR.AC-1 |
+| 1.14 | Essential Contacts configured (SECURITY/TECHNICAL/LEGAL/SUSPENSION) | `check_1_14_essential_contacts` | LOW | DE.AE-5 |
 
 ### Section 2 — Cloud Storage (2 checks)
 
@@ -107,13 +117,18 @@ Each row maps to one function in `src/checks.py`. If it's not in this table, it'
 | 2.1 | Uniform bucket-level access (no legacy ACL) | `check_2_1_uniform_access` | HIGH | PR.AC-3 |
 | 2.3 | No public buckets (allUsers/allAuthenticatedUsers) | `check_2_3_no_public_buckets` | CRITICAL | PR.AC-3 |
 
-### Section 3 — Logging (1 check)
+### Section 3 — Logging & Monitoring (6 checks)
 
 | # | CIS Control | Function | Severity | NIST CSF 2.0 |
 |---|------------|----------|----------|--------------|
 | 3.1 | Audit logging on `allServices` for Admin Read, Data Read, and Data Write with no exemptions | `check_3_1_audit_logging_all_services` | HIGH | DE.AE-3 |
+| 2.2 | At least one log sink covers all entries (catch-all filter) | `check_2_2_log_sink_configured` | HIGH | DE.AE-3 |
+| 2.4 | Log metric filter for project ownership (`SetIamPolicy`) changes | `check_2_4_log_metric_project_ownership` | MEDIUM | DE.AE-3 |
+| 2.7 | Log metric filter for VPC network changes | `check_2_7_log_metric_vpc_changes` | MEDIUM | DE.AE-3 |
+| 2.10 | Log metric filter for audit-config changes | `check_2_10_log_metric_audit_config` | MEDIUM | DE.AE-3 |
+| 2.13 | Cloud Asset Inventory API reachable | `check_2_13_cloud_asset_inventory` | LOW | ID.AM-1 |
 
-### Section 4 — Networking (4 checks)
+### Section 4 — Networking (5 checks)
 
 | # | CIS Control | Function | Severity | NIST CSF 2.0 |
 |---|------------|----------|----------|--------------|
@@ -121,6 +136,30 @@ Each row maps to one function in `src/checks.py`. If it's not in this table, it'
 | 4.2 | No unrestricted SSH/RDP (0.0.0.0/0 on 22/3389) | `check_4_2_no_unrestricted_ssh_rdp` | HIGH | PR.AC-5 |
 | 4.3 | VPC flow logs on all subnets | `check_4_3_vpc_flow_logs` | MEDIUM | DE.CM-1 |
 | 4.4 | Private Google Access on all subnets | `check_4_4_private_google_access` | MEDIUM | PR.AC-5 |
+| 3.10 | Cloud DNS logging enabled on all policies | `check_3_10_dns_logging` | MEDIUM | DE.CM-1 |
+
+### Section 5 — Compute / VM (4 checks)
+
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 4.5 | Block project-wide SSH keys on every instance | `check_4_5_block_project_wide_ssh` | MEDIUM | PR.AC-1 |
+| 4.6 | Confidential VM enabled | `check_4_6_confidential_vm` | LOW | PR.DS-1 |
+| 4.7 | Shielded VM (vTPM + integrity monitoring) | `check_4_7_shielded_vm` | MEDIUM | PR.DS-1 |
+| 4.8 | Compute disks encrypted with CMEK | `check_4_8_disk_cmek` | MEDIUM | PR.DS-1 |
+
+### Section 6 — Cloud SQL (2 checks)
+
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 6.1 | Cloud SQL instances do not use a public IP | `check_6_1_cloudsql_no_public_ip` | HIGH | PR.AC-5 |
+| 6.4 | Cloud SQL instances require SSL | `check_6_4_cloudsql_require_ssl` | HIGH | PR.DS-2 |
+
+### Section 7 — BigQuery (2 checks)
+
+| # | CIS Control | Function | Severity | NIST CSF 2.0 |
+|---|------------|----------|----------|--------------|
+| 7.1 | BigQuery datasets not exposed to `allUsers`/`allAuthenticatedUsers` | `check_7_1_bigquery_not_public` | CRITICAL | PR.AC-3 |
+| 7.2 | BigQuery datasets configured with a default CMEK key | `check_7_2_bigquery_default_cmek` | MEDIUM | PR.DS-1 |
 
 ## Roadmap — Documented but Not Yet Automated
 
@@ -129,13 +168,12 @@ These controls are part of the CIS GCP Foundations v3.0 benchmark but are *not* 
 | # | CIS Control | Why it matters |
 |---|------------|----------------|
 | 1.2 | MFA enforced org-wide | Requires Workspace Admin SDK access, not in this skill's scope |
-| 1.5 | No keys for default compute/App Engine SAs | Specialised filter on top of 1.3 |
-| 1.6 | No project-wide SSH keys | Compute metadata read |
 | 1.7 | SA impersonation scoped | IAM Recommender or policy walker |
-| 2.2 | Bucket retention policy on compliance buckets | Requires labeling convention |
-| 2.4 | CMEK encryption on sensitive data | KMS + Storage join |
-| 3.2–3.4 | Logging metrics and alert policies | `google-cloud-logging` + `google-cloud-monitoring` |
-| 4.5 | SSL policies enforce TLS 1.2+ | Compute API SSL policies |
+| 1.10 | Rotate user-managed SA keys (specialised filter) | Overlaps `check_1_4_sa_key_rotation`; specialise per-key-type later |
+| 2.5–2.6, 2.8–2.9, 2.11–2.12 | Additional log metric filters & monitoring alert policies | Requires `google-cloud-monitoring` for AlertPolicy listing |
+| 3.3, 3.5, 3.9 | DNSSEC + RSASHA1 + load-balancer logging | Compute API + Cloud DNS deeper coverage |
+| 6.2, 6.3, 6.5–6.7 | Cloud SQL trace/binlog/cloud-functions log retention | sqladmin discovery deeper coverage |
+| 7.3 | BigQuery dataset audit logging | Cross-cuts with §3.1 audit configs |
 
 ## Usage
 
@@ -145,8 +183,12 @@ python src/checks.py --project my-project-id
 
 # Run specific section
 python src/checks.py --project my-project-id --section iam
+python src/checks.py --project my-project-id --section storage
 python src/checks.py --project my-project-id --section logging
 python src/checks.py --project my-project-id --section networking
+python src/checks.py --project my-project-id --section compute
+python src/checks.py --project my-project-id --section cloudsql
+python src/checks.py --project my-project-id --section bigquery
 
 # Output JSON
 python src/checks.py --project my-project-id --output json --output-format ocsf > cis-gcp-results.json

--- a/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
@@ -1,8 +1,9 @@
 """
 CIS GCP Foundations Benchmark v3.0 — Automated Assessment
 
-10 CIS controls across IAM, Storage, Logging, and Networking.
-Read-only: requires roles/viewer + roles/iam.securityReviewer.
+30 CIS controls across IAM, Storage, Logging, Networking, Compute,
+Cloud SQL, and BigQuery. Read-only: requires roles/viewer +
+roles/iam.securityReviewer.
 
 Frameworks:
     CIS GCP Foundations v3.0
@@ -429,6 +430,943 @@ def check_4_4_private_google_access(compute_client, project_id: str) -> Finding:
 
 
 # ---------------------------------------------------------------------------
+# Section 1 — IAM (additional)
+# ---------------------------------------------------------------------------
+
+
+_SA_ADMIN_ROLES = {
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountUser",
+}
+
+_KMS_ADMIN_ROLES = {
+    "roles/cloudkms.admin",
+    "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+    "roles/cloudkms.cryptoKeyEncrypter",
+    "roles/cloudkms.cryptoKeyDecrypter",
+}
+
+
+def _members_per_role(policy, role_set: set[str]) -> dict[str, set[str]]:
+    """Group members by the subset of `role_set` they hold in this policy."""
+    out: dict[str, set[str]] = {}
+    for binding in getattr(policy, "bindings", []) or []:
+        role = getattr(binding, "role", None)
+        if role is None and isinstance(binding, dict):
+            role = binding.get("role")
+        if role not in role_set:
+            continue
+        members = getattr(binding, "members", None)
+        if members is None and isinstance(binding, dict):
+            members = binding.get("members")
+        for m in members or []:
+            out.setdefault(m, set()).add(role)
+    return out
+
+
+def check_1_5_separation_sa_admin(crm_client, project_id: str) -> Finding:
+    """CIS 1.5 — Separation of duties for service account admin roles.
+
+    No principal should hold *both* serviceAccountAdmin and serviceAccountUser.
+    """
+    try:
+        policy = crm_client.get_iam_policy(request={"resource": f"projects/{project_id}"})
+        per_member = _members_per_role(policy, _SA_ADMIN_ROLES)
+        offenders = sorted(m for m, roles in per_member.items() if len(roles) > 1)
+        return Finding(
+            control_id="1.5",
+            title="Separation of duties for SA admin roles",
+            section="iam",
+            severity="MEDIUM",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} principals hold both serviceAccountAdmin and serviceAccountUser"
+                if offenders
+                else "No principal holds both SA admin and SA user roles"
+            ),
+            nist_csf="PR.AC-4",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="1.5",
+            title="Separation of duties for SA admin roles",
+            section="iam",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-4",
+        )
+
+
+def check_1_6_disable_sa_key_creation(orgpolicy_client, project_id: str) -> Finding:
+    """CIS 1.6 — Org policy disables service account key creation."""
+    try:
+        constraint = "constraints/iam.disableServiceAccountKeyCreation"
+        policy = orgpolicy_client.get_org_policy(
+            request={"resource": f"projects/{project_id}", "constraint": constraint}
+        )
+        boolean_policy = getattr(policy, "boolean_policy", None)
+        if boolean_policy is None and isinstance(policy, dict):
+            boolean_policy = policy.get("boolean_policy")
+        enforced = bool(getattr(boolean_policy, "enforced", False)) if boolean_policy else False
+        if isinstance(boolean_policy, dict):
+            enforced = bool(boolean_policy.get("enforced", False))
+        return Finding(
+            control_id="1.6",
+            title="Org policy disables SA key creation",
+            section="iam",
+            severity="MEDIUM",
+            status="PASS" if enforced else "FAIL",
+            detail=(
+                "iam.disableServiceAccountKeyCreation enforced"
+                if enforced
+                else "iam.disableServiceAccountKeyCreation NOT enforced"
+            ),
+            nist_csf="PR.AC-1",
+            resources=[constraint],
+        )
+    except Exception as e:
+        return Finding(
+            control_id="1.6",
+            title="Org policy disables SA key creation",
+            section="iam",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-1",
+        )
+
+
+def check_1_11_separation_kms(crm_client, project_id: str) -> Finding:
+    """CIS 1.11 — Separation of duties for KMS-related roles."""
+    try:
+        policy = crm_client.get_iam_policy(request={"resource": f"projects/{project_id}"})
+        per_member = _members_per_role(policy, _KMS_ADMIN_ROLES)
+        offenders = sorted(
+            f"{m} -> {sorted(roles)}"
+            for m, roles in per_member.items()
+            if "roles/cloudkms.admin" in roles and len(roles) > 1
+        )
+        return Finding(
+            control_id="1.11",
+            title="Separation of duties for KMS roles",
+            section="iam",
+            severity="MEDIUM",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} principals hold cloudkms.admin and crypto-key roles"
+                if offenders
+                else "No principal holds both cloudkms.admin and a crypto-key role"
+            ),
+            nist_csf="PR.AC-4",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="1.11",
+            title="Separation of duties for KMS roles",
+            section="iam",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-4",
+        )
+
+
+def check_1_12_kms_keys_not_public(kms_client, project_id: str) -> Finding:
+    """CIS 1.12 — KMS keys not anonymously / publicly accessible."""
+    try:
+        public_keys: list[str] = []
+        locations = list(
+            kms_client.list_key_rings(request={"parent": f"projects/{project_id}/locations/-"})
+        )
+        for ring in locations:
+            ring_name = getattr(ring, "name", None) or (ring.get("name") if isinstance(ring, dict) else "")
+            if not ring_name:
+                continue
+            keys = list(kms_client.list_crypto_keys(request={"parent": ring_name}))
+            for key in keys:
+                key_name = getattr(key, "name", None) or (key.get("name") if isinstance(key, dict) else "")
+                policy = kms_client.get_iam_policy(request={"resource": key_name})
+                for binding in getattr(policy, "bindings", []) or []:
+                    members = getattr(binding, "members", None)
+                    if members is None and isinstance(binding, dict):
+                        members = binding.get("members")
+                    members = members or []
+                    if "allUsers" in members or "allAuthenticatedUsers" in members:
+                        public_keys.append(key_name)
+                        break
+        return Finding(
+            control_id="1.12",
+            title="KMS keys not publicly accessible",
+            section="iam",
+            severity="CRITICAL",
+            status="FAIL" if public_keys else "PASS",
+            detail=(
+                f"{len(public_keys)} KMS keys exposed to allUsers/allAuthenticatedUsers"
+                if public_keys
+                else "No KMS keys exposed to public principals"
+            ),
+            nist_csf="PR.AC-3",
+            resources=public_keys,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="1.12",
+            title="KMS keys not publicly accessible",
+            section="iam",
+            severity="CRITICAL",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-3",
+        )
+
+
+def check_1_13_api_keys_restricted(apikeys_client, project_id: str) -> Finding:
+    """CIS 1.13 — API keys carry application + API restrictions."""
+    try:
+        keys = list(apikeys_client.list_keys(request={"parent": f"projects/{project_id}/locations/global"}))
+        unrestricted: list[str] = []
+        for key in keys:
+            name = getattr(key, "name", None) or (key.get("name") if isinstance(key, dict) else "")
+            display = getattr(key, "display_name", None) or (
+                key.get("display_name") if isinstance(key, dict) else ""
+            )
+            label = display or name
+            restrictions = getattr(key, "restrictions", None)
+            if restrictions is None and isinstance(key, dict):
+                restrictions = key.get("restrictions")
+            if not restrictions:
+                unrestricted.append(label)
+                continue
+            api_targets = getattr(restrictions, "api_targets", None)
+            if api_targets is None and isinstance(restrictions, dict):
+                api_targets = restrictions.get("api_targets")
+            has_app_restrictions = any(
+                bool(getattr(restrictions, attr, None) or (
+                    restrictions.get(attr) if isinstance(restrictions, dict) else None
+                ))
+                for attr in (
+                    "browser_key_restrictions",
+                    "server_key_restrictions",
+                    "android_key_restrictions",
+                    "ios_key_restrictions",
+                )
+            )
+            if not has_app_restrictions or not api_targets:
+                unrestricted.append(label)
+        return Finding(
+            control_id="1.13",
+            title="API keys carry usage restrictions",
+            section="iam",
+            severity="MEDIUM",
+            status="FAIL" if unrestricted else "PASS",
+            detail=(
+                f"{len(unrestricted)} API keys missing application or API restrictions"
+                if unrestricted
+                else "All API keys carry both application and API restrictions"
+            ),
+            nist_csf="PR.AC-1",
+            resources=unrestricted,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="1.13",
+            title="API keys carry usage restrictions",
+            section="iam",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-1",
+        )
+
+
+def check_1_14_essential_contacts(contacts_client, project_id: str) -> Finding:
+    """CIS 1.14 — Essential Contacts configured for security categories."""
+    try:
+        required = {"SECURITY", "TECHNICAL", "LEGAL", "SUSPENSION"}
+        contacts = list(contacts_client.list_contacts(request={"parent": f"projects/{project_id}"}))
+        seen: set[str] = set()
+        for contact in contacts:
+            categories = getattr(contact, "notification_category_subscriptions", None)
+            if categories is None and isinstance(contact, dict):
+                categories = contact.get("notification_category_subscriptions")
+            for c in categories or []:
+                seen.add(str(c).upper())
+        missing = sorted(required - seen)
+        return Finding(
+            control_id="1.14",
+            title="Essential Contacts configured",
+            section="iam",
+            severity="LOW",
+            status="FAIL" if missing else "PASS",
+            detail=(
+                f"missing essential contact categories: {', '.join(missing)}"
+                if missing
+                else "All required essential contact categories configured"
+            ),
+            nist_csf="DE.AE-5",
+            resources=missing,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="1.14",
+            title="Essential Contacts configured",
+            section="iam",
+            severity="LOW",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.AE-5",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Logging & Monitoring
+# ---------------------------------------------------------------------------
+
+
+def check_2_2_log_sink_configured(logging_client, project_id: str) -> Finding:
+    """CIS 2.2 — At least one log sink covers all log entries (filter empty)."""
+    try:
+        sinks = list(logging_client.list_sinks(request={"parent": f"projects/{project_id}"}))
+        catch_all = []
+        for sink in sinks:
+            sink_filter = getattr(sink, "filter", None)
+            if sink_filter is None and isinstance(sink, dict):
+                sink_filter = sink.get("filter")
+            destination = getattr(sink, "destination", None) or (
+                sink.get("destination") if isinstance(sink, dict) else ""
+            )
+            if not sink_filter:
+                catch_all.append(str(destination))
+        return Finding(
+            control_id="2.2",
+            title="Log sink covers all entries",
+            section="logging",
+            severity="HIGH",
+            status="PASS" if catch_all else "FAIL",
+            detail=(
+                f"{len(catch_all)} catch-all sink(s) configured"
+                if catch_all
+                else "No log sink with empty filter (catch-all) found"
+            ),
+            nist_csf="DE.AE-3",
+            resources=catch_all,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="2.2",
+            title="Log sink covers all entries",
+            section="logging",
+            severity="HIGH",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.AE-3",
+        )
+
+
+def _has_metric_with_filter(logging_client, project_id: str, needle: str) -> bool:
+    metrics = list(logging_client.list_log_metrics(request={"parent": f"projects/{project_id}"}))
+    for metric in metrics:
+        f = getattr(metric, "filter", None)
+        if f is None and isinstance(metric, dict):
+            f = metric.get("filter")
+        if f and needle in f:
+            return True
+    return False
+
+
+def check_2_4_log_metric_project_ownership(logging_client, project_id: str) -> Finding:
+    """CIS 2.4 — Log metric filter for project ownership assignment changes."""
+    try:
+        needle = "SetIamPolicy"
+        present = _has_metric_with_filter(logging_client, project_id, needle)
+        return Finding(
+            control_id="2.4",
+            title="Log metric filter for project ownership changes",
+            section="logging",
+            severity="MEDIUM",
+            status="PASS" if present else "FAIL",
+            detail=(
+                "Metric filter on SetIamPolicy is present"
+                if present
+                else "No metric filter on SetIamPolicy found"
+            ),
+            nist_csf="DE.AE-3",
+        )
+    except Exception as e:
+        return Finding(
+            control_id="2.4",
+            title="Log metric filter for project ownership changes",
+            section="logging",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.AE-3",
+        )
+
+
+def check_2_7_log_metric_vpc_changes(logging_client, project_id: str) -> Finding:
+    """CIS 2.7 — Log metric filter for VPC network changes."""
+    try:
+        needle = "compute.networks"
+        present = _has_metric_with_filter(logging_client, project_id, needle)
+        return Finding(
+            control_id="2.7",
+            title="Log metric filter for VPC network changes",
+            section="logging",
+            severity="MEDIUM",
+            status="PASS" if present else "FAIL",
+            detail=(
+                "Metric filter on compute.networks is present"
+                if present
+                else "No metric filter on compute.networks found"
+            ),
+            nist_csf="DE.AE-3",
+        )
+    except Exception as e:
+        return Finding(
+            control_id="2.7",
+            title="Log metric filter for VPC network changes",
+            section="logging",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.AE-3",
+        )
+
+
+def check_2_10_log_metric_audit_config(logging_client, project_id: str) -> Finding:
+    """CIS 2.10 — Log metric filter for audit-config changes."""
+    try:
+        needle = "AuditConfig"
+        present = _has_metric_with_filter(logging_client, project_id, needle)
+        return Finding(
+            control_id="2.10",
+            title="Log metric filter for audit-config changes",
+            section="logging",
+            severity="MEDIUM",
+            status="PASS" if present else "FAIL",
+            detail=(
+                "Metric filter on AuditConfig changes is present"
+                if present
+                else "No metric filter on AuditConfig changes found"
+            ),
+            nist_csf="DE.AE-3",
+        )
+    except Exception as e:
+        return Finding(
+            control_id="2.10",
+            title="Log metric filter for audit-config changes",
+            section="logging",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.AE-3",
+        )
+
+
+def check_2_13_cloud_asset_inventory(asset_client, project_id: str) -> Finding:
+    """CIS 2.13 — Cloud Asset Inventory accessible (a successful list_assets call)."""
+    try:
+        page = asset_client.list_assets(request={"parent": f"projects/{project_id}"})
+        # Materialise at most one entry — proves the API is enabled and reachable.
+        iterator = iter(page)
+        try:
+            next(iterator)
+        except StopIteration:
+            pass
+        return Finding(
+            control_id="2.13",
+            title="Cloud Asset Inventory enabled",
+            section="logging",
+            severity="LOW",
+            status="PASS",
+            detail="cloudasset.googleapis.com responded successfully",
+            nist_csf="ID.AM-1",
+        )
+    except Exception as e:
+        return Finding(
+            control_id="2.13",
+            title="Cloud Asset Inventory enabled",
+            section="logging",
+            severity="LOW",
+            status="FAIL",
+            detail=str(e),
+            nist_csf="ID.AM-1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Networking (additional)
+# ---------------------------------------------------------------------------
+
+
+def check_3_10_dns_logging(dns_client, project_id: str) -> Finding:
+    """CIS 3.10 — Cloud DNS logging enabled on all VPC network policies."""
+    try:
+        policies = list(dns_client.list(project=project_id))
+        unlogged: list[str] = []
+        for policy in policies:
+            name = getattr(policy, "name", None) or (
+                policy.get("name") if isinstance(policy, dict) else ""
+            )
+            enable = getattr(policy, "enable_logging", None)
+            if enable is None and isinstance(policy, dict):
+                enable = policy.get("enable_logging")
+            if not enable:
+                unlogged.append(str(name))
+        return Finding(
+            control_id="3.10",
+            title="Cloud DNS logging enabled",
+            section="networking",
+            severity="MEDIUM",
+            status="FAIL" if unlogged else "PASS",
+            detail=(
+                f"{len(unlogged)} DNS policies without logging"
+                if unlogged
+                else "All Cloud DNS policies enable logging"
+            ),
+            nist_csf="DE.CM-1",
+            resources=unlogged,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="3.10",
+            title="Cloud DNS logging enabled",
+            section="networking",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="DE.CM-1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Compute (VM)
+# ---------------------------------------------------------------------------
+
+
+def _list_aggregated_instances(compute_client, project_id: str):
+    """Yield (zone_label, instance) tuples from an aggregated_list response."""
+    request = {"project": project_id}
+    response = compute_client.aggregated_list(request=request)
+    if hasattr(response, "items") and not callable(response.items):
+        items = response.items  # type: ignore[assignment]
+    else:
+        items = response
+    if isinstance(items, dict):
+        iterable = items.items()
+    else:
+        iterable = items
+    for entry in iterable:
+        if isinstance(entry, tuple) and len(entry) == 2:
+            zone, scoped = entry
+            instances = getattr(scoped, "instances", None)
+            if instances is None and isinstance(scoped, dict):
+                instances = scoped.get("instances")
+            for inst in instances or []:
+                yield zone, inst
+        else:
+            instances = getattr(entry, "instances", None)
+            if instances is None and isinstance(entry, dict):
+                instances = entry.get("instances")
+            for inst in instances or []:
+                yield "", inst
+
+
+def check_4_5_block_project_wide_ssh(compute_client, project_id: str) -> Finding:
+    """CIS 4.5 — Compute instances block project-wide SSH keys."""
+    try:
+        offenders: list[str] = []
+        for zone, inst in _list_aggregated_instances(compute_client, project_id):
+            name = getattr(inst, "name", None) or (
+                inst.get("name") if isinstance(inst, dict) else ""
+            )
+            metadata = getattr(inst, "metadata", None)
+            if metadata is None and isinstance(inst, dict):
+                metadata = inst.get("metadata")
+            items = getattr(metadata, "items", None) if metadata else None
+            if items is None and isinstance(metadata, dict):
+                items = metadata.get("items")
+            blocked = False
+            for item in items or []:
+                key = getattr(item, "key", None) or (
+                    item.get("key") if isinstance(item, dict) else ""
+                )
+                value = getattr(item, "value", None) or (
+                    item.get("value") if isinstance(item, dict) else ""
+                )
+                if key == "block-project-ssh-keys" and str(value).lower() == "true":
+                    blocked = True
+                    break
+            if not blocked:
+                offenders.append(f"{zone}/{name}".strip("/"))
+        return Finding(
+            control_id="4.5",
+            title="Block project-wide SSH keys",
+            section="compute",
+            severity="MEDIUM",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} instances allow project-wide SSH keys"
+                if offenders
+                else "All instances block project-wide SSH keys"
+            ),
+            nist_csf="PR.AC-1",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="4.5",
+            title="Block project-wide SSH keys",
+            section="compute",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-1",
+        )
+
+
+def check_4_6_confidential_vm(compute_client, project_id: str) -> Finding:
+    """CIS 4.6 — Confidential VM enabled on all instances."""
+    try:
+        offenders: list[str] = []
+        for zone, inst in _list_aggregated_instances(compute_client, project_id):
+            name = getattr(inst, "name", None) or (
+                inst.get("name") if isinstance(inst, dict) else ""
+            )
+            cc = getattr(inst, "confidential_instance_config", None)
+            if cc is None and isinstance(inst, dict):
+                cc = inst.get("confidential_instance_config")
+            enabled = bool(getattr(cc, "enable_confidential_compute", False)) if cc else False
+            if isinstance(cc, dict):
+                enabled = bool(cc.get("enable_confidential_compute", False))
+            if not enabled:
+                offenders.append(f"{zone}/{name}".strip("/"))
+        return Finding(
+            control_id="4.6",
+            title="Confidential VM enabled",
+            section="compute",
+            severity="LOW",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} instances without Confidential VM"
+                if offenders
+                else "All instances use Confidential VM"
+            ),
+            nist_csf="PR.DS-1",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="4.6",
+            title="Confidential VM enabled",
+            section="compute",
+            severity="LOW",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-1",
+        )
+
+
+def check_4_7_shielded_vm(compute_client, project_id: str) -> Finding:
+    """CIS 4.7 — Shielded VM (vTPM + integrity monitoring) on all instances."""
+    try:
+        offenders: list[str] = []
+        for zone, inst in _list_aggregated_instances(compute_client, project_id):
+            name = getattr(inst, "name", None) or (
+                inst.get("name") if isinstance(inst, dict) else ""
+            )
+            cfg = getattr(inst, "shielded_instance_config", None)
+            if cfg is None and isinstance(inst, dict):
+                cfg = inst.get("shielded_instance_config")
+            v_tpm = bool(getattr(cfg, "enable_vtpm", False)) if cfg else False
+            integ = bool(getattr(cfg, "enable_integrity_monitoring", False)) if cfg else False
+            if isinstance(cfg, dict):
+                v_tpm = bool(cfg.get("enable_vtpm", False))
+                integ = bool(cfg.get("enable_integrity_monitoring", False))
+            if not (v_tpm and integ):
+                offenders.append(f"{zone}/{name}".strip("/"))
+        return Finding(
+            control_id="4.7",
+            title="Shielded VM enabled",
+            section="compute",
+            severity="MEDIUM",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} instances missing vTPM or integrity monitoring"
+                if offenders
+                else "All instances enable vTPM and integrity monitoring"
+            ),
+            nist_csf="PR.DS-1",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="4.7",
+            title="Shielded VM enabled",
+            section="compute",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-1",
+        )
+
+
+def check_4_8_disk_cmek(compute_client, project_id: str) -> Finding:
+    """CIS 4.8 — Compute disks encrypted with CMEK (customer-managed)."""
+    try:
+        offenders: list[str] = []
+        for zone, inst in _list_aggregated_instances(compute_client, project_id):
+            name = getattr(inst, "name", None) or (
+                inst.get("name") if isinstance(inst, dict) else ""
+            )
+            disks = getattr(inst, "disks", None)
+            if disks is None and isinstance(inst, dict):
+                disks = inst.get("disks")
+            for disk in disks or []:
+                disk_name = getattr(disk, "device_name", None) or (
+                    disk.get("device_name") if isinstance(disk, dict) else ""
+                )
+                key = getattr(disk, "disk_encryption_key", None)
+                if key is None and isinstance(disk, dict):
+                    key = disk.get("disk_encryption_key")
+                kms_name = getattr(key, "kms_key_name", None) if key else None
+                if isinstance(key, dict):
+                    kms_name = key.get("kms_key_name")
+                if not kms_name:
+                    offenders.append(f"{zone}/{name}/{disk_name}".strip("/"))
+        return Finding(
+            control_id="4.8",
+            title="Compute disks encrypted with CMEK",
+            section="compute",
+            severity="MEDIUM",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} disks lack CMEK encryption"
+                if offenders
+                else "All compute disks use CMEK"
+            ),
+            nist_csf="PR.DS-1",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="4.8",
+            title="Compute disks encrypted with CMEK",
+            section="compute",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Cloud SQL
+# ---------------------------------------------------------------------------
+
+
+def _sql_instances(sql_client, project_id: str):
+    response = sql_client.list(project=project_id)
+    items = getattr(response, "items", None)
+    if items is None and isinstance(response, dict):
+        items = response.get("items")
+    if items is None:
+        items = response  # treat as iterable
+    return list(items or [])
+
+
+def check_6_1_cloudsql_no_public_ip(sql_client, project_id: str) -> Finding:
+    """CIS 6.1 — Cloud SQL instances do not use a public IP."""
+    try:
+        offenders: list[str] = []
+        for inst in _sql_instances(sql_client, project_id):
+            name = getattr(inst, "name", None) or (
+                inst.get("name") if isinstance(inst, dict) else ""
+            )
+            settings = getattr(inst, "settings", None)
+            if settings is None and isinstance(inst, dict):
+                settings = inst.get("settings")
+            ip_cfg = getattr(settings, "ip_configuration", None) if settings else None
+            if isinstance(settings, dict):
+                ip_cfg = settings.get("ip_configuration")
+            ipv4 = getattr(ip_cfg, "ipv4_enabled", None) if ip_cfg else None
+            if isinstance(ip_cfg, dict):
+                ipv4 = ip_cfg.get("ipv4_enabled")
+            if ipv4 is True:
+                offenders.append(str(name))
+        return Finding(
+            control_id="6.1",
+            title="Cloud SQL not configured with public IP",
+            section="cloudsql",
+            severity="HIGH",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} Cloud SQL instances have public IPv4 enabled"
+                if offenders
+                else "No Cloud SQL instances expose a public IP"
+            ),
+            nist_csf="PR.AC-5",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="6.1",
+            title="Cloud SQL not configured with public IP",
+            section="cloudsql",
+            severity="HIGH",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-5",
+        )
+
+
+def check_6_4_cloudsql_require_ssl(sql_client, project_id: str) -> Finding:
+    """CIS 6.4 — Cloud SQL instances require SSL connections."""
+    try:
+        offenders: list[str] = []
+        for inst in _sql_instances(sql_client, project_id):
+            name = getattr(inst, "name", None) or (
+                inst.get("name") if isinstance(inst, dict) else ""
+            )
+            settings = getattr(inst, "settings", None)
+            if settings is None and isinstance(inst, dict):
+                settings = inst.get("settings")
+            ip_cfg = getattr(settings, "ip_configuration", None) if settings else None
+            if isinstance(settings, dict):
+                ip_cfg = settings.get("ip_configuration")
+            require_ssl = getattr(ip_cfg, "require_ssl", None) if ip_cfg else None
+            if isinstance(ip_cfg, dict):
+                require_ssl = ip_cfg.get("require_ssl")
+            if not require_ssl:
+                offenders.append(str(name))
+        return Finding(
+            control_id="6.4",
+            title="Cloud SQL require SSL",
+            section="cloudsql",
+            severity="HIGH",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} Cloud SQL instances do not require SSL"
+                if offenders
+                else "All Cloud SQL instances require SSL"
+            ),
+            nist_csf="PR.DS-2",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="6.4",
+            title="Cloud SQL require SSL",
+            section="cloudsql",
+            severity="HIGH",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-2",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — BigQuery
+# ---------------------------------------------------------------------------
+
+
+def check_7_1_bigquery_not_public(bq_client, project_id: str) -> Finding:
+    """CIS 7.1 — BigQuery datasets not anonymously / publicly accessible."""
+    try:
+        public: list[str] = []
+        datasets = list(bq_client.list_datasets(project=project_id))
+        for ds_ref in datasets:
+            dataset = bq_client.get_dataset(ds_ref)
+            access_entries = getattr(dataset, "access_entries", None)
+            if access_entries is None and isinstance(dataset, dict):
+                access_entries = dataset.get("access_entries")
+            for entry in access_entries or []:
+                entity = (
+                    getattr(entry, "entity_id", None)
+                    or getattr(entry, "entity_type", None)
+                    or (entry.get("entity_id") if isinstance(entry, dict) else None)
+                )
+                if entity in {"allUsers", "allAuthenticatedUsers"}:
+                    ds_id = getattr(dataset, "dataset_id", None) or (
+                        dataset.get("dataset_id") if isinstance(dataset, dict) else ""
+                    )
+                    public.append(str(ds_id))
+                    break
+        return Finding(
+            control_id="7.1",
+            title="BigQuery datasets not publicly accessible",
+            section="bigquery",
+            severity="CRITICAL",
+            status="FAIL" if public else "PASS",
+            detail=(
+                f"{len(public)} BigQuery datasets exposed to allUsers/allAuthenticatedUsers"
+                if public
+                else "No public BigQuery datasets"
+            ),
+            nist_csf="PR.AC-3",
+            resources=public,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="7.1",
+            title="BigQuery datasets not publicly accessible",
+            section="bigquery",
+            severity="CRITICAL",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.AC-3",
+        )
+
+
+def check_7_2_bigquery_default_cmek(bq_client, project_id: str) -> Finding:
+    """CIS 7.2 — BigQuery datasets configured with a default CMEK key."""
+    try:
+        offenders: list[str] = []
+        datasets = list(bq_client.list_datasets(project=project_id))
+        for ds_ref in datasets:
+            dataset = bq_client.get_dataset(ds_ref)
+            ds_id = getattr(dataset, "dataset_id", None) or (
+                dataset.get("dataset_id") if isinstance(dataset, dict) else ""
+            )
+            enc = getattr(dataset, "default_encryption_configuration", None)
+            if enc is None and isinstance(dataset, dict):
+                enc = dataset.get("default_encryption_configuration")
+            kms_name = getattr(enc, "kms_key_name", None) if enc else None
+            if isinstance(enc, dict):
+                kms_name = enc.get("kms_key_name")
+            if not kms_name:
+                offenders.append(str(ds_id))
+        return Finding(
+            control_id="7.2",
+            title="BigQuery datasets use default CMEK",
+            section="bigquery",
+            severity="MEDIUM",
+            status="FAIL" if offenders else "PASS",
+            detail=(
+                f"{len(offenders)} BigQuery datasets without a default CMEK key"
+                if offenders
+                else "All BigQuery datasets have a default CMEK key"
+            ),
+            nist_csf="PR.DS-1",
+            resources=offenders,
+        )
+    except Exception as e:
+        return Finding(
+            control_id="7.2",
+            title="BigQuery datasets use default CMEK",
+            section="bigquery",
+            severity="MEDIUM",
+            status="ERROR",
+            detail=str(e),
+            nist_csf="PR.DS-1",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -437,11 +1375,21 @@ def _status_symbol(status: str) -> str:
     return {"PASS": "\033[92m✓\033[0m", "FAIL": "\033[91m✗\033[0m", "ERROR": "\033[90m?\033[0m"}.get(status, "?")
 
 
+def _try_import(module_path: str, attr: str | None = None):
+    """Best-effort import: returns the symbol or None when the SDK is missing."""
+    try:
+        mod = importlib.import_module(module_path)
+    except ImportError:
+        return None
+    return getattr(mod, attr) if attr else mod
+
+
 def run_assessment(project_id: str, section: str | None = None) -> list[Finding]:
     """Run all checks. Imports GCP SDKs at call time to fail gracefully."""
     try:
         from google.cloud import iam_admin_v1, resourcemanager_v3
         from google.cloud.compute_v1.services.firewalls import FirewallsClient
+        from google.cloud.compute_v1.services.instances import InstancesClient
         from google.cloud.compute_v1.services.networks import NetworksClient
         from google.cloud.compute_v1.services.subnetworks import SubnetworksClient
 
@@ -458,7 +1406,37 @@ def run_assessment(project_id: str, section: str | None = None) -> list[Finding]
     fw = FirewallsClient()
     nw = NetworksClient()
     sn = SubnetworksClient()
+    instances = InstancesClient()
 
+    # Optional clients — when their SDK isn't installed, the corresponding
+    # checks emit ERROR findings rather than blowing up the whole runner.
+    OrgPolicyClient = _try_import("google.cloud.orgpolicy_v2", "OrgPolicyClient")
+    KMSClient = _try_import("google.cloud.kms_v1", "KeyManagementServiceClient")
+    APIKeysClient = _try_import("google.cloud.api_keys_v2", "ApiKeysClient")
+    EssentialContactsClient = _try_import(
+        "google.cloud.essential_contacts_v1", "EssentialContactsServiceClient"
+    )
+    LoggingClient = _try_import("google.cloud.logging_v2", "ConfigServiceV2Client")
+    LogMetricsClient = _try_import("google.cloud.logging_v2", "MetricsServiceV2Client")
+    AssetClient = _try_import("google.cloud.asset_v1", "AssetServiceClient")
+    DNSPoliciesClient = _try_import("google.cloud.dns_v1.services.policies", "PoliciesClient")
+    SQLClient = _try_import("googleapiclient.discovery", "build")
+    BQClient = _try_import("google.cloud.bigquery", "Client")
+
+    orgpol = OrgPolicyClient() if OrgPolicyClient else None
+    kms = KMSClient() if KMSClient else None
+    apikeys = APIKeysClient() if APIKeysClient else None
+    contacts = EssentialContactsClient() if EssentialContactsClient else None
+    log_cfg = LoggingClient() if LoggingClient else None
+    log_metrics = LogMetricsClient() if LogMetricsClient else None
+    asset = AssetClient() if AssetClient else None
+    dns = DNSPoliciesClient() if DNSPoliciesClient else None
+    sql = SQLClient("sqladmin", "v1beta4").instances() if SQLClient else None  # type: ignore[misc]
+    bq = BQClient(project=project_id) if BQClient else None
+
+    # The logging-config client lists sinks; the metrics client lists log metrics.
+    # The 2.4 / 2.7 / 2.10 helper expects a single object exposing both
+    # `list_log_metrics` (metrics client) — we use the metrics client there.
     findings: list[Finding] = []
 
     checks = {
@@ -466,6 +1444,12 @@ def run_assessment(project_id: str, section: str | None = None) -> list[Finding]
             lambda: check_1_1_no_gmail_accounts(crm, project_id),
             lambda: check_1_3_no_sa_keys(iam, project_id),
             lambda: check_1_4_sa_key_rotation(iam, project_id),
+            lambda: check_1_5_separation_sa_admin(crm, project_id),
+            lambda: check_1_6_disable_sa_key_creation(orgpol, project_id),
+            lambda: check_1_11_separation_kms(crm, project_id),
+            lambda: check_1_12_kms_keys_not_public(kms, project_id),
+            lambda: check_1_13_api_keys_restricted(apikeys, project_id),
+            lambda: check_1_14_essential_contacts(contacts, project_id),
         ],
         "storage": [
             lambda: check_2_1_uniform_access(gcs, project_id),
@@ -473,12 +1457,32 @@ def run_assessment(project_id: str, section: str | None = None) -> list[Finding]
         ],
         "logging": [
             lambda: check_3_1_audit_logging_all_services(crm, project_id),
+            lambda: check_2_2_log_sink_configured(log_cfg, project_id),
+            lambda: check_2_4_log_metric_project_ownership(log_metrics, project_id),
+            lambda: check_2_7_log_metric_vpc_changes(log_metrics, project_id),
+            lambda: check_2_10_log_metric_audit_config(log_metrics, project_id),
+            lambda: check_2_13_cloud_asset_inventory(asset, project_id),
         ],
         "networking": [
             lambda: check_4_1_default_network_deleted(nw, project_id),
             lambda: check_4_2_no_unrestricted_ssh_rdp(fw, project_id),
             lambda: check_4_3_vpc_flow_logs(sn, project_id),
             lambda: check_4_4_private_google_access(sn, project_id),
+            lambda: check_3_10_dns_logging(dns, project_id),
+        ],
+        "compute": [
+            lambda: check_4_5_block_project_wide_ssh(instances, project_id),
+            lambda: check_4_6_confidential_vm(instances, project_id),
+            lambda: check_4_7_shielded_vm(instances, project_id),
+            lambda: check_4_8_disk_cmek(instances, project_id),
+        ],
+        "cloudsql": [
+            lambda: check_6_1_cloudsql_no_public_ip(sql, project_id),
+            lambda: check_6_4_cloudsql_require_ssl(sql, project_id),
+        ],
+        "bigquery": [
+            lambda: check_7_1_bigquery_not_public(bq, project_id),
+            lambda: check_7_2_bigquery_default_cmek(bq, project_id),
         ],
     }
 
@@ -518,7 +1522,11 @@ def print_summary(findings: list[Finding]) -> None:
 def main():
     parser = argparse.ArgumentParser(description="CIS GCP Foundations Benchmark v3.0 Assessment")
     parser.add_argument("--project", required=True, help="GCP project ID")
-    parser.add_argument("--section", choices=["iam", "storage", "logging", "networking"], help="Run specific section")
+    parser.add_argument(
+        "--section",
+        choices=["iam", "storage", "logging", "networking", "compute", "cloudsql", "bigquery"],
+        help="Run specific section",
+    )
     parser.add_argument("--output", choices=["console", "json"], default="console")
     parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
     args = parser.parse_args()

--- a/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/src/checks.py
@@ -595,7 +595,7 @@ def check_1_12_kms_keys_not_public(kms_client, project_id: str) -> Finding:
                         members = binding.get("members")
                     members = members or []
                     if "allUsers" in members or "allAuthenticatedUsers" in members:
-                        public_keys.append(key_name)
+                        public_keys.append(str(key_name))
                         break
         return Finding(
             control_id="1.12",
@@ -638,7 +638,7 @@ def check_1_13_api_keys_restricted(apikeys_client, project_id: str) -> Finding:
             if restrictions is None and isinstance(key, dict):
                 restrictions = key.get("restrictions")
             if not restrictions:
-                unrestricted.append(label)
+                unrestricted.append(str(label))
                 continue
             api_targets = getattr(restrictions, "api_targets", None)
             if api_targets is None and isinstance(restrictions, dict):
@@ -655,7 +655,7 @@ def check_1_13_api_keys_restricted(apikeys_client, project_id: str) -> Finding:
                 )
             )
             if not has_app_restrictions or not api_targets:
-                unrestricted.append(label)
+                unrestricted.append(str(label))
         return Finding(
             control_id="1.13",
             title="API keys carry usage restrictions",
@@ -953,7 +953,7 @@ def _list_aggregated_instances(compute_client, project_id: str):
     request = {"project": project_id}
     response = compute_client.aggregated_list(request=request)
     if hasattr(response, "items") and not callable(response.items):
-        items = response.items  # type: ignore[assignment]
+        items = response.items
     else:
         items = response
     if isinstance(items, dict):
@@ -1431,7 +1431,7 @@ def run_assessment(project_id: str, section: str | None = None) -> list[Finding]
     log_metrics = LogMetricsClient() if LogMetricsClient else None
     asset = AssetClient() if AssetClient else None
     dns = DNSPoliciesClient() if DNSPoliciesClient else None
-    sql = SQLClient("sqladmin", "v1beta4").instances() if SQLClient else None  # type: ignore[misc]
+    sql = SQLClient("sqladmin", "v1beta4").instances() if SQLClient else None
     bq = BQClient(project=project_id) if BQClient else None
 
     # The logging-config client lists sinks; the metrics client lists log metrics.

--- a/skills/evaluation/cspm-gcp-cis-benchmark/tests/test_checks.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/tests/test_checks.py
@@ -130,3 +130,497 @@ class TestFindingStructure:
         f = check_1_1_no_gmail_accounts(mock_crm, "test-project")
         assert f.nist_csf == "PR.AC-1"
         assert f.control_id == "1.1"
+
+
+# ---------------------------------------------------------------------------
+# New IAM checks (1.5, 1.6, 1.11, 1.12, 1.13, 1.14)
+# ---------------------------------------------------------------------------
+
+
+def _binding(role, members):
+    b = MagicMock()
+    b.role = role
+    b.members = list(members)
+    return b
+
+
+class TestIAMSeparationAndKMS:
+    def test_1_5_dual_role_holder_fails(self):
+        crm = MagicMock()
+        policy = MagicMock()
+        policy.bindings = [
+            _binding("roles/iam.serviceAccountAdmin", ["user:dev@x.com"]),
+            _binding("roles/iam.serviceAccountUser", ["user:dev@x.com"]),
+        ]
+        crm.get_iam_policy.return_value = policy
+        f = _CHECKS.check_1_5_separation_sa_admin(crm, "p")
+        assert f.status == "FAIL"
+        assert f.resources == ["user:dev@x.com"]
+
+    def test_1_5_distinct_holders_pass(self):
+        crm = MagicMock()
+        policy = MagicMock()
+        policy.bindings = [
+            _binding("roles/iam.serviceAccountAdmin", ["user:a@x.com"]),
+            _binding("roles/iam.serviceAccountUser", ["user:b@x.com"]),
+        ]
+        crm.get_iam_policy.return_value = policy
+        assert _CHECKS.check_1_5_separation_sa_admin(crm, "p").status == "PASS"
+
+    def test_1_6_org_policy_enforced_passes(self):
+        client = MagicMock()
+        policy = MagicMock()
+        policy.boolean_policy.enforced = True
+        client.get_org_policy.return_value = policy
+        assert _CHECKS.check_1_6_disable_sa_key_creation(client, "p").status == "PASS"
+
+    def test_1_6_org_policy_not_enforced_fails(self):
+        client = MagicMock()
+        policy = MagicMock()
+        policy.boolean_policy.enforced = False
+        client.get_org_policy.return_value = policy
+        assert _CHECKS.check_1_6_disable_sa_key_creation(client, "p").status == "FAIL"
+
+    def test_1_11_kms_admin_plus_crypto_role_fails(self):
+        crm = MagicMock()
+        policy = MagicMock()
+        policy.bindings = [
+            _binding("roles/cloudkms.admin", ["user:bob@x.com"]),
+            _binding("roles/cloudkms.cryptoKeyEncrypterDecrypter", ["user:bob@x.com"]),
+        ]
+        crm.get_iam_policy.return_value = policy
+        f = _CHECKS.check_1_11_separation_kms(crm, "p")
+        assert f.status == "FAIL"
+        assert any("bob" in r for r in f.resources)
+
+    def test_1_11_admin_only_passes(self):
+        crm = MagicMock()
+        policy = MagicMock()
+        policy.bindings = [
+            _binding("roles/cloudkms.admin", ["user:bob@x.com"]),
+        ]
+        crm.get_iam_policy.return_value = policy
+        assert _CHECKS.check_1_11_separation_kms(crm, "p").status == "PASS"
+
+    def test_1_12_public_kms_key_fails(self):
+        kms = MagicMock()
+        ring = MagicMock()
+        ring.name = "projects/p/locations/us/keyRings/r"
+        kms.list_key_rings.return_value = [ring]
+        key = MagicMock()
+        key.name = "projects/p/locations/us/keyRings/r/cryptoKeys/k1"
+        kms.list_crypto_keys.return_value = [key]
+        binding = MagicMock()
+        binding.members = ["allUsers"]
+        policy = MagicMock()
+        policy.bindings = [binding]
+        kms.get_iam_policy.return_value = policy
+        f = _CHECKS.check_1_12_kms_keys_not_public(kms, "p")
+        assert f.status == "FAIL"
+        assert "k1" in f.resources[0]
+
+    def test_1_12_private_kms_key_passes(self):
+        kms = MagicMock()
+        ring = MagicMock()
+        ring.name = "projects/p/locations/us/keyRings/r"
+        kms.list_key_rings.return_value = [ring]
+        key = MagicMock()
+        key.name = "projects/p/locations/us/keyRings/r/cryptoKeys/k1"
+        kms.list_crypto_keys.return_value = [key]
+        binding = MagicMock()
+        binding.members = ["user:owner@x.com"]
+        policy = MagicMock()
+        policy.bindings = [binding]
+        kms.get_iam_policy.return_value = policy
+        assert _CHECKS.check_1_12_kms_keys_not_public(kms, "p").status == "PASS"
+
+    def test_1_13_unrestricted_api_key_fails(self):
+        client = MagicMock()
+        key = MagicMock()
+        key.name = "projects/p/locations/global/keys/abc"
+        key.display_name = "abc"
+        key.restrictions = None
+        client.list_keys.return_value = [key]
+        f = _CHECKS.check_1_13_api_keys_restricted(client, "p")
+        assert f.status == "FAIL"
+        assert "abc" in f.resources
+
+    def test_1_13_restricted_api_key_passes(self):
+        client = MagicMock()
+        key = MagicMock()
+        key.name = "projects/p/locations/global/keys/abc"
+        key.display_name = "abc"
+        restrictions = MagicMock()
+        restrictions.api_targets = [MagicMock()]
+        restrictions.browser_key_restrictions = MagicMock()
+        restrictions.server_key_restrictions = None
+        restrictions.android_key_restrictions = None
+        restrictions.ios_key_restrictions = None
+        key.restrictions = restrictions
+        client.list_keys.return_value = [key]
+        assert _CHECKS.check_1_13_api_keys_restricted(client, "p").status == "PASS"
+
+    def test_1_14_missing_categories_fails(self):
+        client = MagicMock()
+        contact = MagicMock()
+        contact.notification_category_subscriptions = ["SECURITY"]
+        client.list_contacts.return_value = [contact]
+        f = _CHECKS.check_1_14_essential_contacts(client, "p")
+        assert f.status == "FAIL"
+        assert {"TECHNICAL", "LEGAL", "SUSPENSION"}.issubset(set(f.resources))
+
+    def test_1_14_all_categories_present_passes(self):
+        client = MagicMock()
+        contact = MagicMock()
+        contact.notification_category_subscriptions = [
+            "SECURITY",
+            "TECHNICAL",
+            "LEGAL",
+            "SUSPENSION",
+        ]
+        client.list_contacts.return_value = [contact]
+        assert _CHECKS.check_1_14_essential_contacts(client, "p").status == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# New Logging checks (2.2, 2.4, 2.7, 2.10, 2.13)
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingMonitoring:
+    def test_2_2_catch_all_sink_passes(self):
+        client = MagicMock()
+        sink = MagicMock()
+        sink.filter = ""
+        sink.destination = "storage.googleapis.com/bkt"
+        client.list_sinks.return_value = [sink]
+        f = _CHECKS.check_2_2_log_sink_configured(client, "p")
+        assert f.status == "PASS"
+        assert "bkt" in f.resources[0]
+
+    def test_2_2_only_filtered_sinks_fails(self):
+        client = MagicMock()
+        sink = MagicMock()
+        sink.filter = "severity>=ERROR"
+        sink.destination = "storage.googleapis.com/bkt"
+        client.list_sinks.return_value = [sink]
+        assert _CHECKS.check_2_2_log_sink_configured(client, "p").status == "FAIL"
+
+    def test_2_4_metric_present_passes(self):
+        client = MagicMock()
+        m = MagicMock()
+        m.filter = "protoPayload.methodName=\"SetIamPolicy\""
+        client.list_log_metrics.return_value = [m]
+        assert _CHECKS.check_2_4_log_metric_project_ownership(client, "p").status == "PASS"
+
+    def test_2_4_metric_missing_fails(self):
+        client = MagicMock()
+        client.list_log_metrics.return_value = []
+        assert _CHECKS.check_2_4_log_metric_project_ownership(client, "p").status == "FAIL"
+
+    def test_2_7_vpc_metric_present_passes(self):
+        client = MagicMock()
+        m = MagicMock()
+        m.filter = "resource.type=\"compute.networks\""
+        client.list_log_metrics.return_value = [m]
+        assert _CHECKS.check_2_7_log_metric_vpc_changes(client, "p").status == "PASS"
+
+    def test_2_7_vpc_metric_missing_fails(self):
+        client = MagicMock()
+        client.list_log_metrics.return_value = []
+        assert _CHECKS.check_2_7_log_metric_vpc_changes(client, "p").status == "FAIL"
+
+    def test_2_10_audit_metric_present_passes(self):
+        client = MagicMock()
+        m = MagicMock()
+        m.filter = "protoPayload.serviceData.policyDelta.auditConfigDeltas.AuditConfig"
+        client.list_log_metrics.return_value = [m]
+        assert _CHECKS.check_2_10_log_metric_audit_config(client, "p").status == "PASS"
+
+    def test_2_10_audit_metric_missing_fails(self):
+        client = MagicMock()
+        client.list_log_metrics.return_value = []
+        assert _CHECKS.check_2_10_log_metric_audit_config(client, "p").status == "FAIL"
+
+    def test_2_13_asset_inventory_reachable_passes(self):
+        client = MagicMock()
+        client.list_assets.return_value = iter([])
+        assert _CHECKS.check_2_13_cloud_asset_inventory(client, "p").status == "PASS"
+
+    def test_2_13_asset_inventory_error_fails(self):
+        client = MagicMock()
+        client.list_assets.side_effect = RuntimeError("Permission denied")
+        f = _CHECKS.check_2_13_cloud_asset_inventory(client, "p")
+        assert f.status == "FAIL"
+        assert "Permission denied" in f.detail
+
+
+# ---------------------------------------------------------------------------
+# New Networking checks (3.10)
+# ---------------------------------------------------------------------------
+
+
+class TestDNSLogging:
+    def test_3_10_unlogged_policy_fails(self):
+        dns = MagicMock()
+        p = MagicMock()
+        p.name = "policy-1"
+        p.enable_logging = False
+        dns.list.return_value = [p]
+        f = _CHECKS.check_3_10_dns_logging(dns, "p")
+        assert f.status == "FAIL"
+        assert f.resources == ["policy-1"]
+
+    def test_3_10_logged_policy_passes(self):
+        dns = MagicMock()
+        p = MagicMock()
+        p.name = "policy-1"
+        p.enable_logging = True
+        dns.list.return_value = [p]
+        assert _CHECKS.check_3_10_dns_logging(dns, "p").status == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# New Compute checks (4.5, 4.6, 4.7, 4.8)
+# ---------------------------------------------------------------------------
+
+
+def _instance(name, **attrs):
+    inst = MagicMock()
+    inst.name = name
+    for k, v in attrs.items():
+        setattr(inst, k, v)
+    return inst
+
+
+def _aggregated(zone, instances):
+    scoped = MagicMock()
+    scoped.instances = instances
+    return [(zone, scoped)]
+
+
+class TestComputeChecks:
+    def test_4_5_unblocked_ssh_fails(self):
+        compute = MagicMock()
+        item = MagicMock()
+        item.key = "block-project-ssh-keys"
+        item.value = "false"
+        meta = MagicMock()
+        meta.items = [item]
+        inst = _instance("vm-1", metadata=meta)
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        f = _CHECKS.check_4_5_block_project_wide_ssh(compute, "p")
+        assert f.status == "FAIL"
+        assert "vm-1" in f.resources[0]
+
+    def test_4_5_blocked_ssh_passes(self):
+        compute = MagicMock()
+        item = MagicMock()
+        item.key = "block-project-ssh-keys"
+        item.value = "true"
+        meta = MagicMock()
+        meta.items = [item]
+        inst = _instance("vm-1", metadata=meta)
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_5_block_project_wide_ssh(compute, "p").status == "PASS"
+
+    def test_4_6_no_confidential_compute_fails(self):
+        compute = MagicMock()
+        cc = MagicMock()
+        cc.enable_confidential_compute = False
+        inst = _instance("vm-1", confidential_instance_config=cc)
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_6_confidential_vm(compute, "p").status == "FAIL"
+
+    def test_4_6_confidential_compute_passes(self):
+        compute = MagicMock()
+        cc = MagicMock()
+        cc.enable_confidential_compute = True
+        inst = _instance("vm-1", confidential_instance_config=cc)
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_6_confidential_vm(compute, "p").status == "PASS"
+
+    def test_4_7_missing_vtpm_fails(self):
+        compute = MagicMock()
+        cfg = MagicMock()
+        cfg.enable_vtpm = False
+        cfg.enable_integrity_monitoring = True
+        inst = _instance("vm-1", shielded_instance_config=cfg)
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_7_shielded_vm(compute, "p").status == "FAIL"
+
+    def test_4_7_full_shielded_vm_passes(self):
+        compute = MagicMock()
+        cfg = MagicMock()
+        cfg.enable_vtpm = True
+        cfg.enable_integrity_monitoring = True
+        inst = _instance("vm-1", shielded_instance_config=cfg)
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_7_shielded_vm(compute, "p").status == "PASS"
+
+    def test_4_8_disk_without_cmek_fails(self):
+        compute = MagicMock()
+        disk = MagicMock()
+        disk.device_name = "boot"
+        disk.disk_encryption_key = None
+        inst = _instance("vm-1", disks=[disk])
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_8_disk_cmek(compute, "p").status == "FAIL"
+
+    def test_4_8_disk_with_cmek_passes(self):
+        compute = MagicMock()
+        key = MagicMock()
+        key.kms_key_name = "projects/p/locations/us/keyRings/r/cryptoKeys/k"
+        disk = MagicMock()
+        disk.device_name = "boot"
+        disk.disk_encryption_key = key
+        inst = _instance("vm-1", disks=[disk])
+        compute.aggregated_list.return_value = _aggregated("zones/us-c1", [inst])
+        assert _CHECKS.check_4_8_disk_cmek(compute, "p").status == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# New Cloud SQL checks (6.1, 6.4)
+# ---------------------------------------------------------------------------
+
+
+def _sql_instance(name, ipv4_enabled=False, require_ssl=False):
+    inst = MagicMock()
+    inst.name = name
+    settings = MagicMock()
+    ip_cfg = MagicMock()
+    ip_cfg.ipv4_enabled = ipv4_enabled
+    ip_cfg.require_ssl = require_ssl
+    settings.ip_configuration = ip_cfg
+    inst.settings = settings
+    return inst
+
+
+class TestCloudSQLChecks:
+    def test_6_1_public_ip_fails(self):
+        sql = MagicMock()
+        sql.list.return_value = [_sql_instance("db-1", ipv4_enabled=True)]
+        f = _CHECKS.check_6_1_cloudsql_no_public_ip(sql, "p")
+        assert f.status == "FAIL"
+        assert "db-1" in f.resources
+
+    def test_6_1_private_ip_passes(self):
+        sql = MagicMock()
+        sql.list.return_value = [_sql_instance("db-1", ipv4_enabled=False)]
+        assert _CHECKS.check_6_1_cloudsql_no_public_ip(sql, "p").status == "PASS"
+
+    def test_6_4_no_ssl_fails(self):
+        sql = MagicMock()
+        sql.list.return_value = [_sql_instance("db-1", require_ssl=False)]
+        assert _CHECKS.check_6_4_cloudsql_require_ssl(sql, "p").status == "FAIL"
+
+    def test_6_4_ssl_required_passes(self):
+        sql = MagicMock()
+        sql.list.return_value = [_sql_instance("db-1", require_ssl=True)]
+        assert _CHECKS.check_6_4_cloudsql_require_ssl(sql, "p").status == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# New BigQuery checks (7.1, 7.2)
+# ---------------------------------------------------------------------------
+
+
+class TestBigQueryChecks:
+    def _bq_with_dataset(self, dataset):
+        bq = MagicMock()
+        bq.list_datasets.return_value = ["ds-ref"]
+        bq.get_dataset.return_value = dataset
+        return bq
+
+    def test_7_1_public_dataset_fails(self):
+        ds = MagicMock()
+        ds.dataset_id = "public_ds"
+        entry = MagicMock()
+        entry.entity_id = "allUsers"
+        ds.access_entries = [entry]
+        bq = self._bq_with_dataset(ds)
+        f = _CHECKS.check_7_1_bigquery_not_public(bq, "p")
+        assert f.status == "FAIL"
+        assert "public_ds" in f.resources
+
+    def test_7_1_private_dataset_passes(self):
+        ds = MagicMock()
+        ds.dataset_id = "private_ds"
+        entry = MagicMock()
+        entry.entity_id = "user:owner@x.com"
+        ds.access_entries = [entry]
+        bq = self._bq_with_dataset(ds)
+        assert _CHECKS.check_7_1_bigquery_not_public(bq, "p").status == "PASS"
+
+    def test_7_2_no_default_cmek_fails(self):
+        ds = MagicMock()
+        ds.dataset_id = "ds_a"
+        ds.default_encryption_configuration = None
+        bq = self._bq_with_dataset(ds)
+        assert _CHECKS.check_7_2_bigquery_default_cmek(bq, "p").status == "FAIL"
+
+    def test_7_2_default_cmek_passes(self):
+        ds = MagicMock()
+        ds.dataset_id = "ds_a"
+        enc = MagicMock()
+        enc.kms_key_name = "projects/p/locations/us/keyRings/r/cryptoKeys/k"
+        ds.default_encryption_configuration = enc
+        bq = self._bq_with_dataset(ds)
+        assert _CHECKS.check_7_2_bigquery_default_cmek(bq, "p").status == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# Error-branch coverage for new checks
+# ---------------------------------------------------------------------------
+
+
+def test_new_checks_error_branches():
+    crm = MagicMock()
+    crm.get_iam_policy.side_effect = RuntimeError("boom")
+    assert _CHECKS.check_1_5_separation_sa_admin(crm, "p").status == "ERROR"
+    assert _CHECKS.check_1_11_separation_kms(crm, "p").status == "ERROR"
+
+    op = MagicMock()
+    op.get_org_policy.side_effect = RuntimeError("x")
+    assert _CHECKS.check_1_6_disable_sa_key_creation(op, "p").status == "ERROR"
+
+    kms = MagicMock()
+    kms.list_key_rings.side_effect = RuntimeError("x")
+    assert _CHECKS.check_1_12_kms_keys_not_public(kms, "p").status == "ERROR"
+
+    api = MagicMock()
+    api.list_keys.side_effect = RuntimeError("x")
+    assert _CHECKS.check_1_13_api_keys_restricted(api, "p").status == "ERROR"
+
+    contacts = MagicMock()
+    contacts.list_contacts.side_effect = RuntimeError("x")
+    assert _CHECKS.check_1_14_essential_contacts(contacts, "p").status == "ERROR"
+
+    log = MagicMock()
+    log.list_sinks.side_effect = RuntimeError("x")
+    assert _CHECKS.check_2_2_log_sink_configured(log, "p").status == "ERROR"
+    log.list_log_metrics.side_effect = RuntimeError("x")
+    assert _CHECKS.check_2_4_log_metric_project_ownership(log, "p").status == "ERROR"
+    assert _CHECKS.check_2_7_log_metric_vpc_changes(log, "p").status == "ERROR"
+    assert _CHECKS.check_2_10_log_metric_audit_config(log, "p").status == "ERROR"
+
+    dns = MagicMock()
+    dns.list.side_effect = RuntimeError("x")
+    assert _CHECKS.check_3_10_dns_logging(dns, "p").status == "ERROR"
+
+    compute = MagicMock()
+    compute.aggregated_list.side_effect = RuntimeError("x")
+    assert _CHECKS.check_4_5_block_project_wide_ssh(compute, "p").status == "ERROR"
+    assert _CHECKS.check_4_6_confidential_vm(compute, "p").status == "ERROR"
+    assert _CHECKS.check_4_7_shielded_vm(compute, "p").status == "ERROR"
+    assert _CHECKS.check_4_8_disk_cmek(compute, "p").status == "ERROR"
+
+    sql = MagicMock()
+    sql.list.side_effect = RuntimeError("x")
+    assert _CHECKS.check_6_1_cloudsql_no_public_ip(sql, "p").status == "ERROR"
+    assert _CHECKS.check_6_4_cloudsql_require_ssl(sql, "p").status == "ERROR"
+
+    bq = MagicMock()
+    bq.list_datasets.side_effect = RuntimeError("x")
+    assert _CHECKS.check_7_1_bigquery_not_public(bq, "p").status == "ERROR"
+    assert _CHECKS.check_7_2_bigquery_default_cmek(bq, "p").status == "ERROR"

--- a/skills/evaluation/cspm-gcp-cis-benchmark/tests/test_checks_extra.py
+++ b/skills/evaluation/cspm-gcp-cis-benchmark/tests/test_checks_extra.py
@@ -395,6 +395,8 @@ def _install_fake_google_modules(monkeypatch):
     networks_mod.NetworksClient = MagicMock()
     subnetworks_mod = types.ModuleType("google.cloud.compute_v1.services.subnetworks")
     subnetworks_mod.SubnetworksClient = MagicMock()
+    instances_mod = types.ModuleType("google.cloud.compute_v1.services.instances")
+    instances_mod.InstancesClient = MagicMock()
 
     monkeypatch.setitem(sys.modules, "google", google)
     monkeypatch.setitem(sys.modules, "google.cloud", cloud)
@@ -408,12 +410,23 @@ def _install_fake_google_modules(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "google.cloud.compute_v1.services.subnetworks", subnetworks_mod
     )
+    monkeypatch.setitem(
+        sys.modules, "google.cloud.compute_v1.services.instances", instances_mod
+    )
 
 
 def test_run_assessment_full_and_section_filter(monkeypatch):
     _install_fake_google_modules(monkeypatch)
     findings = _CHECKS.run_assessment(project_id="p")
-    assert {f.section for f in findings} == {"iam", "storage", "logging", "networking"}
+    assert {f.section for f in findings} >= {
+        "iam",
+        "storage",
+        "logging",
+        "networking",
+        "compute",
+        "cloudsql",
+        "bigquery",
+    }
     # Section filter
     filtered = _CHECKS.run_assessment(project_id="p", section="iam")
     assert {f.section for f in filtered} == {"iam"}


### PR DESCRIPTION
Closes #434 (sub-track of #254). Lifts CIS GCP Foundations v3 control coverage from 10 / 60 to 30 / 60 — **17% → 50%**, hitting the per-platform target.

## Controls added (20)

- IAM (6): 1.5, 1.6, 1.11, 1.12, 1.13, 1.14
- Logging/Monitoring (5): 2.2, 2.4, 2.7, 2.10, 2.13
- Networking (1): 3.10
- Compute (4): 4.5, 4.6, 4.7, 4.8
- Cloud SQL (2): 6.1, 6.4
- BigQuery (2): 7.1, 7.2

## Skipped (semantic duplicates with already-shipped checks)

- 1.10 rotate user-managed SA keys — overlaps existing `check_1_4_sa_key_rotation`
- 3.6 / 3.7 RDP / SSH from internet — covered by existing `check_4_2_no_unrestricted_ssh_rdp`
- 3.8 VPC Flow Logs — covered by existing `check_4_3_vpc_flow_logs`
- 5.1 anonymous buckets — covered by `check_2_3_no_public_buckets`
- 5.2 uniform bucket access — covered by `check_2_1_uniform_access`

## Test count delta

41 → **82** (+41).

## Validation

- pytest skill suite + repo-wide green (2017 passed)
- ruff clean
- All three regen `--check` gates pass

## SDK gating

Optional GCP SDKs (`orgpolicy_v2`, `kms_v1`, `api_keys_v2`, `essential_contacts_v1`, `logging_v2`, `asset_v1`, `dns_v1`, `sqladmin`, `bigquery`) are imported lazily in `run_assessment`; when missing they surface as `ERROR` findings rather than crashing the runner.