### PR TITLE
feat(examples): add governed LangGraph agent harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ More visuals (Mermaid sources under [`docs/diagrams/`](docs/diagrams/), GitHub r
 - [`mcp-trust-boundary.mmd`](docs/diagrams/mcp-trust-boundary.mmd) — wrapper lifecycle sequence (every guard, every short-circuit branch)
 - [`agent-topology.mmd`](docs/diagrams/agent-topology.mmd) — local stdio clients vs remote / HTTP / library / runner
 - [`agentic-soc-orchestrator.mmd`](docs/diagrams/agentic-soc-orchestrator.mmd) — optional LangGraph / LangChain workflow over deterministic skills and non-bypassable trust rails
+- [`langgraph-agent-harness.mmd`](docs/diagrams/langgraph-agent-harness.mmd) — multi-agent LangGraph harness with HITL, retry, escalation, and audit/eval routing
 
 Deeper reads: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · [`docs/HARNESS.md`](docs/HARNESS.md) · [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) · [`docs/SKILL_COMPOSITION.md`](docs/SKILL_COMPOSITION.md)
 
@@ -104,9 +105,9 @@ next.
 
 The shipped [`examples/agents/langgraph_security_graph.py`](examples/agents/langgraph_security_graph.py)
 shows the reference pattern as an actual optional LangGraph `StateGraph`:
-one graph node per skill layer, a bounded LLM/agent triage node, explicit
-state, conditional edges for HITL/retry/escalation/writeback, and a hard HITL
-node before remediation. The end-to-end route is
+one graph node per skill layer, a bounded multi-agent harness, explicit
+state, an agent-run ledger, conditional edges for HITL/retry/escalation/writeback,
+and a hard HITL node before remediation. The end-to-end route is
 `ingest -> normalize -> enrich -> correlate -> confidence score -> MITRE/CVSS/EPSS/KEV map -> LLM triage -> analyst review -> dry-run remediation -> retry/escalate/writeback -> audit/eval`
 without moving trust into prompts.
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ reproducible code paths, while the graph decides which approved surface to call
 next.
 
 The shipped [`examples/agents/langgraph_security_graph.py`](examples/agents/langgraph_security_graph.py)
-shows the reference pattern: one graph node per skill layer, explicit state,
-and a hard HITL node before remediation. Production teams can expand that into
-`ingest -> normalize -> enrich -> correlate -> confidence score -> MITRE/CVSS/EPSS/KEV map -> analyst review -> dry-run remediation -> audit/eval writeback`
+shows the reference pattern as an actual optional LangGraph `StateGraph`:
+one graph node per skill layer, a bounded LLM/agent triage node, explicit
+state, conditional edges for HITL/retry/escalation/writeback, and a hard HITL
+node before remediation. The end-to-end route is
+`ingest -> normalize -> enrich -> correlate -> confidence score -> MITRE/CVSS/EPSS/KEV map -> LLM triage -> analyst review -> dry-run remediation -> retry/escalate/writeback -> audit/eval`
 without moving trust into prompts.
 
 ![Optional agentic SOC orchestrator: LangGraph or LangChain controls the workflow DAG and LLM/model choice, while cloud-ai-security-skills owns deterministic ingest, normalize, enrich, correlate, map, review, audit, eval artifacts, sandbox/RLIMIT, allowlist, dry-run, HITL, and HMAC audit rails.](docs/images/agentic-soc-orchestrator.svg)

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -44,6 +44,9 @@ ingest -> normalize -> enrich -> correlate -> confidence -> map
    blocked  -> writeback
 ```
 
+Diagram source:
+[`docs/diagrams/langgraph-agent-harness.mmd`](diagrams/langgraph-agent-harness.mmd).
+
 The LLM/agent harness records provider/model/mode in state and audit output.
 Its allowed outputs are intentionally narrow: rank findings, summarize
 evidence, draft analyst notes, and request human review. It cannot set CVSS,
@@ -51,6 +54,12 @@ MITRE, EPSS, KEV, tenant scope, idempotency keys, HITL approval, dry-run state,
 or audit-chain facts. The compiled LangGraph path uses conditional edges for
 HITL, retryable API errors, terminal API errors, duplicate write suppression,
 and audit/eval writeback; the offline runner mirrors those routes for tests.
+
+The example exposes a concrete `agents` manifest and `agent_runs` ledger:
+`evidence-agent`, `risk-map-agent`, `triage-agent`, `review-gate`,
+`remediation-planner`, `retry-coordinator`, `escalation-agent`, and
+`audit-writer`. Each run carries an authority label plus input/output hashes
+so replay can detect drift without trusting prompt text.
 
 ## Customization knobs
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -28,6 +28,30 @@ surfaces. None of them forks the skill model:
 | **Library SDK** | [`skills/_shared/library.py`](../skills/_shared/library.py) | external Python apps that want to call skills as functions |
 | **Persistent runners** | [`runners/{aws-s3-sqs,gcp-gcs-pubsub,azure-blob-eventgrid}-detect/`](../runners/) | event-driven detection at cloud scale |
 
+## Optional agentic SOC harness
+
+LangGraph / LangChain / SOAR sit above the five skill surfaces. They may own
+workflow state, model choice, routing, retries, checkpointing, escalation, and
+analyst-note drafting, but they do not own security facts or write authority.
+
+The reference implementation is
+[`examples/agents/langgraph_security_graph.py`](../examples/agents/langgraph_security_graph.py):
+
+```text
+ingest -> normalize -> enrich -> correlate -> confidence -> map
+-> bounded LLM triage -> analyst review
+   approved -> dry-run remediation -> retry/escalate/writeback
+   blocked  -> writeback
+```
+
+The LLM/agent harness records provider/model/mode in state and audit output.
+Its allowed outputs are intentionally narrow: rank findings, summarize
+evidence, draft analyst notes, and request human review. It cannot set CVSS,
+MITRE, EPSS, KEV, tenant scope, idempotency keys, HITL approval, dry-run state,
+or audit-chain facts. The compiled LangGraph path uses conditional edges for
+HITL, retryable API errors, terminal API errors, duplicate write suppression,
+and audit/eval writeback; the offline runner mirrors those routes for tests.
+
 ## Customization knobs
 
 Five tiers of override. Outer wins:

--- a/docs/diagrams/langgraph-agent-harness.mmd
+++ b/docs/diagrams/langgraph-agent-harness.mmd
@@ -1,0 +1,32 @@
+%% Governed multi-agent LangGraph harness over deterministic security skills.
+%% Keep security facts in skill nodes; use agents for routing, review, and bounded drafting.
+
+flowchart LR
+    classDef agent fill:#0b1830,stroke:#60a5fa,color:#dbeafe
+    classDef fact fill:#052e2b,stroke:#34d399,color:#ecfdf5
+    classDef gate fill:#3b2403,stroke:#f59e0b,color:#fef3c7
+    classDef write fill:#4c0519,stroke:#fb7185,color:#fff1f2
+    classDef audit fill:#1f2937,stroke:#94a3b8,color:#f8fafc
+
+    subgraph LG["LangGraph StateGraph: nodes, edges, conditions, checkpoints"]
+        E["Evidence agent<br/>ingest · normalize · enrich · correlate"]:::fact
+        R["Risk map agent<br/>confidence · MITRE · CVSS · EPSS · KEV"]:::fact
+        T["Triage agent<br/>LLM optional<br/>rank · summarize · draft only"]:::agent
+        H["Review gate<br/>operator approval only"]:::gate
+        P["Remediation planner<br/>dry-run only<br/>stable idempotency key"]:::write
+        Q["Retry coordinator<br/>retryable API error<br/>same key"]:::gate
+        X["Escalation agent<br/>terminal API error<br/>human queue"]:::gate
+        A["Audit writer<br/>agent ledger · state hash · eval"]:::audit
+    end
+
+    Rails["Non-bypassable rails<br/>allowlist intersection · HITL · dry-run · HMAC audit · RLIMIT"]:::audit
+
+    E --> R --> T --> H
+    H -- blocked --> A
+    H -- approved --> P
+    P -- dry-run OK --> A
+    P -- retryable --> Q --> A
+    P -- terminal --> X --> A
+    Rails -. enforced around tool calls .-> E
+    Rails -. constrains LLM authority .-> T
+    Rails -. gates write paths .-> P

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -81,9 +81,9 @@ python examples/agents/anthropic_sdk_security_agent.py
 
 The LangGraph reference is dependency-light by default but also includes a
 real optional `StateGraph` runtime. The graph keeps security facts in
-deterministic skill nodes, adds a bounded LLM/agent triage node that can only
-rank/summarize/draft/request review, and uses conditional edges for HITL,
-retry, terminal-error escalation, duplicate suppression, and writeback.
+deterministic skill nodes, adds a bounded multi-agent harness with an
+auditable `agent_runs` ledger, and uses conditional edges for HITL, retry,
+terminal-error escalation, duplicate suppression, and writeback.
 
 ```bash
 # Blocked path: no approval context, no remediation action.
@@ -117,9 +117,10 @@ python examples/agents/langgraph_security_graph.py
 The LangGraph summary includes `integrity.evidence_hash`,
 `integrity.state_hash`, stable workflow/remediation idempotency keys, and
 retryable-vs-terminal API error classification. It also includes the
-`harness` provider/model/mode and bounded `agent_recommendations` so operators
-can see which model would have drafted the analyst note without letting that
-model set policy, mappings, approvals, or audit facts. Use
+`harness` provider/model/mode, `agents` manifest, `agent_runs` ledger, and
+bounded `agent_recommendations` so operators can see which role and model would
+have drafted the analyst note without letting that model set policy, mappings,
+approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
 
 See each example file's module-level docstring for framework-specific

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -79,10 +79,11 @@ uv sync --group dev --extra aws
 python examples/agents/anthropic_sdk_security_agent.py
 ```
 
-The LangGraph reference is also dependency-light: it does not require the
-LangGraph package for the demo trace, but its node functions are shaped so a
-production runner can drop them into `StateGraph` without changing the trust
-boundary.
+The LangGraph reference is dependency-light by default but also includes a
+real optional `StateGraph` runtime. The graph keeps security facts in
+deterministic skill nodes, adds a bounded LLM/agent triage node that can only
+rank/summarize/draft/request review, and uses conditional edges for HITL,
+retry, terminal-error escalation, duplicate suppression, and writeback.
 
 ```bash
 # Blocked path: no approval context, no remediation action.
@@ -99,6 +100,13 @@ uv sync --group dev --group langgraph
 DEMO_LANGGRAPH_RUNTIME=yes \
 python examples/agents/langgraph_security_graph.py
 
+# Optional LLM/agent harness metadata: provider/model are recorded in audit,
+# but LLM output is still limited to rank/summarize/draft/request-review.
+DEMO_EXTERNAL_LLM_ALLOWED=yes \
+DEMO_LLM_PROVIDER=openai \
+DEMO_LLM_MODEL=gpt-4.1-mini \
+python examples/agents/langgraph_security_graph.py
+
 # Retryable API error path: no write intent is created without approval;
 # approved retries reuse the same remediation idempotency key.
 DEMO_APPROVE=yes \
@@ -108,7 +116,10 @@ python examples/agents/langgraph_security_graph.py
 
 The LangGraph summary includes `integrity.evidence_hash`,
 `integrity.state_hash`, stable workflow/remediation idempotency keys, and
-retryable-vs-terminal API error classification. Use
+retryable-vs-terminal API error classification. It also includes the
+`harness` provider/model/mode and bounded `agent_recommendations` so operators
+can see which model would have drafted the analyst note without letting that
+model set policy, mappings, approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
 
 See each example file's module-level docstring for framework-specific

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -60,6 +60,7 @@ ApiErrorClassification = Literal["retryable", "terminal"]
 LlmMode = Literal["deterministic_offline", "external_llm_optional"]
 ReviewRoute = Literal["remediate", "writeback"]
 RemediationRoute = Literal["retry_queue", "escalate", "writeback"]
+AgentKind = Literal["deterministic_skill", "llm_optional", "human_gate", "governance"]
 
 
 class CallerContext(TypedDict):
@@ -120,6 +121,24 @@ class AgentHarnessConfig(TypedDict):
     model: str
     allowed_outputs: list[str]
     prompt_hash: str
+
+
+class AgentDefinition(TypedDict):
+    agent_id: str
+    kind: AgentKind
+    owns: list[WorkflowStage]
+    authority: str
+    allowed_outputs: list[str]
+    forbidden_outputs: list[str]
+
+
+class AgentRunRecord(TypedDict):
+    run_id: str
+    agent_id: str
+    stage: WorkflowStage
+    authority: str
+    input_hash: str
+    output_hash: str
 
 
 class AgentRecommendation(TypedDict):
@@ -187,6 +206,8 @@ class GraphState(TypedDict, total=False):
     confidence_scores: list[ConfidenceScore]
     framework_maps: list[FrameworkMap]
     harness_config: AgentHarnessConfig
+    agent_manifest: list[AgentDefinition]
+    agent_runs: list[AgentRunRecord]
     agent_recommendations: list[AgentRecommendation]
     review_decision: ReviewDecision
     remediation_result: RemediationResult
@@ -209,6 +230,103 @@ def _emit_node(stage: WorkflowStage, **payload: Any) -> None:
 def _stable_hash(payload: Any) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _agent_manifest() -> list[AgentDefinition]:
+    return [
+        {
+            "agent_id": "evidence-agent",
+            "kind": "deterministic_skill",
+            "owns": ["ingest", "normalize", "enrich", "correlate"],
+            "authority": "read_only_evidence_collection",
+            "allowed_outputs": ["raw_events", "ocsf_events", "findings", "correlations"],
+            "forbidden_outputs": ["approval", "write_intent", "policy_override"],
+        },
+        {
+            "agent_id": "risk-map-agent",
+            "kind": "deterministic_skill",
+            "owns": ["confidence", "map"],
+            "authority": "deterministic_security_facts",
+            "allowed_outputs": ["confidence_scores", "framework_maps"],
+            "forbidden_outputs": ["approval", "write_intent", "audit_chain_mutation"],
+        },
+        {
+            "agent_id": "triage-agent",
+            "kind": "llm_optional",
+            "owns": ["llm_triage"],
+            "authority": "rank_summarize_draft_only",
+            "allowed_outputs": ["rank_findings", "summarize_evidence", "draft_analyst_note", "request_human_review"],
+            "forbidden_outputs": ["approval", "cvss", "mitre", "epss", "kev", "write_intent", "audit_chain_mutation"],
+        },
+        {
+            "agent_id": "review-gate",
+            "kind": "human_gate",
+            "owns": ["review"],
+            "authority": "operator_attested_approval_only",
+            "allowed_outputs": ["approved", "blocked", "approval_context"],
+            "forbidden_outputs": ["synthetic_approval", "model_attested_approval"],
+        },
+        {
+            "agent_id": "remediation-planner",
+            "kind": "deterministic_skill",
+            "owns": ["remediate"],
+            "authority": "dry_run_after_hitl_only",
+            "allowed_outputs": ["dry_run_plan", "idempotency_key", "retry_decision"],
+            "forbidden_outputs": ["apply", "ungated_write", "new_idempotency_key_on_retry"],
+        },
+        {
+            "agent_id": "retry-coordinator",
+            "kind": "governance",
+            "owns": ["retry_queue"],
+            "authority": "bounded_retry_same_idempotency_key",
+            "allowed_outputs": ["retry_record"],
+            "forbidden_outputs": ["new_write_intent", "approval_bypass"],
+        },
+        {
+            "agent_id": "escalation-agent",
+            "kind": "governance",
+            "owns": ["escalate"],
+            "authority": "terminal_error_human_queue",
+            "allowed_outputs": ["escalation_record"],
+            "forbidden_outputs": ["auto_apply", "silent_drop"],
+        },
+        {
+            "agent_id": "audit-writer",
+            "kind": "deterministic_skill",
+            "owns": ["writeback"],
+            "authority": "append_only_audit_eval",
+            "allowed_outputs": ["audit_record", "eval_record", "state_hash"],
+            "forbidden_outputs": ["overwrite_history", "remove_agent_run"],
+        },
+    ]
+
+
+def _agent_by_id(agent_id: str) -> AgentDefinition:
+    for agent in _agent_manifest():
+        if agent["agent_id"] == agent_id:
+            return agent
+    raise KeyError(agent_id)
+
+
+def _record_agent_run(
+    state: GraphState,
+    *,
+    agent_id: str,
+    stage: WorkflowStage,
+    inputs: Any,
+    outputs: Any,
+) -> None:
+    state.setdefault("agent_manifest", _agent_manifest())
+    agent = _agent_by_id(agent_id)
+    runs = state.setdefault("agent_runs", [])
+    runs.append({
+        "run_id": f"run-{len(runs) + 1:02d}-{agent_id}",
+        "agent_id": agent_id,
+        "stage": stage,
+        "authority": agent["authority"],
+        "input_hash": _stable_hash(inputs)[:16],
+        "output_hash": _stable_hash(outputs)[:16],
+    })
 
 
 def _agent_harness_config() -> AgentHarnessConfig:
@@ -295,6 +413,7 @@ def route_after_remediation(state: GraphState) -> RemediationRoute:
 def ingest_node(state: GraphState) -> GraphState:
     """Collect raw evidence from an approved source surface."""
     _append_trace(state, "ingest")
+    state.setdefault("agent_manifest", _agent_manifest())
     raw_events = state.get("raw_events") or [{
         "source": "cloudtrail",
         "event_name": "CreateAccessKey",
@@ -382,6 +501,19 @@ def correlate_node(state: GraphState) -> GraphState:
             "window_minutes": 15,
         })
     state["correlations"] = correlations
+    _record_agent_run(
+        state,
+        agent_id="evidence-agent",
+        stage="correlate",
+        inputs={
+            "raw_events": state.get("raw_events"),
+            "ocsf_events": state.get("ocsf_events"),
+        },
+        outputs={
+            "findings": state.get("findings"),
+            "correlations": correlations,
+        },
+    )
     _emit_node("correlate", joins=["identity", "resource", "tool"], correlations=len(correlations))
     return state
 
@@ -422,6 +554,17 @@ def map_node(state: GraphState) -> GraphState:
             "controls": ["CIS-1.4", "NIST-CSF-PR.AA"],
         })
     state["framework_maps"] = maps
