### PR TITLE
fix(diagrams): drop HTML entities that break GitHub Mermaid renderer

### DIFF
--- a/docs/diagrams/agent-topology.mmd
+++ b/docs/diagrams/agent-topology.mmd
@@ -34,4 +34,4 @@ flowchart TB
 
   mcp --> guards{"Guards<br/>allowlist · dry-run · HITL · RLIMIT · audit"}:::wrap
   guards --> reg["SkillSpec registry<br/>(SKILL.md frontmatter)"]:::registry
-  reg --> skills["76 shipped skill bundles<br/>(skills/&lt;category&gt;/&lt;name&gt;/)"]:::skills
+  reg --> skills["90 shipped skill bundles<br/>(skills/[category]/[name]/)"]:::skills

--- a/docs/diagrams/mcp-trust-boundary.mmd
+++ b/docs/diagrams/mcp-trust-boundary.mmd
@@ -6,7 +6,7 @@ sequenceDiagram
   participant Agent as Agent (Claude / Cursor / Codex / …)
   participant Wrap as mcp-server (stdio)
   participant Guards as Guards (allowlist · dry-run · HITL · RLIMIT)
-  participant Skill as skills/&lt;cat&gt;/&lt;name&gt;/src/&lt;entry&gt;.py
+  participant Skill as "skills/[cat]/[name]/src/[entry].py"
   participant Sink as Audit log (JSONL · HMAC chain)
 
   Agent->>Wrap: tools/call name, args, _caller_context, _approval_context
@@ -24,7 +24,7 @@ sequenceDiagram
     Guards-->>Wrap: refuse
     Wrap-->>Agent: -32602 approval required
     Wrap->>Sink: audit_event result=error
-  else min_approvers &gt; approvals supplied
+  else min_approvers exceeds approvals supplied
     Guards-->>Wrap: refuse
     Wrap-->>Agent: -32602 N approvers required
     Wrap->>Sink: audit_event result=error

--- a/docs/diagrams/surface-comparison.mmd
+++ b/docs/diagrams/surface-comparison.mmd
@@ -11,7 +11,7 @@ flowchart TD
 
   subgraph SURFACES["Six surfaces · same SKILL.md + src/ + tests/"]
     direction LR
-    cli["CLI / pipes<br/>python skills/&lt;x&gt;/&lt;y&gt;/src/&lt;entry&gt;.py<br/>local user trust"]:::surface
+    cli["CLI / pipes<br/>python skills/[x]/[y]/src/[entry].py<br/>local user trust"]:::surface
     ci["CI<br/>.github/workflows/ci.yml<br/>repo-trusted runner"]:::surface
     mcp["MCP wrapper (stdio)<br/>JSON-RPC 2.0<br/>Claude Code · Desktop · Cursor · Codex · Cortex · Windsurf · Zed"]:::surface
     web["Webhook receiver<br/>FastAPI + HMAC + bearer<br/>S3 EventBridge · vendor callback · API gateway"]:::surface


### PR DESCRIPTION
GitHub flagged \`docs/diagrams/mcp-trust-boundary.mmd\` with a Mermaid parse error at line 6 — the trust-boundary diagram wasn't rendering on the file's preview pane.

## Root cause

HTML entities (\`&lt;\`, \`&gt;\`, \`&amp;\`) inside Mermaid sequence-diagram participant labels and flowchart node labels. GitHub's Mermaid version expects arrow / link tokens at those positions and chokes on the entity characters.

## Fixes (3 files, 4 edits)

- **`mcp-trust-boundary.mmd`** line 9: `Skill as skills/<cat>/<name>/src/<entry>.py` → quoted-string label with square-bracket placeholders.
- **`mcp-trust-boundary.mmd`** line 27: `else min_approvers > approvals supplied` → `else min_approvers exceeds approvals supplied` (avoids the bare `>` inside an alt-branch label).
- **`agent-topology.mmd`** line 37: `(skills/<category>/<name>/)` → `(skills/[category]/[name]/)`. Also bumped stale `76 shipped skill bundles` → `90 shipped skill bundles` to match v0.10.0.
- **`surface-comparison.mmd`** line 14: `python skills/<x>/<y>/src/<entry>.py` → `python skills/[x]/[y]/src/[entry].py`.

Square brackets are unambiguous in Mermaid label context and render identically across versions.

## Validation

- No behaviour change; rendering only.
- Sibling `pipeline-blast-radius.mmd` carries `&amp;` inside a quoted node (\`MITRE ATT&amp;CK\`) — GitHub renders quoted-string labels with entities cleanly, so left alone.

Post-v0.10.0 polish. Tag stays at v0.10.0.