### PR TITLE
feat(workday): add audit ingest vendor story

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,15 +26,15 @@ Skills are organised into layered categories. See [`skills/README.md`](skills/RE
 
 Current shipped surface on `main`:
 
-- **`ingestion/`**: 19 ingest skills plus 4 source adapters
+- **`ingestion/`**: 20 ingest skills plus 4 source adapters
 - **`discovery/`**: 5 read-only skills including `iam-departures-reconciler`
-- **`detection/`**: 66 deterministic ATT&CK-tagged detectors
+- **`detection/`**: 67 deterministic ATT&CK-tagged detectors
 - **`evaluation/`**: 12 posture / benchmark families
 - **`view/`**: 2 render/export skills
 - **`remediation/`**: 12 HITL-gated write skills across AWS, GCP, Azure, Kubernetes, Okta, Workspace, Entra, and MCP
 - **`output/`**: 3 append-only sinks
 
-**Total shipped: 123 skill bundles.** Auto-generated per-framework rollup in [`docs/FRAMEWORK_COVERAGE.md`](docs/FRAMEWORK_COVERAGE.md); per-skill registry in [`docs/framework-coverage.json`](docs/framework-coverage.json).
+**Total shipped: 125 skill bundles.** Auto-generated per-framework rollup in [`docs/FRAMEWORK_COVERAGE.md`](docs/FRAMEWORK_COVERAGE.md); per-skill registry in [`docs/framework-coverage.json`](docs/framework-coverage.json).
 
 Notable current skills that older agent memory often misses:
 
@@ -42,6 +42,7 @@ Notable current skills that older agent memory often misses:
 - network closed loops now include `remediate-aws-sg-revoke`, `remediate-azure-nsg-revoke`, and `remediate-gcp-firewall-revoke`
 - identity / SaaS containment now includes `remediate-entra-credential-revoke`, `remediate-workspace-session-kill`, and `iam-departures-azure-entra` / `iam-departures-gcp`
 - MCP / AI-native coverage includes both `detect-prompt-injection-mcp-proxy` and `remediate-mcp-tool-quarantine`
+- Workday coverage now includes `ingest-workday-audit-ocsf` and `detect-mass-termination-anomaly`
 
 Compose via stdin/stdout pipes. The shared wire contract is pinned in
 [`skills/detection-engineering/OCSF_CONTRACT.md`](skills/detection-engineering/OCSF_CONTRACT.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Agentic security skills for cloud and AI — 123 shipped skill bundles. OCSF 1.8 on the wire. 143 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, GitHub, Slack, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![Agentic security skills for cloud and AI — 125 shipped skill bundles. OCSF 1.8 on the wire. 143 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, GitHub, Slack, Workday, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -12,7 +12,7 @@
   <a href="https://github.com/msaad00/agent-bom"><img alt="Scanned by agent-bom" src="https://img.shields.io/badge/scanned_by-agent--bom-164e63"></a>
 </p>
 
-<p align="center"><strong>123 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed, runs everywhere the same bundle can.</strong></p>
+<p align="center"><strong>125 production-grade security skills for cloud and AI — OCSF on the wire, MCP-ready, HITL-audited, sandboxed, runs everywhere the same bundle can.</strong></p>
 
 ---
 
@@ -51,24 +51,24 @@ Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent 
 
 ## What this repo gives you
 
-**123 shipped skill bundles** — atomic, deterministic, single-concern. Twelve are guarded write paths; the rest are read-only skills or append-only source/output adapters. Drop one into a pipeline, an agent, a Step Function, or a `python ... | python ...` one-liner.
+**125 shipped skill bundles** — atomic, deterministic, single-concern. Twelve are guarded write paths; the rest are read-only skills or append-only source/output adapters. Drop one into a pipeline, an agent, a Step Function, or a `python ... | python ...` one-liner.
 
 | Layer | Count | Purpose | Output |
 |---|---:|---|---|
-| **Ingest** | 19 | normalize raw cloud / identity / K8s / MCP / SaaS signal | OCSF 1.8 (native opt-in) |
+| **Ingest** | 20 | normalize raw cloud / identity / K8s / MCP / SaaS signal | OCSF 1.8 (native opt-in) |
 | **Discover** | 5 | inventory · graph · AI BOM · evidence · IAM-departure planning | native / bridge JSON |
-| **Detect** | 66 | deterministic rules tagged with MITRE ATT&CK / ATLAS / OWASP | OCSF Detection Finding 2004 |
+| **Detect** | 67 | deterministic rules tagged with MITRE ATT&CK / ATLAS / OWASP | OCSF Detection Finding 2004 |
 | **Evaluate** | 12 | 143 posture and benchmark checks across CIS / NIST / NIST AI RMF / SOC 2 | compliance result |
 | **Remediate** | 12 | guarded write paths — IAM departures × 3 clouds, network revoke × 3, session/credential kill × 4, K8s × 2, MCP tool quarantine | audited action trail |
 | **View** | 2 | findings → review formats | SARIF · Mermaid |
 | **Output** | 3 | append-only sinks | S3 · Snowflake · ClickHouse |
 | **Sources** | 4 | warehouse query adapters | S3 Select · Snowflake · Databricks · ClickHouse |
 
-**Total: 123 shipped skills.**  Live counts and per-framework coverage in [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) (auto-generated, CI-gated).
+**Total: 125 shipped skills.**  Live counts and per-framework coverage in [`docs/COVERAGE_SNAPSHOT.md`](docs/COVERAGE_SNAPSHOT.md) (auto-generated, CI-gated).
 
 **Find a skill:** [`docs/SKILL_INDEX.md`](docs/SKILL_INDEX.md) groups every shipped skill by **environment** (AWS · GCP · Azure/Entra · K8s · Identity · AI/MCP · Web · Cross-env) and by **purpose** (ingest / discover / detect / evaluate / remediate / view / output / source), and points at the framework-mapping docs for control-catalog pivots.
 
-**Which vendor signals normalize to OCSF today?** [`docs/INGEST_COVERAGE.md`](docs/INGEST_COVERAGE.md) — the canonical vendor × source × OCSF class matrix, **19 mappings shipped** (AWS · GCP · Azure · Entra · K8s · Okta · Workspace · MCP · **GitHub · Slack**) plus the 6 documented roadmap rows (Workday, Salesforce, SAP, native ClickHouse audit, AWS web-app exfil pipeline, Workspace beyond-login).
+**Which vendor signals normalize to OCSF today?** [`docs/INGEST_COVERAGE.md`](docs/INGEST_COVERAGE.md) — the canonical vendor × source × OCSF class matrix, **20 mappings shipped** (AWS · GCP · Azure · Entra · K8s · Okta · Workspace · MCP · **GitHub · Slack · Workday**) plus the 5 documented roadmap rows (Salesforce, SAP, native ClickHouse audit, AWS web-app exfil pipeline, Workspace beyond-login).
 
 **Why use these skills (vs ad-hoc Python your agent writes at runtime, vs LLM-written skills you commit, vs your team writing 90 from scratch)?** [`docs/WHY.md`](docs/WHY.md) — three different alternatives, three different answers. This repo is built for LLMs and agents to invoke (MCP, Agent SDK, library, CLI, webhook, runners — every surface). What you can't prompt-generate: the trust contract (HITL gates, three-layer sandbox, HMAC-chained audit, allowlist intersection, OCSF wire lock), the calibration values (real-corpus thresholds), the cross-cutting maintenance (OCSF version bumps, MITRE catalog updates, vendor schema drift). Cost framing: ~12 engineer-weeks of harness + ~240 hours of detector content to reach v0.10.0 parity, then the maintenance tax per release.
 
@@ -183,7 +183,7 @@ Full discussion: [`docs/ARCHITECTURE.md §3 + §6`](docs/ARCHITECTURE.md). Pinne
 <details>
 <summary><b>Closed-loop coverage</b> — which detections have a paired remediation</summary>
 
-![Closed-loop coverage matrix — 13 of 66 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, GCP service-account-token minting, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, tool-output-exfiltration-instructions, Snowflake bulk egress, Snowflake share creation, Snowflake account-key creation, Snowflake warehouse resize burst, Snowflake unauthorized grant, Snowflake failed-MFA burst, Snowflake session-policy bypass, Snowflake network-policy disable, Snowflake replication-config change, ClickHouse bulk export, Databricks token-creation, Databricks Unity Catalog cross-workspace share, Databricks MLflow model exfil, Databricks cluster init-script abuse, Databricks workspace admin grant, Databricks secret-scope read burst, GitHub PAT creation, GitHub org-secret exposure, GitHub Actions secret disclosure, Workspace OAuth grant, and Workspace admin-role grant slices are detection-first today.](docs/images/coverage-matrix.svg)
+![Closed-loop coverage matrix — 13 of 67 shipped detections are closed loops today; lateral movement is intentionally detection-only, and the AWS access-key, AWS login-profile, AWS discovery-burst, AWS cross-account S3 copy, AWS/GCP/Azure logging-impairment, AWS/GCP model-artifact download, GCP service-account-key creation, GCP service-account-token minting, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, tool-output-exfiltration-instructions, Snowflake bulk egress, Snowflake share creation, Snowflake account-key creation, Snowflake warehouse resize burst, Snowflake unauthorized grant, Snowflake failed-MFA burst, Snowflake session-policy bypass, Snowflake network-policy disable, Snowflake replication-config change, ClickHouse bulk export, Databricks token-creation, Databricks Unity Catalog cross-workspace share, Databricks MLflow model exfil, Databricks cluster init-script abuse, Databricks workspace admin grant, Databricks secret-scope read burst, GitHub PAT creation, GitHub org-secret exposure, GitHub Actions secret disclosure, Workspace OAuth grant, Workspace admin-role grant, and Workday mass-termination anomaly slices are detection-first today.](docs/images/coverage-matrix.svg)
 
 </details>
 

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -47,6 +47,7 @@ is the row you can take to your auditor.
 | `ingest-slack-audit-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `ingest-vpc-flow-logs-gcp-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `ingest-vpc-flow-logs-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `ingest-workday-audit-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `ingest-workspace-admin-ocsf` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `source-clickhouse-query` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `source-databricks-query` | ingestion | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -92,6 +93,7 @@ is the row you can take to your auditor.
 | `detect-github-pat-creation` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-google-workspace-suspicious-login` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-lateral-movement` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
+| `detect-mass-termination-anomaly` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-mcp-adversarial-input-corpus` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-mcp-model-artifact-tampering` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
 | `detect-mcp-model-token-flood` | detection | ✅ | ✅ | ✅ | ✅ golden fixture | ✅ 1.8 | ✅ |
@@ -153,7 +155,7 @@ is the row you can take to your auditor.
 | `sink-s3-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 | `sink-snowflake-jsonl` | output | ⚠️ append-only sink | ✅ | ✅ | ✅ audit + re-verify | n/a | ✅ |
 
-_123 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
+_125 skills · generated from SKILL.md frontmatter + layer conventions. Run `python scripts/generate_security_bar_matrix.py` to refresh after adding a skill; CI enforces parity via `--check`._
 <!-- AUTO-GENERATED MATRIX END -->
 
 ## How to add a skill that satisfies the bar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,11 +190,11 @@ For the detailed contract, see:
 | Layer | Status | Current shape |
 |---|---|---|
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
-| L1 ingest | shipping | 17 source-specific ingesters plus 3 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
-| L2 discover | shipping | environment graph, AI BOM, cloud control evidence, control evidence |
-| L3 detect | shipping | 66 shipped detectors across cloud, identity, Kubernetes, MCP / agent, warehouse, and SaaS signals (GitHub, Slack, Workspace) |
-| L4 evaluate | shipping | 7 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, and model-serving paths with native and opt-in OCSF 2003 output |
-| L5 remediate | shipping | IAM departures is the flagship write path; Okta session kill ships as the containment remediator |
+| L1 ingest | shipping | 20 source-specific ingesters plus 4 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
+| L2 discover | shipping | 5 read-only inventory, graph, AI BOM, cloud control evidence, and departure-planning skills |
+| L3 detect | shipping | 67 shipped detectors across cloud, identity, Kubernetes, MCP / agent, warehouse, and SaaS signals (GitHub, Slack, Workspace, Workday) |
+| L4 evaluate | shipping | 12 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, AI RMF, and model-serving paths with native and opt-in OCSF 2003 output |
+| L5 remediate | shipping | 12 HITL-gated write paths across IAM departures, network revocation, session / credential containment, Kubernetes, Workspace, Entra, and MCP |
 | L6 view | shipping | SARIF and Mermaid attack-flow exports |
 | L7 sinks | shipping | `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`, and `sink-s3-jsonl` ship today under `skills/output/` |
 | L8 query packs | partial shipping | `packs/lateral-movement/` and `packs/privilege-escalation-k8s/` are shipped; broader pack coverage remains future work |

--- a/docs/COVERAGE_SNAPSHOT.md
+++ b/docs/COVERAGE_SNAPSHOT.md
@@ -6,7 +6,7 @@ Auto-generated from [`framework-coverage.json`](framework-coverage.json) by [`sc
 python scripts/coverage_summary.py --write
 ```
 
-**Total shipped skills:** 123
+**Total shipped skills:** 125
 
 ## By cloud / vendor
 
@@ -14,23 +14,23 @@ Skills overlap when a skill targets multiple providers (the `multi` row), so the
 
 | Cloud / vendor | Skills | % of repo |
 |---|---:|---:|
-| AWS | 26 | 21.1% |
-| Multi-cloud (vendor-neutral) | 21 | 17.1% |
-| Azure | 19 | 15.4% |
-| GCP | 18 | 14.6% |
-| MCP / AI runtime | 14 | 11.4% |
-| Snowflake | 13 | 10.6% |
-| Kubernetes | 9 | 7.3% |
-| Databricks | 9 | 7.3% |
-| Google Workspace | 6 | 4.9% |
-| ClickHouse | 5 | 4.1% |
-| Okta | 4 | 3.3% |
-| Microsoft Entra | 4 | 3.3% |
-| github | 4 | 3.3% |
-| Slack | 4 | 3.3% |
+| AWS | 26 | 20.8% |
+| Multi-cloud (vendor-neutral) | 21 | 16.8% |
+| Azure | 19 | 15.2% |
+| GCP | 18 | 14.4% |
+| MCP / AI runtime | 14 | 11.2% |
+| Snowflake | 13 | 10.4% |
+| Kubernetes | 9 | 7.2% |
+| Databricks | 9 | 7.2% |
+| Google Workspace | 6 | 4.8% |
+| ClickHouse | 5 | 4.0% |
+| Okta | 4 | 3.2% |
+| Microsoft Entra | 4 | 3.2% |
+| github | 4 | 3.2% |
+| Slack | 4 | 3.2% |
+| Workday | 3 | 2.4% |
 | Microsoft Graph | 3 | 2.4% |
 | Containers (runtime) | 3 | 2.4% |
-| Workday | 1 | 0.8% |
 
 ## By framework
 
@@ -38,20 +38,20 @@ Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF 
 
 | Framework | Skills | % of repo |
 |---|---:|---:|
-| OCSF 1.8 | 102 | 82.9% |
-| MITRE ATT&CK v14 | 81 | 65.9% |
-| OWASP Top 10 | 22 | 17.9% |
-| SOC 2 TSC | 22 | 17.9% |
-| NIST CSF 2.0 | 22 | 17.9% |
-| OWASP LLM Top 10 | 19 | 15.4% |
-| MITRE ATLAS | 17 | 13.8% |
-| OWASP MCP Top 10 | 11 | 8.9% |
-| NIST AI RMF | 8 | 6.5% |
-| CIS AWS v3 | 6 | 4.9% |
-| CIS Azure v2.1 | 6 | 4.9% |
-| CIS GCP v3 | 5 | 4.1% |
-| ISO 27001:2022 | 5 | 4.1% |
-| PCI DSS 4.0 | 4 | 3.3% |
+| OCSF 1.8 | 104 | 83.2% |
+| MITRE ATT&CK v14 | 82 | 65.6% |
+| OWASP Top 10 | 23 | 18.4% |
+| SOC 2 TSC | 22 | 17.6% |
+| NIST CSF 2.0 | 22 | 17.6% |
+| OWASP LLM Top 10 | 19 | 15.2% |
+| MITRE ATLAS | 17 | 13.6% |
+| OWASP MCP Top 10 | 11 | 8.8% |
+| NIST AI RMF | 8 | 6.4% |
+| CIS AWS v3 | 6 | 4.8% |
+| CIS Azure v2.1 | 6 | 4.8% |
+| CIS GCP v3 | 5 | 4.0% |
+| ISO 27001:2022 | 5 | 4.0% |
+| PCI DSS 4.0 | 4 | 3.2% |
 | CycloneDX ML-BOM | 2 | 1.6% |
 | CIS Controls v8 | 2 | 1.6% |
 | CIS Kubernetes | 2 | 1.6% |
@@ -61,11 +61,11 @@ Skills can carry multiple framework tags (e.g. a CIS check tagged with NIST CSF 
 
 | Layer | Skills | % of repo |
 |---|---:|---:|
-| detection | 66 | 53.7% |
-| ingestion | 23 | 18.7% |
-| evaluation | 12 | 9.8% |
-| remediation | 12 | 9.8% |
-| discovery | 5 | 4.1% |
+| detection | 67 | 53.6% |
+| ingestion | 24 | 19.2% |
+| evaluation | 12 | 9.6% |
+| remediation | 12 | 9.6% |
+| discovery | 5 | 4.0% |
 | output | 3 | 2.4% |
 | view | 2 | 1.6% |
 

--- a/docs/FRAMEWORK_COVERAGE.md
+++ b/docs/FRAMEWORK_COVERAGE.md
@@ -4,14 +4,14 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 
 - Registry version: `0.11.0`
 - Registry updated: `2026-05-17`
-- Total shipped skills in registry: **123**
+- Total shipped skills in registry: **125**
 
 ## Roll-up
 
 | Framework | Version | Shipped skills mapped | Coverage target |
 |---|---|---|---|
-| OCSF | 1.8.0 | **102** | — |
-| MITRE ATT&CK | v14 | **81** | 100% mapped coverage |
+| OCSF | 1.8.0 | **104** | — |
+| MITRE ATT&CK | v14 | **82** | 100% mapped coverage |
 | MITRE ATLAS | current | **17** | 100% mapped coverage |
 | CIS AWS Foundations | v3.0 | **6** | — |
 | CIS GCP Foundations | v3.0 | **5** | — |
@@ -24,7 +24,7 @@ This file is **generated from [`framework-coverage.json`](framework-coverage.jso
 | SOC 2 TSC | current | **22** | 100% mapped coverage |
 | PCI DSS | 4.0 | **4** | 100% mapped coverage |
 | ISO 27001 | 2022 | **5** | — |
-| OWASP Top 10 | 2021 | **22** | — |
+| OWASP Top 10 | 2021 | **23** | — |
 | OWASP LLM Top 10 | current | **19** | — |
 | OWASP MCP Top 10 | current | **11** | — |
 | CycloneDX ML-BOM | current | **2** | — |
@@ -37,7 +37,7 @@ Shipped skills mapped counts the number of skills in the registry that declare t
 
 - Registry id: `ocsf-1.8`
 
-Shipped skills mapped: **102**
+Shipped skills mapped: **104**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -76,6 +76,7 @@ Shipped skills mapped: **102**
 | [`detect-github-pat-creation`](../skills/detection/detect-github-pat-creation) | detection | github | source-control, tokens, identities |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
+| [`detect-mass-termination-anomaly`](../skills/detection/detect-mass-termination-anomaly) | detection | workday | identities, hr-events, offboarding, audit-logs |
 | [`detect-mcp-adversarial-input-corpus`](../skills/detection/detect-mcp-adversarial-input-corpus) | detection | mcp | prompts, tools |
 | [`detect-mcp-model-artifact-tampering`](../skills/detection/detect-mcp-model-artifact-tampering) | detection | mcp | model-artifacts, tools |
 | [`detect-mcp-model-token-flood`](../skills/detection/detect-mcp-model-token-flood) | detection | mcp | models, rate-limits |
@@ -133,6 +134,7 @@ Shipped skills mapped: **102**
 | [`ingest-slack-audit-ocsf`](../skills/ingestion/ingest-slack-audit-ocsf) | ingestion | slack | identities, channels, workspaces, oauth-apps, audit-logs |
 | [`ingest-vpc-flow-logs-gcp-ocsf`](../skills/ingestion/ingest-vpc-flow-logs-gcp-ocsf) | ingestion | gcp | network, flow-logs |
 | [`ingest-vpc-flow-logs-ocsf`](../skills/ingestion/ingest-vpc-flow-logs-ocsf) | ingestion | aws | network, flow-logs |
+| [`ingest-workday-audit-ocsf`](../skills/ingestion/ingest-workday-audit-ocsf) | ingestion | workday | identities, hr-events, offboarding, audit-logs |
 | [`ingest-workspace-admin-ocsf`](../skills/ingestion/ingest-workspace-admin-ocsf) | ingestion | google-workspace | identities, authentication, oauth, admin-roles, audit-logs |
 | [`source-clickhouse-query`](../skills/ingestion/source-clickhouse-query) | ingestion | clickhouse | lakehouse, query-results, audit-logs |
 | [`source-databricks-query`](../skills/ingestion/source-databricks-query) | ingestion | databricks | lakehouse, query-results, audit-logs |
@@ -151,7 +153,7 @@ Shipped skills mapped: **102**
 - Asset classes in scope: identities, api, network, clusters, containers, findings
 - Coverage target: 100% mapped coverage
 
-Shipped skills mapped: **81**
+Shipped skills mapped: **82**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -189,6 +191,7 @@ Shipped skills mapped: **81**
 | [`detect-github-pat-creation`](../skills/detection/detect-github-pat-creation) | detection | github | source-control, tokens, identities |
 | [`detect-google-workspace-suspicious-login`](../skills/detection/detect-google-workspace-suspicious-login) | detection | google-workspace | identities, authentication, sessions, mfa |
 | [`detect-lateral-movement`](../skills/detection/detect-lateral-movement) | detection | aws, azure, gcp, multi | iam-roles, role-sessions, applications, service-accounts, service-account-keys, iam-credentials, service-principals, managed-identities, federated-credentials, app-role-assignments, sessions, api, network |
+| [`detect-mass-termination-anomaly`](../skills/detection/detect-mass-termination-anomaly) | detection | workday | identities, hr-events, offboarding, audit-logs |
 | [`detect-mcp-shadow-tool-injection`](../skills/detection/detect-mcp-shadow-tool-injection) | detection | mcp | tools, tool-metadata, supply-chain |
 | [`detect-mcp-tool-drift`](../skills/detection/detect-mcp-tool-drift) | detection | mcp, multi | agent-tools, supply-chain, tool-metadata |
 | [`detect-okta-mfa-fatigue`](../skills/detection/detect-okta-mfa-fatigue) | detection | okta | identities, authentication, mfa, sessions |
@@ -461,7 +464,7 @@ Shipped skills mapped: **5**
 
 - Registry id: `owasp-top-10`
 
-Shipped skills mapped: **22**
+Shipped skills mapped: **23**
 
 | Skill | Layer | Providers | Asset classes |
 |---|---|---|---|
@@ -471,6 +474,7 @@ Shipped skills mapped: **22**
 | [`detect-databricks-secret-scope-read-burst`](../skills/detection/detect-databricks-secret-scope-read-burst) | detection | databricks | warehouse, secrets, credentials |
 | [`detect-databricks-unity-catalog-cross-workspace-share`](../skills/detection/detect-databricks-unity-catalog-cross-workspace-share) | detection | databricks | warehouse, unity-catalog, delta-sharing |
 | [`detect-databricks-workspace-admin-grant`](../skills/detection/detect-databricks-workspace-admin-grant) | detection | databricks | warehouse, identities, rbac |
+| [`detect-mass-termination-anomaly`](../skills/detection/detect-mass-termination-anomaly) | detection | workday | identities, hr-events, offboarding, audit-logs |
 | [`detect-slack-admin-elevation`](../skills/detection/detect-slack-admin-elevation) | detection | slack | identities, rbac, saas |
 | [`detect-slack-external-channel-add`](../skills/detection/detect-slack-external-channel-add) | detection | slack | identities, channels, saas |
 | [`detect-slack-oauth-app-install-broad-scope`](../skills/detection/detect-slack-oauth-app-install-broad-scope) | detection | slack | identities, oauth-apps, saas |

--- a/docs/FRAMEWORK_MAPPINGS.md
+++ b/docs/FRAMEWORK_MAPPINGS.md
@@ -20,7 +20,7 @@ from individual `SKILL.md` files.
 | Framework | Status | Where it appears |
 |---|---|---|
 | **OCSF 1.8** | core wire contract | all ingestion, detection, and view flows |
-| **MITRE ATT&CK v14** | strong and broader | 81 mapped skills across cloud, identity, Kubernetes, container, MCP, Databricks, and remediation paths. Auto-generated rollup in [`docs/FRAMEWORK_COVERAGE.md`](FRAMEWORK_COVERAGE.md); per-skill mapping in [`docs/framework-coverage.json`](framework-coverage.json) |
+| **MITRE ATT&CK v14** | strong and broader | 82 mapped skills across cloud, identity, Kubernetes, container, MCP, SaaS, Databricks, and remediation paths. Auto-generated rollup in [`docs/FRAMEWORK_COVERAGE.md`](FRAMEWORK_COVERAGE.md); per-skill mapping in [`docs/framework-coverage.json`](framework-coverage.json) |
 | **MITRE ATLAS** | partial but real | AI-oriented evaluation, discovery, MCP prompt-injection plus response-layer override and exfiltration detection, and the first AWS + GCP cloud-native model-artifact collection slices |
 | **CIS Benchmarks / Controls** | strong | AWS, GCP, Azure, Kubernetes, container evaluation skills |
 | **NIST CSF 2.0** | strong | evaluation and some remediation skills |

--- a/docs/INGEST_COVERAGE.md
+++ b/docs/INGEST_COVERAGE.md
@@ -7,7 +7,7 @@ This page is the single source of truth for **"which signal can I send and
 get OCSF out the other side?"** The rows below are the canonical answer at
 HEAD; the roadmap rows below are tracked in their linked issues.
 
-## Currently shipped — 19 ingest skills
+## Currently shipped — 20 ingest skills
 
 | Vendor | Source signal | OCSF 1.8 class | Skill |
 |---|---|---|---|
@@ -30,9 +30,10 @@ HEAD; the roadmap rows below are tracked in their linked issues.
 | GitHub | Organization Audit Log | API Activity 6003 / Authentication 3002 / User Access 3005 | [`ingest-github-audit-log-ocsf`](../skills/ingestion/ingest-github-audit-log-ocsf/) — closes [`#31`](https://github.com/msaad00/cloud-ai-security-skills/issues/31) |
 | MCP proxy | JSON-RPC request/response log | Application Activity 6002 | [`ingest-mcp-proxy-ocsf`](../skills/ingestion/ingest-mcp-proxy-ocsf/) |
 | Slack | Audit Logs API (`/audit/v1/logs`, Enterprise Grid) | Authentication 3002 / User Access 3005 / API Activity 6003 | [`ingest-slack-audit-ocsf`](../skills/ingestion/ingest-slack-audit-ocsf/) — closes [`#33`](https://github.com/msaad00/cloud-ai-security-skills/issues/33) |
+| Workday | REST / RaaS audit and HR lifecycle report exports | Account Change 3001 | [`ingest-workday-audit-ocsf`](../skills/ingestion/ingest-workday-audit-ocsf/) — closes [`#34`](https://github.com/msaad00/cloud-ai-security-skills/issues/34) |
 | AWS / GCP / Azure | Cross-cloud secret-scan + AI-BOM input pipes | (consumed by downstream detect-agent-credential-leak-mcp / discover-ai-bom) | covered transitively via the four above |
 
-> 20 rows for 19 ingest skills: Entra, Okta, GitHub, Slack, AWS Config, and Workspace Admin each emit
+> 21 rows for 20 ingest skills: Entra, Okta, GitHub, Slack, AWS Config, Workspace Admin, and Workday each emit
 > multiple OCSF classes depending on the source event family, so each is
 > listed once in the table but produces more than one OCSF class on the wire.
 
@@ -60,7 +61,6 @@ records already shaped as OCSF API Activity 6003 by an upstream pipeline.
 | ClickHouse | `system.query_log` native ingest | API Activity 6003 | [`#436`](https://github.com/msaad00/cloud-ai-security-skills/issues/436) — `ingest-clickhouse-query-log-ocsf` |
 | AWS | Lambda + API Gateway access logs | HTTP Activity 4002 | [`#253`](https://github.com/msaad00/cloud-ai-security-skills/issues/253) — first detection-side use case is the web-app exfil arc |
 | Google Workspace | Drive / Mobile feeds (beyond login, token, and admin role activity) | API Activity 6003 + User Access 3005 | [`#32`](https://github.com/msaad00/cloud-ai-security-skills/issues/32) — follow-on vendor depth |
-| Workday | HR events stream | (proprietary → canonical departure manifest, not OCSF) | [`#34`](https://github.com/msaad00/cloud-ai-security-skills/issues/34) — vendor story PR N; existing `iam-departures-reconciler` is the consumer |
 | Salesforce | Setup Audit Trail + Event Monitoring | API Activity 6003 + Authentication 3002 | [`#35`](https://github.com/msaad00/cloud-ai-security-skills/issues/35) — vendor story PR O |
 | SAP | Security Audit Log | API Activity 6003 | [`#36`](https://github.com/msaad00/cloud-ai-security-skills/issues/36) — vendor story PR P |
 

--- a/docs/SKILL_INDEX.md
+++ b/docs/SKILL_INDEX.md
@@ -1,6 +1,6 @@
 # Skill index — find a skill fast
 
-The same 123 skill bundles, pivoted three ways:
+The same 125 skill bundles, pivoted three ways:
 
 1. **[By environment](#by-environment)** — pick a cloud or platform, see every skill that touches it.
 2. **[By purpose](#by-purpose)** — pick a layer (ingest / discover / detect / evaluate / remediate / view / output / source).
@@ -107,14 +107,16 @@ not do, and what it talks to.
 | Remediate | [`remediate-okta-session-kill`](../skills/remediation/remediate-okta-session-kill/) | HITL — kill Okta sessions on principal |
 | Remediate | [`remediate-workspace-session-kill`](../skills/remediation/remediate-workspace-session-kill/) | HITL — sign-out Workspace user |
 
-### SaaS (Slack) — 4 skills
+### SaaS (Slack · Workday) — 6 skills
 
 | Layer | Skill | What it does |
 |---|---|---|
 | Ingest | [`ingest-slack-audit-ocsf`](../skills/ingestion/ingest-slack-audit-ocsf/) | Slack Audit Logs API → OCSF Authentication 3002 / User Access 3005 / API Activity 6003 |
+| Ingest | [`ingest-workday-audit-ocsf`](../skills/ingestion/ingest-workday-audit-ocsf/) | Workday REST / RaaS audit reports → OCSF Account Change 3001 |
 | Detect | [`detect-slack-external-channel-add`](../skills/detection/detect-slack-external-channel-add/) | T1078.004 — external guest added to a sensitive Slack channel |
 | Detect | [`detect-slack-oauth-app-install-broad-scope`](../skills/detection/detect-slack-oauth-app-install-broad-scope/) | T1098.005 — Slack app installed with broad OAuth scopes |
 | Detect | [`detect-slack-admin-elevation`](../skills/detection/detect-slack-admin-elevation/) | T1098.003 — Slack admin/owner role grant outside change window |
+| Detect | [`detect-mass-termination-anomaly`](../skills/detection/detect-mass-termination-anomaly/) | T1098 — Workday termination spike across a short HR offboarding window |
 
 ### AI runtime · MCP · model serving — 20 skills
 
@@ -193,16 +195,16 @@ not do, and what it talks to.
 
 | Layer | Count | Index |
 |---|---:|---|
-| Ingest | 19 | [`skills/ingestion/`](../skills/ingestion/) (excludes the 4 warehouse sources below) |
+| Ingest | 20 | [`skills/ingestion/`](../skills/ingestion/) (excludes the 4 warehouse sources below) |
 | Discover | 5 | [`skills/discovery/`](../skills/discovery/) |
-| Detect | 66 | [`skills/detection/`](../skills/detection/) |
+| Detect | 67 | [`skills/detection/`](../skills/detection/) |
 | Evaluate | 12 | [`skills/evaluation/`](../skills/evaluation/) |
 | Remediate | 12 | [`skills/remediation/`](../skills/remediation/) |
 | View | 2 | [`skills/view/`](../skills/view/) |
 | Output | 3 | [`skills/output/`](../skills/output/) |
 | Source | 4 | warehouse adapters: `source-clickhouse-query`, `source-databricks-query`, `source-s3-select`, `source-snowflake-query` (filed under `skills/ingestion/` on disk) |
 
-Total = 19 + 5 + 66 + 12 + 12 + 2 + 3 + 4 = **123**.
+Total = 20 + 5 + 67 + 12 + 12 + 2 + 3 + 4 = **125**.
 
 ## By framework
 

--- a/docs/WORKDAY_OCSF_DEPARTURES.md
+++ b/docs/WORKDAY_OCSF_DEPARTURES.md
@@ -1,0 +1,30 @@
+# Workday OCSF Departures
+
+Use `ingest-workday-audit-ocsf` when Workday audit or RaaS reports are already
+exported and the departures workflow should consume a common OCSF stream instead
+of running another Workday-specific query.
+
+## First command
+
+```bash
+python skills/ingestion/ingest-workday-audit-ocsf/src/ingest.py workday-audit-report.json > workday-audit.ocsf.jsonl
+python skills/detection/detect-mass-termination-anomaly/src/detect.py workday-audit.ocsf.jsonl > workday-termination-findings.ocsf.jsonl
+```
+
+The first artifact is OCSF Account Change (3001) JSONL. Termination events carry
+`unmapped.workday.event_family=termination`, the worker identity in `user`, and
+tenant-specific report evidence under `unmapped.workday.raw`.
+
+## Departures reconciler path
+
+`iam-departures-reconciler` remains compatible with its existing direct Workday
+RaaS source for operators that have not moved HR evidence into OCSF yet. The
+preferred path for new pipelines is:
+
+1. Export the Workday audit/RaaS report upstream.
+2. Normalize it with `ingest-workday-audit-ocsf`.
+3. Feed Account Change (3001) termination records into the departures manifest
+   builder or the mass-termination detector before IAM remediation.
+
+This keeps the Workday credential boundary in the upstream collector and lets
+CI, MCP, persistent runners, and downstream IAM skills share one event contract.

--- a/docs/framework-coverage.json
+++ b/docs/framework-coverage.json
@@ -163,6 +163,31 @@
       ]
     },
     {
+      "path": "skills/detection/detect-mass-termination-anomaly",
+      "layer": "detection",
+      "providers": [
+        "workday"
+      ],
+      "asset_classes": [
+        "identities",
+        "hr-events",
+        "offboarding",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8",
+        "mitre-attack-v14",
+        "owasp-top-10"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
       "path": "skills/detection/detect-aws-access-key-creation",
       "layer": "detection",
       "providers": [
@@ -2409,6 +2434,29 @@
         "authentication",
         "oauth",
         "admin-roles",
+        "audit-logs"
+      ],
+      "frameworks": [
+        "ocsf-1.8"
+      ],
+      "coverage_status": "validated",
+      "execution_modes": [
+        "cli",
+        "ci",
+        "mcp",
+        "persistent"
+      ]
+    },
+    {
+      "path": "skills/ingestion/ingest-workday-audit-ocsf",
+      "layer": "ingestion",
+      "providers": [
+        "workday"
+      ],
+      "asset_classes": [
+        "identities",
+        "hr-events",
+        "offboarding",
         "audit-logs"
       ],
       "frameworks": [

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 19 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 66 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 12 benchmark families covering 143 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 20 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 67 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 12 benchmark families covering 143 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -64,15 +64,15 @@
       </g>
       <text x="110" y="540" font-size="13" fill="#94a3b8">AWS · GCP · Azure · K8s</text>
       <text x="110" y="560" font-size="13" fill="#94a3b8">Okta · Entra · Workspace</text>
-      <text x="110" y="580" font-size="13" fill="#94a3b8">Snowflake · Databricks</text>
-      <text x="110" y="600" font-size="13" fill="#94a3b8">S3 · ClickHouse · MCP</text>
+      <text x="110" y="580" font-size="13" fill="#94a3b8">Slack · Workday · Snowflake</text>
+      <text x="110" y="600" font-size="13" fill="#94a3b8">Databricks · ClickHouse · MCP</text>
     </g>
 
     <!-- L1 Ingest + L2 Discover (boxes widened to 260, descriptions wrapped to 2 short lines) -->
     <g filter="url(#shadow)">
       <rect x="322" y="228" width="260" height="180" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
       <text x="354" y="270" font-size="18" font-weight="800" fill="#dbeafe">L1 Ingest</text>
-      <text x="354" y="332" font-size="56" font-weight="900" fill="#ffffff">19 + 4</text>
+      <text x="354" y="332" font-size="56" font-weight="900" fill="#ffffff">20 + 4</text>
       <text x="354" y="364" font-size="15" fill="#bfdbfe">normalize source data to</text>
       <text x="354" y="386" font-size="15" fill="#bfdbfe">OCSF 1.8 or native JSONL</text>
 
@@ -87,7 +87,7 @@
     <g filter="url(#shadow)">
       <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
       <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">66</text>
+      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">67</text>
       <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
       <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
 

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="2650" viewBox="0 0 1400 2650" role="img" aria-labelledby="cm-title cm-desc">
   <title id="cm-title">cloud-ai-security-skills — detection and posture coverage matrix</title>
-  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (66) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of sixty-six detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, GCP service-account-key, GCP service-account-token-minting, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, tool-output-exfiltration-instructions, Workspace OAuth grant, and Workspace admin-role grant slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
+  <desc id="cm-desc">Coverage matrix visualizing the gap between shipped detection and posture skills and their paired remediation, with ATT&amp;CK or ATLAS technique IDs where the detector emits them and framework notes where it does not. Rows list every shipped detection (67) plus every CSPM benchmark family (4 native CIS scopes). Columns are: skill name, mapping or note, detector or check shipped status, paired remediation status, and the tracking issue or notes. Green cells mean a closed loop is shipped; amber cells mean a remediation skill is on the roadmap; red cells mean no remediation exists or is planned. Thirteen of sixty-seven detection rows are closed loops today; lateral-movement is intentionally detection-only because the response is per-arm fan-out via existing remediation skills, and the access-key, login-profile, GCP service-account-key, GCP service-account-token-minting, discovery-burst, cross-account-copy, logging-impairment, AWS and GCP model-artifact-download, MCP credential-leak, system-prompt-extraction, tool-output-policy-bypass, tool-output-exfiltration-instructions, Workspace OAuth grant, Workspace admin-role grant, and Workday mass-termination anomaly slices are still detection-first. The matrix is the single source of truth for closed-loop coverage and updates whenever a remediation skill ships.</desc>
 
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
@@ -51,7 +51,7 @@
   <line x1="48" y1="212" x2="1352" y2="212" stroke="#334155" stroke-width="1.5"/>
 
   <!-- DETECTION SECTION -->
-  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (66)</text>
+  <text x="48" y="244" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">DETECTION (67)</text>
 
   <!-- Row stride 38 starting at y=276; badge y = row_text_y - 16 (badge height 22) -->
   <g font-family="Inter, system-ui, sans-serif">
@@ -516,6 +516,13 @@
     <rect x="880"  y="2038" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
     <text x="1020" y="2054" fill="#fee2e2" font-size="13">detection-only — Workspace protected admin role grant outside break-glass allowlist (#32)</text>
   </g>
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="48"   y="2194" fill="#f1f5f9" font-size="14">detect-mass-termination-anomaly</text>
+    <text x="430"  y="2194" fill="#cbd5e1" font-size="14">T1098 (TA0003) · OWASP A01:2021</text>
+    <rect x="760"  y="2178" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
+    <rect x="880"  y="2178" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
+    <text x="1020" y="2194" fill="#fee2e2" font-size="13">detection-only — Workday termination spike before IAM departure remediation (#34)</text>
+  </g>
 
   <!-- EVALUATION SECTION -->
   <text x="48" y="2310" fill="#5eead4" font-family="Inter, system-ui, sans-serif" font-size="15" font-weight="900">EVALUATION / CSPM (4 platforms · 91 checks · NIST AI RMF 40 subcategories)</text>
@@ -575,7 +582,7 @@
 
   <!-- Footer (two lines to fit canvas) -->
   <g font-family="Inter, system-ui, sans-serif">
-    <text x="48" y="2596" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 66</tspan> · <tspan fill="#f87171" font-weight="900">remaining red rows are detection-first; no autonomous remediation is implied.</tspan></text>
+    <text x="48" y="2596" fill="#94a3b8" font-size="13">Closed-loop ratio: <tspan fill="#5eead4" font-weight="900">13 / 67</tspan> · <tspan fill="#f87171" font-weight="900">remaining red rows are detection-first; no autonomous remediation is implied.</tspan></text>
     <text x="48" y="2614" fill="#94a3b8" font-size="13">All writes are HITL-gated, dry-run-default, and dual-audited · contract enforced by scripts/validate_safe_skill_bar.py · CSPM auto-remediation tracked at #242 #254</text>
   </g>
 </svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="540" viewBox="0 0 1280 540" role="img" aria-labelledby="title desc">
   <title id="title">agentic security skills for cloud and AI — production-grade security skills for cloud and AI systems</title>
-  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 123 shipped skill bundles, OCSF 1.8, 143 CIS + NIST AI RMF benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 19 ingest, 5 discover, 66 detect, 12 evaluate, 12 remediate, 2 view, 3 output, and 4 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Slack, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
+  <desc id="desc">Hero banner for the agentic security skills for cloud and AI repository (cloud-ai-security-skills). Left panel shows the wordmark, tagline, and capability pills for 125 shipped skill bundles, OCSF 1.8, 143 CIS + NIST AI RMF benchmark checks, MITRE ATT&amp;CK, MITRE ATLAS, OWASP Top 10, OWASP LLM Top 10 framework coverage, MCP-audited tool calls, and HITL dual-audited remediation. Right panel shows the current shipped layer counts: 20 ingest, 5 discover, 67 detect, 12 evaluate, 12 remediate, 2 view, 3 output, and 4 source adapters. A footer strip shows vendor coverage across AWS, GCP, Azure, Kubernetes, Okta, Entra, Google Workspace, Slack, Workday, Snowflake, Databricks, ClickHouse, and MCP plus access surfaces for CLI, CI, MCP, and runners.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -66,7 +66,7 @@
     <g transform="translate(80,272)">
       <g>
         <rect x="0" y="0" width="160" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
-        <text x="14" y="23" fill="#93c5fd" font-size="16" font-weight="900">123</text>
+        <text x="14" y="23" fill="#93c5fd" font-size="16" font-weight="900">125</text>
         <text x="48" y="23" fill="#dbe4f0" font-size="12" font-weight="700">shipped skills</text>
       </g>
       <g transform="translate(172,0)">
@@ -137,7 +137,7 @@
       <g>
         <rect x="0" y="0" width="206" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
         <text x="14" y="23" fill="#dbeafe" font-size="13" font-weight="800">L1 Ingest</text>
-        <text x="190" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">19</text>
+        <text x="190" y="23" text-anchor="end" fill="#93c5fd" font-size="13" font-weight="900">20</text>
       </g>
       <g transform="translate(218,0)">
         <rect x="0" y="0" width="206" height="36" rx="12" fill="#0f1d36" stroke="#3b82f6"/>
@@ -147,7 +147,7 @@
       <g transform="translate(0,48)">
         <rect x="0" y="0" width="206" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>
         <text x="14" y="23" fill="#d1fae5" font-size="13" font-weight="800">L3 Detect</text>
-        <text x="190" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">66</text>
+        <text x="190" y="23" text-anchor="end" fill="#5eead4" font-size="13" font-weight="900">67</text>
       </g>
       <g transform="translate(218,48)">
         <rect x="0" y="0" width="206" height="36" rx="12" fill="#0f2a28" stroke="#2dd4bf"/>

--- a/docs/images/runtime-surfaces.svg
+++ b/docs/images/runtime-surfaces.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1320" height="640" viewBox="0 0 1320 640" role="img" aria-labelledby="runtime-title runtime-desc">
   <title id="runtime-title">cloud-ai-security-skills runtime surfaces</title>
-  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 123 shipped skills — 19 ingest, 66 detect, 5 discover, 12 eval, 12 remediate, 2 view, 3 sink, 4 source.</desc>
+  <desc id="runtime-desc">Runtime architecture diagram. Four invocation surfaces — MCP clients, CLI, CI, cloud runners — all call the same shipped skill bundle. Only MCP clients go through the repo MCP server; CLI, CI, and cloud runners import the skill bundle directly. The shared bundle emits native JSONL, OCSF 1.8, SARIF 2.1.0, Mermaid flow, CycloneDX BOM, audit records, and evidence JSON. Counts: 125 shipped skills — 20 ingest, 67 detect, 5 discover, 12 eval, 12 remediate, 2 view, 3 sink, 4 source.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -86,10 +86,10 @@
       <text x="704" y="180" font-size="11" fill="#99f6e4">SKILL.md + src/ + tests/ per skill</text>
 
       <!-- Current shipped counts -->
-      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">123</text>
+      <text x="704" y="254" font-size="64" font-weight="900" fill="#ffffff">125</text>
       <text x="830" y="254" font-size="28" font-weight="800" fill="#ffffff">skills</text>
 
-      <text x="704" y="282" font-size="11" fill="#5eead4">19 ingest · 66 detect · 5 discover · 12 eval</text>
+      <text x="704" y="282" font-size="11" fill="#5eead4">20 ingest · 67 detect · 5 discover · 12 eval</text>
       <text x="704" y="300" font-size="11" fill="#5eead4">12 remediate · 2 view · 3 sink · 4 source</text>
 
       <line x1="704" y1="322" x2="1016" y2="322" stroke="#0d3833" stroke-width="1"/>

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,6 +37,9 @@ Raw source formats to OCSF 1.8 JSONL.
 | [`ingest-okta-system-log-ocsf`](ingestion/ingest-okta-system-log-ocsf/) | Okta System Log |
 | [`ingest-google-workspace-login-ocsf`](ingestion/ingest-google-workspace-login-ocsf/) | Google Workspace login audit |
 | [`ingest-workspace-admin-ocsf`](ingestion/ingest-workspace-admin-ocsf/) | Google Workspace Admin SDK Reports login, token, and admin-role audit |
+| [`ingest-github-audit-log-ocsf`](ingestion/ingest-github-audit-log-ocsf/) | GitHub Organization Audit Log |
+| [`ingest-slack-audit-ocsf`](ingestion/ingest-slack-audit-ocsf/) | Slack Audit Logs API |
+| [`ingest-workday-audit-ocsf`](ingestion/ingest-workday-audit-ocsf/) | Workday REST / RaaS audit reports |
 | [`ingest-k8s-audit-ocsf`](ingestion/ingest-k8s-audit-ocsf/) | Kubernetes audit logs |
 | [`ingest-mcp-proxy-ocsf`](ingestion/ingest-mcp-proxy-ocsf/) | MCP proxy activity |
 
@@ -54,6 +57,7 @@ Deterministic OCSF-to-finding rules.
 | [`detect-admin-role-grant-workspace`](detection/detect-admin-role-grant-workspace/) | protected Google Workspace admin role grant outside break-glass allowlist |
 | [`detect-google-workspace-suspicious-login`](detection/detect-google-workspace-suspicious-login/) | provider-marked suspicious Workspace login or repeated failures followed by success |
 | [`detect-suspicious-oauth-grant-workspace`](detection/detect-suspicious-oauth-grant-workspace/) | Google Workspace OAuth client authorized with high-risk scopes |
+| [`detect-mass-termination-anomaly`](detection/detect-mass-termination-anomaly/) | Workday mass-termination spike across a short HR offboarding window |
 | [`detect-aws-access-key-creation`](detection/detect-aws-access-key-creation/) | successful AWS IAM `CreateAccessKey` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-aws-login-profile-creation`](detection/detect-aws-login-profile-creation/) | successful AWS IAM `CreateLoginProfile` operations against IAM users (T1098.001 Additional Cloud Credentials) |
 | [`detect-gcp-service-account-key-creation`](detection/detect-gcp-service-account-key-creation/) | successful GCP IAM `CreateServiceAccountKey` operations against service accounts (T1098.001 Additional Cloud Credentials) |

--- a/skills/detection/detect-mass-termination-anomaly/REFERENCES.md
+++ b/skills/detection/detect-mass-termination-anomaly/REFERENCES.md
@@ -1,0 +1,7 @@
+# References
+
+- Workday REST API reference: https://community.workday.com/sites/default/files/file-hosting/restapi/
+- Workday Reporting and Analytics admin guide: https://doc.workday.com/admin-guide/en-us/reporting-and-analytics/
+- OCSF 1.8 Account Change: https://schema.ocsf.io/1.8.0/classes/account_change
+- OCSF 1.8 Detection Finding: https://schema.ocsf.io/1.8.0/classes/detection_finding
+- MITRE ATT&CK T1098 Account Manipulation: https://attack.mitre.org/techniques/T1098/

--- a/skills/detection/detect-mass-termination-anomaly/REFERENCES.md
+++ b/skills/detection/detect-mass-termination-anomaly/REFERENCES.md
@@ -1,7 +1,6 @@
 # References
 
 - Workday REST API reference: https://community.workday.com/sites/default/files/file-hosting/restapi/
-- Workday Reporting and Analytics admin guide: https://doc.workday.com/admin-guide/en-us/reporting-and-analytics/
 - OCSF 1.8 Account Change: https://schema.ocsf.io/1.8.0/classes/account_change
 - OCSF 1.8 Detection Finding: https://schema.ocsf.io/1.8.0/classes/detection_finding
 - MITRE ATT&CK T1098 Account Manipulation: https://attack.mitre.org/techniques/T1098/

--- a/skills/detection/detect-mass-termination-anomaly/SKILL.md
+++ b/skills/detection/detect-mass-termination-anomaly/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: detect-mass-termination-anomaly
+description: >-
+  Detect sudden spikes in Workday termination events that may indicate a
+  compromised HR account, unauthorized bulk offboarding, or an unapproved
+  workforce action. Reads OCSF 1.8 Account Change (3001) or native events
+  emitted by `ingest-workday-audit-ocsf`, groups distinct workers into
+  time windows, skips explicitly approved batch IDs, and emits OCSF Detection
+  Finding (2004) tagged with MITRE ATT&CK T1098. Use when the user mentions
+  Workday terminations, HR offboarding spikes, or insider-risk review. Do NOT
+  use on raw Workday reports before normalization, on non-Workday IAM events,
+  or as remediation.
+purpose: Detect Workday mass-termination spikes in normalized HR lifecycle events.
+capability: detect
+persistence: none
+telemetry: stderr_jsonl
+privilege_escalation: none
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: ocsf
+output_formats: native, ocsf
+concurrency_safety: stateless
+metadata:
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/detection/detect-mass-termination-anomaly
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+    - MITRE ATT&CK v14
+    - OWASP Top 10
+  cloud:
+    - workday
+---
+
+# detect-mass-termination-anomaly
+
+## Use when
+
+- You normalized Workday audit/report events with `ingest-workday-audit-ocsf`
+- You need to detect termination spikes before downstream IAM remediation runs
+- You want a stateless HR lifecycle detector for insider-risk and account-governance review
+
+## Do NOT use
+
+- On raw Workday REST/RaaS payloads before ingestion
+- On Entra, Okta, Google Workspace, Slack, or cloud IAM lifecycle events
+- As remediation; termination reversal or IAM disablement belongs in a HITL-gated write skill
+
+## Detection logic
+
+One pass over OCSF Account Change events:
+
+1. Require producer `ingest-workday-audit-ocsf`.
+2. Require `unmapped.workday.event_family=termination`.
+3. Bucket events into `WORKDAY_TERMINATION_WINDOW_MINUTES` windows. Default is `60`.
+4. Require at least `WORKDAY_TERMINATION_COUNT_THRESHOLD` distinct workers. Default is `10`.
+5. Ignore events whose batch ID is present in `WORKDAY_APPROVED_TERMINATION_BATCH_IDS`.
+
+Operators can tune thresholds with:
+
+```bash
+export WORKDAY_TERMINATION_WINDOW_MINUTES=30
+export WORKDAY_TERMINATION_COUNT_THRESHOLD=5
+export WORKDAY_APPROVED_TERMINATION_BATCH_IDS="planned-layoff-2026-06-06"
+```
+
+## Output contract
+
+Default output is OCSF Detection Finding (class `2004`) with:
+
+- deterministic `metadata.uid`
+- `finding_info.types[] = ["workday-mass-termination-anomaly", "OWASP-Top-10-A01"]`
+- MITRE ATT&CK `T1098`
+- window start/end, threshold, workers, supervisory orgs, batch IDs, and raw event IDs in evidence
+
+Severity is `HIGH`.
+
+## Usage
+
+```bash
+cat workday-audit.ocsf.jsonl | python src/detect.py > workday-termination-findings.ocsf.jsonl
+```
+
+## Roadmap
+
+Part of Workday vendor story issue #34.

--- a/skills/detection/detect-mass-termination-anomaly/src/detect.py
+++ b/skills/detection/detect-mass-termination-anomaly/src/detect.py
@@ -1,0 +1,335 @@
+"""Detect sudden spikes in Workday termination Account Change events."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.errors import ContractError, SkillError, emit_error  # noqa: E402
+from skills._shared.identity import VENDOR_NAME as REPO_VENDOR  # noqa: E402
+from skills._shared.logging import get_logger  # noqa: E402
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "detect-mass-termination-anomaly"
+OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-06"
+REPO_NAME = "cloud-ai-security-skills"
+
+_log = get_logger(__name__, skill=SKILL_NAME, layer="detection")
+
+OUTPUT_FORMATS = ("ocsf", "native")
+
+ACCOUNT_CHANGE_CLASS_UID = 3001
+FINDING_CLASS_UID = 2004
+FINDING_CLASS_NAME = "Detection Finding"
+FINDING_CATEGORY_UID = 2
+FINDING_CATEGORY_NAME = "Findings"
+FINDING_ACTIVITY_CREATE = 1
+FINDING_TYPE_UID = FINDING_CLASS_UID * 100 + FINDING_ACTIVITY_CREATE
+
+SEVERITY_HIGH = 4
+STATUS_SUCCESS = 1
+
+WORKDAY_INGEST_SKILL = "ingest-workday-audit-ocsf"
+WINDOW_MINUTES_ENV = "WORKDAY_TERMINATION_WINDOW_MINUTES"
+COUNT_THRESHOLD_ENV = "WORKDAY_TERMINATION_COUNT_THRESHOLD"
+APPROVED_BATCH_IDS_ENV = "WORKDAY_APPROVED_TERMINATION_BATCH_IDS"
+DEFAULT_WINDOW_MINUTES = 60
+DEFAULT_COUNT_THRESHOLD = 10
+
+MITRE_VERSION = "v14"
+MITRE_TACTIC_UID = "TA0003"
+MITRE_TACTIC_NAME = "Persistence"
+MITRE_TECHNIQUE_UID = "T1098"
+MITRE_TECHNIQUE_NAME = "Account Manipulation"
+
+OWASP_FINDING_TYPE = "OWASP-Top-10-A01"
+
+
+def _now_ms() -> int:
+    return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _parse_positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    if not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        emit_stderr_event(SKILL_NAME, level="warning", event="invalid_env_int", message=f"{name} must be an integer", env_var=name)
+        return default
+    return value if value > 0 else default
+
+
+def _parse_env_set(name: str) -> frozenset[str]:
+    raw = os.environ.get(name, "")
+    if not raw.strip():
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _event_time(event: dict[str, Any]) -> int:
+    raw = event.get("time_ms") or event.get("time") or 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _metadata_uid(event: dict[str, Any]) -> str:
+    return str(event.get("event_uid") or (event.get("metadata") or {}).get("uid") or "")
+
+
+def _producer(event: dict[str, Any]) -> str:
+    if event.get("source_skill"):
+        return str(event["source_skill"])
+    metadata = event.get("metadata") or {}
+    product = metadata.get("product") or {}
+    feature = product.get("feature") or {}
+    return str(feature.get("name") or "")
+
+
+def _workday_block(event: dict[str, Any]) -> dict[str, Any]:
+    if event.get("schema_mode") in {"canonical", "native"}:
+        native_block = event.get("workday")
+        return native_block if isinstance(native_block, dict) else {}
+    block = ((event.get("unmapped") or {}).get("workday")) or {}
+    return block if isinstance(block, dict) else {}
+
+
+def _event_family(event: dict[str, Any]) -> str:
+    block = _workday_block(event)
+    return str(block.get("event_family") or event.get("event_family") or "").strip().lower()
+
+
+def _batch_id(event: dict[str, Any]) -> str:
+    block = _workday_block(event)
+    raw_value = block.get("raw")
+    raw: dict[str, Any] = raw_value if isinstance(raw_value, dict) else {}
+    for key in ("batch_id", "batchId", "campaign_id", "campaignId", "transaction_id", "transactionId"):
+        value = block.get(key) or raw.get(key)
+        if value not in (None, ""):
+            return str(value).strip()
+    return ""
+
+
+def _worker_id(event: dict[str, Any]) -> str:
+    user = event.get("user") or {}
+    block = _workday_block(event)
+    return str(user.get("uid") or user.get("email_addr") or user.get("name") or block.get("worker_id") or block.get("worker_email") or "").strip()
+
+
+def _worker_label(event: dict[str, Any]) -> str:
+    user = event.get("user") or {}
+    return str(user.get("email_addr") or user.get("name") or user.get("uid") or _worker_id(event)).strip()
+
+
+def _org(event: dict[str, Any]) -> str:
+    block = _workday_block(event)
+    raw_value = block.get("raw")
+    raw: dict[str, Any] = raw_value if isinstance(raw_value, dict) else {}
+    return str(block.get("supervisory_org") or raw.get("supervisory_org") or raw.get("supervisoryOrg") or raw.get("organization") or "").strip()
+
+
+def _is_relevant(event: dict[str, Any]) -> bool:
+    if event.get("class_uid") != ACCOUNT_CHANGE_CLASS_UID and event.get("record_type") != "account_change":
+        return False
+    if _producer(event) != WORKDAY_INGEST_SKILL:
+        return False
+    if _event_family(event) != "termination":
+        return False
+    return bool(_worker_id(event))
+
+
+def _window_start(time_ms: int, window_minutes: int) -> int:
+    bucket_ms = window_minutes * 60 * 1000
+    return (time_ms // bucket_ms) * bucket_ms
+
+
+def _finding_uid(window_start_ms: int, count: int, raw_event_uids: list[str]) -> str:
+    material = f"{window_start_ms}|{count}|{'|'.join(sorted(raw_event_uids))}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"det-workday-mass-termination-{digest}"
+
+
+def _build_native_finding(events: list[dict[str, Any]], window_start_ms: int, window_minutes: int, threshold: int) -> dict[str, Any]:
+    workers = sorted({_worker_label(event) for event in events if _worker_label(event)})
+    orgs = sorted({_org(event) for event in events if _org(event)})
+    batch_ids = sorted({_batch_id(event) for event in events if _batch_id(event)})
+    raw_event_uids = [_metadata_uid(event) for event in events if _metadata_uid(event)]
+    finding_uid = _finding_uid(window_start_ms, len(events), raw_event_uids)
+    window_end_ms = window_start_ms + window_minutes * 60 * 1000
+
+    description = (
+        f"Workday produced {len(events)} termination events in {window_minutes} minutes, "
+        f"meeting threshold {threshold}. Review HR batch approval, initiators, and downstream IAM deprovisioning before automated remediation."
+    )
+
+    observables: list[dict[str, Any]] = [
+        {"name": "workday.termination.count", "type": "Counter", "value": str(len(events))},
+    ]
+    for worker in workers[:20]:
+        observables.append({"name": "user.uid", "type": "User Name", "value": worker})
+    for org in orgs[:10]:
+        observables.append({"name": "workday.supervisory_org", "type": "Resource", "value": org})
+
+    return {
+        "schema_mode": "native",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "detection_finding",
+        "source_skill": SKILL_NAME,
+        "output_format": "native",
+        "finding_uid": finding_uid,
+        "event_uid": finding_uid,
+        "provider": "Workday",
+        "time_ms": window_end_ms,
+        "severity": "high",
+        "severity_id": SEVERITY_HIGH,
+        "status": "success",
+        "status_id": STATUS_SUCCESS,
+        "title": f"Workday mass termination anomaly: {len(events)} events in {window_minutes} minutes",
+        "description": description,
+        "finding_types": ["workday-mass-termination-anomaly", OWASP_FINDING_TYPE],
+        "first_seen_time_ms": min((_event_time(event) for event in events), default=window_start_ms),
+        "last_seen_time_ms": max((_event_time(event) for event in events), default=window_end_ms),
+        "mitre_attacks": [
+            {
+                "version": MITRE_VERSION,
+                "tactic_uid": MITRE_TACTIC_UID,
+                "tactic_name": MITRE_TACTIC_NAME,
+                "technique_uid": MITRE_TECHNIQUE_UID,
+                "technique_name": MITRE_TECHNIQUE_NAME,
+            }
+        ],
+        "observables": observables,
+        "evidence": {
+            "termination_count": len(events),
+            "threshold": threshold,
+            "window_minutes": window_minutes,
+            "window_start_time_ms": window_start_ms,
+            "window_end_time_ms": window_end_ms,
+            "workers": workers[:50],
+            "supervisory_orgs": orgs,
+            "batch_ids": batch_ids,
+            "raw_event_uids": raw_event_uids,
+        },
+    }
+
+
+def _render_ocsf_finding(native_finding: dict[str, Any]) -> dict[str, Any]:
+    attack = native_finding["mitre_attacks"][0]
+    return {
+        "activity_id": FINDING_ACTIVITY_CREATE,
+        "category_uid": FINDING_CATEGORY_UID,
+        "category_name": FINDING_CATEGORY_NAME,
+        "class_uid": FINDING_CLASS_UID,
+        "class_name": FINDING_CLASS_NAME,
+        "type_uid": FINDING_TYPE_UID,
+        "severity_id": native_finding["severity_id"],
+        "status_id": native_finding["status_id"],
+        "time": native_finding["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": native_finding["event_uid"],
+            "product": {
+                "name": REPO_NAME,
+                "vendor_name": REPO_VENDOR,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["identity", "workday", "termination", "detection"],
+        },
+        "finding_info": {
+            "uid": native_finding["finding_uid"],
+            "title": native_finding["title"],
+            "desc": native_finding["description"],
+            "types": native_finding["finding_types"],
+            "attacks": [
+                {
+                    "version": attack["version"],
+                    "tactic": {"uid": attack["tactic_uid"], "name": attack["tactic_name"]},
+                    "technique": {"uid": attack["technique_uid"], "name": attack["technique_name"]},
+                }
+            ],
+        },
+        "evidence": native_finding["evidence"],
+        "observables": native_finding["observables"],
+    }
+
+
+def iter_records(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for lineno, raw in enumerate(stream, start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(SKILL_NAME, level="warning", event="json_parse_failed", message=str(exc), line=lineno)
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def detect(stream: Iterable[str], output_format: str = "ocsf") -> list[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ContractError(f"unsupported output_format `{output_format}`")
+    window_minutes = _parse_positive_int_env(WINDOW_MINUTES_ENV, DEFAULT_WINDOW_MINUTES)
+    threshold = _parse_positive_int_env(COUNT_THRESHOLD_ENV, DEFAULT_COUNT_THRESHOLD)
+    approved_batch_ids = _parse_env_set(APPROVED_BATCH_IDS_ENV)
+    buckets: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for event in iter_records(stream):
+        if not _is_relevant(event):
+            continue
+        batch_id = _batch_id(event)
+        if batch_id and batch_id in approved_batch_ids:
+            continue
+        event_time = _event_time(event) or _now_ms()
+        buckets[_window_start(event_time, window_minutes)].append(event)
+
+    findings: list[dict[str, Any]] = []
+    for window_start_ms, events in sorted(buckets.items()):
+        distinct_workers = {_worker_id(event) for event in events if _worker_id(event)}
+        if len(distinct_workers) < threshold:
+            continue
+        native = _build_native_finding(events, window_start_ms, window_minutes, threshold)
+        findings.append(native if output_format == "native" else _render_ocsf_finding(native))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect Workday mass termination anomalies.")
+    parser.add_argument("input", nargs="?", help="Input OCSF/native JSONL. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="ocsf")
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    try:
+        for finding in detect(in_stream, output_format=args.output_format):
+            out_stream.write(json.dumps(finding, separators=(",", ":")) + "\n")
+    except SkillError as exc:
+        emit_error(SKILL_NAME, exc)
+        return 2
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/detection/detect-mass-termination-anomaly/tests/conftest.py
+++ b/skills/detection/detect-mass-termination-anomaly/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/skills/detection/detect-mass-termination-anomaly/tests/test_detect.py
+++ b/skills/detection/detect-mass-termination-anomaly/tests/test_detect.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = ROOT / "skills/detection/detect-mass-termination-anomaly/src/detect.py"
+spec = importlib.util.spec_from_file_location("workday_mass_termination_detect", MODULE_PATH)
+assert spec and spec.loader
+detect_mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = detect_mod
+spec.loader.exec_module(detect_mod)
+
+
+def _event(worker_id: int, batch_id: str = "batch-1", minutes: int = 0) -> dict[str, object]:
+    return {
+        "class_uid": 3001,
+        "time": 1780754400000 + minutes * 60 * 1000,
+        "metadata": {
+            "uid": f"evt-{worker_id}",
+            "product": {"feature": {"name": "ingest-workday-audit-ocsf"}},
+        },
+        "user": {"uid": f"W-{worker_id:04d}", "email_addr": f"worker{worker_id}@example.com"},
+        "unmapped": {
+            "workday": {
+                "event_family": "termination",
+                "worker_id": f"W-{worker_id:04d}",
+                "worker_email": f"worker{worker_id}@example.com",
+                "supervisory_org": "Engineering",
+                "raw": {"batchId": batch_id},
+            }
+        },
+    }
+
+
+def test_detects_mass_termination_threshold(monkeypatch) -> None:
+    monkeypatch.setenv("WORKDAY_TERMINATION_COUNT_THRESHOLD", "3")
+    events = "\n".join(json.dumps(_event(i)) for i in range(1, 4)) + "\n"
+
+    findings = detect_mod.detect(StringIO(events), output_format="native")
+
+    assert len(findings) == 1
+    assert findings[0]["evidence"]["termination_count"] == 3
+    assert findings[0]["evidence"]["workers"][0] == "worker1@example.com"
+    assert findings[0]["mitre_attacks"][0]["technique_uid"] == "T1098"
+
+
+def test_ignores_events_below_threshold(monkeypatch) -> None:
+    monkeypatch.setenv("WORKDAY_TERMINATION_COUNT_THRESHOLD", "4")
+    events = "\n".join(json.dumps(_event(i)) for i in range(1, 4)) + "\n"
+
+    assert detect_mod.detect(StringIO(events), output_format="native") == []
+
+
+def test_ignores_approved_batch(monkeypatch) -> None:
+    monkeypatch.setenv("WORKDAY_TERMINATION_COUNT_THRESHOLD", "3")
+    monkeypatch.setenv("WORKDAY_APPROVED_TERMINATION_BATCH_IDS", "batch-1")
+    events = "\n".join(json.dumps(_event(i)) for i in range(1, 4)) + "\n"
+
+    assert detect_mod.detect(StringIO(events), output_format="native") == []
+
+
+def test_cli_outputs_ocsf(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("WORKDAY_TERMINATION_COUNT_THRESHOLD", "3")
+    src = tmp_path / "workday-events.jsonl"
+    src.write_text("\n".join(json.dumps(_event(i)) for i in range(1, 4)) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(MODULE_PATH), str(src)],
+        check=True,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "WORKDAY_TERMINATION_COUNT_THRESHOLD": "3"},
+    )
+
+    lines = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0]["class_uid"] == 2004
+    assert lines[0]["finding_info"]["attacks"][0]["technique"]["uid"] == "T1098"

--- a/skills/ingestion/ingest-workday-audit-ocsf/REFERENCES.md
+++ b/skills/ingestion/ingest-workday-audit-ocsf/REFERENCES.md
@@ -1,6 +1,4 @@
 # References
 
 - Workday REST API reference: https://community.workday.com/sites/default/files/file-hosting/restapi/
-- Workday Reporting and Analytics admin guide: https://doc.workday.com/admin-guide/en-us/reporting-and-analytics/
-- Workday Report-as-a-Service export pattern: https://help.apideck.com/en/articles/5850818
 - OCSF 1.8 Account Change: https://schema.ocsf.io/1.8.0/classes/account_change

--- a/skills/ingestion/ingest-workday-audit-ocsf/REFERENCES.md
+++ b/skills/ingestion/ingest-workday-audit-ocsf/REFERENCES.md
@@ -1,0 +1,6 @@
+# References
+
+- Workday REST API reference: https://community.workday.com/sites/default/files/file-hosting/restapi/
+- Workday Reporting and Analytics admin guide: https://doc.workday.com/admin-guide/en-us/reporting-and-analytics/
+- Workday Report-as-a-Service export pattern: https://help.apideck.com/en/articles/5850818
+- OCSF 1.8 Account Change: https://schema.ocsf.io/1.8.0/classes/account_change

--- a/skills/ingestion/ingest-workday-audit-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-workday-audit-ocsf/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ingest-workday-audit-ocsf
+description: >-
+  Convert Workday REST, Report-as-a-Service, or audit report exports into OCSF
+  1.8 Account Change (3001) events for HR identity lifecycle monitoring.
+  Recognizes termination, rehire, hire, and worker-change events from common
+  Workday report fields while preserving tenant-specific fields under
+  `unmapped.workday.raw`. Use when the user has Workday audit/report JSON and
+  needs an OCSF stream for IAM departures, mass-termination detection, or
+  downstream offboarding evidence. Do NOT use as a live Workday collector, on
+  payroll or compensation content, or as remediation.
+purpose: Convert Workday HR audit/report records into OCSF Account Change events.
+capability: ingest
+persistence: none
+telemetry: stderr_jsonl
+privilege_escalation: none
+license: Apache-2.0
+approval_model: none
+execution_modes: jit, ci, mcp, persistent
+side_effects: none
+input_formats: raw
+output_formats: native, ocsf
+concurrency_safety: stateless
+compatibility: >-
+  Requires Python 3.11+. No Workday SDK required when REST/RaaS/audit report
+  payloads are already exported. Read-only normalizer; never calls Workday APIs.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/cloud-ai-security-skills
+  source: https://github.com/msaad00/cloud-ai-security-skills/tree/main/skills/ingestion/ingest-workday-audit-ocsf
+  version: 0.1.0
+  frameworks:
+    - OCSF 1.8
+  cloud: workday
+  capability: read-only
+---
+
+# ingest-workday-audit-ocsf
+
+Normalize Workday audit/report exports into OCSF 1.8 Account Change events with
+deterministic IDs and preserved tenant evidence.
+
+## Use when
+
+- You have Workday REST, RaaS, or audit report JSON already exported upstream
+- You need termination, hire, rehire, or worker-change events in an OCSF stream
+- You want `iam-departures-reconciler` or a detector to consume HR events without another direct Workday query
+- You need native JSONL for a pipeline that is not OCSF-aware yet
+
+## Do NOT use
+
+- As a live collector; OAuth and Workday API collection stay upstream
+- On payroll, compensation, benefits, or personal-data report content beyond lifecycle audit fields
+- To infer findings directly; use detection skills on the normalized stream
+- To terminate, rehire, disable, or otherwise change Workday or IAM state
+
+## Input contract
+
+Accepts these Workday export shapes:
+
+1. A response object with `Report_Entry[]`
+2. Objects with `data[]`, `events[]`, `items[]`, or `value[]`
+3. A single audit/report object
+4. A JSON array of audit/report objects
+5. JSONL, one object or wrapper per line
+
+The skill classifies common event names and report fields such as
+`eventName`, `businessProcess`, `businessProcessType`, `action`,
+`terminationDate`, `rehireDate`, `workerId`, `workerEmail`, `supervisoryOrg`,
+and `initiatedBy`. Unsupported tenant-specific fields are preserved under
+`unmapped.workday.raw` rather than guessed.
+
+## Output contract
+
+Default output is OCSF 1.8 Account Change JSONL:
+
+- `activity_id=4` for termination
+- `activity_id=1` for hire
+- `activity_id=3` for rehire, worker-change, or generic account-change events
+
+Every event includes:
+
+- deterministic `metadata.uid`
+- epoch-ms `time`
+- `actor`, `user`, and `resources` where present
+- Workday-native evidence under `unmapped.workday`
+
+With `--output-format native`, the skill emits the repo-owned canonical
+projection with `schema_mode: "native"` and a `workday` evidence block.
+
+## Usage
+
+```bash
+python src/ingest.py workday-audit-report.json > workday-audit.ocsf.jsonl
+python src/ingest.py workday-audit-report.json --output-format native > workday-audit.native.jsonl
+```
+
+## Security guardrails
+
+- Read-only only. No Workday API calls and no token handling.
+- Preserves raw report evidence for audit correlation.
+- Keeps invalid records visible in `stderr_jsonl` so coverage gaps are measurable.
+
+## Roadmap
+
+Part of Workday vendor story issue #34.

--- a/skills/ingestion/ingest-workday-audit-ocsf/src/ingest.py
+++ b/skills/ingestion/ingest-workday-audit-ocsf/src/ingest.py
@@ -1,0 +1,456 @@
+"""Convert Workday audit/report exports into OCSF Account Change events.
+
+Input: Workday REST/RaaS JSON exported upstream. Supports objects, arrays,
+       JSONL, and common wrappers such as Report_Entry, data, events, or items.
+Output: JSONL of OCSF 1.8 Account Change (3001) records, or the repo-owned
+        native projection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skills._shared.identity import VENDOR_NAME  # noqa: E402
+from skills._shared.runtime_telemetry import emit_stderr_event  # noqa: E402
+
+SKILL_NAME = "ingest-workday-audit-ocsf"
+OCSF_VERSION = "1.8.0"
+CANONICAL_VERSION = "2026-06"
+OUTPUT_FORMATS = ("ocsf", "native")
+
+CATEGORY_UID = 3
+CATEGORY_NAME = "Identity & Access Management"
+ACCOUNT_CHANGE_CLASS_UID = 3001
+ACCOUNT_CHANGE_CLASS_NAME = "Account Change"
+ACCOUNT_CHANGE_CREATE = 1
+ACCOUNT_CHANGE_UPDATE = 3
+ACCOUNT_CHANGE_DELETE = 4
+ACCOUNT_CHANGE_OTHER = 99
+
+STATUS_UNKNOWN = 0
+STATUS_SUCCESS = 1
+STATUS_FAILURE = 2
+
+SEVERITY_INFORMATIONAL = 1
+SEVERITY_LOW = 2
+SEVERITY_MEDIUM = 3
+
+WRAPPER_KEYS = (
+    "Report_Entry",
+    "report_entries",
+    "reports",
+    "data",
+    "events",
+    "items",
+    "value",
+)
+
+EVENT_NAME_KEYS = (
+    "event_name",
+    "eventName",
+    "activity",
+    "action",
+    "business_process",
+    "businessProcess",
+    "business_process_type",
+    "businessProcessType",
+    "transaction_type",
+    "transactionType",
+    "type",
+)
+
+ACTOR_KEYS = (
+    "initiated_by",
+    "initiatedBy",
+    "actor",
+    "performed_by",
+    "performedBy",
+    "created_by",
+    "createdBy",
+    "user",
+)
+
+WORKER_ID_KEYS = ("worker_id", "workerId", "employee_id", "employeeId", "worker")
+WORKER_EMAIL_KEYS = ("worker_email", "workerEmail", "email", "email_address", "emailAddress", "primary_email", "primaryEmail")
+EFFECTIVE_TIME_KEYS = ("effective_at", "effectiveAt", "effective_date", "effectiveDate", "event_time", "eventTime", "timestamp", "time")
+TERMINATION_TIME_KEYS = ("termination_date", "terminationDate", "terminated_at", "terminatedAt")
+REHIRE_TIME_KEYS = ("rehire_date", "rehireDate", "rehired_at", "rehiredAt")
+
+
+def parse_ts_ms(value: Any) -> int:
+    if value in (None, ""):
+        return int(datetime.now(timezone.utc).timestamp() * 1000)
+    if isinstance(value, (int, float)):
+        raw = int(value)
+        return raw if raw > 10_000_000_000 else raw * 1000
+    text = str(value).strip()
+    if not text:
+        return int(datetime.now(timezone.utc).timestamp() * 1000)
+    if text.isdigit():
+        raw = int(text)
+        return raw if raw > 10_000_000_000 else raw * 1000
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except ValueError:
+        return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _first(record: dict[str, Any], keys: Iterable[str]) -> Any:
+    for key in keys:
+        value = record.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _flatten_label(value: Any) -> str:
+    if isinstance(value, dict):
+        for key in ("descriptor", "name", "displayName", "id", "uid", "value"):
+            item = value.get(key)
+            if item not in (None, ""):
+                return str(item)
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    if isinstance(value, list):
+        return ",".join(_flatten_label(item) for item in value if item not in (None, ""))
+    return "" if value in (None, "") else str(value)
+
+
+def _event_name(record: dict[str, Any]) -> str:
+    return _flatten_label(_first(record, EVENT_NAME_KEYS)).strip()
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    lowered = text.lower().replace("_", " ").replace("-", " ")
+    return any(term in lowered for term in terms)
+
+
+def _event_family(record: dict[str, Any]) -> str:
+    name = _event_name(record)
+    status_text = _flatten_label(_first(record, ("employment_status", "employmentStatus", "status"))).lower()
+    reason = _flatten_label(_first(record, ("reason", "termination_reason", "terminationReason"))).lower()
+    joined = " ".join(part for part in (name, status_text, reason) if part)
+    if _contains_any(joined, ("termination", "terminate employee", "end employment", "employee terminated", "worker terminated")):
+        return "termination"
+    if _contains_any(joined, ("rehire", "re hire", "return from termination")):
+        return "rehire"
+    if _contains_any(joined, ("hire", "new worker", "employee hire", "worker hire")):
+        return "hire"
+    if _contains_any(joined, ("worker change", "job change", "position change", "employment change")):
+        return "worker_change"
+    return "account_change"
+
+
+def _activity_id(family: str) -> int:
+    if family == "hire":
+        return ACCOUNT_CHANGE_CREATE
+    if family == "termination":
+        return ACCOUNT_CHANGE_DELETE
+    if family in {"rehire", "worker_change", "account_change"}:
+        return ACCOUNT_CHANGE_UPDATE
+    return ACCOUNT_CHANGE_OTHER
+
+
+def _status_id(record: dict[str, Any]) -> int:
+    text = _flatten_label(_first(record, ("status", "result", "outcome", "event_status", "eventStatus"))).lower()
+    if not text:
+        return STATUS_SUCCESS
+    if any(term in text for term in ("fail", "error", "denied", "cancel", "rescinded")):
+        return STATUS_FAILURE
+    if any(term in text for term in ("success", "complete", "completed", "approved", "done")):
+        return STATUS_SUCCESS
+    return STATUS_UNKNOWN
+
+
+def _status_name(status_id: int) -> str:
+    return {STATUS_SUCCESS: "success", STATUS_FAILURE: "failure", STATUS_UNKNOWN: "unknown"}.get(status_id, "unknown")
+
+
+def _severity_id(family: str, status_id: int) -> int:
+    if status_id == STATUS_FAILURE:
+        return SEVERITY_LOW
+    if family == "termination":
+        return SEVERITY_MEDIUM
+    return SEVERITY_INFORMATIONAL
+
+
+def _severity_name(severity_id: int) -> str:
+    return {
+        SEVERITY_INFORMATIONAL: "informational",
+        SEVERITY_LOW: "low",
+        SEVERITY_MEDIUM: "medium",
+    }.get(severity_id, "unknown")
+
+
+def _actor(record: dict[str, Any]) -> dict[str, Any]:
+    raw = _first(record, ACTOR_KEYS)
+    raw_dict = _as_dict(raw)
+    name = _flatten_label(raw)
+    uid = _flatten_label(_first(raw_dict, ("id", "uid", "worker_id", "workerId", "user_id", "userId")))
+    email = _flatten_label(_first(raw_dict, WORKER_EMAIL_KEYS))
+    if not email and "@" in name:
+        email = name
+    user: dict[str, Any] = {}
+    if uid:
+        user["uid"] = uid
+    if email:
+        user["email_addr"] = email
+        user["name"] = email
+    elif name:
+        user["name"] = name
+    return {"user": user} if user else {}
+
+
+def _worker_user(record: dict[str, Any]) -> dict[str, Any]:
+    worker = _as_dict(record.get("worker")) or _as_dict(record.get("employee"))
+    uid = _flatten_label(_first(record, WORKER_ID_KEYS) or _first(worker, WORKER_ID_KEYS + ("id", "uid")))
+    email = _flatten_label(_first(record, WORKER_EMAIL_KEYS) or _first(worker, WORKER_EMAIL_KEYS))
+    name = _flatten_label(_first(record, ("worker_name", "workerName", "employee_name", "employeeName", "name")) or _first(worker, ("name", "displayName", "descriptor")))
+    user: dict[str, Any] = {}
+    if uid:
+        user["uid"] = uid
+    if email:
+        user["email_addr"] = email
+        user["name"] = email
+    elif name:
+        user["name"] = name
+    if user:
+        user.setdefault("type", "User")
+    return user
+
+
+def _resources(record: dict[str, Any]) -> list[dict[str, Any]]:
+    resources: list[dict[str, Any]] = []
+    for key, resource_type in (
+        ("business_process", "workday_business_process"),
+        ("businessProcess", "workday_business_process"),
+        ("supervisory_org", "workday_supervisory_org"),
+        ("supervisoryOrg", "workday_supervisory_org"),
+        ("organization", "workday_organization"),
+    ):
+        value = _flatten_label(record.get(key))
+        if value:
+            resources.append({"type": resource_type, "name": value})
+    return resources
+
+
+def _stable_uid(record: dict[str, Any], family: str) -> str:
+    material = {
+        "event_name": _event_name(record),
+        "family": family,
+        "worker": _flatten_label(_first(record, WORKER_ID_KEYS) or _first(record, WORKER_EMAIL_KEYS)),
+        "effective": _flatten_label(_first(record, EFFECTIVE_TIME_KEYS) or _first(record, TERMINATION_TIME_KEYS)),
+        "source_id": _flatten_label(_first(record, ("id", "uid", "event_id", "eventId", "transaction_id", "transactionId"))),
+    }
+    if not any(material.values()):
+        material["raw"] = json.dumps(record, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")).hexdigest()
+
+
+def _workday_unmapped(record: dict[str, Any], family: str) -> dict[str, Any]:
+    return {
+        "event_family": family,
+        "event_name": _event_name(record),
+        "worker_id": _flatten_label(_first(record, WORKER_ID_KEYS)),
+        "worker_email": _flatten_label(_first(record, WORKER_EMAIL_KEYS)),
+        "effective_at": _flatten_label(_first(record, EFFECTIVE_TIME_KEYS)),
+        "termination_date": _flatten_label(_first(record, TERMINATION_TIME_KEYS)),
+        "rehire_date": _flatten_label(_first(record, REHIRE_TIME_KEYS)),
+        "business_process": _flatten_label(_first(record, ("business_process", "businessProcess", "business_process_type", "businessProcessType"))),
+        "supervisory_org": _flatten_label(_first(record, ("supervisory_org", "supervisoryOrg", "organization"))),
+        "reason": _flatten_label(_first(record, ("reason", "termination_reason", "terminationReason"))),
+        "raw": record,
+    }
+
+
+def validate_record(record: dict[str, Any]) -> tuple[bool, str]:
+    if not isinstance(record, dict):
+        return False, "not a dict"
+    if not (_event_name(record) or _first(record, WORKER_ID_KEYS) or _first(record, WORKER_EMAIL_KEYS)):
+        return False, "missing event name and worker identifiers"
+    return True, ""
+
+
+def _build_canonical_event(record: dict[str, Any]) -> dict[str, Any]:
+    family = _event_family(record)
+    status_id = _status_id(record)
+    severity_id = _severity_id(family, status_id)
+    time_source = _first(record, EFFECTIVE_TIME_KEYS) or _first(record, TERMINATION_TIME_KEYS) or _first(record, REHIRE_TIME_KEYS)
+    event_uid = _stable_uid(record, family)
+    event_name = _event_name(record) or family
+
+    out: dict[str, Any] = {
+        "schema_mode": "canonical",
+        "canonical_schema_version": CANONICAL_VERSION,
+        "record_type": "account_change",
+        "source_skill": SKILL_NAME,
+        "event_uid": event_uid,
+        "provider": "Workday",
+        "activity_id": _activity_id(family),
+        "activity_name": family,
+        "class_uid": ACCOUNT_CHANGE_CLASS_UID,
+        "class_name": ACCOUNT_CHANGE_CLASS_NAME,
+        "severity_id": severity_id,
+        "severity": _severity_name(severity_id),
+        "status_id": status_id,
+        "status": _status_name(status_id),
+        "time_ms": parse_ts_ms(time_source),
+        "event_name": event_name,
+        "event_family": family,
+        "workday": _workday_unmapped(record, family),
+    }
+    for key, value in (
+        ("actor", _actor(record)),
+        ("user", _worker_user(record)),
+        ("resources", _resources(record)),
+    ):
+        if value:
+            out[key] = value
+    user = out.get("user") or {}
+    out["message"] = f"Workday {family.replace('_', ' ')} event for {user.get('email_addr') or user.get('uid') or 'worker'}"
+    return out
+
+
+def _render_ocsf_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "activity_id": canonical["activity_id"],
+        "category_uid": CATEGORY_UID,
+        "category_name": CATEGORY_NAME,
+        "class_uid": ACCOUNT_CHANGE_CLASS_UID,
+        "class_name": ACCOUNT_CHANGE_CLASS_NAME,
+        "type_uid": ACCOUNT_CHANGE_CLASS_UID * 100 + int(canonical["activity_id"]),
+        "severity_id": canonical["severity_id"],
+        "status_id": canonical["status_id"],
+        "time": canonical["time_ms"],
+        "metadata": {
+            "version": OCSF_VERSION,
+            "uid": canonical["event_uid"],
+            "product": {
+                "name": "cloud-ai-security-skills",
+                "vendor_name": VENDOR_NAME,
+                "feature": {"name": SKILL_NAME},
+            },
+            "labels": ["identity", "workday", "audit", "ingest"],
+        },
+        "unmapped": {"workday": canonical["workday"]},
+    }
+    for field in ("actor", "user", "resources", "message"):
+        if canonical.get(field):
+            out[field] = canonical[field]
+    return out
+
+
+def _render_native_event(canonical: dict[str, Any]) -> dict[str, Any]:
+    native = dict(canonical)
+    native["schema_mode"] = "native"
+    native["output_format"] = "native"
+    return native
+
+
+def convert_record(record: dict[str, Any], output_format: str = "ocsf") -> dict[str, Any]:
+    canonical = _build_canonical_event(record)
+    if output_format == "native":
+        return _render_native_event(canonical)
+    return _render_ocsf_event(canonical)
+
+
+def _yield_wrapped(value: Any) -> Iterable[dict[str, Any]]:
+    if isinstance(value, list):
+        for item in value:
+            yield from _yield_wrapped(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for key in WRAPPER_KEYS:
+        wrapped = value.get(key)
+        if isinstance(wrapped, list):
+            for item in wrapped:
+                yield from _yield_wrapped(item)
+            return
+        if isinstance(wrapped, dict):
+            yield from _yield_wrapped(wrapped)
+            return
+    yield value
+
+
+def iter_raw_records(stream: Iterable[str]) -> Iterable[dict[str, Any]]:
+    buf = list(stream)
+    if not buf:
+        return
+    full = "\n".join(line.rstrip("\n") for line in buf).strip()
+    if not full:
+        return
+
+    try:
+        whole = json.loads(full)
+    except json.JSONDecodeError:
+        whole = None
+
+    if whole is not None:
+        yield from _yield_wrapped(whole)
+        return
+
+    for lineno, raw_line in enumerate(buf, start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emit_stderr_event(SKILL_NAME, level="warning", event="json_parse_failed", message=str(exc), line=lineno)
+            continue
+        yield from _yield_wrapped(obj)
+
+
+def ingest(stream: Iterable[str], output_format: str = "ocsf") -> Iterable[dict[str, Any]]:
+    if output_format not in OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output_format `{output_format}`")
+    for record in iter_raw_records(stream):
+        ok, reason = validate_record(record)
+        if not ok:
+            emit_stderr_event(SKILL_NAME, level="warning", event="invalid_record", message=f"skipping record: {reason}", reason=reason)
+            continue
+        try:
+            yield convert_record(record, output_format=output_format)
+        except Exception as exc:
+            emit_stderr_event(SKILL_NAME, level="warning", event="convert_error", message=f"skipping record: {exc}", error=str(exc))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert Workday audit/report exports to OCSF Account Change events.")
+    parser.add_argument("input", nargs="?", help="Input JSON/JSONL file. Defaults to stdin.")
+    parser.add_argument("--output", "-o", help="Output JSONL file. Defaults to stdout.")
+    parser.add_argument("--output-format", choices=OUTPUT_FORMATS, default="ocsf")
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if not args.input else open(args.input, "r", encoding="utf-8")
+    out_stream = sys.stdout if not args.output else open(args.output, "w", encoding="utf-8")
+    try:
+        for event in ingest(in_stream, output_format=args.output_format):
+            out_stream.write(json.dumps(event, separators=(",", ":"), default=str) + "\n")
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ingestion/ingest-workday-audit-ocsf/tests/conftest.py
+++ b/skills/ingestion/ingest-workday-audit-ocsf/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/skills/ingestion/ingest-workday-audit-ocsf/tests/test_ingest.py
+++ b/skills/ingestion/ingest-workday-audit-ocsf/tests/test_ingest.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = ROOT / "skills/ingestion/ingest-workday-audit-ocsf/src/ingest.py"
+spec = importlib.util.spec_from_file_location("workday_audit_ingest", MODULE_PATH)
+assert spec and spec.loader
+ingest_mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ingest_mod
+spec.loader.exec_module(ingest_mod)
+
+
+def _termination(worker_id: str = "W-1001", email: str = "departed@example.com") -> dict[str, object]:
+    return {
+        "eventName": "Terminate Employee",
+        "eventTime": "2026-06-06T14:30:00Z",
+        "workerId": worker_id,
+        "workerEmail": email,
+        "businessProcess": "Terminate Employee",
+        "supervisoryOrg": "Engineering",
+        "terminationDate": "2026-06-06",
+        "reason": "Voluntary",
+        "initiatedBy": {"id": "hr-admin-1", "emailAddress": "hr@example.com"},
+        "batchId": "offboarding-2026-06-06",
+    }
+
+
+def test_ingests_workday_report_entry_as_account_change() -> None:
+    payload = {"Report_Entry": [_termination()]}
+    records = list(ingest_mod.ingest(StringIO(json.dumps(payload)), output_format="ocsf"))
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["class_uid"] == 3001
+    assert record["class_name"] == "Account Change"
+    assert record["activity_id"] == 4
+    assert record["user"]["uid"] == "W-1001"
+    assert record["user"]["email_addr"] == "departed@example.com"
+    assert record["unmapped"]["workday"]["event_family"] == "termination"
+    assert record["unmapped"]["workday"]["raw"]["batchId"] == "offboarding-2026-06-06"
+
+
+def test_native_projection_preserves_workday_fields() -> None:
+    records = list(ingest_mod.ingest(StringIO(json.dumps(_termination())), output_format="native"))
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["schema_mode"] == "native"
+    assert record["record_type"] == "account_change"
+    assert record["event_family"] == "termination"
+    assert record["workday"]["business_process"] == "Terminate Employee"
+    assert record["actor"]["user"]["email_addr"] == "hr@example.com"
+
+
+def test_ingests_jsonl_data_wrapper() -> None:
+    payload = {"data": [_termination("W-1002", "worker2@example.com")]}
+    records = list(ingest_mod.ingest(StringIO(json.dumps(payload) + "\n"), output_format="ocsf"))
+
+    assert len(records) == 1
+    assert records[0]["user"]["email_addr"] == "worker2@example.com"
+
+
+def test_skips_invalid_record() -> None:
+    assert list(ingest_mod.ingest(StringIO(json.dumps({"not": "workday"})), output_format="ocsf")) == []
+
+
+def test_cli_outputs_jsonl(tmp_path: Path) -> None:
+    src = tmp_path / "workday.json"
+    src.write_text(json.dumps({"Report_Entry": [_termination()]}), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(MODULE_PATH), str(src)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    lines = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0]["metadata"]["product"]["feature"]["name"] == "ingest-workday-audit-ocsf"


### PR DESCRIPTION
Summary
- Add ingest-workday-audit-ocsf to normalize Workday REST/RaaS audit and HR lifecycle report exports into OCSF Account Change 3001 or native JSONL.
- Add detect-mass-termination-anomaly for termination spikes from the normalized Workday stream, with window/threshold tuning and approved batch suppression.
- Add Workday OCSF departures integration docs and refresh coverage counts, framework registry, README/index text, and SVG count surfaces to 125 skills / 20 ingest / 67 detect.

Verification
- uv run pytest -q
- uv run ruff check .
- bash scripts/run_mypy.sh
- python scripts/validate_skill_contract.py
- python scripts/validate_framework_coverage.py
- python scripts/validate_doc_counts.py
- python scripts/validate_skill_count_consistency.py
- python scripts/generate_security_bar_matrix.py --check
- python scripts/coverage_summary.py --check
- python scripts/generate_framework_coverage_doc.py --check
- python scripts/validate_safe_skill_bar.py
- python scripts/validate_ocsf_metadata.py
- uv run python scripts/validate_golden_ocsf.py
- git diff --check
- rsvg-convert rendered hero-banner.svg, architecture-layers.svg, runtime-surfaces.svg, and coverage-matrix.svg; inspected PNGs for readability and overlap.

Notes
- Closes #34.
- Existing direct Workday RaaS path in iam-departures-reconciler remains as compatibility; new docs route fresh pipelines through the OCSF stream.