+    _record_agent_run(
+        state,
+        agent_id="risk-map-agent",
+        stage="map",
+        inputs={
+            "findings": state.get("findings"),
+            "enrichments": state.get("enrichments"),
+            "confidence_scores": state.get("confidence_scores"),
+        },
+        outputs={"framework_maps": maps},
+    )
     _emit_node("map", frameworks=["MITRE", "CVSS", "EPSS", "KEV", "CIS", "NIST"], mappings=len(maps))
     return state
 
@@ -462,6 +605,17 @@ def llm_triage_node(state: GraphState) -> GraphState:
         })
     state["harness_config"] = harness_config
     state["agent_recommendations"] = recommendations
+    _record_agent_run(
+        state,
+        agent_id="triage-agent",
+        stage="llm_triage",
+        inputs={
+            "confidence_scores": state.get("confidence_scores"),
+            "framework_maps": state.get("framework_maps"),
+            "harness_config": harness_config,
+        },
+        outputs={"agent_recommendations": recommendations},
+    )
     _emit_node(
         "llm_triage",
         mode=harness_config["mode"],
@@ -499,6 +653,13 @@ def analyst_review_node(state: GraphState) -> GraphState:
             "reason": "review blocked; remediation node not routed",
         }
     state["review_decision"] = decision
