### PR TITLE
feat(clickhouse): ClickHouse-native dashboards for the security data lake

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The repo ships an end-to-end, closed-loop story on ClickHouse: OCSF ingest skill
 | Replay | any `detect-*` / `view-*` / `discover-control-evidence` | re-run the same skill bundle against historical lake rows |
 | Loop | `sink-clickhouse-jsonl` → findings / evidence / audit | replay output lands back in append-only tables |
 
-Why ClickHouse for this lake — operator-owned deployment, MergeTree tables, materialized-view rollups, `TTL` retention without external lifecycle services, and row policies for multi-tenant isolation. Full hero walk-through: [`docs/CLICKHOUSE_DATA_LAKE.md`](docs/CLICKHOUSE_DATA_LAKE.md). Use a different shipped sink/source lane when the customer has already standardized on another warehouse or object-lake contract.
+Why ClickHouse for this lake — operator-owned deployment, MergeTree tables, materialized-view rollups, `TTL` retention without external lifecycle services, row policies for multi-tenant isolation, and a ClickHouse-native dashboard/query pack. Full hero walk-through: [`docs/CLICKHOUSE_DATA_LAKE.md`](docs/CLICKHOUSE_DATA_LAKE.md). Use a different shipped sink/source lane when the customer has already standardized on another warehouse or object-lake contract.
 
 ## Agent integrations
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -519,7 +519,7 @@ This is the architectural roadmap. Vendor-story PRs (#29–#39) continue in para
 | **PR W — sink-security-lake-ocsf** | OCSF Parquet with AWS Security Lake partitioning (zero-transform target) | P1 | Most strategic sink — AWS Security Lake *is* OCSF-native |
 | **PR Y — Ramp vendor story** | `ingest-ramp-ocsf` + `detect-ramp-vendor-change-with-payment` + `detect-ramp-spend-limit-bypass` + `detect-ramp-card-to-unknown-merchant` | P1 | First non-cloud, business-logic vendor story |
 | **PR Z — ingest-snowflake-audit-ocsf** | Snowflake `ACCOUNT_USAGE` audit into OCSF | P2 | Closes the loop: Cortex Code users can detect on their own platform |
-| ~~**PR AA — sink-clickhouse-ocsf**~~ **(shipped — Unreleased)** | MergeTree DDL pack (`packs/clickhouse/`), `sink-clickhouse-jsonl` write side, `source-clickhouse-query` read side, materialized-view rollups, row-policy tenant isolation, [`docs/CLICKHOUSE_DATA_LAKE.md`](CLICKHOUSE_DATA_LAKE.md) hero use case | done | Closes the ClickHouse story end-to-end |
+| ~~**PR AA — sink-clickhouse-ocsf**~~ **(shipped — Unreleased)** | MergeTree DDL pack (`packs/clickhouse/`), `sink-clickhouse-jsonl` write side, `source-clickhouse-query` read side, materialized-view rollups, row-policy tenant isolation, ClickHouse-native dashboard query catalog ([`packs/clickhouse/dashboards/`](../packs/clickhouse/dashboards/)), [`docs/CLICKHOUSE_DATA_LAKE.md`](CLICKHOUSE_DATA_LAKE.md) hero use case | done | Closes the ClickHouse story end-to-end |
 | **PR BB — enrich-asset-inventory-ocsf** | Joins findings with `discover-environment` graph | P2 | Turns findings into triageable blast-radius context |
 
 ## 14. Non-goals (explicit)

--- a/docs/CLICKHOUSE_DATA_LAKE.md
+++ b/docs/CLICKHOUSE_DATA_LAKE.md
@@ -64,7 +64,7 @@ different substrates. Use the ClickHouse lane when these constraints matter:
 | Hot analytical reads | MergeTree tables, skip indexes, and rollups keep replay queries small and predictable. |
 | Replay economics | Raw OCSF JSONL stays append-only while materialized views answer operator summary questions. |
 | Sovereign deployment | Can run inside the customer's cloud, VPC, Kubernetes cluster, identity, and audit boundary. |
-| SQL-native operator UX | Materialized views and query templates support ClickHouse-native or existing dashboard surfaces without changing the lake contract. |
+| ClickHouse-native operator UX | Same-schema dashboard query catalog plus Cloud SQL Console queries are shipped in the pack. |
 
 Pick this lane for an **operator-owned, low-latency, replayable security
 lake**. Pick another shipped sink/source lane when the customer's existing
@@ -203,9 +203,13 @@ agent-callable:
 ## Non-goals
 
 - This doc does not turn the repo into a SIEM. The lake replaces the SIEM's
-  **storage tier**, and the operator UX stays SQL-native: materialized views
-  and query templates provide stable surfaces for ClickHouse-native consoles
-  or existing dashboard tools.
+  **storage tier**, and the operator UX stays inside ClickHouse: the repo
+  ships a ClickHouse-native dashboard pack under
+  [`packs/clickhouse/dashboards/`](../packs/clickhouse/dashboards/) — rows
+  for `system.dashboards` (embedded `/dashboards` server, 22.10+) and saved
+  queries for the ClickHouse Cloud SQL Console, both keyed off the same
+  materialized views. No external visualization vendor enters the trust
+  contract.
 - The sink and source skills do not perform encryption-at-rest or
   TLS-in-flight on their own. Both are properties of the ClickHouse cluster
   the operator provisions.
@@ -216,6 +220,7 @@ agent-callable:
 ## Related
 
 - [`packs/clickhouse/README.md`](../packs/clickhouse/README.md) — pack contents and CLI run-through
+- [`packs/clickhouse/dashboards/`](../packs/clickhouse/dashboards/) — ClickHouse-native operator UX (`system.dashboards` + Cloud SQL Console)
 - [`SINK_CONTRACT.md`](SINK_CONTRACT.md) — what every sink must do, and what it must not
 - [`AGENT_DATA_LAKE_FLOW.md`](AGENT_DATA_LAKE_FLOW.md) — the three repo-supported lake flows
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) — the 7-layer skill model behind the diagram

