### PR TITLE
release: v0.9.0 — agentic posture, coverage depth, sandboxing, two new diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,54 @@ The format is loosely based on Keep a Changelog.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-10 — Agentic posture: trust contract, coverage depth, sandboxing
+
+Skills count on `main`: **79** (15 ingest, 5 discover, 32 detect, 7 evaluate,
+12 remediate, 2 view, 3 output, 3 sources). Three new web-app detectors land
+the first OWASP Top 10 coverage; CIS depth hits the 50%-per-platform target on
+all three clouds; the sandboxing umbrella closes; the cross-cutting reliability
+contract is shipped + exercised on 19 of 32 detectors.
+
+### Coverage milestones
+
+- **CIS AWS Foundations v3**: 20 → 29 controls = **50%** (#445, closes #432)
+- **CIS Azure Foundations v2.1**: 8 → 32 controls = **53%** (#448, closes #433)
+- **CIS GCP Foundations v3**: 10 → 30 controls = **50%** (#449, closes #434)
+- **OWASP Top 10**: 0 → 30% (#446, closes #431) — A01 broken access control · A03 injection · A07 auth failures
+- **#254** umbrella per-platform CIS target: hit across all three clouds
+
+### Added
+
+- **Cross-cutting reliability contract** (#437, closes #429). `skills/_shared/{retry,errors,logging}.py`. Bounded exponential-backoff retry with hard floors / ceilings, `SkillError` hierarchy + `emit_error()` envelope, JSON-formatted structured logger that propagates `SKILL_CORRELATION_ID`. Migrated onto 19 detectors (#443, #444, #451).
+- **Sandboxing umbrella closed** (#427).
+  - Layer 1 — container hardening (#438): non-root UID 65532, read-only rootfs, `--cap-drop=ALL`, `no-new-privileges`, default seccomp. Helm chart + hardened Dockerfile for both webhook receiver and MCP server.
+  - Layer 2 — opt-in OS sandbox (#447): `bwrap` (Linux) / `sandbox-exec` (macOS), per-skill profile derived from SKILL.md `network_egress`. Off by default; `CLOUD_SECURITY_MCP_SANDBOX=on`.
+  - Layer 3 — RLIMIT enforcement (#428): `RLIMIT_AS` 1 GB · `RLIMIT_FSIZE` 100 MB · `RLIMIT_CPU` mirrors wrapper timeout. Always-on for every skill subprocess.
+- **Durable HMAC-chained audit** (#410, closes #396). One JSONL record per resolved tool call; `prev_hash` + `chain_hash` keyed by `CLOUD_SECURITY_AUDIT_HMAC_KEY`; tamper-evident. New `scripts/verify_audit_chain.py`.
+- **MCP wrapper hardening** (#424, closes #413 #414). `additionalProperties: false` on context objects; structured tool annotations replace the description blob (`category`, `capability`, `approvalModel`, `executionModes`, `sideEffects`, `inputFormats`, `outputFormats`, `networkEgress`, `callerRoles`, `approverRoles`, `minApprovers`).
+- **Webhook receiver runner** (#426, closes #425). FastAPI app, default-deny routing, per-skill HMAC + bearer auth, sink fan-out to S3 / Snowflake / ClickHouse. Hardened image + Helm chart.
+- **Python SDK shim** (#439). `skills/_shared/library.py` lets external Python apps call shipped skills as functions with the same trust controls.
+- **Persistent worker pool** (#452, closes #416). Opt-in via `CLOUD_SECURITY_MCP_WORKER_POOL=on`; one warm interpreter per skill; idle TTL + output-overflow kill. ~10× cold-start savings on CSPM benchmark walks.
+- **Skill composition contract** (#422). `docs/SKILL_COMPOSITION.md` + four shipped presets (`presets/preset-*.json`) + reference workflow under `examples/workflows/`.
+- **Harness doc** (#439). `docs/HARNESS.md` indexes the five customization surfaces, pins the scope boundary, and traces every Anthropic-published recommendation to the in-repo file that satisfies it.
+- **Three Mermaid diagrams** (#442, closes #418). `docs/diagrams/`: MCP trust boundary · multi-agent topology · pipeline blast radius.
+- **Auto-generated coverage snapshot** (#430). `docs/COVERAGE_SNAPSHOT.md` regenerable from `framework-coverage.json`; CI gate refuses drift.
+- **Per-framework control coverage** (#441). Depth metric (covered control IDs / framework total), not skill count proxy.
+- **76 → 79 MCP-callable skills** (#411). Top-level `handler.py` shims for the three `iam-departures-*` remediation skills closed the README's "76 shipped" overclaim.
+
+### CI / DX
+
+- **Tier-2 jobs parallelised** (#450). `lint` / `skill-contract` / `type-check` no longer chain serially. Critical-path PRs ~6-8 min → ~3-4 min.
+- **Batched doc-regen check** with a unified self-heal hint. Top-level `Makefile` with `make docs-regen` / `docs-check` / `validate` / `test` / `ruff`.
+- **Structural validator** (#412) — fails closed on stale or half-built skill subtrees.
+- **Behavioral skill-runtime validator** (#409) — every shipped skill imports cleanly. Coverage floors 80% global + per-layer.
+- **Preset CI gate** (#422) — `scripts/validate_presets.py` refuses any preset referencing a skill that does not ship.
+
+### README
+
+- Tightened to leading-OSS shape (#440, Langfuse / ClickHouse pattern). 339 → 150 lines. Quickstart promoted above architecture; Trust Posture replaces three prose paragraphs with one eight-row table.
+- Hero banner refresh (#421, #423) — new wordmark "agentic security skills for cloud and AI", framework pills extended to MITRE ATT&CK / ATLAS / OWASP Top 10 / OWASP LLM Top 10.
+
 ## [0.8.1] — 2026-04-24 — Freeze hardening and release sweep fix
 
 Skills count on `main`: **73** (15 ingest, 5 discover, 26 detect, 7 evaluate,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.8.1-0ea5e9"></a>
+  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.9.0-0ea5e9"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache_2.0-blue"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11+-blue"></a>
   <a href="https://schema.ocsf.io/1.8.0"><img alt="OCSF 1.8" src="https://img.shields.io/badge/OCSF-1.8-22d3ee"></a>
@@ -12,7 +12,7 @@
   <a href="https://github.com/msaad00/agent-bom"><img alt="Scanned by agent-bom" src="https://img.shields.io/badge/scanned_by-agent--bom-164e63"></a>
 </p>
 
-<p align="center"><strong>76 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, runs everywhere the same bundle can.</strong></p>
+<p align="center"><strong>79 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed, runs everywhere the same bundle can.</strong></p>
 
 ---
 
@@ -63,6 +63,14 @@ External signals enter through two intake layers, pass through two analyze layer
 ![Clean architecture layers diagram — signals feed intake, analyze, act, and persist stages across the seven shipped skill layers.](docs/images/architecture-layers.svg)
 
 ![Clean runtime surfaces diagram — MCP, CLI, CI, and cloud runners all invoke the same shared skill bundle.](docs/images/runtime-surfaces.svg)
+
+More visuals (Mermaid sources under [`docs/diagrams/`](docs/diagrams/), GitHub renders inline):
+
+- [`skill-hierarchy.mmd`](docs/diagrams/skill-hierarchy.mmd) — every shipped layer × every shipped skill, grouped by sub-domain (AWS / GCP / Azure / Identity / K8s / AI-MCP / Web)
+- [`surface-comparison.mmd`](docs/diagrams/surface-comparison.mmd) — the six shipped surfaces (CLI · CI · MCP · webhook · library · runners) and the eight trust controls behind every one
+- [`pipeline-blast-radius.mmd`](docs/diagrams/pipeline-blast-radius.mmd) — colour-coded by capability so the trust boundary is visible at a glance
+- [`mcp-trust-boundary.mmd`](docs/diagrams/mcp-trust-boundary.mmd) — wrapper lifecycle sequence (every guard, every short-circuit branch)
+- [`agent-topology.mmd`](docs/diagrams/agent-topology.mmd) — local stdio clients vs remote / HTTP / library / runner
 
 Deeper reads: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · [`docs/HARNESS.md`](docs/HARNESS.md) · [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) · [`docs/SKILL_COMPOSITION.md`](docs/SKILL_COMPOSITION.md)
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -17,6 +17,8 @@ mmdc -i docs/diagrams/<name>.mmd -o docs/images/<name>.svg -t dark -b transparen
 | [`mcp-trust-boundary.mmd`](mcp-trust-boundary.mmd) | sequence of: agent → MCP wrapper → guards → skill subprocess → audit log; including the dry-run / HITL / `min_approvers` short-circuit branches | `docs/MCP_AUDIT_CONTRACT.md`, `docs/HARNESS.md` |
 | [`agent-topology.mmd`](agent-topology.mmd) | local stdio clients (Claude Code/Desktop, Cursor, Windsurf, Codex, Cortex, Zed) vs remote / HTTP clients (Claude.ai web, runners, GitHub Actions); shared registry behind both surfaces | `docs/HARNESS.md`, `docs/integrations/README.md` |
 | [`pipeline-blast-radius.mmd`](pipeline-blast-radius.mmd) | data flowing left-to-right with each layer colour-coded by capability — read-only ingest/discover/detect/evaluate, HITL-gated remediate, write-only sink — so the trust boundary is visible at a glance | `docs/ARCHITECTURE.md`, `README.md` |
+| [`skill-hierarchy.mmd`](skill-hierarchy.mmd) | every shipped layer × every shipped skill, grouped by sub-domain (AWS / GCP / Azure / Identity / K8s / MCP / Web). Renders the full 79-skill surface in one picture | `docs/ARCHITECTURE.md`, `README.md` |
+| [`surface-comparison.mmd`](surface-comparison.mmd) | the six shipped surfaces (CLI · CI · MCP · webhook · library · runners) with the eight trust controls and the shared registry that sits behind every one | `docs/HARNESS.md`, `README.md` |
 
 ## Authoring rules
 

--- a/docs/diagrams/skill-hierarchy.mmd
+++ b/docs/diagrams/skill-hierarchy.mmd
@@ -1,0 +1,159 @@
+%% Skill hierarchy — every layer × every shipped skill, with arrows
+%% showing which OCSF / native streams flow between them. Read this
+%% with docs/ARCHITECTURE.md §3 (Layer model) and the per-layer
+%% trust-boundary colour key from pipeline-blast-radius.mmd.
+flowchart TB
+  classDef intake fill:#0f1d36,stroke:#3b82f6,color:#dbeafe
+  classDef analyze fill:#0f2a28,stroke:#2dd4bf,color:#d1fae5
+  classDef act fill:#2a1708,stroke:#f59e0b,color:#fef3c7
+  classDef write fill:#2a0b1e,stroke:#ef4444,color:#fca5a5
+  classDef sink fill:#1f142e,stroke:#a78bfa,color:#ede9fe
+  classDef view fill:#11202c,stroke:#0ea5e9,color:#bae6fd
+  classDef discover fill:#142036,stroke:#60a5fa,color:#dbeafe
+  classDef raw fill:#0f172a,stroke:#475569,color:#f8fafc
+
+  RAW[("raw payloads<br/>vendor-native logs")]:::raw
+
+  subgraph L0["L0 · Sources"]
+    direction LR
+    src_s3["source-s3-select"]:::intake
+    src_sf["source-snowflake-query"]:::intake
+    src_db["source-databricks-query"]:::intake
+  end
+
+  subgraph L1["L1 · Ingest · 15 skills · raw → OCSF 1.8"]
+    direction LR
+    i_ct["ingest-cloudtrail-ocsf"]:::intake
+    i_vpc_aws["ingest-vpc-flow-logs-ocsf"]:::intake
+    i_vpc_gcp["ingest-vpc-flow-logs-gcp-ocsf"]:::intake
+    i_nsg["ingest-nsg-flow-logs-azure-ocsf"]:::intake
+    i_gd["ingest-guardduty-ocsf"]:::intake
+    i_sh["ingest-security-hub-ocsf"]:::intake
+    i_scc["ingest-gcp-scc-ocsf"]:::intake
+    i_def["ingest-azure-defender-for-cloud-ocsf"]:::intake
+    i_gcp["ingest-gcp-audit-ocsf"]:::intake
+    i_az["ingest-azure-activity-ocsf"]:::intake
+    i_entra["ingest-entra-directory-audit-ocsf"]:::intake
+    i_okta["ingest-okta-system-log-ocsf"]:::intake
+    i_gws["ingest-google-workspace-login-ocsf"]:::intake
+    i_k8s["ingest-k8s-audit-ocsf"]:::intake
+    i_mcp["ingest-mcp-proxy-ocsf"]:::intake
+  end
+
+  subgraph L2["L2 · Discover · 5 skills · live posture / inventory"]
+    direction LR
+    d_aibom["discover-ai-bom"]:::discover
+    d_cce["discover-cloud-control-evidence"]:::discover
+    d_ce["discover-control-evidence"]:::discover
+    d_env["discover-environment"]:::discover
+    d_iam["iam-departures-reconciler"]:::discover
+  end
+
+  subgraph L3["L3 · Detect · 32 skills · OCSF Detection Finding 2004"]
+    direction TB
+    subgraph L3aws["AWS"]
+      direction LR
+      d_aws_ak["aws-access-key-creation"]:::analyze
+      d_aws_lp["aws-login-profile-creation"]:::analyze
+      d_aws_eb["aws-enumeration-burst"]:::analyze
+      d_aws_sg["aws-open-security-group"]:::analyze
+      d_aws_ma["aws-model-artifact-download"]:::analyze
+      d_aws_ct["cloudtrail-disabled"]:::analyze
+      d_aws_s3["s3-cross-account-copy"]:::analyze
+    end
+    subgraph L3gcp["GCP"]
+      direction LR
+      d_gcp_au["gcp-audit-logs-disabled"]:::analyze
+      d_gcp_fw["gcp-open-firewall"]:::analyze
+      d_gcp_sa["gcp-service-account-key-creation"]:::analyze
+      d_gcp_tk["gcp-service-account-token-minting"]:::analyze
+      d_gcp_ma["gcp-model-artifact-download"]:::analyze
+    end
+    subgraph L3az["Azure / Entra"]
+      direction LR
+      d_az_al["azure-activity-logs-disabled"]:::analyze
+      d_az_ng["azure-open-nsg"]:::analyze
+      d_en_cred["entra-credential-addition"]:::analyze
+      d_en_role["entra-role-grant-escalation"]:::analyze
+    end
+    subgraph L3id["Identity / SaaS"]
+      direction LR
+      d_okta_mfa["okta-mfa-fatigue"]:::analyze
+      d_okta_cs["credential-stuffing-okta"]:::analyze
+      d_gws_login["google-workspace-suspicious-login"]:::analyze
+    end
+    subgraph L3k8s["Kubernetes"]
+      direction LR
+      d_k8s_pe["privilege-escalation-k8s"]:::analyze
+      d_k8s_ce["container-escape-k8s"]:::analyze
+      d_k8s_sec["sensitive-secret-read-k8s"]:::analyze
+      d_lat["lateral-movement"]:::analyze
+    end
+    subgraph L3mcp["AI / MCP runtime"]
+      direction LR
+      d_mcp_pi["prompt-injection-mcp-proxy"]:::analyze
+      d_mcp_td["mcp-tool-drift"]:::analyze
+      d_mcp_cl["agent-credential-leak-mcp"]:::analyze
+      d_mcp_sp["system-prompt-extraction"]:::analyze
+      d_mcp_ex["tool-output-exfiltration-instructions"]:::analyze
+      d_mcp_pb["tool-output-policy-bypass"]:::analyze
+    end
+    subgraph L3web["Web / OWASP"]
+      direction LR
+      d_web_ac["web-broken-access-control"]:::analyze
+      d_web_inj["web-injection"]:::analyze
+      d_web_auth["web-auth-failures"]:::analyze
+    end
+  end
+
+  subgraph L4["L4 · Evaluate · 7 skills · CIS / NIST / SOC 2 posture"]
+    direction LR
+    e_aws["cspm-aws-cis-benchmark<br/>29 / 58 controls"]:::analyze
+    e_az["cspm-azure-cis-benchmark<br/>32 / 60 controls"]:::analyze
+    e_gcp["cspm-gcp-cis-benchmark<br/>30 / 60 controls"]:::analyze
+    e_k8s["k8s-security-benchmark"]:::analyze
+    e_cont["container-security"]:::analyze
+    e_gpu["gpu-cluster-security"]:::analyze
+    e_mod["model-serving-security"]:::analyze
+  end
+
+  subgraph L5["L5 · Remediate · 12 guarded write paths · HITL gated"]
+    direction LR
+    r_iam_aws["iam-departures-aws"]:::write
+    r_iam_az["iam-departures-azure-entra"]:::write
+    r_iam_gcp["iam-departures-gcp"]:::write
+    r_aws_sg["remediate-aws-sg-revoke"]:::write
+    r_az_nsg["remediate-azure-nsg-revoke"]:::write
+    r_gcp_fw["remediate-gcp-firewall-revoke"]:::write
+    r_okta["remediate-okta-session-kill"]:::write
+    r_gws["remediate-workspace-session-kill"]:::write
+    r_entra["remediate-entra-credential-revoke"]:::write
+    r_k8s_ce["remediate-container-escape-k8s"]:::write
+    r_k8s_rb["remediate-k8s-rbac-revoke"]:::write
+    r_mcp["remediate-mcp-tool-quarantine"]:::write
+  end
+
+  subgraph L6["L6 · View · 2 · OCSF → review formats"]
+    direction LR
+    v_sarif["convert-ocsf-to-sarif"]:::view
+    v_mmd["convert-ocsf-to-mermaid-attack-flow"]:::view
+  end
+
+  subgraph L7["L7 · Output · 3 sinks · append-only persistence"]
+    direction LR
+    s_s3["sink-s3-jsonl"]:::sink
+    s_sf["sink-snowflake-jsonl"]:::sink
+    s_ch["sink-clickhouse-jsonl"]:::sink
+  end
+
+  RAW --> L1
+  L0 --> L1
+  L1 --> L3
+  L2 --> L4
+  L2 --> L5
+  L3 --> L6
+  L3 --> L7
+  L3 --> L5
+  L4 --> L7
+  L4 --> L5
+  L5 --> L7

--- a/docs/diagrams/surface-comparison.mmd
+++ b/docs/diagrams/surface-comparison.mmd
@@ -1,0 +1,48 @@
+%% Surface comparison — six shipped surfaces with the same skill bundle
+%% behind every one. Each surface adds its own transport + auth +
+%% guardrail layer; every column converges at the SkillSpec registry
+%% and the 79 atomic skills below it.
+flowchart TD
+  classDef surface fill:#0f1d36,stroke:#3b82f6,color:#dbeafe
+  classDef control fill:#1f142e,stroke:#a78bfa,color:#ede9fe
+  classDef registry fill:#312e81,stroke:#a78bfa,color:#ede9fe
+  classDef skills fill:#0f172a,stroke:#475569,color:#f8fafc
+  classDef gate fill:#2a1708,stroke:#f59e0b,color:#fef3c7
+
+  subgraph SURFACES["Six surfaces · same SKILL.md + src/ + tests/"]
+    direction LR
+    cli["CLI / pipes<br/>python skills/&lt;x&gt;/&lt;y&gt;/src/&lt;entry&gt;.py<br/>local user trust"]:::surface
+    ci["CI<br/>.github/workflows/ci.yml<br/>repo-trusted runner"]:::surface
+    mcp["MCP wrapper (stdio)<br/>JSON-RPC 2.0<br/>Claude Code · Desktop · Cursor · Codex · Cortex · Windsurf · Zed"]:::surface
+    web["Webhook receiver<br/>FastAPI + HMAC + bearer<br/>S3 EventBridge · vendor callback · API gateway"]:::surface
+    lib["Library SDK<br/>skills/_shared/library.py<br/>any Python app"]:::surface
+    runners["Persistent runners<br/>S3-SQS · GCS-PubSub · Blob-EventGrid<br/>event-driven at cloud scale"]:::surface
+  end
+
+  subgraph CONTROLS["Trust controls · enforced before subprocess fires"]
+    direction LR
+    allow["Allowlist intersection<br/>operator ∩ caller ∩ preset"]:::control
+    safewrite["Read-only by default<br/>--dry-run / --apply gate"]:::control
+    hitl["HITL · min_approvers<br/>_approval_context required"]:::gate
+    rlimit["RLIMIT cap<br/>AS · FSIZE · CPU"]:::control
+    sandbox["OS sandbox<br/>bwrap / sandbox-exec<br/>opt-in"]:::control
+    audit["Durable HMAC audit<br/>JSONL chain"]:::control
+    retry["Bounded retry<br/>≤10 attempts × 600s budget"]:::control
+    log["Structured log<br/>get_logger() correlation_id"]:::control
+  end
+
+  subgraph CORE["Same registry behind every surface"]
+    direction LR
+    registry["SkillSpec registry<br/>SKILL.md frontmatter"]:::registry
+    skills79["79 shipped atomic skills<br/>15 ingest · 5 discover · 32 detect · 7 evaluate · 12 remediate · 2 view · 3 output · 3 sources"]:::skills
+  end
+
+  cli --> CONTROLS
+  ci --> CONTROLS
+  mcp --> CONTROLS
+  web --> CONTROLS
+  lib --> CONTROLS
+  runners --> CONTROLS
+
+  CONTROLS --> registry
+  registry --> skills79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cloud-ai-security-skills"
-version = "0.8.1"
-description = "Security skills for cloud and AI with repo-native and OCSF modes."
+version = "0.9.0"
+description = "Agentic security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "cloud-ai-security-skills"
-version = "0.8.1"
+version = "0.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Tags the repo for v0.9.0 release. Major delta from v0.8.1.

## Highlights

- **CIS depth at 50%+ on all three clouds** (closes #254 per-platform target): AWS 50%, Azure 53%, GCP 50%
- **Sandboxing umbrella closed** (#427): RLIMIT (#428) + container hardening (#438) + opt-in OS sandbox (#447)
- **Cross-cutting reliability contract** (#437): retry / errors / structured logging exercised on 19 of 32 detectors
- **OWASP Top 10 first three** (#446): A01 / A03 / A07
- **Two new diagrams** under `docs/diagrams/`: skill-hierarchy + surface-comparison
- **76 → 79 shipped skills**

## What ships in this PR

- pyproject.toml version 0.8.1 → **0.9.0** + description refreshed
- README badge + tagline bumped (`76 → 79` production-grade skills)
- New CHANGELOG entry covering ~30 merged PRs from this session
- Two new Mermaid sources:
  - **`skill-hierarchy.mmd`** renders the full **79-skill** surface grouped by sub-domain (AWS · GCP · Azure / Entra · Identity / SaaS · K8s · AI / MCP runtime · Web / OWASP)
  - **`surface-comparison.mmd`** renders the **six** shipped surfaces (CLI · CI · MCP · webhook · library · runners) with the **eight** trust controls behind them
- README cross-links the new diagrams in the Architecture section
- All auto-generated docs (COVERAGE_SNAPSHOT, FRAMEWORK_COVERAGE, SECURITY_BAR) re-checked clean

## After merge

- Tag `v0.9.0`
- Cut GitHub Release with the CHANGELOG body
- The Quickstart example in the README will work as-is; `git clone --branch v0.9.0` becomes the canonical install line

## Test plan

- [x] `pytest` repo-wide green (~2070 tests)
- [x] All three doc-regen `--check` gates clean
- [x] `scripts/validate_skill_count_consistency.py` passes (total 79, detection 32, remediation 12, evaluation 7)
- [x] `ruff check` clean
- [x] No `* [N].*` Finder duplicates leaked into the commit