+    _record_agent_run(
+        state,
+        agent_id="review-gate",
+        stage="review",
+        inputs={"agent_recommendations": state.get("agent_recommendations")},
+        outputs=decision,
+    )
     _emit_node("review", status=decision["status"], reason=decision["reason"])
     return state
 
@@ -514,6 +675,13 @@ def dry_run_remediation_node(state: GraphState) -> GraphState:
             "skill": ALLOWED_SKILLS_REMEDIATION,
             "reason": "no approval_context; HITL gate blocked remediation",
         }
+        _record_agent_run(
+            state,
+            agent_id="remediation-planner",
+            stage="remediate",
+            inputs={"review_decision": decision},
+            outputs=state["remediation_result"],
+        )
         _emit_node("remediate", status="skipped", reason="hitl_not_approved")
         return state
 
@@ -549,6 +717,13 @@ def dry_run_remediation_node(state: GraphState) -> GraphState:
             "idempotency_key": remediation_key,
             "approval": approval,
         }
+        _record_agent_run(
+            state,
+            agent_id="remediation-planner",
+            stage="remediate",
+            inputs=approved_payload,
+            outputs=state["remediation_result"],
+        )
         _emit_node("remediate", status="skipped", reason="duplicate_idempotency_key", idempotency_key=remediation_key)
         return state
 
