### PR TITLE
release: v0.10.0 — vendor depth, AI governance, runtime reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,74 +11,75 @@ The format is loosely based on Keep a Changelog.
 
 ## [Unreleased]
 
-### Added
+## [0.10.0] — 2026-05-10 — Vendor depth, AI governance, runtime reliability
 
-- **`detect-snowflake-share-creation`** — Snowflake secure data share creation
-  detector for #436. Reads OCSF 1.8 API Activity (class 6003) records
-  normalized from Snowflake `query_history`, fires on `CREATE_SHARE` and
-  `ALTER_SHARE_ADD_ACCOUNTS` events, emits a Detection Finding tagged with
-  MITRE ATT&CK T1537 Transfer Data to Cloud Account. Severity HIGH.
-- **`detect-snowflake-account-key-creation`** — Snowflake RSA public-key
-  auth detector for #436. Fires on `ALTER USER ... SET RSA_PUBLIC_KEY` (slot
-  1 and slot 2), tagged T1098.001 Additional Cloud Credentials. Severity HIGH.
-- **`detect-snowflake-warehouse-resize-burst`** — Snowflake compute-scale
-  anomaly detector for #436. Groups `ALTER_WAREHOUSE` by `warehouse_name`
-  across a sliding window (env `SNOWFLAKE_RESIZE_WINDOW_MIN`, default 60 min),
-  fires when cumulative size-index jump ≥ `SNOWFLAKE_RESIZE_MIN_SIZE_JUMP`
-  (default 3). Tagged T1496 Resource Hijacking. Severity MEDIUM.
-- **`detect-snowflake-unauthorized-grant`** — Snowflake privileged-role
-  escalation detector for #436. Fires on `GRANT_ROLE` where the granted
-  role is in `SNOWFLAKE_PRIVILEGED_ROLES` AND the granter is not on
-  `SNOWFLAKE_AUTHORIZED_GRANTERS` (default empty = fail-open with stderr
-  warning). Tagged T1098.003. Severity HIGH.
-- **`evaluate-nist-ai-rmf-govern` / `-map` / `-measure` / `-manage`** —
-  first NIST AI RMF 1.0 expansion slice for #435. Four evaluation skills,
-  one per NIST AI RMF core function. Each implements a curated subset of 10
-  high-impact subcategories (40 total) as a manifest-completeness + freshness
-  audit, emits OCSF Compliance Finding (class 2003) per subcategory with
-  `compliance.requirement` set to the subcategory ID. Each SKILL.md
-  documents implemented subcategories explicitly and lists deferred ones in
-  Roadmap. Manifest contract is shared (`documented`, `review_cadence_days`,
-  `last_reviewed`, `evidence_uri`, `coverage`), fed via per-function env
-  var. Honesty caveat in every SKILL.md: "manifest-completeness check, not
-  the qualitative org-level assessment NIST AI RMF requires."
-- Detection layer 35 → 39; evaluation layer 7 → 11; repo total 82 → 90.
-  Brings #436 from 3/18 to 7/18 (1 Snowflake, 5 Databricks, 5 ClickHouse
-  remain) and #435 from 4 to 8 of 12+ planned.
-- **`detect-snowflake-bulk-data-egress`** — first warehouse-platform vendor-depth
-  detector for #436. Reads OCSF 1.8 API Activity (class 6003) records from a
-  Snowflake ingest pipeline, groups by `actor.user.uid` across a 60-minute
-  sliding window, and emits an OCSF Detection Finding (class 2004) tagged with
-  MITRE ATT&CK T1567 Exfiltration Over Web Service when cumulative
-  `bytes_scanned`, `rows_unloaded`, and distinct `stage_name` fan-out cross
-  configurable thresholds. Detection layer count moves from 32 → 33; repo
-  total moves from 79 → 80. Lands 1 of 18 detectors planned for #436;
-  remaining 17 (5 Snowflake, 6 Databricks, 6 ClickHouse) stay open.
-- **`detect-clickhouse-bulk-export`** — first ClickHouse detector for #436.
-  Reads OCSF 1.8 API Activity (class 6003) records normalized from
-  ClickHouse `system.query_log`, filters on
-  `metadata.product.vendor_name == "ClickHouse"`, drops failed queries, keeps
-  rows whose SQL text matches one of `INTO OUTFILE`,
-  `INSERT INTO FUNCTION s3(`, or `URL(`, groups by `actor.user.uid` across a
-  60-minute sliding window (env `CLICKHOUSE_EXPORT_WINDOW_MIN`), and emits an
-  OCSF Detection Finding (class 2004) tagged with MITRE ATT&CK T1567
-  Exfiltration Over Web Service when cumulative `read_bytes` crosses the
-  configurable byte threshold (default 10 GiB, env
-  `CLICKHOUSE_EXPORT_BYTE_THRESHOLD`). Detection layer moves 33 → 34; repo
-  total 80 → 81.
-- **`detect-databricks-token-creation`** — first Databricks vendor-depth
-  detector for #436. Reads OCSF 1.8 API Activity (class 6003) records emitted
-  by an upstream Databricks audit-log ingest pipeline, matches successful
-  `tokens/create` operations on the Databricks token-management surface, and
-  emits one OCSF Detection Finding (class 2004) per issuance tagged with MITRE
-  ATT&CK T1098.001 (Additional Cloud Credentials, tactic TA0003 Persistence).
-  Severity HIGH — Databricks PATs never expire by default and grant headless
-  API access at the issuing principal's full scope. Emits
-  `unmapped_event_type` stderr telemetry on Databricks token-management
-  operations not yet in the recognized map so operators can grep the unmapped
-  feed and propose new mappings without losing visibility. Detection layer
-  moves 34 → 35; repo total 81 → 82. Lands 3 of 18 detectors planned for
-  #436; remaining 15 (5 Snowflake, 5 Databricks, 5 ClickHouse) stay open.
+Skills count on `main`: **90** (15 ingest, 5 discover, 39 detect, 11 evaluate,
+12 remediate, 2 view, 3 output, 3 sources). First vendor-depth detection
+slice on Snowflake / ClickHouse / Databricks, four NIST AI RMF 1.0 evaluators,
+runner reliability bundle closes, authenticated MCP SSE / streamable-HTTP
+transport with a rotation contract, and the audit-honesty trio lands.
+
+### Vendor depth — Snowflake / Databricks / ClickHouse (#436 partial)
+
+- **`detect-snowflake-bulk-data-egress`** (#462) — warehouse egress slice.
+  Groups OCSF API Activity by `actor.user.uid` over a 60-min window, fires on
+  combined `bytes_scanned` / `rows_unloaded` / `stage_name` thresholds (T1567).
+- **`detect-snowflake-share-creation` / `-account-key-creation` /
+  `-warehouse-resize-burst` / `-unauthorized-grant`** (#468) — T1537 / T1098.001
+  / T1496 / T1098.003 covering data shares, RSA auth, compute-scale anomaly,
+  and privileged-role grants.
+- **`detect-clickhouse-bulk-export`** (#464) — `system.query_log` filter on
+  `INTO OUTFILE` / `INSERT INTO FUNCTION s3(` / `URL(`, fires on cumulative
+  `read_bytes` crossing the byte threshold (T1567). **`detect-databricks-token-creation`**
+  (#465) — fires on successful `tokens/create` (T1098.001), emits
+  `unmapped_event_type` stderr telemetry for ops not yet in the map.
+- **7 of 18 #436 detectors shipped; 11 remain** (4 Snowflake, 5 Databricks,
+  5 ClickHouse).
+
+### AI governance (#435 partial)
+
+- **`evaluate-nist-ai-rmf-govern` / `-map` / `-measure` / `-manage`** (#469)
+  — one evaluator per NIST AI RMF 1.0 core function, 10 curated subcategories
+  each (**40 total**), emitted as OCSF Compliance Finding 2003 per
+  subcategory. Each SKILL.md carries the caveat that this is a
+  manifest-completeness audit, not the qualitative org-level assessment NIST
+  AI RMF requires. **8 of 12+ #435 evaluators shipped.**
+
+### Runtime reliability (#198, #199 closed)
+
+- **CI-driven runner e2e harness + auto-generated runtime profiles** (#467)
+  exercising the three runner templates; writes the p50/p95 table into
+  `docs/RUNTIME_PROFILES.md` on every scheduled run. First numbers (N=20):
+  `mcp-sse` jsonrpc-ping 23.86/49.16 ms, `webhook-receiver` cloudtrail-ingest
+  75.83/77.58 ms, `cloud-runner-aws-s3-sqs` ingest 32.24/33.96 ms — regression
+  sentinels, not customer-scale throughput.
+
+### MCP transport surface (#415 closed)
+
+- **SSE + streamable-HTTP transport with bearer auth** (#463, slice 1) —
+  authenticated listener alongside the stdio wrapper; preserves existing
+  trust controls and HMAC-chained audit. **Helm/Docker deployment + bearer-key
+  rotation contract** (#466, slice 2).
+
+### Audit honesty (#406, #403, #404 closed)
+
+- **Azure subscription parser refactor, Okta unmapped-event counter,
+  golden-fixture provenance doc** (#458) — closes the ambient-subscription
+  footgun (#406), surfaces Okta event types not in the recognized map (#403),
+  and documents fixture collection + review (#404).
+
+### Quality / infrastructure
+
+- **Per-detector precision/recall scorer** (#460, closes #419) and
+  **captured-fixture corpus with provenance gate** (#459, closes #420) —
+  quantitative detector scoring replaces the "looked good on a fixture" proxy.
+- **CSPM evaluation depth +542 tests** (#461, closes #405), **banner overflow
+  + skill-index doc** (#454), **mypy upper bound bumped to <3** (#457).
+
+### Changed
+
+- Detection 32 → 39; evaluation 7 → 11; total 79 → 90. Benchmark checks
+  91 → 131 (91 CIS + 40 NIST AI RMF subcategories).
 
 ## [0.9.0] — 2026-05-10 — Agentic posture: trust contract, coverage depth, sandboxing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![Agentic security skills for cloud and AI — 90 shipped skill bundles. OCSF 1.8 on the wire. 91 CIS and Kubernetes benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![Agentic security skills for cloud and AI — 90 shipped skill bundles. OCSF 1.8 on the wire. 131 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.9.0-0ea5e9"></a>
+  <a href="CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.10.0-0ea5e9"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache_2.0-blue"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11+-blue"></a>
   <a href="https://schema.ocsf.io/1.8.0"><img alt="OCSF 1.8" src="https://img.shields.io/badge/OCSF-1.8-22d3ee"></a>
@@ -20,7 +20,7 @@
 
 ```bash
 # 1 · Clone a tagged release
-git clone --branch v0.8.1 https://github.com/msaad00/cloud-ai-security-skills.git
+git clone --branch v0.10.0 https://github.com/msaad00/cloud-ai-security-skills.git
 cd cloud-ai-security-skills
 
 # 2 · Install only the deps the skills you'll run need

--- a/docs/diagrams/skill-hierarchy.mmd
+++ b/docs/diagrams/skill-hierarchy.mmd
@@ -49,7 +49,7 @@ flowchart TB
     d_iam["iam-departures-reconciler"]:::discover
   end
 
-  subgraph L3["L3 · Detect · 32 skills · OCSF Detection Finding 2004"]
+  subgraph L3["L3 · Detect · 39 skills · OCSF Detection Finding 2004"]
     direction TB
     subgraph L3aws["AWS"]
       direction LR
@@ -104,9 +104,19 @@ flowchart TB
       d_web_inj["web-injection"]:::analyze
       d_web_auth["web-auth-failures"]:::analyze
     end
+    subgraph L3warehouse["Warehouse / Lakehouse"]
+      direction LR
+      d_sf_egress["snowflake-bulk-data-egress"]:::analyze
+      d_sf_share["snowflake-share-creation"]:::analyze
+      d_sf_key["snowflake-account-key-creation"]:::analyze
+      d_sf_resize["snowflake-warehouse-resize-burst"]:::analyze
+      d_sf_grant["snowflake-unauthorized-grant"]:::analyze
+      d_ch_exp["clickhouse-bulk-export"]:::analyze
+      d_db_tok["databricks-token-creation"]:::analyze
+    end
   end
 
-  subgraph L4["L4 · Evaluate · 7 skills · CIS / NIST / SOC 2 posture"]
+  subgraph L4["L4 · Evaluate · 11 skills · CIS / NIST / NIST AI RMF / SOC 2 posture"]
     direction LR
     e_aws["cspm-aws-cis-benchmark<br/>29 / 58 controls"]:::analyze
     e_az["cspm-azure-cis-benchmark<br/>32 / 60 controls"]:::analyze
@@ -115,6 +125,13 @@ flowchart TB
     e_cont["container-security"]:::analyze
     e_gpu["gpu-cluster-security"]:::analyze
     e_mod["model-serving-security"]:::analyze
+    subgraph L4ai["AI Governance · NIST AI RMF 1.0"]
+      direction LR
+      e_ai_gov["evaluate-nist-ai-rmf-govern"]:::analyze
+      e_ai_map["evaluate-nist-ai-rmf-map"]:::analyze
+      e_ai_meas["evaluate-nist-ai-rmf-measure"]:::analyze
+      e_ai_mgmt["evaluate-nist-ai-rmf-manage"]:::analyze
+    end
   end
 
   subgraph L5["L5 · Remediate · 12 guarded write paths · HITL gated"]

--- a/docs/diagrams/surface-comparison.mmd
+++ b/docs/diagrams/surface-comparison.mmd
@@ -1,7 +1,7 @@
 %% Surface comparison — six shipped surfaces with the same skill bundle
 %% behind every one. Each surface adds its own transport + auth +
 %% guardrail layer; every column converges at the SkillSpec registry
-%% and the 79 atomic skills below it.
+%% and the 90 atomic skills below it.
 flowchart TD
   classDef surface fill:#0f1d36,stroke:#3b82f6,color:#dbeafe
   classDef control fill:#1f142e,stroke:#a78bfa,color:#ede9fe
@@ -34,7 +34,7 @@ flowchart TD
   subgraph CORE["Same registry behind every surface"]
     direction LR
     registry["SkillSpec registry<br/>SKILL.md frontmatter"]:::registry
-    skills79["79 shipped atomic skills<br/>15 ingest · 5 discover · 32 detect · 7 evaluate · 12 remediate · 2 view · 3 output · 3 sources"]:::skills
+    skills79["90 shipped atomic skills<br/>15 ingest · 5 discover · 39 detect · 11 evaluate · 12 remediate · 2 view · 3 output · 3 sources"]:::skills
   end
 
   cli --> CONTROLS

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 39 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 11 benchmark families covering 91 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 15 ingesters plus 3 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 39 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 11 benchmark families covering 131 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -93,8 +93,8 @@
 
       <rect x="642" y="440" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="482" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
-      <text x="674" y="544" font-size="56" font-weight="900" fill="#ffffff">7</text>
-      <text x="674" y="576" font-size="15" fill="#a7f3d0">91 benchmark checks across</text>
+      <text x="674" y="544" font-size="56" font-weight="900" fill="#ffffff">11</text>
+      <text x="674" y="576" font-size="15" fill="#a7f3d0">131 benchmark checks across</text>
       <text x="674" y="598" font-size="15" fill="#a7f3d0">CIS · K8s · container · AI</text>
     </g>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1760" viewBox="0 0 1400 1760" role="img" aria-labelledby="cm-title cm-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1890" viewBox="0 0 1400 1890" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
   <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (39) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of twenty-nine detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, GCP service-account-key, GCP service-account-token-minting, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, and tool-output-exfiltration-instructions slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
@@ -12,8 +12,8 @@
     </pattern>
   </defs>
 
-  <rect width="1400" height="1740" fill="url(#bg2)"/>
-  <rect width="1400" height="1740" fill="url(#grid2)"/>
+  <rect width="1400" height="1870" fill="url(#bg2)"/>
+  <rect width="1400" height="1870" fill="url(#grid2)"/>
 
   <!-- Title block -->
   <text x="48" y="62" fill="#f1f5f9" font-family="Inter, system-ui, sans-serif" font-size="30" font-weight="900">Closed-loop coverage matrix</text>
@@ -329,7 +329,7 @@
   </g>
 
   <!-- EVALUATION SECTION -->
-  <text x="48" y="1588" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks)</text>
+  <text x="48" y="1588" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks · NIST AI RMF 40 subcategories)</text>
 
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="1602" fill="#f1f5f9" font-size="15">cspm-aws-cis-benchmark</text>
@@ -358,11 +358,35 @@
     <rect x="760"  y="1676" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1676" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
     <text x="1020" y="1692" fill="#dbeafe" font-size="13">posture-only · selective containment exists elsewhere</text>
+
+    <text x="48"   y="1722" fill="#f1f5f9" font-size="15">evaluate-nist-ai-rmf-govern</text>
+    <text x="430"  y="1722" fill="#cbd5e1" font-size="14">NIST AI RMF 1.0 GOVERN (10 subcategories)</text>
+    <rect x="760"  y="1706" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1706" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1722" fill="#dbeafe" font-size="13">manifest-completeness audit · org-level qualitative assessment deferred (#435)</text>
+
+    <text x="48"   y="1752" fill="#f1f5f9" font-size="15">evaluate-nist-ai-rmf-map</text>
+    <text x="430"  y="1752" fill="#cbd5e1" font-size="14">NIST AI RMF 1.0 MAP (10 subcategories)</text>
+    <rect x="760"  y="1736" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1736" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1752" fill="#dbeafe" font-size="13">manifest-completeness audit · org-level qualitative assessment deferred (#435)</text>
+
+    <text x="48"   y="1782" fill="#f1f5f9" font-size="15">evaluate-nist-ai-rmf-measure</text>
+    <text x="430"  y="1782" fill="#cbd5e1" font-size="14">NIST AI RMF 1.0 MEASURE (10 subcategories)</text>
+    <rect x="760"  y="1766" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1766" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1782" fill="#dbeafe" font-size="13">manifest-completeness audit · org-level qualitative assessment deferred (#435)</text>
+
+    <text x="48"   y="1812" fill="#f1f5f9" font-size="15">evaluate-nist-ai-rmf-manage</text>
+    <text x="430"  y="1812" fill="#cbd5e1" font-size="14">NIST AI RMF 1.0 MANAGE (10 subcategories)</text>
+    <rect x="760"  y="1796" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="1796" width="40" height="22" rx="4" fill="#1e3a8a" stroke="#3b82f6"/>
+    <text x="1020" y="1812" fill="#dbeafe" font-size="13">manifest-completeness audit · org-level qualitative assessment deferred (#435)</text>
   </g>
 
   <!-- Footer (two lines to fit canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="1726" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 39</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, GCP service-account-key/token-minting, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, response-exfiltration, Snowflake bulk-egress, Snowflake share-creation, Snowflake account-key, Snowflake warehouse resize-burst, Snowflake unauthorized-grant, ClickHouse bulk-export, and Databricks token-creation slices are detection-first today</tspan></text>
-    <text x="48" y="1744" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
+    <text x="48" y="1856" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 39</tspan> · <tspan fill="#f87171" font-weight="900">lateral-movement stays detection-only by design, and the AWS access-key, login-profile, GCP service-account-key/token-minting, discovery, exfiltration, logging, AWS and GCP model-artifact collection, MCP leakage, system-prompt, policy-bypass, response-exfiltration, Snowflake bulk-egress, Snowflake share-creation, Snowflake account-key, Snowflake warehouse resize-burst, Snowflake unauthorized-grant, ClickHouse bulk-export, and Databricks token-creation slices are detection-first today</tspan></text>
+    <text x="48" y="1874" fill="#94a3b8" font-size="13">All writes HITL-gated, dry-run-default, dual-audited (DynamoDB + KMS S3, before + after) · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="540" viewBox="0 0 1400 540" role="img" aria-labelledby="title desc">
   <title id="title">agentic security skills for cloud and AI — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 90 shipped skill bundles, OCSF 1.8, 91 benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 39 detect, 11 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 90 shipped skill bundles, OCSF 1.8, 131 CIS + NIST AI RMF benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 15 ingest, 5 discover, 39 detect, 11 evaluate, 12 remediate, 2 view, 3 output, and 3 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -66,7 +66,7 @@
     <g transform="translate(80,272)">
       <g>
         <rect x="0" y="0" width="170" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">76</text>
+        <text x="16" y="23" fill="#93c5fd" font-size="16" font-weight="900">90</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(182,0)">
@@ -75,7 +75,7 @@
       </g>
       <g transform="translate(328,0)">
         <rect x="0" y="0" width="200" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
-        <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">91</text>
+        <text x="16" y="23" fill="#5eead4" font-size="16" font-weight="900">131</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="13" font-weight="700">benchmark checks</text>
       </g>
     </g>
@@ -145,12 +145,12 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="194" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">29</text>
+        <text x="194" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">39</text>
       </g>
       <g transform="translate(222,48)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L4 Evaluate</text>
-        <text x="194" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">7</text>
+        <text x="194" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">11</text>
       </g>
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="210" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -86,10 +86,10 @@
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
       <!-- Counts: 76 total, current breakdown -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">79</text>
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">90</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 39 detect · 5 discover · 7 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">15 ingest · 39 detect · 5 discover · 11 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 3 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloud-ai-security-skills"
-version = "0.9.0"
+version = "0.10.0"
 description = "Agentic security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "cloud-ai-security-skills"
-version = "0.9.0"
+version = "0.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.10.0**. After this lands, tag `v0.10.0` and cut the GitHub Release.

Rolls up the 14 substantive PRs merged since v0.9.0 into one CHANGELOG section, bumps version + uv.lock, refreshes hand-edited SVGs and Mermaid sources to the new counts, and regenerates the auto-generated coverage / framework / security-bar docs.

## Deliverables

- **Version bump** — `pyproject.toml` 0.9.0 → 0.10.0; `uv.lock` self-pin re-stamped (one-line diff, no transitive moves).
- **CHANGELOG `[0.10.0]` section** — dated 2026-05-10, 69 content lines, 6 grouped subsections (Vendor depth, AI governance, Runtime reliability, MCP transport, Audit honesty, Quality / infrastructure), and a `### Changed` count callout. `[Unreleased]` emptied.
- **README** — version badge 0.9.0 → 0.10.0; hero alt text updated to "131 CIS + NIST AI RMF benchmark checks"; Quickstart branch v0.8.1 → v0.10.0; Compliance frameworks line already lists NIST AI RMF.
- **SVGs (hand-edited; no Mermaid regen)** —
  - `hero-banner.svg`: shipped-skills 76 → 90, benchmark-checks 91 → 131, L3 Detect 29 → 39, L4 Evaluate 7 → 11, desc text updated.
  - `architecture-layers.svg`: L4 big number 7 → 11; desc "11 benchmark families covering 91 checks" → "131 checks".
  - `runtime-surfaces.svg`: big number 79 → 90; row "15 ingest · 39 detect · 5 discover · 7 eval" → "11 eval".
  - `coverage-matrix.svg`: EVALUATION header now reads "4 platforms · 91 checks · NIST AI RMF 40 subcategories"; 4 NIST AI RMF rows appended under the EVALUATION section; canvas height 1760 → 1890, footer relocated.
- **Diagram sources** — `skill-hierarchy.mmd`: L3 32 → 39 with a new WAREHOUSE subgraph (7 nodes); L4 7 → 11 with a new AI-GOVERNANCE subgraph (4 NIST AI RMF nodes). `surface-comparison.mmd`: 79 → 90 in the comment header and the SkillSpec registry node label.
- **Auto-doc regen** — `coverage_summary.py --write`, `generate_framework_coverage_doc.py`, `generate_security_bar_matrix.py` all idempotent (no diff produced).

## Count bump

| Surface | v0.9.0 | v0.10.0 |
| --- | --- | --- |
| Total skills | 79 | **90** |
| Detection | 32 | **39** |
| Evaluation | 7 | **11** |
| Benchmark checks | 91 | **131** (91 CIS + 40 NIST AI RMF subcategories) |

## Validation

All 13 acceptance gates pass on this branch:

```
validate_skill_count_consistency   total=90 detection=39 remediation=12 evaluation=11
validate_skill_contract            passed for 90 skills
validate_framework_coverage        90 skills · 18 frameworks
validate_skill_structure           passed
validate_skill_runtime             imported 90 entrypoints
validate_safe_skill_bar            passed
validate_dependency_consistency    passed
validate_ocsf_metadata             passed
validate_captured_provenance       2 fixtures validated
coverage_summary.py --check        in sync
generate_security_bar_matrix --check  in sync (90 skills)
generate_framework_coverage_doc --check  in sync
ruff check                         All checks passed!
pytest skills/                     2763 passed in 4.73s
```

`uv lock` produced no transitive moves — only the package self-pin flipped 0.9.0 → 0.10.0.

## Test plan

- [ ] Validators in CI green on this PR.
- [ ] Merge to main.
- [ ] Tag `v0.10.0` locally + push tag.
- [ ] Cut GitHub Release using the CHANGELOG `[0.10.0]` body.