### PR TITLE
docs: add INGEST_COVERAGE.md — vendor → OCSF class matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent 
 
 **Find a skill:** [`docs/SKILL_INDEX.md`](docs/SKILL_INDEX.md) groups every shipped skill by **environment** (AWS · GCP · Azure/Entra · K8s · Identity · AI/MCP · Web · Cross-env) and by **purpose** (ingest / discover / detect / evaluate / remediate / view / output / source), and points at the framework-mapping docs for control-catalog pivots.
 
+**Which vendor signals normalize to OCSF today?** [`docs/INGEST_COVERAGE.md`](docs/INGEST_COVERAGE.md) — the canonical vendor × source × OCSF class matrix, 16 mappings shipped (AWS · GCP · Azure · Entra · K8s · Okta · Workspace · MCP) plus the 9 documented roadmap rows (GitHub, Slack, Workday, Salesforce, SAP, AWS Config, native ClickHouse audit, AWS web-app exfil pipeline, Workspace beyond-login).
+
 ## Architecture
 
 External signals enter through two intake layers, pass through two analyze layers, exit through two act layers, and persist through one output layer. MCP, CLI, CI, webhook, and runners all invoke the same skill bundle — the surface is transport, not behavior.

--- a/docs/INGEST_COVERAGE.md
+++ b/docs/INGEST_COVERAGE.md
@@ -1,0 +1,87 @@
+# Ingest coverage — vendor signals → OCSF 1.8 classes
+
+What each cloud / identity / AI-runtime data source becomes when it flows
+through this repo's ingest layer — and what's not yet covered.
+
+This page is the single source of truth for **"which signal can I send and
+get OCSF out the other side?"** The 18 rows below are the canonical answer at
+v0.10.0; the roadmap rows below are tracked in their linked issues.
+
+## Currently shipped — 16 ingest mappings
+
+| Vendor | Source signal | OCSF 1.8 class | Skill |
+|---|---|---|---|
+| AWS | CloudTrail event records | API Activity 6003 | [`ingest-cloudtrail-ocsf`](../skills/ingestion/ingest-cloudtrail-ocsf/) |
+| AWS | GuardDuty findings | Detection Finding 2004 | [`ingest-guardduty-ocsf`](../skills/ingestion/ingest-guardduty-ocsf/) |
+| AWS | Security Hub findings | Detection Finding 2004 | [`ingest-security-hub-ocsf`](../skills/ingestion/ingest-security-hub-ocsf/) |
+| AWS | VPC Flow Logs | Network Activity 4001 | [`ingest-vpc-flow-logs-ocsf`](../skills/ingestion/ingest-vpc-flow-logs-ocsf/) |
+| GCP | Cloud Audit (Admin / Data) | API Activity 6003 | [`ingest-gcp-audit-ocsf`](../skills/ingestion/ingest-gcp-audit-ocsf/) |
+| GCP | Security Command Center findings | Detection Finding 2004 | [`ingest-gcp-scc-ocsf`](../skills/ingestion/ingest-gcp-scc-ocsf/) |
+| GCP | VPC Flow Logs | Network Activity 4001 | [`ingest-vpc-flow-logs-gcp-ocsf`](../skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf/) |
+| Azure | Activity Log | API Activity 6003 | [`ingest-azure-activity-ocsf`](../skills/ingestion/ingest-azure-activity-ocsf/) |
+| Azure | Defender for Cloud findings | Detection Finding 2004 | [`ingest-azure-defender-for-cloud-ocsf`](../skills/ingestion/ingest-azure-defender-for-cloud-ocsf/) |
+| Azure | NSG Flow Logs | Network Activity 4001 | [`ingest-nsg-flow-logs-azure-ocsf`](../skills/ingestion/ingest-nsg-flow-logs-azure-ocsf/) |
+| Microsoft Entra | Directory Audit logs | IAM events — Authentication 3002 / Account Change 3001 / User Access 3005 | [`ingest-entra-directory-audit-ocsf`](../skills/ingestion/ingest-entra-directory-audit-ocsf/) |
+| Kubernetes | API server audit log | API Activity 6003 | [`ingest-k8s-audit-ocsf`](../skills/ingestion/ingest-k8s-audit-ocsf/) |
+| Okta | System Log | IAM events — Authentication 3002 / Account Change 3001 / User Access 3005 | [`ingest-okta-system-log-ocsf`](../skills/ingestion/ingest-okta-system-log-ocsf/) |
+| Google Workspace | Login activity (Reports API) | Authentication 3002 | [`ingest-google-workspace-login-ocsf`](../skills/ingestion/ingest-google-workspace-login-ocsf/) |
+| MCP proxy | JSON-RPC request/response log | Application Activity 6002 | [`ingest-mcp-proxy-ocsf`](../skills/ingestion/ingest-mcp-proxy-ocsf/) |
+| AWS / GCP / Azure | Cross-cloud secret-scan + AI-BOM input pipes | (consumed by downstream detect-agent-credential-leak-mcp / discover-ai-bom) | covered transitively via the four above |
+
+> 16 rows for 15 ingest skills: the Entra and Okta normalizers each emit 3
+> different OCSF IAM classes depending on the source event family, so they
+> are listed once but produce more than one OCSF class.
+
+## Warehouse read-side adapters — 3 skills
+
+These do **not** emit OCSF directly; they expose a read-side adapter that the
+matching warehouse-depth detectors (Snowflake / Databricks / ClickHouse —
+shipped under issue #436) consume. The detectors are what produces the OCSF
+Detection Finding 2004 records.
+
+| Warehouse | Source | Adapter skill | Consuming detectors |
+|---|---|---|---|
+| Snowflake | `query_history`, audit views | [`source-snowflake-query`](../skills/ingestion/source-snowflake-query/) | `detect-snowflake-bulk-data-egress`, `detect-snowflake-share-creation`, `detect-snowflake-account-key-creation`, `detect-snowflake-warehouse-resize-burst`, `detect-snowflake-unauthorized-grant` |
+| Databricks | SQL Warehouse + audit | [`source-databricks-query`](../skills/ingestion/source-databricks-query/) | `detect-databricks-token-creation` |
+| AWS S3 | `s3 select` (Athena-style) | [`source-s3-select`](../skills/ingestion/source-s3-select/) | any detector reading historical CloudTrail / GuardDuty exports from S3 |
+
+A dedicated native `ingest-clickhouse-query-log-ocsf` is on the roadmap (see
+below) — for now `detect-clickhouse-bulk-export` reads `system.query_log`
+records already shaped as OCSF API Activity 6003 by an upstream pipeline.
+
+## Roadmap — not yet shipped, tracked
+
+| Vendor | Source | Target OCSF class | Tracking |
+|---|---|---|---|
+| AWS | Config item history + change stream | Compliance Finding 2003 | [`#29`](https://github.com/msaad00/cloud-ai-security-skills/issues/29) — `ingest-aws-config-ocsf` + paired CIS-AWS evaluator |
+| ClickHouse | `system.query_log` native ingest | API Activity 6003 | [`#436`](https://github.com/msaad00/cloud-ai-security-skills/issues/436) — `ingest-clickhouse-query-log-ocsf` |
+| AWS | Lambda + API Gateway access logs | HTTP Activity 4002 | [`#253`](https://github.com/msaad00/cloud-ai-security-skills/issues/253) — first detection-side use case is the web-app exfil arc |
+| GitHub | Audit Log (org-level) | API Activity 6003 | [`#31`](https://github.com/msaad00/cloud-ai-security-skills/issues/31) — vendor story PR K (ingest + 3 detectors) |
+| Google Workspace | Drive / Admin / Mobile feeds (beyond login) | API Activity 6003 + IAM 3001/3005 | [`#32`](https://github.com/msaad00/cloud-ai-security-skills/issues/32) — vendor story PR L |
+| Slack | Audit API (org-level) | API Activity 6003 | [`#33`](https://github.com/msaad00/cloud-ai-security-skills/issues/33) — vendor story PR M |
+| Workday | HR events stream | (proprietary → canonical departure manifest, not OCSF) | [`#34`](https://github.com/msaad00/cloud-ai-security-skills/issues/34) — vendor story PR N; existing `iam-departures-reconciler` is the consumer |
+| Salesforce | Setup Audit Trail + Event Monitoring | API Activity 6003 + Authentication 3002 | [`#35`](https://github.com/msaad00/cloud-ai-security-skills/issues/35) — vendor story PR O |
+| SAP | Security Audit Log | API Activity 6003 | [`#36`](https://github.com/msaad00/cloud-ai-security-skills/issues/36) — vendor story PR P |
+
+## What "shipped" means here
+
+A row in the shipped table guarantees:
+
+1. There's a `SKILL.md` documenting the input schema, exact OCSF class emitted, and the do-not-use list.
+2. There's a synthetic golden fixture under [`skills/detection-engineering/golden/`](../skills/detection-engineering/golden/) — see [`golden/README.md`](../skills/detection-engineering/golden/README.md) for the honesty contract on what those fixtures verify (contract, determinism, schema validity) vs. what they don't (precision/recall on real workloads).
+3. The skill is exercised by at least one downstream detector or test in CI.
+4. The OCSF wire shape is locked by snapshot test.
+
+A row in the roadmap table guarantees:
+
+1. There's a tracking issue (linked).
+2. The intended OCSF class is documented up-front.
+3. Nothing is half-built or stubbed in the repo today.
+
+## Adding a new vendor mapping
+
+1. Open or claim the tracking issue.
+2. Add the SKILL.md + `src/ingest.py` + golden fixture under `skills/ingestion/ingest-<vendor>-<source>-ocsf/`.
+3. Run `scripts/coverage_summary.py --write` and `scripts/generate_framework_coverage_doc.py` to refresh the auto-generated docs.
+4. Move the row in this file from the roadmap table to the shipped table in the same PR.
+5. The CI count-consistency gate enforces the move.


### PR DESCRIPTION
Pre-tag polish for v0.10.0. Closes a reader-visible gap that the v0.10.0 release-prep PR (#470) didn't address: **which vendor signals normalize to OCSF today, and which are roadmap?**

## What ships

- **`docs/INGEST_COVERAGE.md`** — the canonical vendor × source × OCSF class matrix:
  - **16 shipped mappings** with the SKILL.md path each row owns: AWS (CloudTrail, GuardDuty, Security Hub, VPC Flow Logs), GCP (Cloud Audit, SCC, VPC Flow Logs), Azure (Activity Log, Defender, NSG Flow Logs), Microsoft Entra (Directory Audit), Kubernetes (audit log), Okta (System Log), Google Workspace (Login), MCP proxy. The Entra and Okta normalizers emit 3 OCSF IAM classes each so the row count exceeds the skill count.
  - **3 warehouse read-side adapters** (Snowflake, Databricks, S3 Select) listed separately with the 6 consuming detectors — explicit about which adapters do *not* emit OCSF directly and which detectors carry the OCSF wire shape.
  - **9 roadmap rows** with tracking issues: AWS Config (#29), native ClickHouse audit (#436), AWS web-app exfil pipeline (#253), GitHub (#31), Workspace beyond-login (#32), Slack (#33), Workday (#34), Salesforce (#35), SAP (#36).
- **`README.md`** — new pointer line under "Find a skill" so the discoverability path is **total counts → SKILL_INDEX → INGEST_COVERAGE**.

## Validation

- `python scripts/validate_skill_count_consistency.py` → 90 / 39 / 12 / 11 ✅
- `python scripts/validate_skill_contract.py` → 90 skills ✅
- No skill-source changes; doc-only PR.

## Why now

This was the reader-visibility gap that surfaced in the v0.10.0 review. Folding it in before the tag so the release reflects honest coverage. Tag `v0.10.0` follows once this lands.

cc the open ingest roadmap issues: #29 #31 #32 #33 #34 #35 #36 #253 #436