### PR TITLE
docs: fix banner overflow + drop redundant arch image + add skill index

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent 
 
 **Total: 79 shipped skills.**  Live counts and per-framework coverage in [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) (auto-generated, CI-gated).
 
+**Find a skill:** [`docs/SKILL_INDEX.md`](docs/SKILL_INDEX.md) groups every shipped skill by **environment** (AWS · GCP · Azure/Entra · K8s · Identity · AI/MCP · Web · Cross-env) and by **purpose** (ingest / discover / detect / evaluate / remediate / view / output / source), and points at the framework-mapping docs for control-catalog pivots.
+
 ## Architecture
 
 External signals enter through two intake layers, pass through two analyze layers, exit through two act layers, and persist through one output layer. MCP, CLI, CI, webhook, and runners all invoke the same skill bundle — the surface is transport, not behavior.
 
 ![Clean architecture layers diagram — signals feed intake, analyze, act, and persist stages across the seven shipped skill layers.](docs/images/architecture-layers.svg)
 
-![Clean runtime surfaces diagram — MCP, CLI, CI, and cloud runners all invoke the same shared skill bundle.](docs/images/runtime-surfaces.svg)
+The runtime surfaces — CLI, CI, MCP, webhook, library, runners — are documented in the [`Agent integrations`](#agent-integrations) table below; they all import the same skill bundle, so there is no second contract to draw.
 
 More visuals (Mermaid sources under [`docs/diagrams/`](docs/diagrams/), GitHub renders inline):
 

--- a/docs/SKILL_INDEX.md
+++ b/docs/SKILL_INDEX.md
@@ -1,0 +1,173 @@
+# Skill index — find a skill fast
+
+The same 79 skill bundles, pivoted three ways:
+
+1. **[By environment](#by-environment)** — pick a cloud or platform, see every skill that touches it.
+2. **[By purpose](#by-purpose)** — pick a layer (ingest / discover / detect / evaluate / remediate / view / output / source).
+3. **[By framework](#by-framework)** — pick a control catalog (CIS / NIST / MITRE ATT&CK / ATLAS / OWASP / OCSF).
+
+Each row is a directory under [`skills/`](../skills/). The `SKILL.md` in each
+directory is the single source of truth for what the skill does, what it does
+not do, and what it talks to.
+
+> Counts are auto-validated by `scripts/validate_count_drift.sh`. If a row
+> moves, the count check fails CI until this index is regenerated.
+
+## By environment
+
+### AWS — 14 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Ingest | [`ingest-cloudtrail-ocsf`](../skills/ingestion/ingest-cloudtrail-ocsf/) | CloudTrail → OCSF 1.8 API Activity 6003 |
+| Ingest | [`ingest-guardduty-ocsf`](../skills/ingestion/ingest-guardduty-ocsf/) | GuardDuty findings → OCSF Detection Finding 2004 |
+| Ingest | [`ingest-security-hub-ocsf`](../skills/ingestion/ingest-security-hub-ocsf/) | Security Hub findings → OCSF |
+| Ingest | [`ingest-vpc-flow-logs-ocsf`](../skills/ingestion/ingest-vpc-flow-logs-ocsf/) | VPC Flow Logs → OCSF Network Activity |
+| Detect | [`detect-aws-access-key-creation`](../skills/detection/detect-aws-access-key-creation/) | T1098.001 — IAM CreateAccessKey on a user |
+| Detect | [`detect-aws-enumeration-burst`](../skills/detection/detect-aws-enumeration-burst/) | T1087 — discovery-burst against IAM/EC2/S3 |
+| Detect | [`detect-aws-login-profile-creation`](../skills/detection/detect-aws-login-profile-creation/) | T1098.001 — IAM CreateLoginProfile (console password) |
+| Detect | [`detect-aws-model-artifact-download`](../skills/detection/detect-aws-model-artifact-download/) | ATLAS AML.T0040 — model exfil via S3 |
+| Detect | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group/) | T1190 — 0.0.0.0/0 added to a security group |
+| Detect | [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled/) | T1562.001 — CloudTrail StopLogging / DeleteTrail |
+| Detect | [`detect-s3-cross-account-copy`](../skills/detection/detect-s3-cross-account-copy/) | T1537 — S3 cross-account exfiltration |
+| Evaluate | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark/) | CIS AWS Foundations v3 — 50% control coverage |
+| Remediate | [`iam-departures-aws`](../skills/remediation/iam-departures-aws/) | HITL — disable / delete IAM users on departure |
+| Remediate | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke/) | HITL — revoke open SG ingress, dry-run-first |
+
+### GCP — 11 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Ingest | [`ingest-gcp-audit-ocsf`](../skills/ingestion/ingest-gcp-audit-ocsf/) | GCP Cloud Audit → OCSF API Activity 6003 |
+| Ingest | [`ingest-gcp-scc-ocsf`](../skills/ingestion/ingest-gcp-scc-ocsf/) | Security Command Center findings → OCSF |
+| Ingest | [`ingest-vpc-flow-logs-gcp-ocsf`](../skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/) | GCP VPC Flow Logs → OCSF Network Activity |
+| Detect | [`detect-gcp-audit-logs-disabled`](../skills/detection/detect-gcp-audit-logs-disabled/) | T1562.001 — `_Default` sink disable / IAM exemption |
+| Detect | [`detect-gcp-model-artifact-download`](../skills/detection/detect-gcp-model-artifact-download/) | ATLAS AML.T0040 — Vertex / GCS model exfil |
+| Detect | [`detect-gcp-open-firewall`](../skills/detection/detect-gcp-open-firewall/) | T1190 — 0.0.0.0/0 firewall ingress |
+| Detect | [`detect-gcp-service-account-key-creation`](../skills/detection/detect-gcp-service-account-key-creation/) | T1098.001 — user-managed SA key issuance |
+| Detect | [`detect-gcp-service-account-token-minting`](../skills/detection/detect-gcp-service-account-token-minting/) | T1098.001 — `signJwt` / `generateAccessToken` abuse |
+| Evaluate | [`cspm-gcp-cis-benchmark`](../skills/evaluation/cspm-gcp-cis-benchmark/) | CIS GCP Foundations v3 — 30 of 60 controls (50%) |
+| Remediate | [`iam-departures-gcp`](../skills/remediation/iam-departures-gcp/) | HITL — remove principals on departure |
+| Remediate | [`remediate-gcp-firewall-revoke`](../skills/remediation/remediate-gcp-firewall-revoke/) | HITL — close open firewall ingress |
+
+### Azure · Entra — 12 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Ingest | [`ingest-azure-activity-ocsf`](../skills/ingestion/ingest-azure-activity-ocsf/) | Azure Activity → OCSF API Activity |
+| Ingest | [`ingest-azure-defender-for-cloud-ocsf`](../skills/ingestion/ingest-azure-defender-for-cloud-ocsf/) | Defender for Cloud findings → OCSF |
+| Ingest | [`ingest-entra-directory-audit-ocsf`](../skills/ingestion/ingest-entra-directory-audit-ocsf/) | Entra directory audit → OCSF |
+| Ingest | [`ingest-nsg-flow-logs-azure-ocsf`](../skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/) | NSG Flow Logs → OCSF Network Activity |
+| Detect | [`detect-azure-activity-logs-disabled`](../skills/detection/detect-azure-activity-logs-disabled/) | T1562.001 — diagnostic-setting deletion |
+| Detect | [`detect-azure-open-nsg`](../skills/detection/detect-azure-open-nsg/) | T1190 — 0.0.0.0/0 NSG ingress |
+| Detect | [`detect-entra-credential-addition`](../skills/detection/detect-entra-credential-addition/) | T1098.001 — app credential addition |
+| Detect | [`detect-entra-role-grant-escalation`](../skills/detection/detect-entra-role-grant-escalation/) | T1098.003 — privileged role grant |
+| Evaluate | [`cspm-azure-cis-benchmark`](../skills/evaluation/cspm-azure-cis-benchmark/) | CIS Azure v2.1 — 53% control coverage |
+| Remediate | [`iam-departures-azure-entra`](../skills/remediation/iam-departures-azure-entra/) | HITL — Entra principal disable on departure |
+| Remediate | [`remediate-azure-nsg-revoke`](../skills/remediation/remediate-azure-nsg-revoke/) | HITL — close open NSG ingress |
+| Remediate | [`remediate-entra-credential-revoke`](../skills/remediation/remediate-entra-credential-revoke/) | HITL — revoke Entra app credentials |
+
+### Kubernetes — 9 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Ingest | [`ingest-k8s-audit-ocsf`](../skills/ingestion/ingest-k8s-audit-ocsf/) | K8s audit → OCSF API Activity 6003 |
+| Detect | [`detect-container-escape-k8s`](../skills/detection/detect-container-escape-k8s/) | T1611 — privileged / hostPath escape |
+| Detect | [`detect-privilege-escalation-k8s`](../skills/detection/detect-privilege-escalation-k8s/) | T1078 — RBAC escalation via cluster-admin grant |
+| Detect | [`detect-sensitive-secret-read-k8s`](../skills/detection/detect-sensitive-secret-read-k8s/) | T1552.001 — anomalous Secret read |
+| Evaluate | [`container-security`](../skills/evaluation/container-security/) | CIS Docker Benchmark v1.6 |
+| Evaluate | [`gpu-cluster-security`](../skills/evaluation/gpu-cluster-security/) | NVIDIA GPU Operator + node hardening |
+| Evaluate | [`k8s-security-benchmark`](../skills/evaluation/k8s-security-benchmark/) | CIS Kubernetes Benchmark v1.10 |
+| Remediate | [`remediate-container-escape-k8s`](../skills/remediation/remediate-container-escape-k8s/) | HITL — quarantine pod / drain node |
+| Remediate | [`remediate-k8s-rbac-revoke`](../skills/remediation/remediate-k8s-rbac-revoke/) | HITL — revoke RoleBindings, dry-run-first |
+
+### Identity (Okta · Google Workspace) — 7 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Ingest | [`ingest-google-workspace-login-ocsf`](../skills/ingestion/ingest-google-workspace-login-ocsf/) | Workspace login events → OCSF Authentication 3002 |
+| Ingest | [`ingest-okta-system-log-ocsf`](../skills/ingestion/ingest-okta-system-log-ocsf/) | Okta System Log → OCSF |
+| Detect | [`detect-credential-stuffing-okta`](../skills/detection/detect-credential-stuffing-okta/) | T1110.004 — high-velocity Okta auth failures |
+| Detect | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login/) | T1078.004 — impossible-travel / risky-IP login |
+| Detect | [`detect-okta-mfa-fatigue`](../skills/detection/detect-okta-mfa-fatigue/) | T1621 — MFA-bombing |
+| Remediate | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill/) | HITL — kill Okta sessions on principal |
+| Remediate | [`remediate-workspace-session-kill`](../skills/remediation/remediate-workspace-session-kill/) | HITL — sign-out Workspace user |
+
+### AI runtime · MCP · model serving — 10 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Ingest | [`ingest-mcp-proxy-ocsf`](../skills/ingestion/ingest-mcp-proxy-ocsf/) | MCP proxy logs → OCSF Application Activity 6002 |
+| Discover | [`discover-ai-bom`](../skills/discovery/discover-ai-bom/) | CycloneDX ML-BOM — models, datasets, tools |
+| Detect | [`detect-agent-credential-leak-mcp`](../skills/detection/detect-agent-credential-leak-mcp/) | OWASP MCP — leaked secrets in `tools/call` results |
+| Detect | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift/) | T1195.001 — tool-poisoning / rug-pull |
+| Detect | [`detect-prompt-injection-mcp-proxy`](../skills/detection/detect-prompt-injection-mcp-proxy/) | OWASP LLM01 — prompt injection patterns |
+| Detect | [`detect-system-prompt-extraction`](../skills/detection/detect-system-prompt-extraction/) | OWASP LLM07 — extraction attempts |
+| Detect | [`detect-tool-output-exfiltration-instructions`](../skills/detection/detect-tool-output-exfiltration-instructions/) | OWASP LLM06 — exfil instructions in tool output |
+| Detect | [`detect-tool-output-policy-bypass`](../skills/detection/detect-tool-output-policy-bypass/) | OWASP LLM02 — agentic policy-bypass payloads |
+| Evaluate | [`model-serving-security`](../skills/evaluation/model-serving-security/) | OWASP LLM Top 10 + ATLAS posture for model APIs |
+| Remediate | [`remediate-mcp-tool-quarantine`](../skills/remediation/remediate-mcp-tool-quarantine/) | HITL — quarantine an MCP tool by fingerprint |
+
+### Web application (OWASP Top 10) — 3 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Detect | [`detect-web-auth-failures`](../skills/detection/detect-web-auth-failures/) | OWASP A07 — auth failure burst |
+| Detect | [`detect-web-broken-access-control`](../skills/detection/detect-web-broken-access-control/) | OWASP A01 — IDOR / forced-browsing |
+| Detect | [`detect-web-injection`](../skills/detection/detect-web-injection/) | OWASP A03 — SQLi / shell / NoSQL / template injection |
+
+### Cross-environment plumbing — 13 skills
+
+| Layer | Skill | What it does |
+|---|---|---|
+| Discover | [`discover-cloud-control-evidence`](../skills/discovery/discover-cloud-control-evidence/) | Per-control evidence (logging / segmentation / encryption / KMS) |
+| Discover | [`discover-control-evidence`](../skills/discovery/discover-control-evidence/) | Cross-cloud control-evidence ledger |
+| Discover | [`discover-environment`](../skills/discovery/discover-environment/) | Inventory + relationship graph |
+| Discover | [`iam-departures-reconciler`](../skills/discovery/iam-departures-reconciler/) | HR-source → canonical departure manifest |
+| Detect | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement/) | Cross-cloud principal-graph traversal |
+| View | [`convert-ocsf-to-mermaid-attack-flow`](../skills/view/convert-ocsf-to-mermaid-attack-flow/) | Findings → MITRE ATT&CK Flow Mermaid |
+| View | [`convert-ocsf-to-sarif`](../skills/view/convert-ocsf-to-sarif/) | Findings → SARIF 2.1.0 |
+| Output | [`sink-clickhouse-jsonl`](../skills/output/sink-clickhouse-jsonl/) | Append-only ClickHouse sink |
+| Output | [`sink-s3-jsonl`](../skills/output/sink-s3-jsonl/) | Append-only S3 sink |
+| Output | [`sink-snowflake-jsonl`](../skills/output/sink-snowflake-jsonl/) | Append-only Snowflake sink |
+| Source | [`source-databricks-query`](../skills/ingestion/source-databricks-query/) | Databricks SQL warehouse adapter |
+| Source | [`source-s3-select`](../skills/ingestion/source-s3-select/) | S3 Select adapter |
+| Source | [`source-snowflake-query`](../skills/ingestion/source-snowflake-query/) | Snowflake warehouse adapter |
+
+## By purpose
+
+| Layer | Count | Index |
+|---|---:|---|
+| Ingest | 15 | [`skills/ingestion/`](../skills/ingestion/) (excludes the 3 warehouse sources below) |
+| Discover | 5 | [`skills/discovery/`](../skills/discovery/) |
+| Detect | 32 | [`skills/detection/`](../skills/detection/) |
+| Evaluate | 7 | [`skills/evaluation/`](../skills/evaluation/) |
+| Remediate | 12 | [`skills/remediation/`](../skills/remediation/) |
+| View | 2 | [`skills/view/`](../skills/view/) |
+| Output | 3 | [`skills/output/`](../skills/output/) |
+| Source | 3 | warehouse adapters: `source-databricks-query`, `source-s3-select`, `source-snowflake-query` (filed under `skills/ingestion/` on disk) |
+
+Total = 15 + 5 + 32 + 7 + 12 + 2 + 3 + 3 = **79**.
+
+## By framework
+
+This index is intentionally a pointer, not a duplicate of the framework
+mappings. Two existing docs are the source of truth:
+
+- [`docs/FRAMEWORK_MAPPINGS.md`](FRAMEWORK_MAPPINGS.md) — every skill's frontmatter `frameworks:` list, rolled up.
+- [`docs/FRAMEWORK_COVERAGE.md`](FRAMEWORK_COVERAGE.md) — auto-generated, CI-gated, per-control depth (not just count).
+
+Quick orientation:
+
+| Framework | Where it lives in this repo |
+|---|---|
+| OCSF 1.8 | wire format on every ingester, every detector, every view |
+| MITRE ATT&CK v14 | `finding_info.attacks` on every detector |
+| MITRE ATLAS | model-exfil + AI-runtime detectors |
+| OWASP Top 10 (web) | `detect-web-*` |
+| OWASP LLM Top 10 | `detect-prompt-injection-*`, `detect-system-prompt-extraction`, `detect-tool-output-*`, `detect-agent-credential-leak-mcp`, `model-serving-security` |
+| OWASP MCP Top 10 | `detect-mcp-tool-drift`, `detect-agent-credential-leak-mcp`, `detect-prompt-injection-mcp-proxy`, `remediate-mcp-tool-quarantine` |
+| CIS AWS / GCP / Azure / K8s / Containers | `cspm-*`, `container-security`, `k8s-security-benchmark` |
+| NIST CSF 2.0 / AI RMF | `cspm-*` benchmark mappings + AI runtime evaluators |
+| SOC 2 / ISO 27001 / PCI / FedRAMP | rolled up via `discover-control-evidence` |
+| CycloneDX ML-BOM | `discover-ai-bom` |

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">29</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">32</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -39,7 +39,7 @@
   <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
     <!-- Eyebrow pill -->
     <g transform="translate(72,40)">