@@ -569,6 +744,13 @@ def dry_run_remediation_node(state: GraphState) -> GraphState:
             "retry_decision": retry_decision,
             "approval": approval,
         }
+        _record_agent_run(
+            state,
+            agent_id="remediation-planner",
+            stage="remediate",
+            inputs={**approved_payload, "api_error": api_error},
+            outputs=state["remediation_result"],
+        )
         _emit_node(
             "remediate",
             status="skipped",
@@ -587,6 +769,13 @@ def dry_run_remediation_node(state: GraphState) -> GraphState:
         "approval": approval,
     }
     state["remediation_result"] = result
+    _record_agent_run(
+        state,
+        agent_id="remediation-planner",
+        stage="remediate",
+        inputs=approved_payload,
+        outputs=result,
+    )
     _emit_node(
         "remediate",
         status="dry_run",
@@ -610,6 +799,13 @@ def retry_queue_node(state: GraphState) -> GraphState:
         "policy": "bounded_retry_same_idempotency_key",
     }
     state["retry_record"] = retry_record
+    _record_agent_run(
+        state,
+        agent_id="retry-coordinator",
+        stage="retry_queue",
+        inputs={"remediation_result": result},
+        outputs=retry_record,
+    )
     _emit_node(
         "retry_queue",
         status=retry_record["status"],
@@ -630,6 +826,13 @@ def escalation_node(state: GraphState) -> GraphState:
         "queue": "security-operations-review",
     }
     state["escalation_record"] = escalation_record
