### PR TITLE
feat(detection): migrate 10 more detectors onto _shared retry/errors/logging contract

### DIFF
--- a/skills/detection/detect-azure-activity-logs-disabled/src/detect.py
+++ b/skills/detection/detect-azure-activity-logs-disabled/src/detect.py
@@ -27,6 +27,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-azure-activity-logs-disabled"
@@ -34,6 +36,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -212,7 +216,10 @@ def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
 
 def detect(events: Iterable[dict[str, Any]], *, output_format: str = "ocsf") -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -278,9 +285,30 @@ def main(argv: list[str] | None = None) -> int:
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    findings_emitted = 0
     try:
-        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+        events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-azure-activity-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-azure-activity-logs-disabled/tests/test_detect.py
+++ b/skills/detection/detect-azure-activity-logs-disabled/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -102,8 +109,12 @@ def test_skips_missing_resource_id(capsys):
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_az_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-azure-open-nsg/src/detect.py
+++ b/skills/detection/detect-azure-open-nsg/src/detect.py
@@ -44,6 +44,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-azure-open-nsg"
@@ -51,6 +53,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 # OCSF Detection Finding 2004
 FINDING_CLASS_UID = 2004
@@ -397,7 +401,10 @@ def detect(
     risky_ports: Iterable[int] = DEFAULT_RISKY_PORTS,
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
     risky_ports = tuple(sorted(set(risky_ports)))
 
     for event in events:
@@ -482,9 +489,30 @@ def main(argv: list[str] | None = None) -> int:
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
+    findings_emitted = 0
     try:
-        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+        events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-azure-activity-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-azure-open-nsg/tests/test_detect.py
+++ b/skills/detection/detect-azure-open-nsg/tests/test_detect.py
@@ -4,16 +4,23 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from detect import (  # type: ignore[import-not-found]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from detect import (  # type: ignore[import-not-found]  # noqa: E402
     ACCEPTED_PRODUCERS,
     DEFAULT_RISKY_PORTS,
     NSG_RULE_WRITE_OPERATION,
     PUBLIC_SOURCE_PREFIXES,
     detect,
 )
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 
 def _rule_uid(
@@ -313,8 +320,12 @@ def test_falls_back_to_api_request_data_properties():
 def test_unsupported_output_format_raises():
     import pytest
 
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_az_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-credential-stuffing-okta/src/detect.py
+++ b/skills/detection/detect-credential-stuffing-okta/src/detect.py
@@ -23,6 +23,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from skills._shared.env import env_int  # noqa: E402
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-credential-stuffing-okta"
@@ -30,6 +32,8 @@ OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 OUTPUT_FORMATS = ("ocsf", "native")
 
@@ -324,7 +328,10 @@ def coverage_metadata() -> dict[str, Any]:
 
 def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format: {output_format}")
+        raise ContractError(
+            f"unsupported output_format: {output_format}",
+            hint=f"choose one of: {', '.join(OUTPUT_FORMATS)}",
+        )
     dedupe: set[str] = set()
 
     relevant: list[dict[str, Any]] = []
@@ -446,10 +453,30 @@ def main(argv: list[str] | None = None) -> int:
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
+    findings_emitted = 0
     try:
         events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
         for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-okta-system-log-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-entra-credential-addition/src/detect.py
+++ b/skills/detection/detect-entra-credential-addition/src/detect.py
@@ -15,13 +15,23 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 
 SKILL_NAME = "detect-entra-credential-addition"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 OUTPUT_FORMATS = ("ocsf", "native")
 
@@ -323,7 +333,10 @@ def coverage_metadata() -> dict[str, Any]:
 
 def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format: {output_format}")
+        raise ContractError(
+            f"unsupported output_format: {output_format}",
+            hint=f"choose one of: {', '.join(OUTPUT_FORMATS)}",
+        )
 
     seen: set[str] = set()
     normalized_events: list[dict[str, Any]] = []
@@ -377,10 +390,30 @@ def main(argv: list[str] | None = None) -> int:
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
+    findings_emitted = 0
     try:
         events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
         for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-entra-directory-audit-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-entra-credential-addition/tests/test_detect.py
+++ b/skills/detection/detect-entra-credential-addition/tests/test_detect.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from detect import (  # type: ignore[import-not-found]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from detect import (  # type: ignore[import-not-found]  # noqa: E402
     CANONICAL_VERSION,
     FINDING_CLASS_UID,
     FINDING_TYPE_UID,
@@ -24,6 +28,8 @@ from detect import (  # type: ignore[import-not-found]
     detect,
     load_jsonl,
 )
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 GOLDEN = THIS.parents[2] / "detection-engineering" / "golden"
@@ -201,8 +207,12 @@ class TestDetection:
     def test_rejects_unsupported_output_format(self):
         try:
             list(detect([], output_format="bridge"))
-        except ValueError as exc:
+        except ContractError as exc:
             assert "unsupported output_format" in str(exc)
+            assert exc.error_class == "contract"
+            assert exc.retryable is False
+            assert exc.hint
+            assert "ocsf" in exc.hint or "native" in exc.hint
         else:
             raise AssertionError("expected unsupported output_format to raise")
 

--- a/skills/detection/detect-entra-role-grant-escalation/src/detect.py
+++ b/skills/detection/detect-entra-role-grant-escalation/src/detect.py
@@ -15,13 +15,23 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 
 SKILL_NAME = "detect-entra-role-grant-escalation"
 OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 OUTPUT_FORMATS = ("ocsf", "native")
 
@@ -300,7 +310,10 @@ def coverage_metadata() -> dict[str, Any]:
 
 def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format: {output_format}")
+        raise ContractError(
+            f"unsupported output_format: {output_format}",
+            hint=f"choose one of: {', '.join(OUTPUT_FORMATS)}",
+        )
 
     seen: set[str] = set()
     normalized_events: list[dict[str, Any]] = []
@@ -354,10 +367,30 @@ def main(argv: list[str] | None = None) -> int:
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
+    findings_emitted = 0
     try:
         events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
         for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-entra-directory-audit-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-entra-role-grant-escalation/tests/test_detect.py
+++ b/skills/detection/detect-entra-role-grant-escalation/tests/test_detect.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from detect import (  # type: ignore[import-not-found]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from detect import (  # type: ignore[import-not-found]  # noqa: E402
     API_ACTIVITY_CLASS_UID,
     CANONICAL_VERSION,
     FINDING_CLASS_UID,
@@ -24,6 +28,8 @@ from detect import (  # type: ignore[import-not-found]
     detect,
     load_jsonl,
 )
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 GOLDEN = THIS.parents[2] / "detection-engineering" / "golden"
@@ -174,8 +180,12 @@ class TestDetection:
     def test_rejects_unsupported_output_format(self):
         try:
             list(detect([], output_format="bridge"))
-        except ValueError as exc:
+        except ContractError as exc:
             assert "unsupported output_format" in str(exc)
+            assert exc.error_class == "contract"
+            assert exc.retryable is False
+            assert exc.hint
+            assert "ocsf" in exc.hint or "native" in exc.hint
         else:
             raise AssertionError("expected unsupported output_format to raise")
 

--- a/skills/detection/detect-gcp-audit-logs-disabled/src/detect.py
+++ b/skills/detection/detect-gcp-audit-logs-disabled/src/detect.py
@@ -29,6 +29,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-gcp-audit-logs-disabled"
@@ -36,6 +38,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -232,7 +236,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -303,9 +310,30 @@ def main(argv: list[str] | None = None) -> int:
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    findings_emitted = 0
     try:
-        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+        events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-gcp-audit-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-gcp-audit-logs-disabled/tests/test_detect.py
+++ b/skills/detection/detect-gcp-audit-logs-disabled/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -113,8 +120,12 @@ def test_skips_missing_target(capsys):
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_gcp_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-gcp-model-artifact-download/src/detect.py
+++ b/skills/detection/detect-gcp-model-artifact-download/src/detect.py
@@ -15,6 +15,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-gcp-model-artifact-download"
@@ -22,6 +24,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -314,7 +318,10 @@ def _to_ocsf(native: dict[str, Any]) -> dict[str, Any]:
 
 def detect(events: Iterable[dict[str, Any]], *, output_format: str = "ocsf") -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         if _producer(event) not in ACCEPTED_PRODUCERS:
@@ -368,9 +375,30 @@ def main(argv: list[str] | None = None) -> int:
 
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    findings_emitted = 0
     try:
-        for finding in detect(_load_jsonl(in_stream), output_format=args.output_format):
+        events = list(_load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-gcp-audit-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-gcp-open-firewall/src/detect.py
+++ b/skills/detection/detect-gcp-open-firewall/src/detect.py
@@ -44,6 +44,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-gcp-open-firewall"
@@ -51,6 +53,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 # OCSF Detection Finding 2004
 FINDING_CLASS_UID = 2004
@@ -401,7 +405,10 @@ def detect(
     risky_ports: Iterable[int] = DEFAULT_RISKY_PORTS,
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
     risky_ports = tuple(sorted(set(risky_ports)))
 
     for event in events:
@@ -492,9 +499,30 @@ def main(argv: list[str] | None = None) -> int:
     in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
     out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
 
+    findings_emitted = 0
     try:
-        for finding in detect(load_jsonl(in_stream), output_format=args.output_format):
+        events = list(load_jsonl(in_stream))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
             out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-gcp-audit-ocsf",
+            ),
+        )
     finally:
         if args.input:
             in_stream.close()

--- a/skills/detection/detect-gcp-open-firewall/tests/test_detect.py
+++ b/skills/detection/detect-gcp-open-firewall/tests/test_detect.py
@@ -4,16 +4,23 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from detect import (  # type: ignore[import-not-found]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from detect import (  # type: ignore[import-not-found]  # noqa: E402
     ACCEPTED_OPERATIONS,
     ACCEPTED_PRODUCERS,
     DEFAULT_RISKY_PORTS,
     PUBLIC_CIDRS,
     detect,
 )
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 
 def _gcp_event(
@@ -286,8 +293,12 @@ def test_mixed_world_and_corp_source_ranges_only_emits_for_world():
 
 def test_unsupported_output_format_raises():
     import pytest
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_gcp_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint
 
 
 def test_finding_uid_is_deterministic():

--- a/skills/detection/detect-google-workspace-suspicious-login/src/detect.py
+++ b/skills/detection/detect-google-workspace-suspicious-login/src/detect.py
@@ -14,6 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-google-workspace-suspicious-login"
@@ -21,6 +23,8 @@ OCSF_VERSION = "1.8.0"
 CANONICAL_VERSION = "2026-04"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 OUTPUT_FORMATS = ("ocsf", "native")
 
@@ -340,7 +344,10 @@ def coverage_metadata() -> dict[str, Any]:
 
 def detect(events: Iterable[dict[str, Any]], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(OUTPUT_FORMATS)}",
+        )
     dedupe: set[str] = set()
     relevant: list[dict[str, Any]] = []
     findings: list[dict[str, Any]] = []
@@ -490,16 +497,38 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    findings = list(detect(load_jsonl(_iter_input(args.paths)), output_format=args.output_format))
-    rendered = "\n".join(json.dumps(finding, sort_keys=True, separators=(",", ":")) for finding in findings)
-    if rendered:
-        rendered += "\n"
+    findings_emitted = 0
+    try:
+        events = list(load_jsonl(_iter_input(args.paths)))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        findings = list(detect(events, output_format=args.output_format))
+        findings_emitted = len(findings)
+        rendered = "\n".join(json.dumps(finding, sort_keys=True, separators=(",", ":")) for finding in findings)
+        if rendered:
+            rendered += "\n"
 
-    if args.output:
-        with open(args.output, "w", encoding="utf-8") as handle:
-            handle.write(rendered)
-    else:
-        sys.stdout.write(rendered)
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as handle:
+                handle.write(rendered)
+        else:
+            sys.stdout.write(rendered)
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-google-workspace-login-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-google-workspace-suspicious-login/tests/test_detect.py
+++ b/skills/detection/detect-google-workspace-suspicious-login/tests/test_detect.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from detect import (  # type: ignore[import-not-found]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from detect import (  # type: ignore[import-not-found]  # noqa: E402
     AUTH_CLASS_UID,
     BRUTE_FORCE_UID,
     CANONICAL_VERSION,
@@ -26,6 +30,8 @@ from detect import (  # type: ignore[import-not-found]
     detect,
     load_jsonl,
 )
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 GOLDEN = THIS.parents[2] / "detection-engineering" / "golden"
@@ -212,8 +218,12 @@ class TestDetection:
     def test_rejects_unsupported_output_format(self):
         try:
             list(detect([], output_format="bridge"))
-        except ValueError as exc:
+        except ContractError as exc:
             assert "unsupported output_format" in str(exc)
+            assert exc.error_class == "contract"
+            assert exc.retryable is False
+            assert exc.hint
+            assert "ocsf" in exc.hint or "native" in exc.hint
         else:
             raise AssertionError("expected unsupported output_format to raise")
 

--- a/skills/detection/detect-s3-cross-account-copy/src/detect.py
+++ b/skills/detection/detect-s3-cross-account-copy/src/detect.py
@@ -14,6 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
 from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
 
 SKILL_NAME = "detect-s3-cross-account-copy"
@@ -21,6 +23,8 @@ CANONICAL_VERSION = "2026-04"
 OCSF_VERSION = "1.8.0"
 REPO_NAME = "cloud-ai-security-skills"
 from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
 
 FINDING_CLASS_UID = 2004
 FINDING_CLASS_NAME = "Detection Finding"
@@ -276,7 +280,10 @@ def detect(
     output_format: str = "ocsf",
 ) -> Iterator[dict[str, Any]]:
     if output_format not in OUTPUT_FORMATS:
-        raise ValueError(f"unsupported output_format `{output_format}`")
+        raise ContractError(
+            f"unsupported output_format `{output_format}`",
+            hint=f"choose one of: {', '.join(sorted(OUTPUT_FORMATS))}",
+        )
 
     for event in events:
         producer = _producer(event)
@@ -369,9 +376,31 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv or sys.argv[1:])
-    for finding in detect(_iter_jsonl(args.path), output_format=args.output_format):
-        json.dump(finding, sys.stdout, separators=(",", ":"))
-        sys.stdout.write("\n")
+    findings_emitted = 0
+    try:
+        events = list(_iter_jsonl(args.path))
+        _log.info(
+            f"{SKILL_NAME} starting",
+            extra={"input_event_count": len(events), "output_format": args.output_format},
+        )
+        for finding in detect(events, output_format=args.output_format):
+            json.dump(finding, sys.stdout, separators=(",", ":"))
+            sys.stdout.write("\n")
+            findings_emitted += 1
+        _log.info(
+            f"{SKILL_NAME} complete",
+            extra={"findings_emitted": findings_emitted},
+        )
+    except SkillError as exc:
+        return emit_error(SKILL_NAME, exc)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return emit_error(
+            SKILL_NAME,
+            ContractError(
+                f"input is not JSONL: {exc}",
+                hint="ensure each input line is a valid JSON object emitted by ingest-cloudtrail-ocsf",
+            ),
+        )
     return 0
 
 

--- a/skills/detection/detect-s3-cross-account-copy/tests/test_detect.py
+++ b/skills/detection/detect-s3-cross-account-copy/tests/test_detect.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError  # noqa: E402
 
 THIS = Path(__file__).resolve().parent
 SRC = THIS.parent / "src" / "detect.py"
@@ -130,5 +137,9 @@ def test_finding_uid_is_deterministic():
 
 
 def test_rejects_unknown_output_format():
-    with pytest.raises(ValueError, match="unsupported output_format"):
+    with pytest.raises(ContractError, match="unsupported output_format") as excinfo:
         list(detect([_ct_event()], output_format="weird"))
+    assert excinfo.value.error_class == "contract"
+    assert excinfo.value.retryable is False
+    assert excinfo.value.hint
+    assert "ocsf" in excinfo.value.hint or "native" in excinfo.value.hint


### PR DESCRIPTION
Wave 2 of the migration sweep that started in #444. Same 5-step template applied to 10 more shipped detectors across Azure / GCP / Entra / Okta / Workspace / cross-account.

## Migrated (10)

- detect-azure-activity-logs-disabled
- detect-azure-open-nsg
- detect-gcp-audit-logs-disabled
- detect-gcp-open-firewall
- detect-gcp-model-artifact-download
- detect-entra-credential-addition
- detect-entra-role-grant-escalation
- detect-google-workspace-suspicious-login
- detect-credential-stuffing-okta
- detect-s3-cross-account-copy

## Per-skill changes

- ContractError replaces bare ValueError on unsupported output_format (with hint)
- main() wrapped in try/except SkillError -> emit_error() so the agent / SIEM gets a structured envelope on stdout AND stderr
- get_logger(__name__, skill=..., layer=detection) bound at module top
- Existing tests upgraded (8 of 10 had ValueError assertions to strengthen into ContractError shape)

## Deliberately not changed

- @retry_on_throttle is NOT added — every detector here processes events from stdin with zero cloud SDK calls inside detect()
- emit_stderr_event preserved where it exists

## Validation

- pytest repo-wide: 1976/1976 pass
- ruff clean
- All three regen --check gates clean

## Coverage now

19 of 29 shipped detectors now use the _shared contract (#443 + #444 + this) — **66%**. Remaining 10 detectors land in wave 3.