-      <rect x="0" y="0" width="220" height="28" rx="14" fill="#0b1628" stroke="#334155"/>
+      <rect x="0" y="0" width="288" height="28" rx="14" fill="#0b1628" stroke="#334155"/>
       <circle cx="18" cy="14" r="3.5" fill="#22d3ee"/>
       <text x="32" y="19" fill="#c7d2fe" font-size="11" font-weight="800" letter-spacing="1.6">OSS · APACHE 2.0 · OCSF 1.8</text>
     </g>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -86,7 +86,7 @@
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
       <!-- Counts: 76 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">76</text>
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">79</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
       <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 32 detect · 5 discover · 7 eval</text>


### PR DESCRIPTION
## What

Three visual / discoverability fixes called out on screenshot review of v0.9.0:

### 1 — Hero banner eyebrow pill no longer truncates
"OSS · APACHE 2.0 · OCSF 1.8" was overflowing its 220-px container at the top-left of the hero. Pill widened to 288 px; text now fits cleanly.

### 2 — Removed the redundant architecture diagram from the README
The README rendered both `architecture-layers.svg` and `runtime-surfaces.svg` back-to-back, and they read as the same diagram from two angles. Kept the layered architecture image; the runtime surfaces are already enumerated in the `Agent integrations` table (CLI / CI / MCP / webhook / library / runners + transport per row), so there is no second contract to draw.