+    _record_agent_run(
+        state,
+        agent_id="escalation-agent",
+        stage="escalate",
+        inputs={"remediation_result": result},
+        outputs=escalation_record,
+    )
     _emit_node(
         "escalate",
         status=escalation_record["status"],
@@ -642,11 +845,26 @@ def escalation_node(state: GraphState) -> GraphState:
 def audit_eval_writeback_node(state: GraphState) -> GraphState:
     """Emit deterministic audit and eval records for the workflow run."""
     _append_trace(state, "writeback")
+    _record_agent_run(
+        state,
+        agent_id="audit-writer",
+        stage="writeback",
+        inputs={
+            "trace": state.get("trace"),
+            "review_decision": state.get("review_decision"),
+            "remediation_result": state.get("remediation_result"),
+            "retry_record": state.get("retry_record"),
+            "escalation_record": state.get("escalation_record"),
+        },
+        outputs={"writeback": "audit_eval_pending"},
+    )
     summary_payload = {
         "caller_context": state.get("caller_context"),
         "trace": state.get("trace"),
         "findings": state.get("findings"),
         "harness_config": state.get("harness_config"),
+        "agent_manifest": state.get("agent_manifest"),
+        "agent_runs": state.get("agent_runs"),
         "agent_recommendations": state.get("agent_recommendations"),
         "integrity": {
             key: value
@@ -674,6 +892,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "state_hash": state_hash,
         "idempotency_key": idempotency.get("remediation_key") or idempotency.get("workflow_key"),
         "api_error_count": len(api_errors),
+        "agent_run_count": len(state.get("agent_runs") or []),
         "retryable_api_error_count": sum(
             1 for error in api_errors if error["classification"] == "retryable"
         ),
@@ -698,6 +917,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "idempotency_key_stable",
             "api_error_classification",
             "llm_harness_bounded",
+            "multi_agent_ledger",
             "conditional_edges",
         ],
         "status": eval_status,
@@ -814,6 +1034,8 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "confidence_scores": final.get("confidence_scores"),
         "framework_maps": final.get("framework_maps"),
         "harness": final.get("harness_config"),
+        "agents": final.get("agent_manifest"),
+        "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),
         "review": final.get("review_decision"),
         "remediation": final.get("remediation_result"),

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -3,8 +3,8 @@
 The production shape this models is:
 
     ingest -> normalize -> enrich -> correlate -> confidence score
-    -> MITRE/CVSS/EPSS/KEV map -> analyst review -> dry-run remediation
-    -> audit/eval writeback
+    -> MITRE/CVSS/EPSS/KEV map -> bounded LLM triage
+    -> analyst review -> dry-run remediation -> audit/eval writeback
 
 Each node is intentionally a thin, deterministic wrapper around what a real
 LangGraph node would call through MCP, CLI, CI, runner, or library surfaces.
@@ -12,10 +12,9 @@ LangGraph owns state, branches, retries, and checkpointing. The skill bundles
 still own facts, schemas, scores, mappings, dry-run behavior, HITL gates, and
 audit/eval artifacts.
 
-The LangGraph SDK is not pinned as a repo dependency. This module stays
-runnable offline and emits the same deterministic trace a graph runner would
-produce. Real code would replace `run_graph` with `StateGraph` assembly and
-keep these node functions as graph nodes.
+The LangGraph SDK is optional. This module stays runnable offline, and
+`DEMO_LANGGRAPH_RUNTIME=yes` compiles the same nodes into a real StateGraph
+with conditional edges for HITL, retry, escalation, and writeback routing.
 
 Run:
 
@@ -50,11 +49,17 @@ WorkflowStage = Literal[
     "correlate",
     "confidence",
     "map",
+    "llm_triage",
     "review",
     "remediate",
+    "retry_queue",
+    "escalate",
     "writeback",
 ]
 ApiErrorClassification = Literal["retryable", "terminal"]
+LlmMode = Literal["deterministic_offline", "external_llm_optional"]
+ReviewRoute = Literal["remediate", "writeback"]
+RemediationRoute = Literal["retry_queue", "escalate", "writeback"]
 
 
 class CallerContext(TypedDict):
@@ -107,6 +112,23 @@ class FrameworkMap(TypedDict):
     epss_percentile: float
     kev_listed: bool
     controls: list[str]
+
+
+class AgentHarnessConfig(TypedDict):
+    mode: LlmMode
+    provider: str
+    model: str
+    allowed_outputs: list[str]
+    prompt_hash: str
+
+
+class AgentRecommendation(TypedDict):
+    finding_uid: str
+    priority: Literal["critical", "high", "medium", "low"]
+    recommended_action: Literal["request_approval", "investigate", "close"]
+    rationale: str
+    generated_by: str
+    output_hash: str
 
 
 class ReviewDecision(TypedDict):
@@ -164,8 +186,12 @@ class GraphState(TypedDict, total=False):
     correlations: list[Correlation]
     confidence_scores: list[ConfidenceScore]
     framework_maps: list[FrameworkMap]
+    harness_config: AgentHarnessConfig
+    agent_recommendations: list[AgentRecommendation]
     review_decision: ReviewDecision
     remediation_result: RemediationResult
+    retry_record: dict[str, Any]
+    escalation_record: dict[str, Any]
     integrity: IntegrityRecord
     idempotency: IdempotencyRecord
     api_errors: list[ApiErrorRecord]
@@ -183,6 +209,40 @@ def _emit_node(stage: WorkflowStage, **payload: Any) -> None:
 def _stable_hash(payload: Any) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _agent_harness_config() -> AgentHarnessConfig:
+    """Describe the LLM/agent harness without requiring a live model."""
+    mode: LlmMode = (
+        "external_llm_optional"
+        if os.environ.get("DEMO_EXTERNAL_LLM_ALLOWED") == "yes"
+        else "deterministic_offline"
+    )
+    provider = os.environ.get("DEMO_LLM_PROVIDER", "deterministic-local")
+    model = os.environ.get("DEMO_LLM_MODEL", "policy-bounded-triage-v1")
+    allowed_outputs = [
+        "rank_findings",
+        "summarize_evidence",
+        "draft_analyst_note",
+        "request_human_review",
+    ]
+    return {
+        "mode": mode,
+        "provider": provider,
+        "model": model,
+        "allowed_outputs": allowed_outputs,
+        "prompt_hash": _stable_hash({
+            "system": "llm may rank, summarize, and draft only",
+            "forbidden": [
+                "approve",
+                "set_security_facts",
+                "change_cvss_mitre_epss_kev",
+                "call_write_tools",
+                "write_audit",
+            ],
+            "allowed_outputs": allowed_outputs,
+        })[:16],
+    }
 
 
 def _classify_api_error(status_code: int) -> ApiErrorClassification:
@@ -215,6 +275,21 @@ def _simulated_api_error(stage: WorkflowStage) -> ApiErrorRecord | None:
 
 def _append_trace(state: GraphState, stage: WorkflowStage) -> None:
     state.setdefault("trace", []).append(stage)
+
+
+def route_after_review(state: GraphState) -> ReviewRoute:
+    decision = state.get("review_decision") or {}
+    return "remediate" if decision.get("status") == "approved" else "writeback"
+
+
+def route_after_remediation(state: GraphState) -> RemediationRoute:
+    result = state.get("remediation_result") or {}
+    reason = result.get("reason")
+    if reason == "retryable_api_error":
+        return "retry_queue"
+    if reason == "terminal_api_error":
+        return "escalate"
+    return "writeback"
 
 
 def ingest_node(state: GraphState) -> GraphState:
@@ -351,6 +426,53 @@ def map_node(state: GraphState) -> GraphState:
     return state
 
 
+def llm_triage_node(state: GraphState) -> GraphState:
+    """Bounded agent layer: rank and summarize only, never decide facts."""
+    _append_trace(state, "llm_triage")
+    harness_config = _agent_harness_config()
+    confidence_by_uid = {
+        score["finding_uid"]: score["score"]
+        for score in state.get("confidence_scores") or []
+    }
+    recommendations = []
+    for mapped in state.get("framework_maps") or []:
+        finding_uid = mapped["finding_uid"]
+        confidence = confidence_by_uid.get(finding_uid, 0.0)
+        recommended_action: Literal["request_approval", "investigate", "close"] = (
+            "request_approval" if confidence >= 0.90 else "investigate"
+        )
+        priority: Literal["critical", "high", "medium", "low"] = (
+            "high" if mapped["cvss"]["base_score"] >= 7.0 else "medium"
+        )
+        recommendation_payload = {
+            "finding_uid": finding_uid,
+            "priority": priority,
+            "recommended_action": recommended_action,
+            "confidence": confidence,
+            "provider": harness_config["provider"],
+            "model": harness_config["model"],
+        }
+        recommendations.append({
+            "finding_uid": finding_uid,
+            "priority": priority,
+            "recommended_action": recommended_action,
+            "rationale": "Deterministic triage from rule confidence, CVSS, EPSS, and mapping coverage.",
+            "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
+            "output_hash": _stable_hash(recommendation_payload)[:16],
+        })
+    state["harness_config"] = harness_config
+    state["agent_recommendations"] = recommendations
+    _emit_node(
+        "llm_triage",
+        mode=harness_config["mode"],
+        provider=harness_config["provider"],
+        model=harness_config["model"],
+        recommendations=len(recommendations),
+        authority="rank_summarize_draft_only",
+    )
+    return state
+
+
 def analyst_review_node(state: GraphState) -> GraphState:
     """Hard pause. No auto-approval and no hallucinated approval context."""
     _append_trace(state, "review")
@@ -370,6 +492,11 @@ def analyst_review_node(state: GraphState) -> GraphState:
             "status": "blocked",
             "reason": "missing approval_context",
             "approval": None,
+        }
+        state["remediation_result"] = {
+            "status": "skipped",
+            "skill": ALLOWED_SKILLS_REMEDIATION,
+            "reason": "review blocked; remediation node not routed",
         }
     state["review_decision"] = decision
     _emit_node("review", status=decision["status"], reason=decision["reason"])
@@ -470,6 +597,48 @@ def dry_run_remediation_node(state: GraphState) -> GraphState:
     return state
 
 
+def retry_queue_node(state: GraphState) -> GraphState:
+    """Schedule a bounded retry without minting a new write intent."""
+    _append_trace(state, "retry_queue")
+    result = state.get("remediation_result") or {}
+    retry_decision = result.get("retry_decision") or {}
+    retry_record = {
+        "status": "scheduled",
+        "idempotency_key": retry_decision.get("idempotency_key"),
+        "max_attempts": retry_decision.get("max_attempts", 0),
+        "retry_after_seconds": retry_decision.get("retry_after_seconds"),
+        "policy": "bounded_retry_same_idempotency_key",
+    }
+    state["retry_record"] = retry_record
+    _emit_node(
+        "retry_queue",
+        status=retry_record["status"],
+        idempotency_key=retry_record["idempotency_key"],
+        max_attempts=retry_record["max_attempts"],
+    )
+    return state
+
+
+def escalation_node(state: GraphState) -> GraphState:
+    """Escalate terminal API failures to a human queue."""
+    _append_trace(state, "escalate")
+    result = state.get("remediation_result") or {}
+    escalation_record = {
+        "status": "queued",
+        "reason": result.get("reason", "manual_review_required"),
+        "idempotency_key": result.get("idempotency_key"),
+        "queue": "security-operations-review",
+    }
+    state["escalation_record"] = escalation_record
+    _emit_node(
+        "escalate",
+        status=escalation_record["status"],
+        reason=escalation_record["reason"],
+        queue=escalation_record["queue"],
+    )
+    return state
+
+
 def audit_eval_writeback_node(state: GraphState) -> GraphState:
     """Emit deterministic audit and eval records for the workflow run."""
     _append_trace(state, "writeback")
@@ -477,6 +646,8 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "caller_context": state.get("caller_context"),
         "trace": state.get("trace"),
         "findings": state.get("findings"),
+        "harness_config": state.get("harness_config"),
+        "agent_recommendations": state.get("agent_recommendations"),
         "integrity": {
             key: value
             for key, value in (state.get("integrity") or {}).items()
@@ -486,6 +657,8 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "api_errors": state.get("api_errors") or [],
         "review_decision": state.get("review_decision"),
         "remediation_result": state.get("remediation_result"),
+        "retry_record": state.get("retry_record"),
+        "escalation_record": state.get("escalation_record"),
     }
     state_hash = _stable_hash(summary_payload)
     integrity = dict(state.get("integrity") or {})
@@ -505,6 +678,10 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             1 for error in api_errors if error["classification"] == "retryable"
         ),
         "remediation_status": state.get("remediation_result", {}).get("status"),
