### PR TITLE
build(deps-dev): bump clickhouse-connect <1 → <2 (replaces #492)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ azure = [
   "azure-mgmt-storage>=21,<25",
 ]
 iam_departures = [
-  "clickhouse-connect>=0.7,<1",
+  "clickhouse-connect>=0.7,<2",
   "databricks-sql-connector>=4.2.5,<5",
   "google-api-python-client>=2,<3",
   { include-group = "http-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -554,7 +554,7 @@ http-client = [
 ]
 http-runtime = [{ name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" }]
 iam-departures = [
-    { name = "clickhouse-connect", specifier = ">=0.7,<1" },
+    { name = "clickhouse-connect", specifier = ">=0.7,<2" },
     { name = "databricks-sql-connector", specifier = ">=4.2.5,<5" },
     { name = "google-api-python-client", specifier = ">=2,<3" },
     { name = "httpx", specifier = ">=0.27,<1" },


### PR DESCRIPTION
Carries the clickhouse-connect bound bump from #492 plus the lockfile refresh that Dependabot needed but couldn't generate. Once this merges, #492 can be closed as superseded.