### PR TITLE
feat(evaluation): add aws config cis ocsf evaluator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,12 @@ Current shipped surface on `main`:
 - **`ingestion/`**: 18 ingest skills plus 4 source adapters
 - **`discovery/`**: 5 read-only skills including `iam-departures-reconciler`
 - **`detection/`**: 64 deterministic ATT&CK-tagged detectors
-- **`evaluation/`**: 11 posture / benchmark families
+- **`evaluation/`**: 12 posture / benchmark families
 - **`view/`**: 2 render/export skills
 - **`remediation/`**: 12 HITL-gated write skills across AWS, GCP, Azure, Kubernetes, Okta, Workspace, Entra, and MCP
 - **`output/`**: 3 append-only sinks
 
-**Total shipped: 119 skill bundles.** Auto-generated per-framework rollup in [`docs/FRAMEWORK_COVERAGE.md`](docs/FRAMEWORK_COVERAGE.md); per-skill registry in [`docs/framework-coverage.json`](docs/framework-coverage.json).
+**Total shipped: 120 skill bundles.** Auto-generated per-framework rollup in [`docs/FRAMEWORK_COVERAGE.md`](docs/FRAMEWORK_COVERAGE.md); per-skill registry in [`docs/framework-coverage.json`](docs/framework-coverage.json).
 
 Notable current skills that older agent memory often misses:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Agentic security skills for cloud and AI — 119 shipped skill bundles. OCSF 1.8 on the wire. 131 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, GitHub, Slack, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![Agentic security skills for cloud and AI — 120 shipped skill bundles. OCSF 1.8 on the wire. 143 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, GitHub, Slack, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -12,7 +12,7 @@
   <a href="https://github.com/msaad00/agent-bom"><img alt="Scanned by agent-bom" src="https://img.shields.io/badge/scanned_by-agent--bom-164e63"></a>
 </p>
 
-<p align="center"><strong>119 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed, runs everywhere the same bundle can.</strong></p>
+<p align="center"><strong>120 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed, runs everywhere the same bundle can.</strong></p>
 
 ---
 
@@ -51,20 +51,20 @@ Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent 
 
 ## What this repo gives you
 
-**119 shipped skill bundles** — atomic, deterministic, single-concern. Twelve are guarded write paths; the rest are read-only skills or append-only source/output adapters. Drop one into a pipeline, an agent, a Step Function, or a `python ... | python ...` one-liner.
+**120 shipped skill bundles** — atomic, deterministic, single-concern. Twelve are guarded write paths; the rest are read-only skills or append-only source/output adapters. Drop one into a pipeline, an agent, a Step Function, or a `python ... | python ...` one-liner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
 | **Ingest** | 18 | normalize raw cloud / identity / K8s / MCP / SaaS signal | OCSF 1.8 (native opt-in) |
 | **Discover** | 5 | inventory · graph · AI BOM · evidence · IAM-departure planning | native / bridge JSON |
 | **Detect** | 64 | deterministic rules tagged with MITRE ATT&CK / ATLAS / OWASP | OCSF Detection Finding 2004 |
-| **Evaluate** | 11 | 131 posture and benchmark checks across CIS / NIST / NIST AI RMF / SOC 2 | compliance result |
+| **Evaluate** | 12 | 143 posture and benchmark checks across CIS / NIST / NIST AI RMF / SOC 2 | compliance result |
 | **Remediate** | 12 | guarded write paths — IAM departures × 3 clouds, network revoke × 3, session/credential kill × 4, K8s × 2, MCP tool quarantine | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks | S3 · Snowflake · ClickHouse |
 | **Sources** | 4 | warehouse query adapters | S3 Select · Snowflake · Databricks · ClickHouse |
 
-**Total: 119 shipped skills.**  Live counts and per-framework coverage in [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) (auto-generated, CI-gated).
+**Total: 120 shipped skills.**  Live counts and per-framework coverage in [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) (auto-generated, CI-gated).
 
 **Find a skill:** [`docs/SKILL_INDEX.md`](docs/SKILL_INDEX.md) groups every shipped skill by **environment** (AWS · GCP · Azure/Entra · K8s · Identity · AI/MCP · Web · Cross-env) and by **purpose** (ingest / discover / detect / evaluate / remediate / view / output / source), and points at the framework-mapping docs for control-catalog pivots.
 

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -124,6 +124,7 @@ is the row you can take to your auditor.
 | `cspm-aws-cis-benchmark` | evaluation | ⚠️ write-capable | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `cspm-azure-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `cspm-gcp-cis-benchmark` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
+| `evaluate-cis-aws-foundations-ocsf` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `evaluate-nist-ai-rmf-govern` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `evaluate-nist-ai-rmf-manage` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
 | `evaluate-nist-ai-rmf-map` | evaluation | ✅ | ✅ | ✅ | ✅ deterministic | ✅ 1.8 opt-in | ✅ |
@@ -149,7 +150,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_119 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_120 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/COVERAGE_SNAPSHOT.md
+++ b/docs/COVERAGE_SNAPSHOT.md
@@ -6,7 +6,7 @@ Auto-generated from [`framework-coverage.json`](framework-coverage.json) by [`sc
 python scripts/coverage_summary.py --write
 ```
 
-**Total shipped skills:** 119
+**Total shipped skills:** 120
 
 ## By cloud / vendor
 
@@ -14,19 +14,19 @@ Skills overlap when a skill targets multiple providers (the `multi` row), so the
 
 | Cloud / vendor | Skills | % of repo |
 |---|---:|---:|
-| AWS | 25 | 21.0% |
-| Multi-cloud (vendor-neutral) | 21 | 17.6% |
-| Azure | 19 | 16.0% |
-| GCP | 18 | 15.1% |
-| MCP / AI runtime | 14 | 11.8% |
-| Snowflake | 13 | 10.9% |
-| Kubernetes | 9 | 7.6% |
-| Databricks | 9 | 7.6% |
+| AWS | 26 | 21.7% |
+| Multi-cloud (vendor-neutral) | 21 | 17.5% |
+| Azure | 19 | 15.8% |
+| GCP | 18 | 15.0% |
+| MCP / AI runtime | 14 | 11.7% |
+| Snowflake | 13 | 10.8% |
+| Kubernetes | 9 | 7.5% |
+| Databricks | 9 | 7.5% |
 | ClickHouse | 5 | 4.2% |
-| Okta | 4 | 3.4% |
-| Microsoft Entra | 4 | 3.4% |
-| github | 4 | 3.4% |
-| Slack | 4 | 3.4% |
+| Okta | 4 | 3.3% |
+| Microsoft Entra | 4 | 3.3% |
+| github | 4 | 3.3% |
+| Slack | 4 | 3.3% |
 | Microsoft Graph | 3 | 2.5% |
 | Google Workspace | 3 | 2.5% |
 | Containers (runtime) | 3 | 2.5% |
@@ -38,20 +38,20 @@ Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF 
 
 | Framework | Skills | % of repo |
 |---|---:|---:|
-| OCSF 1.8 | 98 | 82.4% |
-| MITRE ATT&CK v14 | 79 | 66.4% |
-| SOC 2 TSC | 21 | 17.6% |
-| NIST CSF 2.0 | 21 | 17.6% |
-| OWASP Top 10 | 20 | 16.8% |
-| OWASP LLM Top 10 | 19 | 16.0% |
-| MITRE ATLAS | 17 | 14.3% |
+| OCSF 1.8 | 99 | 82.5% |
+| MITRE ATT&CK v14 | 79 | 65.8% |
+| SOC 2 TSC | 22 | 18.3% |
+| NIST CSF 2.0 | 22 | 18.3% |
+| OWASP Top 10 | 20 | 16.7% |
+| OWASP LLM Top 10 | 19 | 15.8% |
+| MITRE ATLAS | 17 | 14.2% |
 | OWASP MCP Top 10 | 11 | 9.2% |
 | NIST AI RMF | 8 | 6.7% |
+| CIS AWS v3 | 6 | 5.0% |
 | CIS Azure v2.1 | 6 | 5.0% |
-| CIS AWS v3 | 5 | 4.2% |
 | CIS GCP v3 | 5 | 4.2% |
-| PCI DSS 4.0 | 4 | 3.4% |
-| ISO 27001:2022 | 4 | 3.4% |
+| ISO 27001:2022 | 5 | 4.2% |
+| PCI DSS 4.0 | 4 | 3.3% |
 | CycloneDX ML-BOM | 2 | 1.7% |
 | CIS Controls v8 | 2 | 1.7% |
 | CIS Kubernetes | 2 | 1.7% |
@@ -61,10 +61,10 @@ Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF 
 
 | Layer | Skills | % of repo |
 |---|---:|---:|
-| detection | 64 | 53.8% |
-| ingestion | 22 | 18.5% |
-| remediation | 12 | 10.1% |
-| evaluation | 11 | 9.2% |
+| detection | 64 | 53.3% |
+| ingestion | 22 | 18.3% |
+| evaluation | 12 | 10.0% |
+| remediation | 12 | 10.0% |
 | discovery | 5 | 4.2% |
 | output | 3 | 2.5% |
 | view | 2 | 1.7% |

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,26 +4,26 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.11.0`
 - Registry updated: `2026-05-17`
-- Total shipped skills in registry: **119**
+- Total shipped skills in registry: **120**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **98** | — |
+| OCSF | 1.8.0 | **99** | — |
 | MITRE ATT&CK | v14 | **79** | 100% mapped coverage |
 | MITRE ATLAS | current | **17** | 100% mapped coverage |
-| CIS AWS Foundations | v3.0 | **5** | — |
+| CIS AWS Foundations | v3.0 | **6** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
 | CIS Azure Foundations | v2.1 | **6** | — |
 | CIS Kubernetes Benchmark | current | **2** | — |
 | CIS Docker Benchmark | current | **1** | — |
 | CIS Controls | v8 | **2** | — |
-| NIST CSF | 2.0 | **21** | 100% mapped coverage |
+| NIST CSF | 2.0 | **22** | 100% mapped coverage |
 | NIST AI RMF | current | **8** | — |
-| SOC 2 TSC | current | **21** | 100% mapped coverage |
+| SOC 2 TSC | current | **22** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
-| ISO 27001 | 2022 | **4** | — |
+| ISO 27001 | 2022 | **5** | — |
 | OWASP Top 10 | 2021 | **20** | — |
 | OWASP LLM Top 10 | current | **19** | — |
 | OWASP MCP Top 10 | current | **11** | — |
@@ -37,7 +37,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **98**
+Shipped skills mapped: **99**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -108,6 +108,7 @@ Shipped skills mapped: **98**
 | [`discover-cloud-control-evidence`](../skills/discovery/discover-cloud-control-evidence) | discovery | aws, azure, gcp, multi | evidence, inventory, network-segmentation, logging, encryption, key-management, ai-endpoints |
 | [`discover-control-evidence`](../skills/discovery/discover-control-evidence) | discovery | multi | evidence, inventory, ai-endpoints |
 | [`discover-environment`](../skills/discovery/discover-environment) | discovery | aws, azure, gcp, kubernetes, containers, multi | inventory, compute, storage, network, logging, clusters, ai-endpoints |
+| [`evaluate-cis-aws-foundations-ocsf`](../skills/evaluation/evaluate-cis-aws-foundations-ocsf) | evaluation | aws | storage, logging, network, security-services, config |
 | [`evaluate-nist-ai-rmf-govern`](../skills/evaluation/evaluate-nist-ai-rmf-govern) | evaluation | multi | ai-systems, policies, manifests |
 | [`evaluate-nist-ai-rmf-manage`](../skills/evaluation/evaluate-nist-ai-rmf-manage) | evaluation | multi | ai-systems, policies, manifests |
 | [`evaluate-nist-ai-rmf-map`](../skills/evaluation/evaluate-nist-ai-rmf-map) | evaluation | multi | ai-systems, policies, manifests |
@@ -264,13 +265,14 @@ Shipped skills mapped: **17**
 
 - Registry id: `cis-aws-v3`
 
-Shipped skills mapped: **5**
+Shipped skills mapped: **6**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`detect-aws-open-security-group`](../skills/detection/detect-aws-open-security-group) | detection | aws | security-groups, ingress-rules, cloudtrail |
 | [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled) | detection | aws | cloudtrail, audit-trails, logging |
 | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark) | evaluation | aws | identities, storage, logging, network |