+        "route": {
+            "after_review": route_after_review(state),
+            "after_remediation": route_after_remediation(state),
+        },
     }
     eval_status: Literal["pass", "blocked"] = (
         "pass" if state.get("remediation_result", {}).get("status") == "dry_run" else "blocked"
@@ -520,6 +697,8 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "integrity_hash_present",
             "idempotency_key_stable",
             "api_error_classification",
+            "llm_harness_bounded",
+            "conditional_edges",
         ],
         "status": eval_status,
     }
@@ -536,23 +715,30 @@ NODES = (
     correlate_node,
     confidence_node,
     map_node,
+    llm_triage_node,
     analyst_review_node,
-    dry_run_remediation_node,
-    audit_eval_writeback_node,
 )
 
 
 def run_graph(initial: GraphState) -> GraphState:
-    """Deterministic linear execution.
-
-    A real LangGraph graph would add conditional edges for retries, sandbox
-    replays, escalation, and checkpointing. The security invariant stays the
-    same: every write path reaches `dry_run_remediation_node` only after
-    `analyst_review_node` provides an approval context.
-    """
+    """Deterministic execution that mirrors the StateGraph route decisions."""
     state: GraphState = dict(initial)
     for node in NODES:
         state = node(state)
+    if route_after_review(state) == "remediate":
+        state = dry_run_remediation_node(state)
+        remediation_route = route_after_remediation(state)
+        if remediation_route == "retry_queue":
+            state = retry_queue_node(state)
+        elif remediation_route == "escalate":
+            state = escalation_node(state)
+    else:
+        state.setdefault("remediation_result", {
+            "status": "skipped",
+            "skill": ALLOWED_SKILLS_REMEDIATION,
+            "reason": "review blocked; remediation node not routed",
+        })
+    state = audit_eval_writeback_node(state)
     return state
 
 
@@ -577,8 +763,11 @@ def build_langgraph_app() -> Any:
     graph.add_node("correlate", correlate_node)
     graph.add_node("confidence", confidence_node)
     graph.add_node("map", map_node)
+    graph.add_node("llm_triage", llm_triage_node)
     graph.add_node("review", analyst_review_node)
     graph.add_node("remediate", dry_run_remediation_node)
+    graph.add_node("retry_queue", retry_queue_node)
+    graph.add_node("escalate", escalation_node)
     graph.add_node("writeback", audit_eval_writeback_node)
     graph.add_edge(START, "ingest")
     graph.add_edge("ingest", "normalize")
@@ -586,9 +775,27 @@ def build_langgraph_app() -> Any:
     graph.add_edge("enrich", "correlate")
     graph.add_edge("correlate", "confidence")
     graph.add_edge("confidence", "map")
-    graph.add_edge("map", "review")
-    graph.add_edge("review", "remediate")
-    graph.add_edge("remediate", "writeback")
+    graph.add_edge("map", "llm_triage")
+    graph.add_edge("llm_triage", "review")
+    graph.add_conditional_edges(
+        "review",
+        route_after_review,
+        {
+            "remediate": "remediate",
+            "writeback": "writeback",
+        },
+    )
+    graph.add_conditional_edges(
+        "remediate",
+        route_after_remediation,
+        {
+            "retry_queue": "retry_queue",
+            "escalate": "escalate",
+            "writeback": "writeback",
+        },
+    )
+    graph.add_edge("retry_queue", "writeback")
+    graph.add_edge("escalate", "writeback")
     graph.add_edge("writeback", END)
     return graph.compile()
 
@@ -606,8 +813,12 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "findings_count": len(final.get("findings") or []),
         "confidence_scores": final.get("confidence_scores"),
         "framework_maps": final.get("framework_maps"),
+        "harness": final.get("harness_config"),
+        "agent_recommendations": final.get("agent_recommendations"),
         "review": final.get("review_decision"),
         "remediation": final.get("remediation_result"),
+        "retry": final.get("retry_record"),
+        "escalation": final.get("escalation_record"),
         "integrity": final.get("integrity"),
         "idempotency": final.get("idempotency"),
         "api_errors": final.get("api_errors") or [],

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -156,6 +156,16 @@ class TestLangGraphSocWorkflow:
     """Regression coverage for the expanded SOC workflow graph."""
 
     SCRIPT = EXAMPLES / "langgraph_security_graph.py"
+    EXPECTED_AGENT_IDS = [
+        "evidence-agent",
+        "risk-map-agent",
+        "triage-agent",
+        "review-gate",
+        "remediation-planner",
+        "retry-coordinator",
+        "escalation-agent",
+        "audit-writer",
+    ]
     EXPECTED_TRACE = [
         "ingest",
         "normalize",
@@ -222,6 +232,15 @@ class TestLangGraphSocWorkflow:
             "draft_analyst_note",
             "request_human_review",
         ]
+        assert [agent["agent_id"] for agent in summary["agents"]] == self.EXPECTED_AGENT_IDS
+        assert [run["agent_id"] for run in summary["agent_runs"]] == [
+            "evidence-agent",
+            "risk-map-agent",
+            "triage-agent",
+            "review-gate",
+            "audit-writer",
+        ]
+        assert all(run["input_hash"] and run["output_hash"] for run in summary["agent_runs"])
         assert summary["agent_recommendations"][0]["recommended_action"] == "request_approval"
         assert summary["agent_recommendations"][0]["generated_by"] == "deterministic-local:policy-bounded-triage-v1"
         assert summary["confidence_scores"][0]["reason_codes"] == [
@@ -248,6 +267,7 @@ class TestLangGraphSocWorkflow:
             "after_review": "writeback",
             "after_remediation": "writeback",
         }