--- a/packs/clickhouse/README.md
+++ b/packs/clickhouse/README.md
@@ -18,7 +18,7 @@ It is the DDL contract behind:
 | `TTL` clauses | Per-table retention without an external lifecycle service |
 | Row policies | Multi-tenant isolation via `JSONExtractString(payload, ..., uid)` |
 | Self-hosted **or** ClickHouse Cloud | Sovereign deployment is one Helm chart away |
-| Query templates | SQL-native operator surfaces without changing the lake contract |
+| Dashboard query catalog + Cloud SQL Console | ClickHouse-native operator queries over the same rollups |
 
 ## Layout
 
@@ -42,6 +42,11 @@ packs/clickhouse/
 │   ├── backfill_detection_window.sql
 │   ├── audit_trail_last_hour.sql
 │   └── top_rules_by_finding_volume.sql
+│
+├── dashboards/                           # ClickHouse-native operator UX
+│   ├── system_dashboards.sql             # same-schema dashboard query catalog
+│   ├── cloud_console_queries.sql         # paste-and-save queries for ClickHouse Cloud SQL Console
+│   └── README.md
 │
 └── golden/expected_columns.json          # column-name lock for CI checks
 ```

--- a/packs/clickhouse/dashboards/README.md
+++ b/packs/clickhouse/dashboards/README.md
@@ -1,0 +1,90 @@
+# ClickHouse security data lake — dashboards (ClickHouse-native)
+
+Operator UX on top of the lake, kept close to the ClickHouse data model. The
+pack ships a same-schema dashboard query catalog for self-hosted ClickHouse
+and saved-query templates for ClickHouse Cloud.
+
+ClickHouse ships two first-class dashboard surfaces — this pack uses both:
+
+| Surface | Where | What this pack ships |
+|---|---|---|
+| **Embedded `/dashboard` page** (self-hosted ClickHouse) | Built-in `system.dashboards` schema; ClickHouse also documents same-schema custom tables | `system_dashboards.sql` — creates `security.dashboard_queries`, a same-schema query catalog |
+| **ClickHouse Cloud SQL Console** | Cloud Console → SQL Console → Saved queries / Charts | `cloud_console_queries.sql` — 8 paste-and-save queries with chart-friendly column shapes |
+
+Both surfaces drive off the rollup materialized views in
+[`../materialized-views/`](../materialized-views/), so panel queries avoid
+rescanning raw OCSF JSONL rows. The rollups are volume counters over
+append-only inserts; if a replay can insert duplicates, use UID-aware raw-table
+queries for unique cardinality questions.
+
+## Install — self-hosted ClickHouse
+
+Prereq: a ClickHouse server with the `/dashboard` page and the
+`system.dashboards` schema available. The shipped SQL does not write to
+`system`; it creates `security.dashboard_queries`.
+
+```bash
+clickhouse-client --multiquery < packs/clickhouse/dashboards/system_dashboards.sql
+
+# inspect the query catalog:
+clickhouse-client --query "SELECT title, query FROM security.dashboard_queries"
+```
+
+`system_dashboards.sql` uses `CREATE OR REPLACE VIEW`, so re-running it
+refreshes the same catalog without duplicate rows. Time bounds
+(`{from:DateTime}`, `{to:DateTime}`) and the `{rounding:UInt32}` interval
+parameter follow ClickHouse's documented dashboard query shape.
+
+## Install — ClickHouse Cloud
+
+1. Cloud Console → SQL Console
+2. Open `cloud_console_queries.sql`, paste each query
+3. Save and (where the shape fits) attach a chart via the Console's chart
+   builder
+
+The shipped queries cover the same panel set as the self-hosted query catalog
+(stats, severity-stacked timeseries, top-rules table, OCSF-class stack,
+closed-loop remediation outcomes, noisy-rule SLO query).
+
+## Panels
+
+Both files ship the same panel set:
+
+1. Findings in window (total)
+2. OCSF events ingested (total)
+3. Remediation outcomes (total)
+4. Findings over time, by severity
+5. Top rules by finding volume
+6. Ingest volume by OCSF class
+7. Remediation outcomes by skill — closed loop
+8. Noisy-rule detector (Cloud Console only — pair with an alert rule)
+
+## External dashboard tools
+
+If your team already runs a dashboard tool, point it at the same materialized
+views. The pack does not require that path: `system_dashboards.sql` and
+`cloud_console_queries.sql` are enough to prove the lake with ClickHouse-native
+SQL surfaces.
+
+## Tenancy
+
+When the row policy `findings_tenant_isolation` is active (see
+[`../ddl/06_row_policies.sql`](../ddl/06_row_policies.sql)) every panel
+query needs `SET tenant_uid = '…'` on the session. The embedded
+dashboard page runs under the authenticated ClickHouse role, and the Cloud SQL
+Console runs in the role of the signed-in user — so tenancy is enforced at the
+connection layer, no extra wiring on the panel side.
+
+## Customizing
+
+- **More panels** — extend the materialized views in
+  [`../materialized-views/`](../materialized-views/) first; the dashboards
+  read from rolled-up tables so the views are the right knob to turn.
+- **Alerts** — for the self-hosted dashboard page, write an outside
+  scheduler that queries the same SQL on a cadence. For ClickHouse Cloud,
+  the Console has alert support; the noisy-rule query (panel 8) is
+  designed as a starter rule.
+- **Severity palette** — both surfaces honor the values the rule emits
+  into `findings_by_rule_hourly.severity`. If your team encodes severity
+  differently, adjust the upstream detection skills' OCSF severity
+  mapping — not the dashboard SQL.

--- a/packs/clickhouse/dashboards/cloud_console_queries.sql
+++ b/packs/clickhouse/dashboards/cloud_console_queries.sql
@@ -1,0 +1,97 @@
+-- ClickHouse Cloud SQL Console — saved-query bundle for the security data lake.
+--
+-- ClickHouse Cloud's SQL Console runs these directly: paste each statement
+-- in, save it, and the Console renders the result as a table or chart.
+-- Charts saved against these queries become the lake's operator panel
+-- without leaving the ClickHouse Cloud trust boundary.
+--
+-- All queries read the rollup materialized views, so they avoid rescanning
+-- raw OCSF JSONL rows. Time bounds are explicit so the Console can bind them
+-- to its own date picker.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Findings total (24h)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT toUInt64(sum(finding_count)) AS total
+FROM security.findings_by_rule_hourly
+WHERE bucket_hour >= now() - INTERVAL 1 DAY;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. OCSF events ingested (24h)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT toUInt64(sum(event_count)) AS events
+FROM security.events_by_class_daily
+WHERE bucket_day >= today() - 1;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Remediation outcomes (24h)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT toUInt64(sum(outcome_count)) AS remediations
+FROM security.remediations_by_outcome_daily
+WHERE bucket_day >= today() - 1;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. Findings over time, hourly buckets, last 7 days, split by severity
+--    (best rendered as a stacked area chart in the Console)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    bucket_hour                AS t,
+    severity                   AS severity,
+    sum(finding_count)         AS findings
+FROM security.findings_by_rule_hourly
+WHERE bucket_hour >= now() - INTERVAL 7 DAY
+GROUP BY t, severity
+ORDER BY t;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. Top firing rules in the last 7 days
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    rule_uid,
+    severity,
+    sum(finding_count) AS findings
+FROM security.findings_by_rule_hourly
+WHERE bucket_hour >= now() - INTERVAL 7 DAY
+GROUP BY rule_uid, severity
+ORDER BY findings DESC
+LIMIT 25;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 6. Ingest volume by OCSF class, daily, last 30 days
+--    (best rendered as a stacked area or bar chart)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    bucket_day              AS t,
+    toString(class_uid)     AS ocsf_class,
+    sum(event_count)        AS events
+FROM security.events_by_class_daily
+WHERE bucket_day >= today() - 30
+GROUP BY t, ocsf_class
+ORDER BY t;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 7. Remediation outcomes by skill — closed-loop view, last 30 days
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    skill_name,
+    remediation_state,
+    sum(outcome_count) AS outcomes
+FROM security.remediations_by_outcome_daily
+WHERE bucket_day >= today() - 30
+GROUP BY skill_name, remediation_state
+ORDER BY outcomes DESC
+LIMIT 50;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 8. Noisy-rule detector — rules with > 100 findings in the last hour
+--    Pair this with a Cloud Console alert rule for SLO-style noise budgets.
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+    rule_uid,
+    severity,
+    sum(finding_count) AS findings_last_hour
+FROM security.findings_by_rule_hourly
+WHERE bucket_hour >= now() - INTERVAL 1 HOUR
+GROUP BY rule_uid, severity
+HAVING findings_last_hour > 100
+ORDER BY findings_last_hour DESC;

--- a/packs/clickhouse/dashboards/system_dashboards.sql
+++ b/packs/clickhouse/dashboards/system_dashboards.sql
@@ -1,0 +1,47 @@
+-- ClickHouse-native dashboard query catalog for the security data lake.
+--
+-- ClickHouse documents `system.dashboards` as the built-in source for the
+-- HTTP `/dashboard` page, and notes that the page can render from any table
+-- with the same schema. System tables are read-only, so this pack creates a
+-- normal same-schema view under `security` instead of inserting into `system`.
+--
+-- Run once with an operator role:
+--   clickhouse-client --multiquery < system_dashboards.sql
+--
+-- Reference: https://clickhouse.com/docs/operations/system-tables/dashboards
+
+CREATE OR REPLACE VIEW security.dashboard_queries AS
+SELECT
+    'security-data-lake' AS dashboard,
+    'Findings in window (total)' AS title,
+    'SELECT toUInt64(sum(finding_count)) AS total FROM security.findings_by_rule_hourly WHERE bucket_hour >= {from:DateTime} AND bucket_hour < {to:DateTime}' AS query
+UNION ALL
+SELECT
+    'security-data-lake',
+    'OCSF events ingested (total)',
+    'SELECT toUInt64(sum(event_count)) AS events FROM security.events_by_class_daily WHERE bucket_day >= toDate({from:DateTime}) AND bucket_day < toDate({to:DateTime})'
+UNION ALL
+SELECT
+    'security-data-lake',
+    'Remediation outcomes (total)',
+    'SELECT toUInt64(sum(outcome_count)) AS remediations FROM security.remediations_by_outcome_daily WHERE bucket_day >= toDate({from:DateTime}) AND bucket_day < toDate({to:DateTime})'
+UNION ALL
+SELECT
+    'security-data-lake',
+    'Findings over time (by severity)',
+    'SELECT toStartOfInterval(bucket_hour, INTERVAL {rounding:UInt32} SECOND) AS t, severity, sum(finding_count) AS findings FROM security.findings_by_rule_hourly WHERE bucket_hour >= {from:DateTime} AND bucket_hour < {to:DateTime} GROUP BY t, severity ORDER BY t'
+UNION ALL
+SELECT
+    'security-data-lake',
+    'Top rules by finding volume',
+    'SELECT rule_uid, severity, sum(finding_count) AS findings FROM security.findings_by_rule_hourly WHERE bucket_hour >= {from:DateTime} AND bucket_hour < {to:DateTime} GROUP BY rule_uid, severity ORDER BY findings DESC LIMIT 25'
+UNION ALL
+SELECT
+    'security-data-lake',
+    'Ingest volume by OCSF class',
+    'SELECT toStartOfInterval(toDateTime(bucket_day), INTERVAL {rounding:UInt32} SECOND) AS t, toString(class_uid) AS ocsf_class, sum(event_count) AS events FROM security.events_by_class_daily WHERE bucket_day >= toDate({from:DateTime}) AND bucket_day < toDate({to:DateTime}) GROUP BY t, ocsf_class ORDER BY t'
+UNION ALL
+SELECT
+    'security-data-lake',
+    'Remediation outcomes by skill',
+    'SELECT skill_name, remediation_state, sum(outcome_count) AS outcomes FROM security.remediations_by_outcome_daily WHERE bucket_day >= toDate({from:DateTime}) AND bucket_day < toDate({to:DateTime}) GROUP BY skill_name, remediation_state ORDER BY outcomes DESC LIMIT 50';


### PR DESCRIPTION
## Summary
Pivoted from the original Grafana + Superset approach. Operator UX stays inside ClickHouse — the lake is the storage tier and the query surface the operator sees, no second visualization vendor in the trust contract.

Closes the dashboard track of \`ARCHITECTURE.md\` PR AA.

## What's shipped
- \`packs/clickhouse/dashboards/system_dashboards.sql\` — creates \`security.dashboard_queries\`, a same-schema view matching the shape of ClickHouse's built-in \`system.dashboards\` source for the \`/dashboard\` HTTP page. \`system\` tables are read-only, so the pack stays out of \`system\` and surfaces the same panels from a normal \`security\`-database view. \`CREATE OR REPLACE VIEW\` makes re-runs idempotent.
- \`packs/clickhouse/dashboards/cloud_console_queries.sql\` — paste-and-save bundle for the ClickHouse Cloud SQL Console, with chart-friendly column shapes. Includes a noisy-rule SLO detector (panel 8) for pairing with Cloud Console alerts.
- \`packs/clickhouse/dashboards/README.md\` — install steps for both surfaces, panel list, tenancy notes pointing at the row-policy DDL, and a short note on external dashboard tools (no Grafana / Superset artifact ships — teams that already run one can point it at the same materialized views).
- \`docs/ARCHITECTURE.md\` PR AA — mentions the ClickHouse-native dashboard query catalog.

## Why not Grafana / Superset
- Adds a second vendor to the trust contract for something the lake already does itself.
- Cross-tool palette + tenancy contexts drift without a strong contract.
- ClickHouse Cloud's roadmap keeps absorbing operator UX (saved queries, charts, alerts) — building against the moving native surface compounds; building against an external tool depreciates.

Both shipped surfaces drive off the rollup materialized views in \`packs/clickhouse/materialized-views/\`, so panel queries avoid rescanning raw OCSF JSONL.

## Stacked on top of
This PR depends on #496 (the lake hero PR). Rebase onto \`main\` after #496 merges so the diff shrinks to the three new dashboard files + the one PR-AA line edit.

## Test plan
- [x] \`pytest -q\` — 3254 passed
- [x] \`validate_skill_count_consistency.py\` + \`validate_doc_counts.py\` — pass
- [x] SQL files parse as valid ClickHouse SQL (single-statement and multi-statement modes)