The `runtime-surfaces.svg` file is retained — it is still linked from `docs/diagrams/README.md` as a deeper visual.

### 3 — Stale counts on architecture SVGs
`architecture-layers.svg`: L3 Detect `29` → `32` (drift since v0.9.0 OWASP detectors landed). `runtime-surfaces.svg`: skill-bundle hub `76` → `79`.

### 4 — `docs/SKILL_INDEX.md` — find a skill fast

New index file that pivots all 79 skills three ways:

- **By environment** — AWS (14) · GCP (11) · Azure/Entra (12) · K8s (9) · Identity (7) · AI/MCP (10) · Web (3) · Cross-env (13)
- **By purpose** — Ingest 15 · Discover 5 · Detect 32 · Evaluate 7 · Remediate 12 · View 2 · Output 3 · Source 3
- **By framework** — pointer to `FRAMEWORK_MAPPINGS.md` and `FRAMEWORK_COVERAGE.md` (already auto-generated, CI-gated)

Linked from the README right under the "What this repo gives you" table.

## Validation

- `scripts/validate_skill_count_consistency.py` → `total=79, detection=32, remediation=12, evaluation=7` ✅
- Total in `SKILL_INDEX.md` matches: 14+11+12+9+7+10+3+13 = 79
- Per-purpose total: 15+5+32+7+12+2+3+3 = 79

## Screens addressed

`Screenshot 2026-05-10 at 1.05.09 AM.png` — eyebrow pill clipping
`Screenshot 2026-05-10 at 1.05.36 AM.png` — duplicate-feeling architecture images