### PR TITLE
ci: parallelise tier-2 + batched doc-regen check + Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   skill-contract:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: lockfile          # parallelised with `lint` and `type-check`; tier-3 jobs still gate on all three
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps
@@ -63,13 +63,25 @@ jobs:
       - run: python scripts/validate_ocsf_metadata.py
       - run: python scripts/validate_skill_count_consistency.py
       - run: python scripts/validate_deny_list_parity.py
-      - run: python scripts/generate_framework_coverage_doc.py --check
-      - run: python scripts/generate_security_bar_matrix.py --check
-      - run: python scripts/coverage_summary.py --check
+      - name: Auto-generated docs in sync (run all generators in --check)
+        run: |
+          set +e
+          python scripts/generate_framework_coverage_doc.py --check; rc1=$?
+          python scripts/generate_security_bar_matrix.py --check;     rc2=$?
+          python scripts/coverage_summary.py --check;                  rc3=$?
+          if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ] || [ $rc3 -ne 0 ]; then
+            echo ""
+            echo "::error::auto-generated docs are stale. Regenerate locally:"
+            echo "::error::  python scripts/generate_framework_coverage_doc.py"
+            echo "::error::  python scripts/generate_security_bar_matrix.py"
+            echo "::error::  python scripts/coverage_summary.py --write"
+            echo "::error::then \`git add docs/FRAMEWORK_COVERAGE.md SECURITY_BAR.md docs/COVERAGE_SNAPSHOT.md\` and commit."
+            exit 1
+          fi
 
   type-check:
     runs-on: ubuntu-latest
-    needs: [lint, skill-contract]
+    needs: lockfile          # parallelised with `lint` and `skill-contract`
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-deps

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+## Convenience targets for contributors. CI does not depend on this
+## file — every command below has a direct shell-script equivalent
+## documented in `CONTRIBUTING.md`.
+
+.PHONY: help docs-regen docs-check validate test ruff
+
+help:
+	@echo "Common targets:"
+	@echo "  make docs-regen  — regenerate every auto-generated doc (run after editing framework-coverage.json or adding a skill)"
+	@echo "  make docs-check  — exit 1 if any auto-generated doc is stale (mirrors the CI gate)"
+	@echo "  make validate    — run every shared validator under scripts/"
+	@echo "  make test        — pytest repo-wide"
+	@echo "  make ruff        — lint everything CI lints"
+
+docs-regen:
+	@echo "Regenerating auto-generated docs..."
+	python scripts/generate_framework_coverage_doc.py
+	python scripts/generate_security_bar_matrix.py
+	python scripts/coverage_summary.py --write
+	@echo ""
+	@echo "Now run \`git status\` and stage any updated files:"
+	@echo "  docs/FRAMEWORK_COVERAGE.md"
+	@echo "  SECURITY_BAR.md"
+	@echo "  docs/COVERAGE_SNAPSHOT.md"
+
+docs-check:
+	@set -e; \
+	python scripts/generate_framework_coverage_doc.py --check; \
+	python scripts/generate_security_bar_matrix.py --check; \
+	python scripts/coverage_summary.py --check
+
+validate:
+	python scripts/validate_skill_contract.py
+	python scripts/validate_skill_integrity.py
+	python scripts/validate_skill_runtime.py
+	python scripts/validate_skill_structure.py
+	python scripts/validate_presets.py
+	python scripts/validate_dependency_consistency.py
+	python scripts/validate_framework_coverage.py
+	python scripts/validate_ocsf_metadata.py
+	python scripts/validate_skill_count_consistency.py
+	python scripts/validate_deny_list_parity.py
+	$(MAKE) docs-check
+
+test:
+	python -m pytest -q --no-header --tb=line
+
+ruff:
+	ruff check skills/ tests/ mcp-server/ scripts/ --config pyproject.toml


### PR DESCRIPTION
Cuts the PR critical path from ~6-8 min to ~3-4 min. Fixes the contributor footgun PR #446 hit (three serial doc-regen failures, three fix cycles).

## What changes

### 1. Parallelise tier-2 jobs

`lint`, `skill-contract`, and `type-check` walk **different scopes**:
- `lint` runs ruff + sqlfluff
- `skill-contract` runs the validator scripts
- `type-check` runs mypy

They had no inter-dependency, but were chained serially. Now each just `needs: lockfile`. Tier-3 (safe-skill-bar + tests) still gates on all three, so a real failure anywhere still blocks the matrix.

### 2. Batched doc-regen check

The three `generate_*.py --check` steps in `skill-contract` are collapsed into one bash step that runs all three and prints a unified self-heal hint when ANY drifts:

```
::error::auto-generated docs are stale. Regenerate locally:
::error::  python scripts/generate_framework_coverage_doc.py
::error::  python scripts/generate_security_bar_matrix.py
::error::  python scripts/coverage_summary.py --write
::error::then `git add docs/FRAMEWORK_COVERAGE.md SECURITY_BAR.md docs/COVERAGE_SNAPSHOT.md` and commit.
```

PR #446 took **three fix-cycles** for this exact reason — the previous shape failed on one generator, then re-failed on the next after the contributor re-pushed.

### 3. Top-level Makefile

```
make docs-regen   regenerate every auto-generated doc
make docs-check   mirror the CI gate locally
make validate     run every scripts/validate_*.py + docs-check
make test         pytest repo-wide
make ruff         CI's lint scope
```

CI doesn't depend on the Makefile — it's contributor convenience only. Mirrors the commands documented in CONTRIBUTING.md.

## Expected effect

| | Before | After |
|---|---:|---:|
| Critical-path serial jobs | 5 (lockfile → lint → contract → type-check → safe-skill-bar) | 2 (lockfile → safe-skill-bar) |
| Doc-regen fail cycles | 1 per generator (3 total) | 1 unified |
| Local doc-regen | 3 separate scripts | `make docs-regen` |
| Wall-clock per PR | ~6-8 min | ~3-4 min (estimated) |

## Test plan

- [x] `yaml.safe_load` parses the new ci.yml
- [x] `make docs-check` clean locally
- [x] `make validate` clean
- [x] `pytest` repo-wide green
- [ ] CI on this PR will be the empirical proof; expect tier-2 jobs to start in parallel after `lockfile`