+        assert summary["audit"]["agent_run_count"] == 5
         assert summary["eval"]["status"] == "blocked"
         assert '"node": "review"' in result.stderr
         assert '"status": "blocked"' in result.stderr
@@ -272,6 +292,15 @@ class TestLangGraphSocWorkflow:
             "after_review": "remediate",
             "after_remediation": "writeback",
         }
+        assert [run["agent_id"] for run in summary["agent_runs"]] == [
+            "evidence-agent",
+            "risk-map-agent",
+            "triage-agent",
+            "review-gate",
+            "remediation-planner",
+            "audit-writer",
+        ]
+        assert summary["audit"]["agent_run_count"] == 6
         assert summary["audit"]["remediation_status"] == "dry_run"
         assert summary["eval"]["status"] == "pass"
 
@@ -287,6 +316,9 @@ class TestLangGraphSocWorkflow:
         assert "call_write_tools" not in summary["harness"]["allowed_outputs"]
         assert summary["agent_recommendations"][0]["generated_by"] == "openai:gpt-4.1-mini"
         assert summary["remediation"]["status"] == "skipped"
+        triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
+        assert "approval" in triage_agent["forbidden_outputs"]
+        assert "write_intent" in triage_agent["forbidden_outputs"]
 
     def test_integrity_and_workflow_idempotency_are_stable(self):
         first, _ = self._run()
@@ -295,6 +327,7 @@ class TestLangGraphSocWorkflow:
         assert first["integrity"]["state_hash"] == second["integrity"]["state_hash"]
         assert first["idempotency"]["workflow_key"] == second["idempotency"]["workflow_key"]
         assert first["audit"]["chain_hash"] == second["audit"]["chain_hash"]
+        assert first["agent_runs"] == second["agent_runs"]
 
     def test_duplicate_remediation_key_suppresses_write_intent(self):
         approved, _ = self._run(approved=True)
@@ -308,6 +341,7 @@ class TestLangGraphSocWorkflow:
         assert "planned_steps" not in replay["remediation"]
         assert replay["idempotency"]["duplicate_write_suppressed"] is True
         assert replay["remediation"]["idempotency_key"] == remediation_key
+        assert replay["audit"]["agent_run_count"] == 6
 
     def test_retryable_api_error_does_not_bypass_hitl(self):
         summary, _ = self._run(extra_env={"DEMO_API_ERROR_STATUS": "429"})
@@ -337,6 +371,11 @@ class TestLangGraphSocWorkflow:
         assert retry_decision["idempotency_key"] == summary["idempotency"]["remediation_key"]
         assert summary["retry"]["status"] == "scheduled"
         assert summary["retry"]["idempotency_key"] == summary["idempotency"]["remediation_key"]
+        assert [run["agent_id"] for run in summary["agent_runs"]][-2:] == [
+            "retry-coordinator",
+            "audit-writer",
+        ]
+        assert summary["audit"]["agent_run_count"] == 7
         assert summary["audit"]["api_error_count"] == 1
         assert summary["audit"]["retryable_api_error_count"] == 1
         assert summary["audit"]["route"]["after_remediation"] == "retry_queue"
@@ -358,6 +397,11 @@ class TestLangGraphSocWorkflow:
         assert summary["remediation"]["retry_decision"]["max_attempts"] == 0
         assert summary["escalation"]["status"] == "queued"
         assert summary["escalation"]["reason"] == "terminal_api_error"
+        assert [run["agent_id"] for run in summary["agent_runs"]][-2:] == [
+            "escalation-agent",
+            "audit-writer",
+        ]
+        assert summary["audit"]["agent_run_count"] == 7
         assert summary["audit"]["api_error_count"] == 1
         assert summary["audit"]["retryable_api_error_count"] == 0
         assert summary["audit"]["route"]["after_remediation"] == "escalate"

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -163,6 +163,18 @@ class TestLangGraphSocWorkflow:
         "correlate",
         "confidence",
         "map",