+| [`evaluate-cis-aws-foundations-ocsf`](../skills/evaluation/evaluate-cis-aws-foundations-ocsf) | evaluation | aws | storage, logging, network, security-services, config |
 | [`ingest-aws-config-ocsf`](../skills/ingestion/ingest-aws-config-ocsf) | ingestion | aws | configuration, security-posture, compliance-evidence |
 | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke) | remediation | aws | security-groups, ingress-rules, audit |
 
@@ -342,7 +344,7 @@ Shipped skills mapped: **2**
 - Asset classes in scope: identities, storage, logging, network, clusters, runtime, evidence
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **21**
+Shipped skills mapped: **22**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -351,6 +353,7 @@ Shipped skills mapped: **21**
 | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark) | evaluation | aws | identities, storage, logging, network |
 | [`cspm-azure-cis-benchmark`](../skills/evaluation/cspm-azure-cis-benchmark) | evaluation | azure | identities, storage, logging, network |
 | [`cspm-gcp-cis-benchmark`](../skills/evaluation/cspm-gcp-cis-benchmark) | evaluation | gcp | identities, storage, logging, network |
+| [`evaluate-cis-aws-foundations-ocsf`](../skills/evaluation/evaluate-cis-aws-foundations-ocsf) | evaluation | aws | storage, logging, network, security-services, config |
 | [`gpu-cluster-security`](../skills/evaluation/gpu-cluster-security) | evaluation | aws, azure, gcp, kubernetes, containers, multi | gpu-fleets, clusters, containers, runtime, tenancy |
 | [`k8s-security-benchmark`](../skills/evaluation/k8s-security-benchmark) | evaluation | kubernetes | clusters, identities, network, logging |
 | [`model-serving-security`](../skills/evaluation/model-serving-security) | evaluation | aws, azure, gcp, multi | ai-endpoints, models, identities, network, logging, guardrails |
@@ -392,7 +395,7 @@ Shipped skills mapped: **8**
 - Asset classes in scope: access, logging, change, evidence, inventory, ai-endpoints
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **21**
+Shipped skills mapped: **22**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -400,6 +403,7 @@ Shipped skills mapped: **21**
 | [`discover-cloud-control-evidence`](../skills/discovery/discover-cloud-control-evidence) | discovery | aws, azure, gcp, multi | evidence, inventory, network-segmentation, logging, encryption, key-management, ai-endpoints |
 | [`discover-control-evidence`](../skills/discovery/discover-control-evidence) | discovery | multi | evidence, inventory, ai-endpoints |
 | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark) | evaluation | aws | identities, storage, logging, network |
+| [`evaluate-cis-aws-foundations-ocsf`](../skills/evaluation/evaluate-cis-aws-foundations-ocsf) | evaluation | aws | storage, logging, network, security-services, config |
 | [`model-serving-security`](../skills/evaluation/model-serving-security) | evaluation | aws, azure, gcp, multi | ai-endpoints, models, identities, network, logging, guardrails |
 | [`ingest-aws-config-ocsf`](../skills/ingestion/ingest-aws-config-ocsf) | ingestion | aws | configuration, security-posture, compliance-evidence |
 | [`sink-clickhouse-jsonl`](../skills/output/sink-clickhouse-jsonl) | output | clickhouse | findings, evidence, audit-logs, lakehouse |
@@ -438,13 +442,14 @@ Shipped skills mapped: **4**
 
 - Registry id: `iso-27001-2022`
 
-Shipped skills mapped: **4**
+Shipped skills mapped: **5**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
 | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark) | evaluation | aws | identities, storage, logging, network |
 | [`cspm-azure-cis-benchmark`](../skills/evaluation/cspm-azure-cis-benchmark) | evaluation | azure | identities, storage, logging, network |
 | [`cspm-gcp-cis-benchmark`](../skills/evaluation/cspm-gcp-cis-benchmark) | evaluation | gcp | identities, storage, logging, network |
+| [`evaluate-cis-aws-foundations-ocsf`](../skills/evaluation/evaluate-cis-aws-foundations-ocsf) | evaluation | aws | storage, logging, network, security-services, config |
 | [`ingest-aws-config-ocsf`](../skills/ingestion/ingest-aws-config-ocsf) | ingestion | aws | configuration, security-posture, compliance-evidence |
 
 ### OWASP Top 10 (2021)

--- a/docs/SKILL_INDEX.md
+++ b/docs/SKILL_INDEX.md
@@ -1,6 +1,6 @@
 # Skill index — find a skill fast
 