+        "llm_triage",
+        "review",
+        "writeback",
+    ]
+    EXPECTED_APPROVED_TRACE = [
+        "ingest",
+        "normalize",
+        "enrich",
+        "correlate",
+        "confidence",
+        "map",
+        "llm_triage",
         "review",
         "remediate",
         "writeback",
@@ -202,6 +214,16 @@ class TestLangGraphSocWorkflow:
         summary, _ = self._run()
         assert summary["trace"] == self.EXPECTED_TRACE
         assert summary["findings_count"] == 1
+        assert summary["harness"]["mode"] == "deterministic_offline"
+        assert summary["harness"]["provider"] == "deterministic-local"
+        assert summary["harness"]["allowed_outputs"] == [
+            "rank_findings",
+            "summarize_evidence",
+            "draft_analyst_note",
+            "request_human_review",
+        ]
+        assert summary["agent_recommendations"][0]["recommended_action"] == "request_approval"
+        assert summary["agent_recommendations"][0]["generated_by"] == "deterministic-local:policy-bounded-triage-v1"
         assert summary["confidence_scores"][0]["reason_codes"] == [
             "rule_match",
             "stable_resource_uid",
@@ -218,9 +240,14 @@ class TestLangGraphSocWorkflow:
         summary, result = self._run()
         assert summary["review"]["status"] == "blocked"
         assert summary["remediation"]["status"] == "skipped"
+        assert summary["remediation"]["reason"] == "review blocked; remediation node not routed"
         assert "planned_steps" not in summary["remediation"]
         assert summary["audit"]["event"] == "agentic_soc_workflow"
         assert summary["audit"]["remediation_status"] == "skipped"
+        assert summary["audit"]["route"] == {
+            "after_review": "writeback",
+            "after_remediation": "writeback",
+        }
         assert summary["eval"]["status"] == "blocked"
         assert '"node": "review"' in result.stderr
         assert '"status": "blocked"' in result.stderr
@@ -231,6 +258,7 @@ class TestLangGraphSocWorkflow:
 
     def test_approval_allows_dry_run_only(self):
         summary, _ = self._run(approved=True)
+        assert summary["trace"] == self.EXPECTED_APPROVED_TRACE
         assert summary["review"]["status"] == "approved"
         assert summary["review"]["approval"]["ticket_id"] == "SEC-LANGGRAPH-1"
         assert summary["remediation"]["status"] == "dry_run"
@@ -240,8 +268,25 @@ class TestLangGraphSocWorkflow:
         assert summary["idempotency"]["remediation_key"] == summary["remediation"]["idempotency_key"]
         assert summary["integrity"]["approved_payload_hash"]
         assert summary["audit"]["idempotency_key"] == summary["remediation"]["idempotency_key"]
+        assert summary["audit"]["route"] == {
+            "after_review": "remediate",
+            "after_remediation": "writeback",
+        }
         assert summary["audit"]["remediation_status"] == "dry_run"
         assert summary["eval"]["status"] == "pass"
+
+    def test_llm_harness_records_provider_model_without_granting_authority(self):
+        summary, _ = self._run(extra_env={
+            "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+            "DEMO_LLM_PROVIDER": "openai",
+            "DEMO_LLM_MODEL": "gpt-4.1-mini",
+        })
+        assert summary["harness"]["mode"] == "external_llm_optional"
+        assert summary["harness"]["provider"] == "openai"
+        assert summary["harness"]["model"] == "gpt-4.1-mini"
+        assert "call_write_tools" not in summary["harness"]["allowed_outputs"]
+        assert summary["agent_recommendations"][0]["generated_by"] == "openai:gpt-4.1-mini"
+        assert summary["remediation"]["status"] == "skipped"
 
     def test_integrity_and_workflow_idempotency_are_stable(self):
         first, _ = self._run()
@@ -268,7 +313,7 @@ class TestLangGraphSocWorkflow:
         summary, _ = self._run(extra_env={"DEMO_API_ERROR_STATUS": "429"})
         assert summary["review"]["status"] == "blocked"
         assert summary["remediation"]["status"] == "skipped"
-        assert summary["remediation"]["reason"] == "no approval_context; HITL gate blocked remediation"
+        assert summary["remediation"]["reason"] == "review blocked; remediation node not routed"
         assert "retry_decision" not in summary["remediation"]
         assert summary["api_errors"] == []
         assert summary["audit"]["api_error_count"] == 0
@@ -278,6 +323,11 @@ class TestLangGraphSocWorkflow:
             approved=True,
             extra_env={"DEMO_API_ERROR_STATUS": "429"},
         )
+        assert summary["trace"] == [
+            *self.EXPECTED_APPROVED_TRACE[:-1],
+            "retry_queue",
+            "writeback",
+        ]
         assert summary["remediation"]["status"] == "skipped"
         assert summary["remediation"]["reason"] == "retryable_api_error"
         assert "planned_steps" not in summary["remediation"]
@@ -285,21 +335,32 @@ class TestLangGraphSocWorkflow:
         retry_decision = summary["remediation"]["retry_decision"]
         assert retry_decision["max_attempts"] == 3
         assert retry_decision["idempotency_key"] == summary["idempotency"]["remediation_key"]
+        assert summary["retry"]["status"] == "scheduled"
+        assert summary["retry"]["idempotency_key"] == summary["idempotency"]["remediation_key"]
         assert summary["audit"]["api_error_count"] == 1
         assert summary["audit"]["retryable_api_error_count"] == 1
+        assert summary["audit"]["route"]["after_remediation"] == "retry_queue"
 
     def test_terminal_api_error_blocks_write_intent(self):
         summary, _ = self._run(
             approved=True,
             extra_env={"DEMO_API_ERROR_STATUS": "403"},
         )
+        assert summary["trace"] == [
+            *self.EXPECTED_APPROVED_TRACE[:-1],
+            "escalate",
+            "writeback",
+        ]
         assert summary["remediation"]["status"] == "skipped"
         assert summary["remediation"]["reason"] == "terminal_api_error"
         assert "planned_steps" not in summary["remediation"]
         assert summary["api_errors"][0]["classification"] == "terminal"
         assert summary["remediation"]["retry_decision"]["max_attempts"] == 0
+        assert summary["escalation"]["status"] == "queued"
+        assert summary["escalation"]["reason"] == "terminal_api_error"
         assert summary["audit"]["api_error_count"] == 1
         assert summary["audit"]["retryable_api_error_count"] == 0
+        assert summary["audit"]["route"]["after_remediation"] == "escalate"
 
     def test_real_langgraph_runtime_when_dependency_is_installed(self):
         pytest.importorskip("langgraph.graph")
@@ -316,9 +377,34 @@ class TestLangGraphSocWorkflow:
         summary = json.loads(result.stdout)
         assert summary["trace"] == self.EXPECTED_TRACE
         assert summary["remediation"]["status"] == "skipped"
+        assert summary["audit"]["route"]["after_review"] == "writeback"
+
+    def test_real_langgraph_runtime_routes_retryable_error(self):
+        pytest.importorskip("langgraph.graph")
+        env = {
+            **os.environ,
+            "DEMO_LANGGRAPH_RUNTIME": "yes",
+            "DEMO_APPROVE": "yes",
+            "DEMO_API_ERROR_STATUS": "429",
+        }
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        summary = json.loads(result.stdout)
+        assert "retry_queue" in summary["trace"]
+        assert summary["audit"]["route"]["after_remediation"] == "retry_queue"
 
     def test_stategraph_builder_is_present_without_importing_dependency(self):
         text = self.SCRIPT.read_text(encoding="utf-8")
         assert "StateGraph(GraphState)" in text
-        assert 'graph.add_edge("review", "remediate")' in text
+        assert "graph.add_conditional_edges" in text
+        assert "route_after_review" in text
+        assert "route_after_remediation" in text
+        assert 'graph.add_node("llm_triage", llm_triage_node)' in text
         assert "DEMO_LANGGRAPH_RUNTIME" in text


### PR DESCRIPTION
Summary
- Adds a governed LangGraph agent harness on top of the merged SOC workflow example.
- Adds a bounded LLM triage node that records provider/model/mode and recommendation hashes, but only permits rank/summarize/draft/request-review outputs.
- Uses real StateGraph conditional edges for HITL approval, retryable API errors, terminal API errors, escalation, and writeback routing.
- Adds a concrete multi-agent manifest and `agent_runs` ledger with per-run authority labels plus stable input/output hashes.
- Adds `docs/diagrams/langgraph-agent-harness.mmd` and updates README/HARNESS/example docs to show the multi-agent workflow boundary.

Verification
- python examples/agents/langgraph_security_graph.py
- DEMO_APPROVE=yes DEMO_API_ERROR_STATUS=429 python examples/agents/langgraph_security_graph.py
- DEMO_LANGGRAPH_RUNTIME=yes uv run --group langgraph python examples/agents/langgraph_security_graph.py
- DEMO_LANGGRAPH_RUNTIME=yes DEMO_APPROVE=yes DEMO_API_ERROR_STATUS=403 uv run --group langgraph python examples/agents/langgraph_security_graph.py
- uv run pytest examples/agents/tests/test_examples.py -q
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- uv run python scripts/validate_dependency_consistency.py
- git diff --check

Notes
- This follows up #509, which was already squash-merged before the final harness work landed.
- The default path remains offline and deterministic; no live model call is made by the example.
- Remediation remains dry-run only and cannot route past HITL approval.
- The multi-agent ledger records evidence-agent, risk-map-agent, triage-agent, review-gate, remediation-planner, retry-coordinator, escalation-agent, and audit-writer runs.