-The same 119 skill bundles, pivoted three ways:
+The same 120 skill bundles, pivoted three ways:
 
 1. **[By environment](#by-environment)** — pick a cloud or platform, see every skill that touches it.
 2. **[By purpose](#by-purpose)** — pick a layer (ingest / discover / detect / evaluate / remediate / view / output / source).
@@ -15,7 +15,7 @@ not do, and what it talks to.
 
 ## By environment
 
-### AWS — 15 skills
+### AWS — 16 skills
 
 | Layer | Skill | What it does |
 |---|---|---|
@@ -32,6 +32,7 @@ not do, and what it talks to.
 | Detect | [`detect-cloudtrail-disabled`](../skills/detection/detect-cloudtrail-disabled/) | T1562.001 — CloudTrail StopLogging / DeleteTrail |
 | Detect | [`detect-s3-cross-account-copy`](../skills/detection/detect-s3-cross-account-copy/) | T1537 — S3 cross-account exfiltration |
 | Evaluate | [`cspm-aws-cis-benchmark`](../skills/evaluation/cspm-aws-cis-benchmark/) | CIS AWS Foundations v3 — 50% control coverage |
+| Evaluate | [`evaluate-cis-aws-foundations-ocsf`](../skills/evaluation/evaluate-cis-aws-foundations-ocsf/) | CIS AWS Foundations v3 — AWS Config OCSF evidence evaluator |
 | Remediate | [`iam-departures-aws`](../skills/remediation/iam-departures-aws/) | HITL — disable / delete IAM users on departure |
 | Remediate | [`remediate-aws-sg-revoke`](../skills/remediation/remediate-aws-sg-revoke/) | HITL — revoke open SG ingress, dry-run-first |
 
@@ -180,6 +181,7 @@ not do, and what it talks to.
 | Output | [`sink-clickhouse-jsonl`](../skills/output/sink-clickhouse-jsonl/) | Append-only ClickHouse sink |
 | Output | [`sink-s3-jsonl`](../skills/output/sink-s3-jsonl/) | Append-only S3 sink |
 | Output | [`sink-snowflake-jsonl`](../skills/output/sink-snowflake-jsonl/) | Append-only Snowflake sink |
+| Source | [`source-clickhouse-query`](../skills/ingestion/source-clickhouse-query/) | ClickHouse warehouse adapter |
 | Source | [`source-databricks-query`](../skills/ingestion/source-databricks-query/) | Databricks SQL warehouse adapter |
 | Source | [`source-s3-select`](../skills/ingestion/source-s3-select/) | S3 Select adapter |
 | Source | [`source-snowflake-query`](../skills/ingestion/source-snowflake-query/) | Snowflake warehouse adapter |
@@ -188,16 +190,16 @@ not do, and what it talks to.
 
 | Layer | Count | Index |
 |---|---:|---|
-| Ingest | 16 | [`skills/ingestion/`](../skills/ingestion/) (excludes the 3 warehouse sources below) |
+| Ingest | 18 | [`skills/ingestion/`](../skills/ingestion/) (excludes the 4 warehouse sources below) |
 | Discover | 5 | [`skills/discovery/`](../skills/discovery/) |
-| Detect | 51 | [`skills/detection/`](../skills/detection/) |
-| Evaluate | 11 | [`skills/evaluation/`](../skills/evaluation/) |
+| Detect | 64 | [`skills/detection/`](../skills/detection/) |
+| Evaluate | 12 | [`skills/evaluation/`](../skills/evaluation/) |
 | Remediate | 12 | [`skills/remediation/`](../skills/remediation/) |
 | View | 2 | [`skills/view/`](../skills/view/) |
 | Output | 3 | [`skills/output/`](../skills/output/) |
-| Source | 3 | warehouse adapters: `source-databricks-query`, `source-s3-select`, `source-snowflake-query` (filed under `skills/ingestion/` on disk) |
+| Source | 4 | warehouse adapters: `source-clickhouse-query`, `source-databricks-query`, `source-s3-select`, `source-snowflake-query` (filed under `skills/ingestion/` on disk) |
 
-Total = 16 + 5 + 51 + 11 + 12 + 2 + 3 + 3 = **103**.
+Total = 18 + 5 + 64 + 12 + 12 + 2 + 3 + 4 = **120**.
 
 ## By framework
 
@@ -217,8 +219,8 @@ Quick orientation:
 | OWASP Top 10 (web) | `detect-web-*` |
 | OWASP LLM Top 10 | `detect-prompt-injection-*`, `detect-system-prompt-extraction`, `detect-tool-output-*`, `detect-agent-credential-leak-mcp`, `detect-mcp-adversarial-input-corpus`, `detect-mcp-model-artifact-tampering`, `detect-mcp-model-token-flood`, `detect-mcp-plugin-supply-chain`, `detect-mcp-unbounded-tool-output`, `model-serving-security` |
 | OWASP MCP Top 10 | `detect-mcp-tool-drift`, `detect-mcp-shadow-tool-injection`, `detect-mcp-plugin-supply-chain`, `detect-mcp-adversarial-input-corpus`, `detect-mcp-unbounded-tool-output`, `detect-agent-credential-leak-mcp`, `detect-prompt-injection-mcp-proxy`, `remediate-mcp-tool-quarantine` |
-| CIS AWS / GCP / Azure / K8s / Containers | `cspm-*`, `container-security`, `k8s-security-benchmark` |
-| NIST CSF 2.0 | `cspm-*` benchmark mappings + AI runtime evaluators |
+| CIS AWS / GCP / Azure / K8s / Containers | `cspm-*`, `evaluate-cis-aws-foundations-ocsf`, `container-security`, `k8s-security-benchmark` |
+| NIST CSF 2.0 | `cspm-*`, `evaluate-cis-aws-foundations-ocsf` benchmark mappings + AI runtime evaluators |
 | NIST AI RMF 1.0 | `evaluate-nist-ai-rmf-{govern,map,measure,manage}` (manifest evaluators) + cross-tagged AI runtime skills |
 | SOC 2 / ISO 27001 / PCI / FedRAMP | rolled up via `discover-control-evidence` |
 | CycloneDX ML-BOM | `discover-ai-bom` |

--- a/docs/diagrams/agent-topology.mmd
+++ b/docs/diagrams/agent-topology.mmd
@@ -34,4 +34,4 @@ flowchart TB
 
   mcp --> guards{"Guards<br/>allowlist · dry-run · HITL · RLIMIT · audit"}:::wrap
   guards --> reg["SkillSpec registry<br/>(SKILL.md frontmatter)"]:::registry
-  reg --> skills["90 shipped skill bundles<br/>(skills/[category]/[name]/)"]:::skills
+  reg --> skills["120 shipped skill bundles<br/>(skills/[category]/[name]/)"]:::skills

--- a/docs/diagrams/surface-comparison.mmd
+++ b/docs/diagrams/surface-comparison.mmd
@@ -1,7 +1,7 @@
 %% Surface comparison — six shipped surfaces with the same skill bundle
 %% behind every one. Each surface adds its own transport + auth +
 %% guardrail layer; every column converges at the SkillSpec registry
-%% and the 90 atomic skills below it.
+%% and the 120 atomic skills below it.
 flowchart TD
   classDef surface fill:#0f1d36,stroke:#3b82f6,color:#dbeafe
   classDef control fill:#1f142e,stroke:#a78bfa,color:#ede9fe
@@ -34,7 +34,7 @@ flowchart TD
   subgraph CORE["Same registry behind every surface"]
     direction LR
     registry["SkillSpec registry<br/>SKILL.md frontmatter"]:::registry
-    skills79["90 shipped atomic skills<br/>15 ingest · 5 discover · 39 detect · 11 evaluate · 12 remediate · 2 view · 3 output · 3 sources"]:::skills
+    skills79["120 shipped atomic skills<br/>18 ingest · 5 discover · 64 detect · 12 evaluate · 12 remediate · 2 view · 3 output · 4 sources"]:::skills
   end
 
   cli --> CONTROLS

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -1877,6 +1877,34 @@
       ]
     },
     {
+      "path": "skills/evaluation/evaluate-cis-aws-foundations-ocsf",
+      "layer": "evaluation",
+      "providers": [
+        "aws"
+      ],
+      "asset_classes": [
+        "storage",
+        "logging",
+        "network",
+        "security-services",
+        "config"
+      ],
+      "frameworks": [
+        "cis-aws-v3",
+        "ocsf-1.8",
+        "nist-csf-2.0",
+        "iso-27001-2022",
+        "soc2-tsc"
+      ],
+      "coverage_status": "tested",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/evaluation/cspm-azure-cis-benchmark",
       "layer": "evaluation",
       "providers": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 18 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 64 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 11 benchmark families covering 131 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 18 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 64 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 12 benchmark families covering 143 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -72,7 +72,7 @@
     <g filter="url(#shadow)">
       <rect x="322" y="228" width="260" height="180" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
       <text x="354" y="270" font-size="18" font-weight="800" fill="#dbeafe">L1 Ingest</text>
-      <text x="354" y="332" font-size="56" font-weight="900" fill="#ffffff">16 + 3</text>
+      <text x="354" y="332" font-size="56" font-weight="900" fill="#ffffff">18 + 4</text>
       <text x="354" y="364" font-size="15" fill="#bfdbfe">normalize source data to</text>
       <text x="354" y="386" font-size="15" fill="#bfdbfe">OCSF 1.8 or native JSONL</text>
 
@@ -87,14 +87,14 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">46</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">64</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 
       <rect x="642" y="440" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="482" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
-      <text x="674" y="544" font-size="56" font-weight="900" fill="#ffffff">11</text>
-      <text x="674" y="576" font-size="15" fill="#a7f3d0">131 benchmark checks across</text>
+      <text x="674" y="544" font-size="56" font-weight="900" fill="#ffffff">12</text>
+      <text x="674" y="576" font-size="15" fill="#a7f3d0">143 benchmark checks across</text>
       <text x="674" y="598" font-size="15" fill="#a7f3d0">CIS · K8s · container · AI</text>
     </g>
 

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="540" viewBox="0 0 1280 540" role="img" aria-labelledby="title desc">
   <title id="title">agentic security skills for cloud and AI — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 119 shipped skill bundles, OCSF 1.8, 131 CIS + NIST AI RMF benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 18 ingest, 5 discover, 64 detect, 11 evaluate, 12 remediate, 2 view, 3 output, and 4 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Slack, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 120 shipped skill bundles, OCSF 1.8, 143 CIS + NIST AI RMF benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 18 ingest, 5 discover, 64 detect, 12 evaluate, 12 remediate, 2 view, 3 output, and 4 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Slack, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -66,7 +66,7 @@
     <g transform="translate(80,272)">
       <g>
         <rect x="0" y="0" width="160" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="14" y="23" fill="#93c5fd" font-size="16" font-weight="900">119</text>
+        <text x="14" y="23" fill="#93c5fd" font-size="16" font-weight="900">120</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="12" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(172,0)">
@@ -75,7 +75,7 @@
       </g>
       <g transform="translate(314,0)">
         <rect x="0" y="0" width="196" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
-        <text x="14" y="23" fill="#5eead4" font-size="16" font-weight="900">131</text>
+        <text x="14" y="23" fill="#5eead4" font-size="16" font-weight="900">143</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="12" font-weight="700">benchmark checks</text>
       </g>
     </g>
@@ -152,7 +152,7 @@
       <g transform="translate(218,48)">
         <rect x="0" y="0" width="206" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L4 Evaluate</text>
-        <text x="190" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">11</text>
+        <text x="190" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">12</text>
       </g>
       <g transform="translate(0,96)">
         <rect x="0" y="0" width="206" height="36" rx="12" fill="#2a1708" stroke="#f59e0b"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 119 shipped skills — 18 ingest, 64 detect, 5 discover, 11 eval, 12 remediate, 2 view, 3 sink, 4 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 120 shipped skills — 18 ingest, 64 detect, 5 discover, 12 eval, 12 remediate, 2 view, 3 sink, 4 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -89,7 +89,7 @@
       <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">98</text>
       <text x="790" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">18 ingest · 64 detect · 5 discover · 11 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">18 ingest · 64 detect · 5 discover · 12 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 4 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -91,6 +91,7 @@ Read-only posture and benchmark evaluation skills.
 | Skill | Scope | Checks |
 |---|---|---:|
 | [`cspm-aws-cis-benchmark`](evaluation/cspm-aws-cis-benchmark/) | AWS | 18 |
+| [`evaluate-cis-aws-foundations-ocsf`](evaluation/evaluate-cis-aws-foundations-ocsf/) | AWS Config OCSF | 12 |
 | [`cspm-gcp-cis-benchmark`](evaluation/cspm-gcp-cis-benchmark/) | GCP | 7 |
 | [`cspm-azure-cis-benchmark`](evaluation/cspm-azure-cis-benchmark/) | Azure | 6 |
 | [`k8s-security-benchmark`](evaluation/k8s-security-benchmark/) | Kubernetes | 10 |

--- a/skills/evaluation/evaluate-cis-aws-foundations-ocsf/REFERENCES.md
+++ b/skills/evaluation/evaluate-cis-aws-foundations-ocsf/REFERENCES.md
@@ -1,0 +1,11 @@
+# References
+
+- CIS AWS Foundations Benchmark v3.0 — https://www.cisecurity.org/benchmark/amazon_web_services
+- OCSF 1.8 Compliance Finding class 2003 — https://schema.ocsf.io/1.8.0/classes/compliance_finding
+- OCSF 1.8 API Activity class 6003 — https://schema.ocsf.io/1.8.0/classes/api_activity
+- AWS Config configuration items — https://docs.aws.amazon.com/config/latest/developerguide/config-item-table.html
+- AWS Config managed rules — https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html
+
+This skill intentionally uses already-collected AWS Config evidence. It does not
+call AWS APIs and does not replace IAM controls that need credential reports,
+password policy reads, root account MFA reads, or live IAM enumeration.

--- a/skills/evaluation/evaluate-cis-aws-foundations-ocsf/SKILL.md
+++ b/skills/evaluation/evaluate-cis-aws-foundations-ocsf/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: evaluate-cis-aws-foundations-ocsf
+description: >-
+  Evaluate AWS Config OCSF evidence against the Config-backed slice of CIS AWS
+  Foundations Benchmark v3.0. Reads OCSF 1.8 API Activity (6003) configuration
+  item records and AWS Config Compliance Finding (2003) records emitted by
+  ingest-aws-config-ocsf, then emits one OCSF Compliance Finding (2003) per
+  implemented CIS control. Covers 12 read-only controls across S3, CloudTrail,
+  security groups, VPC flow logs, GuardDuty, and Security Hub. Use when the user
+  wants CIS AWS evaluation from already-collected AWS Config evidence without
+  live AWS API calls. Do NOT use as a full replacement for
+  cspm-aws-cis-benchmark IAM/live-account checks yet; IAM and CloudWatch alarm
+  controls remain intentionally out of scope for this decoupled slice.
+purpose: Evaluate AWS Config OCSF evidence against the Config-backed slice of CIS AWS Foundations Benchmark v3.0.
+capability: evaluate
+persistence: none
+telemetry: stderr_jsonl
+privilege_escalation: read
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf, native
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. No cloud SDKs, credentials, or network egress needed.
+  Reads local JSON/JSONL evidence produced by ingest-aws-config-ocsf.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/evaluation/evaluate-cis-aws-foundations-ocsf
+  version: 0.1.0
+  frameworks:
+    - CIS AWS Foundations v3.0
+    - OCSF 1.8
+    - NIST CSF 2.0
+    - ISO 27001:2022
+    - SOC 2 TSC
+  cloud: aws
+---
+
+# Evaluate — CIS AWS Foundations over AWS Config OCSF
+
+Read-only evaluator for the decoupled AWS posture path:
+
+```text
+AWS Config export -> ingest-aws-config-ocsf -> evaluate-cis-aws-foundations-ocsf
+```
+
+The skill does not call AWS. It evaluates already-collected configuration item
+and Config rule evidence and emits one native or OCSF Compliance Finding per
+implemented control.
+
+## Use When
+
+- You already collect AWS Config configuration item history or snapshots.
+- You need CIS AWS posture findings in OCSF without live AWS credentials.
+- You want to prove the ingest-decouples-from-evaluate architecture before
+  retiring legacy live-account checks.
+
+## Do Not Use
+
+- As a full replacement for `cspm-aws-cis-benchmark` yet.
+- For IAM controls that require credential report or account password policy
+  evidence.
+- For CloudWatch alarm controls unless that evidence has been modeled into AWS
+  Config records.
+
+## Implemented Controls
+
+| ID | Control | Evidence |
+|---|---|---|
+| 2.1 | S3 default encryption | `AWS::S3::Bucket` configuration or AWS Config rule |
+| 2.2 | S3 server access logging | `AWS::S3::Bucket` configuration or AWS Config rule |
+| 2.3 | S3 public access blocked | `AWS::S3::Bucket` configuration or AWS Config rule |
+| 2.4 | S3 versioning enabled | `AWS::S3::Bucket` configuration or AWS Config rule |
+| 3.1 | CloudTrail multi-region | `AWS::CloudTrail::Trail` configuration or AWS Config rule |
+| 3.2 | CloudTrail log validation | `AWS::CloudTrail::Trail` configuration or AWS Config rule |
+| 3.5 | CloudTrail KMS encryption | `AWS::CloudTrail::Trail` configuration or AWS Config rule |
+| 4.1 | No unrestricted SSH | `AWS::EC2::SecurityGroup` ingress or AWS Config rule |
+| 4.2 | No unrestricted RDP | `AWS::EC2::SecurityGroup` ingress or AWS Config rule |
+| 4.3 | VPC flow logs enabled | `AWS::EC2::VPC` + `AWS::EC2::FlowLog` evidence |
+| 6.1 | GuardDuty enabled | `AWS::GuardDuty::Detector` evidence or AWS Config rule |
+| 6.2 | Security Hub enabled | `AWS::SecurityHub::Hub` evidence or AWS Config rule |
+
+## Roadmap
+
+The following CIS AWS v3.0 controls remain in the legacy live-account evaluator
+until equivalent evidence is available in the decoupled pipeline:
+
+- IAM controls: 1.1 through 1.7
+- CloudTrail S3 bucket public access: 3.3
+- CloudWatch alarms: 3.4
+- CloudTrail data events: 3.6
+
+## Usage
+
+```bash
+# OCSF JSONL from the ingester
+python skills/ingestion/ingest-aws-config-ocsf/src/ingest.py aws-config.json \
+  | python skills/evaluation/evaluate-cis-aws-foundations-ocsf/src/checks.py
+
+# Native JSON array
+python src/checks.py aws-config.ocsf.jsonl --output json
+
+# OCSF Compliance Finding output
+python src/checks.py aws-config.ocsf.jsonl --output json --output-format ocsf
+
+# Single control
+python src/checks.py aws-config.ocsf.jsonl --control 2.1
+```
+
+Exit code is `1` when any HIGH or CRITICAL implemented control fails, `0` when
+only pass / medium fail / not-applicable results remain, and `2` for malformed
+input.

--- a/skills/evaluation/evaluate-cis-aws-foundations-ocsf/src/checks.py
+++ b/skills/evaluation/evaluate-cis-aws-foundations-ocsf/src/checks.py
@@ -1,0 +1,767 @@
+"""Evaluate CIS AWS Foundations controls from AWS Config OCSF evidence.
+
+This is the decoupled evaluator half of the AWS Config roadmap path:
+`ingest-aws-config-ocsf` records configuration evidence, this skill reads that
+evidence without calling AWS APIs, and the output is one Compliance Finding per
+implemented CIS AWS Foundations v3.0 control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.evaluation_ocsf import findings_to_native, findings_to_ocsf  # noqa: E402
+
+SKILL_NAME = "evaluate-cis-aws-foundations-ocsf"
+BENCHMARK_NAME = "CIS AWS Foundations Benchmark v3.0 over AWS Config OCSF"
+PROVIDER_NAME = "AWS"
+FRAMEWORKS = ("CIS AWS Foundations v3.0", "OCSF 1.8", "NIST CSF 2.0", "ISO 27001:2022", "SOC 2 TSC")
+OUTPUT_FORMATS = ("native", "ocsf")
+
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+STATUS_NA = "NOT_APPLICABLE"
+STATUS_ERROR = "ERROR"
+
+
+@dataclass(frozen=True)
+class Control:
+    control_id: str
+    title: str
+    section: str
+    severity: str
+    nist_csf: str
+    iso_27001: str
+    remediation: str
+
+
+@dataclass
+class Finding:
+    control_id: str
+    title: str
+    section: str
+    severity: str
+    status: str
+    detail: str = ""
+    remediation: str = ""
+    cis_control: str = ""
+    nist_csf: str = ""
+    iso_27001: str = ""
+    resources: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ConfigItem:
+    resource_type: str
+    resource_id: str
+    resource_name: str
+    account_uid: str
+    region: str
+    time_ms: int
+    configuration: dict[str, Any]
+    tags: dict[str, str]
+    relationships: list[dict[str, str]]
+    source_uid: str
+
+
+@dataclass(frozen=True)
+class ConfigCompliance:
+    rule_name: str
+    status: str
+    resource_type: str
+    resource_id: str
+    account_uid: str
+    region: str
+    time_ms: int
+    description: str
+
+
+CONTROLS: tuple[Control, ...] = (
+    Control(
+        "2.1",
+        "S3 buckets have default server-side encryption enabled",
+        "storage",
+        "HIGH",
+        "PR.DS-1",
+        "A.8.24",
+        "Enable S3 default encryption with SSE-S3 or SSE-KMS on every bucket.",
+    ),
+    Control(
+        "2.2",
+        "S3 buckets have server access logging enabled",
+        "storage",
+        "MEDIUM",
+        "DE.AE-3",
+        "A.8.15",
+        "Configure S3 server access logging to a controlled log bucket.",
+    ),
+    Control(
+        "2.3",
+        "S3 buckets block public access",
+        "storage",
+        "CRITICAL",
+        "PR.AC-3",
+        "A.8.3",
+        "Enable all four S3 public access block settings at bucket or account scope.",
+    ),
+    Control(
+        "2.4",
+        "S3 buckets have versioning enabled",
+        "storage",
+        "MEDIUM",
+        "PR.DS-1",
+        "A.8.13",
+        "Enable S3 bucket versioning for recovery and evidence retention.",
+    ),
+    Control(
+        "3.1",
+        "CloudTrail trails are multi-region",
+        "logging",
+        "CRITICAL",
+        "DE.AE-3",
+        "A.8.15",
+        "Create or update CloudTrail trails with IsMultiRegionTrail enabled.",
+    ),
+    Control(
+        "3.2",
+        "CloudTrail log file validation is enabled",
+        "logging",
+        "HIGH",
+        "PR.DS-6",
+        "A.8.15",
+        "Enable CloudTrail log file validation on every trail.",
+    ),
+    Control(
+        "3.5",
+        "CloudTrail logs are encrypted with KMS",
+        "logging",
+        "MEDIUM",
+        "PR.DS-1",
+        "A.8.24",
+        "Set a customer-managed KMS key on CloudTrail log delivery.",
+    ),
+    Control(
+        "4.1",
+        "Security groups do not allow unrestricted SSH",
+        "networking",
+        "HIGH",
+        "PR.AC-5",
+        "A.8.20",
+        "Restrict inbound TCP/22 to approved administrative networks.",
+    ),
+    Control(
+        "4.2",
+        "Security groups do not allow unrestricted RDP",
+        "networking",
+        "HIGH",
+        "PR.AC-5",
+        "A.8.20",
+        "Restrict inbound TCP/3389 to approved administrative networks.",
+    ),
+    Control(
+        "4.3",
+        "VPC flow logs are enabled",
+        "networking",
+        "MEDIUM",
+        "DE.CM-1",
+        "A.8.16",
+        "Enable VPC flow logs for each VPC and retain them in a monitored sink.",
+    ),
+    Control(
+        "6.1",
+        "GuardDuty is enabled",
+        "security-services",
+        "MEDIUM",
+        "DE.CM-1",
+        "A.8.16",
+        "Enable GuardDuty detectors in each account and region.",
+    ),
+    Control(
+        "6.2",
+        "Security Hub is enabled",
+        "security-services",
+        "MEDIUM",
+        "DE.CM-1",
+        "A.8.16",
+        "Enable Security Hub and import AWS Foundational Security Best Practices.",
+    ),
+)
+
+DOCUMENTED_NOT_IMPLEMENTED: tuple[str, ...] = (
+    "1.1",
+    "1.2",
+    "1.3",
+    "1.4",
+    "1.5",
+    "1.6",
+    "1.7",
+    "3.3",
+    "3.4",
+    "3.6",
+)
+
+CONFIG_RULE_TO_CONTROL = {
+    "s3-bucket-server-side-encryption-enabled": "2.1",
+    "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "2.1",
+    "s3-bucket-logging-enabled": "2.2",
+    "S3_BUCKET_LOGGING_ENABLED": "2.2",
+    "s3-bucket-public-read-prohibited": "2.3",
+    "s3-bucket-public-write-prohibited": "2.3",
+    "S3_BUCKET_PUBLIC_READ_PROHIBITED": "2.3",
+    "S3_BUCKET_PUBLIC_WRITE_PROHIBITED": "2.3",
+    "s3-bucket-versioning-enabled": "2.4",
+    "S3_BUCKET_VERSIONING_ENABLED": "2.4",
+    "multi-region-cloudtrail-enabled": "3.1",
+    "MULTI_REGION_CLOUD_TRAIL_ENABLED": "3.1",
+    "cloud-trail-log-file-validation-enabled": "3.2",
+    "CLOUD_TRAIL_LOG_FILE_VALIDATION_ENABLED": "3.2",
+    "cloud-trail-encryption-enabled": "3.5",
+    "CLOUD_TRAIL_ENCRYPTION_ENABLED": "3.5",
+    "restricted-ssh": "4.1",
+    "INCOMING_SSH_DISABLED": "4.1",
+    "restricted-common-ports": "4.2",
+    "VPC_FLOW_LOGS_ENABLED": "4.3",
+    "vpc-flow-logs-enabled": "4.3",
+    "GUARDDUTY_ENABLED_CENTRALIZED": "6.1",
+    "guardduty-enabled-centralized": "6.1",
+    "SECURITYHUB_ENABLED": "6.2",
+    "securityhub-enabled": "6.2",
+}
+
+
+def benchmark_metadata() -> dict[str, Any]:
+    return {
+        "frameworks": list(FRAMEWORKS),
+        "implemented_controls": [control.control_id for control in CONTROLS],
+        "implemented_count": len(CONTROLS),
+        "documented_not_implemented": list(DOCUMENTED_NOT_IMPLEMENTED),
+        "input_classes": [6003, 2003],
+        "source_skill": "ingest-aws-config-ocsf",
+    }
+
+
+def load_records(path: str | Path | None, stream: Iterable[str] | None = None) -> list[dict[str, Any]]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    elif stream is not None:
+        text = "".join(stream)
+    else:
+        text = sys.stdin.read()
+    return parse_records(text)
+
+
+def parse_records(text: str) -> list[dict[str, Any]]:
+    text = text.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        records: list[dict[str, Any]] = []
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"line {lineno}: JSON parse failed: {exc}") from exc
+            if not isinstance(obj, dict):
+                raise ValueError(f"line {lineno}: JSONL records must be objects")
+            records.append(obj)
+        return records
+    if isinstance(parsed, list):
+        if not all(isinstance(item, dict) for item in parsed):
+            raise ValueError("JSON array input must contain objects")
+        return list(parsed)
+    if isinstance(parsed, dict):
+        return [parsed]
+    raise ValueError(f"input must be JSON object, array, or JSONL; got {type(parsed).__name__}")
+
+
+def _lower_keys(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k).lower(): _lower_keys(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_lower_keys(v) for v in value]
+    return value
+
+
+def _get_ci(record: dict[str, Any]) -> ConfigItem | None:
+    record_type = str(record.get("record_type") or "")
+    class_uid = int(record.get("class_uid") or 0)
+    if record_type != "aws_config_configuration_item" and class_uid != 6003:
+        return None
+
+    if record_type == "aws_config_configuration_item":
+        resource = record.get("resource") if isinstance(record.get("resource"), dict) else {}
+        return ConfigItem(
+            resource_type=str(record.get("resource_type") or resource.get("type") or ""),
+            resource_id=str(record.get("resource_id") or resource.get("uid") or ""),
+            resource_name=str(resource.get("name") or record.get("resource_id") or ""),
+            account_uid=str(record.get("account_uid") or ""),
+            region=str(record.get("region") or resource.get("region") or ""),
+            time_ms=int(record.get("time_ms") or 0),
+            configuration=record.get("configuration") if isinstance(record.get("configuration"), dict) else {},
+            tags=record.get("tags") if isinstance(record.get("tags"), dict) else {},
+            relationships=record.get("relationships") if isinstance(record.get("relationships"), list) else [],
+            source_uid=str(record.get("event_uid") or ""),
+        )
+
+    unmapped = record.get("unmapped") if isinstance(record.get("unmapped"), dict) else {}
+    aws_config = unmapped.get("aws_config") if isinstance(unmapped.get("aws_config"), dict) else {}
+    resources = record.get("resources") if isinstance(record.get("resources"), list) else []
+    resource = resources[0] if resources and isinstance(resources[0], dict) else {}
+    cloud = record.get("cloud") if isinstance(record.get("cloud"), dict) else {}
+    account = cloud.get("account") if isinstance(cloud.get("account"), dict) else {}
+    return ConfigItem(
+        resource_type=str(resource.get("type") or ""),
+        resource_id=str(resource.get("uid") or resource.get("name") or ""),
+        resource_name=str(resource.get("name") or resource.get("uid") or ""),
+        account_uid=str(account.get("uid") or ""),
+        region=str(resource.get("region") or cloud.get("region") or ""),
+        time_ms=int(record.get("time") or 0),
+        configuration=aws_config.get("configuration") if isinstance(aws_config.get("configuration"), dict) else {},
+        tags=aws_config.get("tags") if isinstance(aws_config.get("tags"), dict) else {},
+        relationships=aws_config.get("relationships") if isinstance(aws_config.get("relationships"), list) else [],
+        source_uid=str(record.get("metadata", {}).get("uid") or ""),
+    )
+
+
+def _get_compliance(record: dict[str, Any]) -> ConfigCompliance | None:
+    record_type = str(record.get("record_type") or "")
+    class_uid = int(record.get("class_uid") or 0)
+    if record_type != "aws_config_compliance_finding" and class_uid != 2003:
+        return None
+
+    if record_type == "aws_config_compliance_finding":
+        return ConfigCompliance(
+            rule_name=str(record.get("rule_name") or ""),
+            status=str(record.get("status") or ""),
+            resource_type=str(record.get("resource_type") or ""),
+            resource_id=str(record.get("resource_id") or ""),
+            account_uid=str(record.get("account_uid") or ""),
+            region=str(record.get("region") or ""),
+            time_ms=int(record.get("time_ms") or 0),
+            description=str(record.get("description") or ""),
+        )
+
+    evidence = record.get("evidence") if isinstance(record.get("evidence"), dict) else {}
+    if evidence.get("source") != "AWS Config":
+        return None
+    compliance = record.get("compliance") if isinstance(record.get("compliance"), dict) else {}
+    resources = record.get("resources") if isinstance(record.get("resources"), list) else []
+    resource = resources[0] if resources and isinstance(resources[0], dict) else {}
+    cloud = record.get("cloud") if isinstance(record.get("cloud"), dict) else {}
+    account = cloud.get("account") if isinstance(cloud.get("account"), dict) else {}
+    finding_info = record.get("finding_info") if isinstance(record.get("finding_info"), dict) else {}
+    return ConfigCompliance(
+        rule_name=str(evidence.get("rule_name") or compliance.get("control") or ""),
+        status=str(compliance.get("status") or ""),
+        resource_type=str(resource.get("type") or ""),
+        resource_id=str(resource.get("uid") or resource.get("name") or ""),
+        account_uid=str(account.get("uid") or ""),
+        region=str(resource.get("region") or cloud.get("region") or ""),
+        time_ms=int(record.get("time") or 0),
+        description=str(finding_info.get("desc") or ""),
+    )
+
+
+def _latest_items(records: list[dict[str, Any]]) -> list[ConfigItem]:
+    by_key: dict[tuple[str, str], ConfigItem] = {}
+    for record in records:
+        item = _get_ci(record)
+        if item is None or not item.resource_type or not item.resource_id:
+            continue
+        key = (item.resource_type, item.resource_id)
+        if key not in by_key or item.time_ms >= by_key[key].time_ms:
+            by_key[key] = item
+    return list(by_key.values())
+
+
+def _compliance_by_control(records: list[dict[str, Any]]) -> dict[str, list[ConfigCompliance]]:
+    mapped: dict[str, list[ConfigCompliance]] = {}
+    for record in records:
+        compliance = _get_compliance(record)
+        if compliance is None or not compliance.rule_name:
+            continue
+        control_id = CONFIG_RULE_TO_CONTROL.get(compliance.rule_name)
+        if control_id is None:
+            control_id = CONFIG_RULE_TO_CONTROL.get(compliance.rule_name.lower())
+        if control_id:
+            mapped.setdefault(control_id, []).append(compliance)
+    return mapped
+
+
+def _items_of(items: list[ConfigItem], resource_type: str) -> list[ConfigItem]:
+    return [item for item in items if item.resource_type == resource_type]
+
+
+def _bool(config: dict[str, Any], *keys: str) -> bool:
+    cur: Any = _lower_keys(config)
+    for key in keys:
+        if not isinstance(cur, dict):
+            return False
+        cur = cur.get(key.lower())
+    return cur is True or str(cur).lower() == "true"
+
+
+def _dict(config: dict[str, Any], *keys: str) -> dict[str, Any]:
+    cur: Any = _lower_keys(config)
+    for key in keys:
+        if not isinstance(cur, dict):
+            return {}
+        cur = cur.get(key.lower())
+    return cur if isinstance(cur, dict) else {}
+
+
+def _list(config: dict[str, Any], *keys: str) -> list[Any]:
+    cur: Any = _lower_keys(config)
+    for key in keys:
+        if not isinstance(cur, dict):
+            return []
+        cur = cur.get(key.lower())
+    return cur if isinstance(cur, list) else []
+
+
+def _resource_label(item: ConfigItem) -> str:
+    region = f":{item.region}" if item.region else ""
+    return f"{item.resource_type}:{item.resource_id}{region}"
+
+
+def _finding(control: Control, status: str, detail: str, resources: list[str]) -> Finding:
+    return Finding(
+        control_id=control.control_id,
+        title=control.title,
+        section=control.section,
+        severity=control.severity,
+        status=status,
+        detail=detail,
+        remediation="" if status == STATUS_PASS else control.remediation,
+        cis_control=f"CIS AWS Foundations v3.0 {control.control_id}",
+        nist_csf=control.nist_csf,
+        iso_27001=control.iso_27001,
+        resources=resources,
+    )
+
+
+def _aggregate_resource_check(
+    control: Control,
+    items: list[ConfigItem],
+    predicate: Any,
+    *,
+    empty_detail: str,
+    fail_detail: str,
+) -> Finding:
+    if not items:
+        return _finding(control, STATUS_NA, empty_detail, [])
+    failed = [_resource_label(item) for item in items if not predicate(item.configuration, item)]
+    if failed:
+        return _finding(control, STATUS_FAIL, f"{fail_detail}: {', '.join(failed)}", failed)
+    return _finding(control, STATUS_PASS, f"{len(items)} resource(s) passed", [_resource_label(i) for i in items])
+
+
+def _has_s3_encryption(config: dict[str, Any], _item: ConfigItem) -> bool:
+    cfg = _dict(config, "bucketEncryption")
+    if cfg:
+        rules = _list(cfg, "serverSideEncryptionConfiguration")
+        return bool(rules)
+    return bool(_list(config, "serverSideEncryptionConfiguration"))
+
+
+def _has_s3_logging(config: dict[str, Any], _item: ConfigItem) -> bool:
+    logging_cfg = _dict(config, "loggingConfiguration")
+    if logging_cfg.get("destinationbucketname") or logging_cfg.get("targetbucket"):
+        return True
+    nested = _dict(config, "bucketLoggingConfiguration", "loggingEnabled")
+    return bool(nested.get("targetbucket") or nested.get("destinationbucketname"))
+
+
+def _has_public_access_block(config: dict[str, Any], _item: ConfigItem) -> bool:
+    pab = _dict(config, "publicAccessBlockConfiguration") or _dict(config, "PublicAccessBlockConfiguration")
+    required = ("blockpublicacls", "ignorepublicacls", "blockpublicpolicy", "restrictpublicbuckets")
+    return bool(pab) and all(pab.get(key) is True for key in required)
+
+
+def _has_versioning(config: dict[str, Any], _item: ConfigItem) -> bool:
+    versioning = _dict(config, "versioningConfiguration")
+    return str(versioning.get("status") or "").lower() == "enabled"
+
+
+def _trail_multi_region(config: dict[str, Any], _item: ConfigItem) -> bool:
+    return _bool(config, "isMultiRegionTrail")
+
+
+def _trail_validation(config: dict[str, Any], _item: ConfigItem) -> bool:
+    return _bool(config, "logFileValidationEnabled")
+
+
+def _trail_kms(config: dict[str, Any], _item: ConfigItem) -> bool:
+    lower = _lower_keys(config)
+    return isinstance(lower, dict) and bool(lower.get("kmskeyid"))
+
+
+def _cidr_open(entry: dict[str, Any]) -> bool:
+    cidr = str(entry.get("cidrip") or entry.get("cidripv6") or "")
+    return cidr in {"0.0.0.0/0", "::/0"}
+
+
+def _permission_covers_port(permission: dict[str, Any], port: int) -> bool:
+    proto = str(permission.get("ipprotocol") or "").lower()
+    if proto == "-1":
+        return True
+    from_port = permission.get("fromport")
+    to_port = permission.get("toport")
+    if from_port is None or to_port is None:
+        return False
+    try:
+        return int(from_port) <= port <= int(to_port)
+    except (TypeError, ValueError):
+        return False
+
+
+def _has_unrestricted_port(config: dict[str, Any], port: int) -> bool:
+    permissions = _list(config, "ipPermissions") or _list(config, "IpPermissions")
+    for permission in permissions:
+        if not isinstance(permission, dict):
+            continue
+        p = _lower_keys(permission)
+        if not isinstance(p, dict) or not _permission_covers_port(p, port):
+            continue
+        ranges = []
+        ranges.extend(p.get("ipranges") if isinstance(p.get("ipranges"), list) else [])
+        ranges.extend(p.get("ipv6ranges") if isinstance(p.get("ipv6ranges"), list) else [])
+        if any(isinstance(entry, dict) and _cidr_open(entry) for entry in ranges):
+            return True
+    return False
+
+
+def _no_unrestricted_ssh(config: dict[str, Any], _item: ConfigItem) -> bool:
+    return not _has_unrestricted_port(config, 22)
+
+
+def _no_unrestricted_rdp(config: dict[str, Any], _item: ConfigItem) -> bool:
+    return not _has_unrestricted_port(config, 3389)
+
+
+def _check_vpc_flow_logs(control: Control, items: list[ConfigItem]) -> Finding:
+    vpcs = _items_of(items, "AWS::EC2::VPC")
+    flowlogs = _items_of(items, "AWS::EC2::FlowLog")
+    if not vpcs:
+        return _finding(control, STATUS_NA, "No AWS::EC2::VPC evidence in input", [])
+    flowlog_vpc_ids: set[str] = set()
+    for flowlog in flowlogs:
+        cfg = _lower_keys(flowlog.configuration)
+        if isinstance(cfg, dict):
+            resource_id = cfg.get("resourceid") or cfg.get("vpcid")
+            if resource_id:
+                flowlog_vpc_ids.add(str(resource_id))
+        for rel in flowlog.relationships:
+            if rel.get("resource_type") == "AWS::EC2::VPC" and rel.get("resource_id"):
+                flowlog_vpc_ids.add(str(rel["resource_id"]))
+    failed = [_resource_label(vpc) for vpc in vpcs if vpc.resource_id not in flowlog_vpc_ids]
+    if failed:
+        return _finding(control, STATUS_FAIL, f"VPCs without flow log evidence: {', '.join(failed)}", failed)
+    return _finding(control, STATUS_PASS, f"{len(vpcs)} VPC(s) have flow log evidence", [_resource_label(v) for v in vpcs])
+
+
+def _check_guardduty(control: Control, items: list[ConfigItem]) -> Finding:
+    detectors = _items_of(items, "AWS::GuardDuty::Detector")
+    if not detectors:
+        return _finding(control, STATUS_FAIL, "No GuardDuty detector evidence in input", [])
+    failed: list[str] = []
+    for detector in detectors:
+        cfg = _lower_keys(detector.configuration)
+        enabled = False
+        if isinstance(cfg, dict):
+            enabled = str(cfg.get("status") or "").lower() == "enabled" or cfg.get("enable") is True
+        if not enabled:
+            failed.append(_resource_label(detector))
+    if failed:
+        return _finding(control, STATUS_FAIL, f"Disabled GuardDuty detector evidence: {', '.join(failed)}", failed)
+    return _finding(control, STATUS_PASS, f"{len(detectors)} GuardDuty detector(s) enabled", [_resource_label(d) for d in detectors])
+
+
+def _check_security_hub(control: Control, items: list[ConfigItem]) -> Finding:
+    hubs = _items_of(items, "AWS::SecurityHub::Hub")
+    if not hubs:
+        return _finding(control, STATUS_FAIL, "No Security Hub hub evidence in input", [])
+    return _finding(control, STATUS_PASS, f"{len(hubs)} Security Hub hub resource(s) present", [_resource_label(h) for h in hubs])
+
+
+def _apply_config_rule_evidence(
+    finding: Finding,
+    compliance: list[ConfigCompliance],
+) -> Finding:
+    if not compliance:
+        return finding
+    failed = [c for c in compliance if c.status.upper() == STATUS_FAIL]
+    if failed:
+        resources = [f"{c.resource_type}:{c.resource_id}:{c.region}" for c in failed if c.resource_id]
+        finding.status = STATUS_FAIL
+        finding.detail = (
+            f"{finding.detail}; " if finding.detail else ""
+        ) + f"AWS Config rule failure evidence: {', '.join(c.rule_name for c in failed)}"
+        finding.resources = sorted(set(finding.resources + resources))
+        return finding
+    passed = [c for c in compliance if c.status.upper() == STATUS_PASS]
+    if finding.status == STATUS_NA and passed:
+        finding.status = STATUS_PASS
+        finding.detail = f"AWS Config rule evidence passed: {', '.join(c.rule_name for c in passed)}"
+        finding.resources = [f"{c.resource_type}:{c.resource_id}:{c.region}" for c in passed if c.resource_id]
+    return finding
+
+
+def run_benchmark(records: list[dict[str, Any]], *, control_id: str | None = None) -> list[Finding]:
+    items = _latest_items(records)
+    compliance = _compliance_by_control(records)
+    findings: list[Finding] = []
+    for control in CONTROLS:
+        if control_id and control.control_id != control_id:
+            continue
+        if control.control_id == "2.1":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::S3::Bucket"),
+                _has_s3_encryption,
+                empty_detail="No AWS::S3::Bucket evidence in input",
+                fail_detail="Buckets without default encryption evidence",
+            )
+        elif control.control_id == "2.2":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::S3::Bucket"),
+                _has_s3_logging,
+                empty_detail="No AWS::S3::Bucket evidence in input",
+                fail_detail="Buckets without server access logging evidence",
+            )
+        elif control.control_id == "2.3":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::S3::Bucket"),
+                _has_public_access_block,
+                empty_detail="No AWS::S3::Bucket evidence in input",
+                fail_detail="Buckets without full public access block evidence",
+            )
+        elif control.control_id == "2.4":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::S3::Bucket"),
+                _has_versioning,
+                empty_detail="No AWS::S3::Bucket evidence in input",
+                fail_detail="Buckets without versioning evidence",
+            )
+        elif control.control_id == "3.1":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::CloudTrail::Trail"),
+                _trail_multi_region,
+                empty_detail="No AWS::CloudTrail::Trail evidence in input",
+                fail_detail="CloudTrail trails without multi-region evidence",
+            )
+        elif control.control_id == "3.2":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::CloudTrail::Trail"),
+                _trail_validation,
+                empty_detail="No AWS::CloudTrail::Trail evidence in input",
+                fail_detail="CloudTrail trails without log validation evidence",
+            )
+        elif control.control_id == "3.5":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::CloudTrail::Trail"),
+                _trail_kms,
+                empty_detail="No AWS::CloudTrail::Trail evidence in input",
+                fail_detail="CloudTrail trails without KMS encryption evidence",
+            )
+        elif control.control_id == "4.1":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::EC2::SecurityGroup"),
+                _no_unrestricted_ssh,
+                empty_detail="No AWS::EC2::SecurityGroup evidence in input",
+                fail_detail="Security groups with unrestricted SSH",
+            )
+        elif control.control_id == "4.2":
+            finding = _aggregate_resource_check(
+                control,
+                _items_of(items, "AWS::EC2::SecurityGroup"),
+                _no_unrestricted_rdp,
+                empty_detail="No AWS::EC2::SecurityGroup evidence in input",
+                fail_detail="Security groups with unrestricted RDP",
+            )
+        elif control.control_id == "4.3":
+            finding = _check_vpc_flow_logs(control, items)
+        elif control.control_id == "6.1":
+            finding = _check_guardduty(control, items)
+        elif control.control_id == "6.2":
+            finding = _check_security_hub(control, items)
+        else:  # pragma: no cover - keeps future control additions explicit
+            finding = _finding(control, STATUS_ERROR, "Control not wired", [])
+        findings.append(_apply_config_rule_evidence(finding, compliance.get(control.control_id, [])))
+    return findings
+
+
+def print_summary(findings: list[Finding]) -> None:
+    counts = {STATUS_PASS: 0, STATUS_FAIL: 0, STATUS_NA: 0, STATUS_ERROR: 0}
+    for finding in findings:
+        counts[finding.status] = counts.get(finding.status, 0) + 1
+    print(f"\n{'=' * 72}")
+    print(f"  {BENCHMARK_NAME}")
+    print(f"  Config-backed controls: {len(CONTROLS)}")
+    print(f"{'=' * 72}\n")
+    icon = {STATUS_PASS: "+", STATUS_FAIL: "x", STATUS_NA: "-", STATUS_ERROR: "?"}
+    for finding in findings:
+        print(f"  [{icon.get(finding.status, '?')}] {finding.control_id:4s} [{finding.severity:8s}] {finding.title}")
+        if finding.status != STATUS_PASS:
+            print(f"      {finding.detail}")
+    print(f"\n  Total: {len(findings)} | PASS {counts[STATUS_PASS]} | FAIL {counts[STATUS_FAIL]} | NA {counts[STATUS_NA]}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=f"{BENCHMARK_NAME} evaluator")
+    parser.add_argument("input", nargs="?", help="OCSF/native JSON or JSONL. Defaults to stdin.")
+    parser.add_argument("--control", help="Run one CIS control ID, e.g. 2.1.")
+    parser.add_argument("--output", choices=["console", "json"], default="console")
+    parser.add_argument("--output-format", choices=list(OUTPUT_FORMATS), default="native")
+    args = parser.parse_args(argv)
+
+    try:
+        records = load_records(args.input)
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    findings = run_benchmark(records, control_id=args.control)
+    if args.output == "json":
+        rendered = (
+            findings_to_ocsf(
+                findings,
+                skill_name=SKILL_NAME,
+                benchmark_name=BENCHMARK_NAME,
+                provider=PROVIDER_NAME,
+                frameworks=list(FRAMEWORKS),
+            )
+            if args.output_format == "ocsf"
+            else findings_to_native(findings)
+        )
+        print(json.dumps(rendered, indent=2))
+    else:
+        print_summary(findings)
+
+    high_fails = [f for f in findings if f.status == STATUS_FAIL and f.severity in {"HIGH", "CRITICAL"}]
+    return 1 if high_fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/evaluation/evaluate-cis-aws-foundations-ocsf/src/checks.py
+++ b/skills/evaluation/evaluate-cis-aws-foundations-ocsf/src/checks.py
@@ -68,8 +68,8 @@ class ConfigItem:
     region: str
     time_ms: int
     configuration: dict[str, Any]
-    tags: dict[str, str]
-    relationships: list[dict[str, str]]
+    tags: dict[str, Any]
+    relationships: list[dict[str, Any]]
     source_uid: str
 
 
@@ -296,6 +296,22 @@ def _lower_keys(value: Any) -> Any:
     return value
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(k): v for k, v in value.items()}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [_as_dict(item) for item in value if isinstance(item, dict)]
+
+
 def _get_ci(record: dict[str, Any]) -> ConfigItem | None:
     record_type = str(record.get("record_type") or "")
     class_uid = int(record.get("class_uid") or 0)
@@ -303,7 +319,7 @@ def _get_ci(record: dict[str, Any]) -> ConfigItem | None:
         return None
 
     if record_type == "aws_config_configuration_item":
-        resource = record.get("resource") if isinstance(record.get("resource"), dict) else {}
+        resource = _as_dict(record.get("resource"))
         return ConfigItem(
             resource_type=str(record.get("resource_type") or resource.get("type") or ""),
             resource_id=str(record.get("resource_id") or resource.get("uid") or ""),
@@ -311,18 +327,19 @@ def _get_ci(record: dict[str, Any]) -> ConfigItem | None:
             account_uid=str(record.get("account_uid") or ""),
             region=str(record.get("region") or resource.get("region") or ""),
             time_ms=int(record.get("time_ms") or 0),
-            configuration=record.get("configuration") if isinstance(record.get("configuration"), dict) else {},
-            tags=record.get("tags") if isinstance(record.get("tags"), dict) else {},
-            relationships=record.get("relationships") if isinstance(record.get("relationships"), list) else [],
+            configuration=_as_dict(record.get("configuration")),
+            tags=_as_dict(record.get("tags")),
+            relationships=_as_dict_list(record.get("relationships")),
             source_uid=str(record.get("event_uid") or ""),
         )
 
-    unmapped = record.get("unmapped") if isinstance(record.get("unmapped"), dict) else {}
-    aws_config = unmapped.get("aws_config") if isinstance(unmapped.get("aws_config"), dict) else {}
-    resources = record.get("resources") if isinstance(record.get("resources"), list) else []
-    resource = resources[0] if resources and isinstance(resources[0], dict) else {}
-    cloud = record.get("cloud") if isinstance(record.get("cloud"), dict) else {}
-    account = cloud.get("account") if isinstance(cloud.get("account"), dict) else {}
+    unmapped = _as_dict(record.get("unmapped"))
+    aws_config = _as_dict(unmapped.get("aws_config"))
+    resources = _as_list(record.get("resources"))
+    resource = _as_dict(resources[0]) if resources else {}
+    cloud = _as_dict(record.get("cloud"))
+    account = _as_dict(cloud.get("account"))
+    metadata = _as_dict(record.get("metadata"))
     return ConfigItem(
         resource_type=str(resource.get("type") or ""),
         resource_id=str(resource.get("uid") or resource.get("name") or ""),
@@ -330,10 +347,10 @@ def _get_ci(record: dict[str, Any]) -> ConfigItem | None:
         account_uid=str(account.get("uid") or ""),
         region=str(resource.get("region") or cloud.get("region") or ""),
         time_ms=int(record.get("time") or 0),
-        configuration=aws_config.get("configuration") if isinstance(aws_config.get("configuration"), dict) else {},
-        tags=aws_config.get("tags") if isinstance(aws_config.get("tags"), dict) else {},
-        relationships=aws_config.get("relationships") if isinstance(aws_config.get("relationships"), list) else [],
-        source_uid=str(record.get("metadata", {}).get("uid") or ""),
+        configuration=_as_dict(aws_config.get("configuration")),
+        tags=_as_dict(aws_config.get("tags")),
+        relationships=_as_dict_list(aws_config.get("relationships")),
+        source_uid=str(metadata.get("uid") or ""),
     )
 
 
@@ -355,15 +372,15 @@ def _get_compliance(record: dict[str, Any]) -> ConfigCompliance | None:
             description=str(record.get("description") or ""),
         )
 
-    evidence = record.get("evidence") if isinstance(record.get("evidence"), dict) else {}
+    evidence = _as_dict(record.get("evidence"))
     if evidence.get("source") != "AWS Config":
         return None
-    compliance = record.get("compliance") if isinstance(record.get("compliance"), dict) else {}
-    resources = record.get("resources") if isinstance(record.get("resources"), list) else []
-    resource = resources[0] if resources and isinstance(resources[0], dict) else {}
-    cloud = record.get("cloud") if isinstance(record.get("cloud"), dict) else {}
-    account = cloud.get("account") if isinstance(cloud.get("account"), dict) else {}
-    finding_info = record.get("finding_info") if isinstance(record.get("finding_info"), dict) else {}
+    compliance = _as_dict(record.get("compliance"))
+    resources = _as_list(record.get("resources"))
+    resource = _as_dict(resources[0]) if resources else {}
+    cloud = _as_dict(record.get("cloud"))
+    account = _as_dict(cloud.get("account"))
+    finding_info = _as_dict(record.get("finding_info"))
     return ConfigCompliance(
         rule_name=str(evidence.get("rule_name") or compliance.get("control") or ""),
         status=str(compliance.get("status") or ""),
@@ -537,9 +554,9 @@ def _has_unrestricted_port(config: dict[str, Any], port: int) -> bool:
         p = _lower_keys(permission)
         if not isinstance(p, dict) or not _permission_covers_port(p, port):
             continue
-        ranges = []
-        ranges.extend(p.get("ipranges") if isinstance(p.get("ipranges"), list) else [])
-        ranges.extend(p.get("ipv6ranges") if isinstance(p.get("ipv6ranges"), list) else [])
+        ranges: list[Any] = []
+        ranges.extend(_as_list(p.get("ipranges")))
+        ranges.extend(_as_list(p.get("ipv6ranges")))
         if any(isinstance(entry, dict) and _cidr_open(entry) for entry in ranges):
             return True
     return False

--- a/skills/evaluation/evaluate-cis-aws-foundations-ocsf/tests/conftest.py
+++ b/skills/evaluation/evaluate-cis-aws-foundations-ocsf/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/skills/evaluation/evaluate-cis-aws-foundations-ocsf/tests/test_checks.py
+++ b/skills/evaluation/evaluate-cis-aws-foundations-ocsf/tests/test_checks.py
@@ -1,0 +1,229 @@
+"""Tests for evaluate-cis-aws-foundations-ocsf."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "checks.py"
+_SPEC = importlib.util.spec_from_file_location("cis_aws_ocsf_checks", _SRC)
+assert _SPEC and _SPEC.loader
+_CHECKS = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _CHECKS
+_SPEC.loader.exec_module(_CHECKS)
+
+BENCHMARK_NAME = _CHECKS.BENCHMARK_NAME
+CONTROLS = _CHECKS.CONTROLS
+DOCUMENTED_NOT_IMPLEMENTED = _CHECKS.DOCUMENTED_NOT_IMPLEMENTED
+FRAMEWORKS = _CHECKS.FRAMEWORKS
+PROVIDER_NAME = _CHECKS.PROVIDER_NAME
+SKILL_NAME = _CHECKS.SKILL_NAME
+STATUS_FAIL = _CHECKS.STATUS_FAIL
+STATUS_NA = _CHECKS.STATUS_NA
+STATUS_PASS = _CHECKS.STATUS_PASS
+benchmark_metadata = _CHECKS.benchmark_metadata
+findings_to_ocsf = _CHECKS.findings_to_ocsf
+load_records = _CHECKS.load_records
+main = _CHECKS.main
+parse_records = _CHECKS.parse_records
+run_benchmark = _CHECKS.run_benchmark
+
+
+def _item(resource_type: str, resource_id: str, config: dict[str, object], *, region: str = "us-east-1") -> dict[str, object]:
+    return {
+        "class_uid": 6003,
+        "time": 1776572400000,
+        "metadata": {"uid": f"ci-{resource_id}"},
+        "cloud": {"provider": "AWS", "account": {"uid": "111122223333"}, "region": region},
+        "resources": [{"uid": resource_id, "name": resource_id, "type": resource_type, "region": region}],
+        "unmapped": {
+            "aws_config": {
+                "configuration": config,
+                "tags": {},
+                "relationships": [],
+            }
+        },
+    }
+
+
+def _passing_records() -> list[dict[str, object]]:
+    return [
+        _item(
+            "AWS::S3::Bucket",
+            "prod-logs",
+            {
+                "bucketEncryption": {"serverSideEncryptionConfiguration": [{"rule": {"sse": "AES256"}}]},
+                "loggingConfiguration": {"destinationBucketName": "central-logs"},
+                "publicAccessBlockConfiguration": {
+                    "blockPublicAcls": True,
+                    "ignorePublicAcls": True,
+                    "blockPublicPolicy": True,
+                    "restrictPublicBuckets": True,
+                },
+                "versioningConfiguration": {"status": "Enabled"},
+            },
+        ),
+        _item(
+            "AWS::CloudTrail::Trail",
+            "org-trail",
+            {"isMultiRegionTrail": True, "logFileValidationEnabled": True, "kmsKeyId": "arn:kms"},
+        ),
+        _item(
+            "AWS::EC2::SecurityGroup",
+            "sg-private",
+            {
+                "ipPermissions": [
+                    {
+                        "ipProtocol": "tcp",
+                        "fromPort": 22,
+                        "toPort": 22,
+                        "ipRanges": [{"cidrIp": "10.0.0.0/8"}],
+                    }
+                ]
+            },
+        ),
+        _item("AWS::EC2::VPC", "vpc-1", {}),
+        _item("AWS::EC2::FlowLog", "fl-1", {"resourceId": "vpc-1"}),
+        _item("AWS::GuardDuty::Detector", "gd-1", {"status": "ENABLED"}),
+        _item("AWS::SecurityHub::Hub", "hub-1", {"subscribedAt": "2026-06-05T00:00:00Z"}),
+    ]
+
+
+class TestInputParsing:
+    def test_parse_json_array_and_jsonl(self):
+        records = _passing_records()[:2]
+        assert parse_records(json.dumps(records)) == records
+        jsonl = "\n".join(json.dumps(record) for record in records)
+        assert parse_records(jsonl) == records
+
+    def test_parse_rejects_non_object_jsonl(self):
+        with pytest.raises(ValueError):
+            parse_records("[1]\n")
+
+    def test_load_records_reads_stream(self):
+        records = load_records(None, stream=[json.dumps(_passing_records()[0])])
+        assert len(records) == 1
+
+
+class TestEvaluation:
+    def test_passing_config_evidence_passes_implemented_controls(self):
+        findings = run_benchmark(_passing_records())
+        assert len(findings) == len(CONTROLS)
+        assert {finding.status for finding in findings} == {STATUS_PASS}
+
+    def test_s3_and_security_group_failures_are_detected(self):
+        records = [
+            _item(
+                "AWS::S3::Bucket",
+                "bad-bucket",
+                {
+                    "publicAccessBlockConfiguration": {
+                        "blockPublicAcls": False,
+                        "ignorePublicAcls": True,
+                        "blockPublicPolicy": True,
+                        "restrictPublicBuckets": False,
+                    },
+                    "versioningConfiguration": {"status": "Suspended"},
+                },
+            ),
+            _item(
+                "AWS::EC2::SecurityGroup",
+                "sg-open",
+                {
+                    "ipPermissions": [
+                        {
+                            "ipProtocol": "tcp",
+                            "fromPort": 22,
+                            "toPort": 3389,
+                            "ipRanges": [{"cidrIp": "0.0.0.0/0"}],
+                        }
+                    ]
+                },
+            ),
+        ]
+        findings = {finding.control_id: finding for finding in run_benchmark(records)}
+        assert findings["2.1"].status == STATUS_FAIL
+        assert findings["2.3"].status == STATUS_FAIL
+        assert findings["2.4"].status == STATUS_FAIL
+        assert findings["4.1"].status == STATUS_FAIL
+        assert findings["4.2"].status == STATUS_FAIL
+        assert "bad-bucket" in findings["2.1"].detail
+        assert "sg-open" in findings["4.1"].detail
+
+    def test_empty_input_is_not_applicable_except_required_services(self):
+        findings = {finding.control_id: finding for finding in run_benchmark([])}
+        assert findings["2.1"].status == STATUS_NA
+        assert findings["4.3"].status == STATUS_NA
+        assert findings["6.1"].status == STATUS_FAIL
+        assert findings["6.2"].status == STATUS_FAIL
+
+    def test_aws_config_rule_evidence_can_fail_without_config_item(self):
+        records = [
+            {
+                "class_uid": 2003,
+                "time": 1776572760000,
+                "cloud": {"provider": "AWS", "account": {"uid": "111122223333"}, "region": "us-east-1"},
+                "resources": [{"uid": "prod-logs", "name": "prod-logs", "type": "AWS::S3::Bucket", "region": "us-east-1"}],
+                "finding_info": {"desc": "Bucket encryption missing."},
+                "compliance": {
+                    "status": "FAIL",
+                    "control": "s3-bucket-server-side-encryption-enabled",
+                    "frameworks": ["AWS Config"],
+                },
+                "evidence": {"source": "AWS Config", "rule_name": "s3-bucket-server-side-encryption-enabled"},
+            }
+        ]
+        findings = {finding.control_id: finding for finding in run_benchmark(records)}
+        assert findings["2.1"].status == STATUS_FAIL
+        assert "AWS Config rule failure evidence" in findings["2.1"].detail
+
+    def test_control_filter_returns_one_finding(self):
+        findings = run_benchmark(_passing_records(), control_id="2.1")
+        assert len(findings) == 1
+        assert findings[0].control_id == "2.1"
+
+
+class TestOcsfProjection:
+    def test_findings_render_as_ocsf_compliance_findings(self):
+        findings = run_benchmark(_passing_records())
+        rendered = findings_to_ocsf(
+            findings,
+            skill_name=SKILL_NAME,
+            benchmark_name=BENCHMARK_NAME,
+            provider=PROVIDER_NAME,
+            frameworks=list(FRAMEWORKS),
+        )
+        assert len(rendered) == len(CONTROLS)
+        assert all(record["class_uid"] == 2003 for record in rendered)
+        assert rendered[0]["cloud"]["provider"] == "AWS"
+        assert "CIS AWS Foundations v3.0 2.1" in rendered[0]["compliance"]["requirements"]
+
+
+class TestCli:
+    def test_main_json_output_success(self, tmp_path: Path, capsys):
+        path = tmp_path / "records.json"
+        path.write_text(json.dumps(_passing_records()), encoding="utf-8")
+        assert main([str(path), "--output", "json"]) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == len(CONTROLS)
+
+    def test_main_returns_2_for_bad_input(self, tmp_path: Path, capsys):
+        path = tmp_path / "bad.jsonl"
+        path.write_text("{bad", encoding="utf-8")
+        assert main([str(path)]) == 2
+        assert "JSON parse failed" in capsys.readouterr().err
+
+
+class TestHonestyContract:
+    def test_metadata_declares_partial_coverage(self):
+        metadata = benchmark_metadata()
+        assert metadata["implemented_count"] == 12
+        assert metadata["source_skill"] == "ingest-aws-config-ocsf"
+        assert set(metadata["implemented_controls"]).isdisjoint(DOCUMENTED_NOT_IMPLEMENTED)
+
+    def test_documented_not_implemented_is_non_empty(self):
+        assert DOCUMENTED_NOT_IMPLEMENTED


### PR DESCRIPTION
## Summary
- Adds `evaluate-cis-aws-foundations-ocsf` for AWS Config OCSF/native evidence.
- Covers 12 Config-backed CIS AWS Foundations v3.0 controls and emits native or OCSF Compliance Finding output.
- Updates the framework registry, skill catalog, count surfaces, and visual docs to `120` skills / `12` evaluation skills / `143` benchmark checks.

## Verification
- `uv run pytest -q skills/evaluation/evaluate-cis-aws-foundations-ocsf/tests`
- `uv run ruff check skills/evaluation/evaluate-cis-aws-foundations-ocsf --config pyproject.toml`
- `python scripts/validate_framework_coverage.py`
- `python scripts/validate_doc_counts.py`
- `python scripts/validate_skill_count_consistency.py`
- `python scripts/generate_security_bar_matrix.py --check`
- `python scripts/coverage_summary.py --check`
- `python scripts/generate_framework_coverage_doc.py --check`
- `python scripts/validate_skill_contract.py`
- `python scripts/validate_safe_skill_bar.py`
- `python scripts/validate_ocsf_metadata.py`
- `uv run pytest -q skills/evaluation/evaluate-cis-aws-foundations-ocsf/tests mcp-server/tests/test_tool_registry.py tests/integration/test_skills_library.py`
- `uv run python scripts/validate_golden_ocsf.py`
- `git diff --check`
- `rsvg-convert docs/images/hero-banner.svg -w 1280 -h 540 -o /tmp/cloud-skills-hero-eval.png`
- `rsvg-convert docs/images/architecture-layers.svg -w 1400 -h 780 -o /tmp/cloud-skills-arch-eval.png`
- `python skills/evaluation/evaluate-cis-aws-foundations-ocsf/src/checks.py skills/detection-engineering/golden/aws_config_sample.ocsf.jsonl --control 2.1 --output json --output-format ocsf > /tmp/evaluate-cis-aws-ocsf.json`

## Notes
- Partially advances #29 by completing the AWS Config OCSF evaluator side after the ingest skill landed.
- IAM/live CIS checks remain in `cspm-aws-cis-benchmark`; this evaluator is intentionally scoped to Config-backed evidence.
- The golden-fixture smoke intentionally exits `1` because the fixture contains a failing AWS Config rule; it emitted one OCSF `2003` finding for control `2.1`.
