### PR TITLE
feat(examples): add LangGraph harness profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ and a hard HITL node before remediation. The end-to-end route is
 `ingest -> normalize -> enrich -> correlate -> confidence score -> MITRE/CVSS/EPSS/KEV map -> LLM triage -> analyst review -> dry-run remediation -> retry/escalate/writeback -> audit/eval`
 without moving trust into prompts.
 
+Operator customization is profile-based: see
+[`examples/agents/harness_profiles/`](examples/agents/harness_profiles/) for
+read-only SOC, analyst triage, and HITL-gated dry-run remediation profiles.
+Profiles set allowlists, caller context, identity hints, and model metadata;
+they never store secrets or grant approval.
+
 ![Optional agentic SOC orchestrator: LangGraph or LangChain controls the workflow DAG and LLM/model choice, while cloud-ai-security-skills owns deterministic ingest, normalize, enrich, correlate, map, review, audit, eval artifacts, sandbox/RLIMIT, allowlist, dry-run, HITL, and HMAC audit rails.](docs/images/agentic-soc-orchestrator.svg)
 
 | Layer | Belongs in | Why |

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -61,6 +61,14 @@ The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `audit-writer`. Each run carries an authority label plus input/output hashes
 so replay can detect drift without trusting prompt text.
 
+Operator profiles live under
+[`examples/agents/harness_profiles/`](../examples/agents/harness_profiles/).
+They are JSON metadata only: allowed skills, caller context, identity hints,
+LLM provider/model metadata, and approval-policy documentation. They do not
+store cloud secrets and they do not grant approval. A remediation profile can
+make a dry-run skill visible, but the graph still needs `_approval_context`
+from the operator's IDP or ticketing workflow before routing to remediation.
+
 ## Customization knobs
 
 Five tiers of override. Outer wins:

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -89,6 +89,10 @@ terminal-error escalation, duplicate suppression, and writeback.
 # Blocked path: no approval context, no remediation action.
 python examples/agents/langgraph_security_graph.py
 
+# Profile path: operator-owned roles, allowlists, identity hints, and model metadata.
+DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/readonly-soc.json \
+python examples/agents/langgraph_security_graph.py
+
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
 DEMO_APPROVE=yes \
 DEMO_APPROVER=reviewer@example.com \
@@ -117,11 +121,20 @@ python examples/agents/langgraph_security_graph.py
 The LangGraph summary includes `integrity.evidence_hash`,
 `integrity.state_hash`, stable workflow/remediation idempotency keys, and
 retryable-vs-terminal API error classification. It also includes the
-`harness` provider/model/mode, `agents` manifest, `agent_runs` ledger, and
-bounded `agent_recommendations` so operators can see which role and model would
-have drafted the analyst note without letting that model set policy, mappings,
-approvals, or audit facts. Use
+`profile`, `effective_allowed_skills`, `harness` provider/model/mode, `agents`
+manifest, `agent_runs` ledger, and bounded `agent_recommendations` so
+operators can see which role and model would have drafted the analyst note
+without letting that model set policy, mappings, approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
+
+Profile examples live under
+[`harness_profiles/`](harness_profiles/):
+
+| Profile | Behavior |
+|---|---|
+| `readonly-soc.json` | read-only SOC replay and triage |
+| `analyst-triage.json` | optional external-model metadata for bounded drafting |
+| `dry-run-remediation.json` | exposes remediation planning, but still requires `DEMO_APPROVE=yes` / approval context |
 
 See each example file's module-level docstring for framework-specific
 prerequisites.

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -1,0 +1,31 @@
+# LangGraph harness profiles
+
+Profiles are operator-owned configuration for the example harness. They do not
+store secrets, credentials, OAuth callbacks, passwords, or approval tokens.
+
+Use a profile with:
+
+```bash
+DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/readonly-soc.json \
+python examples/agents/langgraph_security_graph.py
+```
+
+Profiles control:
+
+- `allowed_skills`: operator-chosen skill surface; the example intersects it
+  with the repo's known read/write skill set.
+- `caller_context`: stable human or agent identity metadata for audit.
+- `cloud_identity_hints`: commands or env hints the agent can surface to a
+  human; credentials stay in the provider CLI/SDK chain.
+- `llm`: provider/model metadata for bounded triage; model output can only
+  rank, summarize, draft, or request human review.
+- `approval_policy`: documentation of the HITL source; profiles never grant
+  approval by themselves.
+
+Included profiles:
+
+| Profile | Use |
+|---|---|
+| `readonly-soc.json` | SOC replay and triage without remediation tools |
+| `analyst-triage.json` | Optional external-model metadata for analyst drafting |
+| `dry-run-remediation.json` | HITL-gated dry-run remediation planning |

--- a/examples/agents/harness_profiles/analyst-triage.json
+++ b/examples/agents/harness_profiles/analyst-triage.json
@@ -1,0 +1,39 @@
+{
+  "profile_id": "analyst-triage",
+  "description": "Analyst triage with optional external model metadata for ranking and analyst-note drafting only.",
+  "allowed_skills": [
+    "ingest-cloudtrail-ocsf",
+    "source-snowflake-query",
+    "detect-lateral-movement",
+    "discover-control-evidence",
+    "convert-ocsf-to-sarif"
+  ],
+  "caller_context": {
+    "user_id": "analyst-triage-agent",
+    "email": "analyst@example.com",
+    "session_id": "analyst-triage-demo",
+    "roles": "security_analyst",
+    "allowed_skills": [
+      "detect-lateral-movement",
+      "discover-control-evidence",
+      "convert-ocsf-to-sarif"
+    ]
+  },
+  "cloud_identity_hints": {
+    "aws": "aws sso login --profile prod-readonly",
+    "snowflake": "snowflake-cli auth login --authenticator externalbrowser"
+  },
+  "llm": {
+    "mode": "external_llm_optional",
+    "provider": "openai",
+    "model": "gpt-4.1-mini"
+  },
+  "approval_policy": {
+    "remediation_requires_approval_context": true,
+    "approval_source": "operator_idp_or_ticketing_system"
+  },
+  "runtime": {
+    "langgraph_runtime_optional": true,
+    "dry_run_default": true
+  }
+}

--- a/examples/agents/harness_profiles/dry-run-remediation.json
+++ b/examples/agents/harness_profiles/dry-run-remediation.json
@@ -1,0 +1,41 @@
+{
+  "profile_id": "dry-run-remediation",
+  "description": "HITL-gated remediation planning profile. The remediation skill is visible, but no path applies changes.",
+  "allowed_skills": [
+    "ingest-cloudtrail-ocsf",
+    "detect-lateral-movement",
+    "discover-control-evidence",
+    "convert-ocsf-to-sarif",
+    "iam-departures-aws"
+  ],
+  "caller_context": {
+    "user_id": "remediation-planner-agent",
+    "email": "security-ops@example.com",
+    "session_id": "dry-run-remediation-demo",
+    "roles": "security_engineer",
+    "allowed_skills": [
+      "detect-lateral-movement",
+      "discover-control-evidence",
+      "iam-departures-aws"
+    ]
+  },
+  "cloud_identity_hints": {
+    "aws": "AWS_PROFILE=prod-breakglass-dryrun",
+    "ticketing": "approval_context must come from the operator ticketing or IDP workflow"
+  },
+  "llm": {
+    "mode": "deterministic_offline",
+    "provider": "deterministic-local",
+    "model": "policy-bounded-triage-v1"
+  },
+  "approval_policy": {
+    "remediation_requires_approval_context": true,
+    "approval_source": "operator_idp_or_ticketing_system",
+    "min_approvers": 1
+  },
+  "runtime": {
+    "langgraph_runtime_optional": true,
+    "dry_run_default": true,
+    "apply_supported": false
+  }
+}

--- a/examples/agents/harness_profiles/readonly-soc.json
+++ b/examples/agents/harness_profiles/readonly-soc.json
@@ -1,0 +1,40 @@
+{
+  "profile_id": "readonly-soc",
+  "description": "Read-only SOC triage: ingest, replay, detect, map, summarize, and stop before remediation.",
+  "allowed_skills": [
+    "ingest-cloudtrail-ocsf",
+    "source-snowflake-query",
+    "detect-lateral-movement",
+    "cspm-aws-cis-benchmark",
+    "discover-control-evidence",
+    "convert-ocsf-to-sarif"
+  ],
+  "caller_context": {
+    "user_id": "soc-readonly-agent",
+    "email": "soc-readonly@example.com",
+    "session_id": "soc-readonly-demo",
+    "roles": "security_analyst",
+    "allowed_skills": [
+      "detect-lateral-movement",
+      "source-snowflake-query",
+      "convert-ocsf-to-sarif"
+    ]
+  },
+  "cloud_identity_hints": {
+    "aws": "AWS_PROFILE=prod-readonly",
+    "snowflake": "snowflake-cli auth login --authenticator externalbrowser"
+  },
+  "llm": {
+    "mode": "deterministic_offline",
+    "provider": "deterministic-local",
+    "model": "policy-bounded-triage-v1"
+  },
+  "approval_policy": {
+    "remediation_requires_approval_context": true,
+    "approval_source": "not_enabled_for_this_profile"
+  },
+  "runtime": {
+    "langgraph_runtime_optional": true,
+    "dry_run_default": true
+  }
+}

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -30,16 +30,18 @@ import json
 import os
 import sys
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Literal, TypedDict
 
-ALLOWED_SKILLS_READ_ONLY = ",".join([
+ALLOWED_SKILLS_READ_ONLY_LIST = [
     "ingest-cloudtrail-ocsf",
     "source-snowflake-query",
     "detect-lateral-movement",
     "cspm-aws-cis-benchmark",
     "discover-control-evidence",
     "convert-ocsf-to-sarif",
-])
+]
+ALLOWED_SKILLS_READ_ONLY = ",".join(ALLOWED_SKILLS_READ_ONLY_LIST)
 ALLOWED_SKILLS_REMEDIATION = "iam-departures-aws"
 
 WorkflowStage = Literal[
@@ -68,6 +70,18 @@ class CallerContext(TypedDict):
     email: str
     session_id: str
     roles: str
+    allowed_skills: list[str]
+
+
+class HarnessProfile(TypedDict, total=False):
+    profile_id: str
+    description: str
+    allowed_skills: list[str]
+    caller_context: CallerContext
+    cloud_identity_hints: dict[str, str]
+    llm: dict[str, str]
+    approval_policy: dict[str, Any]
+    runtime: dict[str, Any]
 
 
 class ApprovalContext(TypedDict):
@@ -198,6 +212,8 @@ class EvalRecord(TypedDict):
 
 class GraphState(TypedDict, total=False):
     caller_context: CallerContext
+    harness_profile: HarnessProfile
+    effective_allowed_skills: list[str]
     raw_events: list[dict[str, Any]]
     ocsf_events: list[dict[str, Any]]
     findings: list[Finding]
@@ -230,6 +246,63 @@ def _emit_node(stage: WorkflowStage, **payload: Any) -> None:
 def _stable_hash(payload: Any) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _default_harness_profile() -> HarnessProfile:
+    return {
+        "profile_id": "inline-default",
+        "description": "Dependency-light local demo profile.",
+        "allowed_skills": ALLOWED_SKILLS_READ_ONLY_LIST,
+        "caller_context": {
+            "user_id": "graph-demo-operator",
+            "email": "graph-demo@example.com",
+            "session_id": "graph-demo-1",
+            "roles": "security_engineer",
+            "allowed_skills": ALLOWED_SKILLS_READ_ONLY_LIST,
+        },
+        "cloud_identity_hints": {
+            "aws": "AWS_PROFILE=prod-readonly",
+            "snowflake": "snowflake-cli auth login --authenticator externalbrowser",
+        },
+        "llm": {
+            "mode": "deterministic_offline",
+            "provider": "deterministic-local",
+            "model": "policy-bounded-triage-v1",
+        },
+        "approval_policy": {
+            "remediation_requires_approval_context": True,
+            "approval_source": "operator_idp_or_ticketing_system",
+        },
+        "runtime": {
+            "langgraph_runtime_optional": True,
+            "dry_run_default": True,
+        },
+    }
+
+
+def load_harness_profile(path_text: str | None = None) -> HarnessProfile:
+    """Load operator profile metadata without reading credentials or secrets."""
+    selected = path_text or os.environ.get("CLOUD_SECURITY_HARNESS_PROFILE") or os.environ.get("DEMO_HARNESS_PROFILE")
+    if not selected:
+        return _default_harness_profile()
+    payload = json.loads(Path(selected).read_text(encoding="utf-8"))
+    default = _default_harness_profile()
+    profile: HarnessProfile = {**default, **payload}
+    profile["caller_context"] = {
+        **default["caller_context"],
+        **payload.get("caller_context", {}),
+    }
+    profile["llm"] = {
+        **default["llm"],
+        **payload.get("llm", {}),
+    }
+    return profile
+
+
+def _effective_allowed_skills(profile: HarnessProfile) -> list[str]:
+    requested = profile.get("allowed_skills") or ALLOWED_SKILLS_READ_ONLY_LIST
+    safe_surface = {*ALLOWED_SKILLS_READ_ONLY_LIST, ALLOWED_SKILLS_REMEDIATION}
+    return [skill for skill in requested if skill in safe_surface]
 
 
 def _agent_manifest() -> list[AgentDefinition]:
@@ -329,15 +402,17 @@ def _record_agent_run(
     })
 
 
-def _agent_harness_config() -> AgentHarnessConfig:
+def _agent_harness_config(state: GraphState) -> AgentHarnessConfig:
     """Describe the LLM/agent harness without requiring a live model."""
+    profile_llm = (state.get("harness_profile") or {}).get("llm", {})
     mode: LlmMode = (
         "external_llm_optional"
         if os.environ.get("DEMO_EXTERNAL_LLM_ALLOWED") == "yes"
+        or profile_llm.get("mode") == "external_llm_optional"
         else "deterministic_offline"
     )
-    provider = os.environ.get("DEMO_LLM_PROVIDER", "deterministic-local")
-    model = os.environ.get("DEMO_LLM_MODEL", "policy-bounded-triage-v1")
+    provider = os.environ.get("DEMO_LLM_PROVIDER") or profile_llm.get("provider", "deterministic-local")
+    model = os.environ.get("DEMO_LLM_MODEL") or profile_llm.get("model", "policy-bounded-triage-v1")
     allowed_outputs = [
         "rank_findings",
         "summarize_evidence",
@@ -414,6 +489,9 @@ def ingest_node(state: GraphState) -> GraphState:
     """Collect raw evidence from an approved source surface."""
     _append_trace(state, "ingest")
     state.setdefault("agent_manifest", _agent_manifest())
+    profile = state.setdefault("harness_profile", _default_harness_profile())
+    effective_skills = _effective_allowed_skills(profile)
+    state["effective_allowed_skills"] = effective_skills
     raw_events = state.get("raw_events") or [{
         "source": "cloudtrail",
         "event_name": "CreateAccessKey",
@@ -421,7 +499,7 @@ def ingest_node(state: GraphState) -> GraphState:
         "resource_uid": "arn:aws:iam::111122223333:user/build-bot",
     }]
     state["raw_events"] = raw_events
-    _emit_node("ingest", allowlist=ALLOWED_SKILLS_READ_ONLY, records=len(raw_events))
+    _emit_node("ingest", allowlist=",".join(effective_skills), profile=profile["profile_id"], records=len(raw_events))
     return state
 
 
@@ -572,7 +650,7 @@ def map_node(state: GraphState) -> GraphState:
 def llm_triage_node(state: GraphState) -> GraphState:
     """Bounded agent layer: rank and summarize only, never decide facts."""
     _append_trace(state, "llm_triage")
-    harness_config = _agent_harness_config()
+    harness_config = _agent_harness_config(state)
     confidence_by_uid = {
         score["finding_uid"]: score["score"]
         for score in state.get("confidence_scores") or []
@@ -860,6 +938,13 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
     )
     summary_payload = {
         "caller_context": state.get("caller_context"),
+        "harness_profile": {
+            "profile_id": (state.get("harness_profile") or {}).get("profile_id"),
+            "allowed_skills": (state.get("harness_profile") or {}).get("allowed_skills"),
+            "cloud_identity_hints": (state.get("harness_profile") or {}).get("cloud_identity_hints"),
+            "approval_policy": (state.get("harness_profile") or {}).get("approval_policy"),
+        },
+        "effective_allowed_skills": state.get("effective_allowed_skills"),
         "trace": state.get("trace"),
         "findings": state.get("findings"),
         "harness_config": state.get("harness_config"),
@@ -887,6 +972,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
     audit_record = {
         "event": "agentic_soc_workflow",
         "correlation_id": state.get("caller_context", {}).get("session_id", "graph-demo-1"),
+        "profile_id": (state.get("harness_profile") or {}).get("profile_id"),
         "chain_hash": state_hash,
         "evidence_hash": integrity.get("evidence_hash"),
         "state_hash": state_hash,
@@ -1029,6 +1115,8 @@ def summarize(final: GraphState) -> dict[str, Any]:
     """Strip state to a stable operator-facing summary."""
     return {
         "caller_context": final.get("caller_context"),
+        "profile": final.get("harness_profile"),
+        "effective_allowed_skills": final.get("effective_allowed_skills"),
         "trace": final.get("trace"),
         "findings_count": len(final.get("findings") or []),
         "confidence_scores": final.get("confidence_scores"),
@@ -1050,13 +1138,10 @@ def summarize(final: GraphState) -> dict[str, Any]:
 
 
 def main() -> int:
+    profile = load_harness_profile()
     initial: GraphState = {
-        "caller_context": {
-            "user_id": "graph-demo-operator",
-            "email": "graph-demo@example.com",
-            "session_id": "graph-demo-1",
-            "roles": "security_engineer",
-        },
+        "harness_profile": profile,
+        "caller_context": profile["caller_context"],
         "raw_events": [{"source": "demo"}],
     }
     if os.environ.get("DEMO_LANGGRAPH_RUNTIME") == "yes":

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -156,6 +156,7 @@ class TestLangGraphSocWorkflow:
     """Regression coverage for the expanded SOC workflow graph."""
 
     SCRIPT = EXAMPLES / "langgraph_security_graph.py"
+    PROFILES = EXAMPLES / "harness_profiles"
     EXPECTED_AGENT_IDS = [
         "evidence-agent",
         "risk-map-agent",
@@ -319,6 +320,54 @@ class TestLangGraphSocWorkflow:
         triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
         assert "approval" in triage_agent["forbidden_outputs"]
         assert "write_intent" in triage_agent["forbidden_outputs"]
+
+    def test_profile_loads_caller_context_and_allowed_skills(self):
+        summary, _ = self._run(extra_env={
+            "DEMO_HARNESS_PROFILE": str(self.PROFILES / "readonly-soc.json"),
+        })
+        assert summary["profile"]["profile_id"] == "readonly-soc"
+        assert summary["caller_context"]["email"] == "soc-readonly@example.com"
+        assert summary["audit"]["profile_id"] == "readonly-soc"
+        assert summary["effective_allowed_skills"] == [
+            "ingest-cloudtrail-ocsf",
+            "source-snowflake-query",
+            "detect-lateral-movement",
+            "cspm-aws-cis-benchmark",
+            "discover-control-evidence",
+            "convert-ocsf-to-sarif",
+        ]
+        assert summary["remediation"]["status"] == "skipped"
+
+    def test_profile_llm_metadata_is_bounded(self):
+        summary, _ = self._run(extra_env={
+            "DEMO_HARNESS_PROFILE": str(self.PROFILES / "analyst-triage.json"),
+        })
+        assert summary["profile"]["profile_id"] == "analyst-triage"
+        assert summary["harness"]["mode"] == "external_llm_optional"
+        assert summary["harness"]["provider"] == "openai"
+        assert summary["harness"]["model"] == "gpt-4.1-mini"
+        assert summary["agent_recommendations"][0]["generated_by"] == "openai:gpt-4.1-mini"
+        assert summary["review"]["status"] == "blocked"
+
+    def test_remediation_profile_does_not_grant_approval(self):
+        summary, _ = self._run(extra_env={
+            "DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json"),
+        })
+        assert summary["profile"]["profile_id"] == "dry-run-remediation"
+        assert "iam-departures-aws" in summary["effective_allowed_skills"]
+        assert summary["review"]["status"] == "blocked"
+        assert summary["remediation"]["status"] == "skipped"
+        assert "planned_steps" not in summary["remediation"]
+
+    def test_remediation_profile_still_requires_explicit_hitl(self):
+        summary, _ = self._run(
+            approved=True,
+            extra_env={"DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json")},
+        )
+        assert summary["profile"]["profile_id"] == "dry-run-remediation"
+        assert summary["review"]["status"] == "approved"
+        assert summary["remediation"]["status"] == "dry_run"
+        assert summary["remediation"]["dry_run"] is True
 
     def test_integrity_and_workflow_idempotency_are_stable(self):
         first, _ = self._run()


### PR DESCRIPTION
Summary
- Adds operator-owned LangGraph harness profiles for read-only SOC triage, analyst triage, and HITL-gated dry-run remediation.
- Teaches the LangGraph example to load a profile from `DEMO_HARNESS_PROFILE` / `CLOUD_SECURITY_HARNESS_PROFILE`, intersect allowed skills with the known safe skill surface, and include profile/effective allowlist metadata in audit output.
- Keeps credentials and approvals out of profiles: profiles carry identity hints and approval policy documentation only; remediation still requires explicit HITL approval context.
- Updates README, HARNESS, and agent-example docs with the profile setup path.

Verification
- DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/readonly-soc.json python examples/agents/langgraph_security_graph.py
- DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/analyst-triage.json python examples/agents/langgraph_security_graph.py
- DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json python examples/agents/langgraph_security_graph.py
- DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json DEMO_APPROVE=yes python examples/agents/langgraph_security_graph.py
- DEMO_LANGGRAPH_RUNTIME=yes DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/analyst-triage.json uv run --group langgraph python examples/agents/langgraph_security_graph.py
- uv run pytest examples/agents/tests/test_examples.py -q
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- for f in examples/agents/harness_profiles/*.json; do python -m json.tool "$f" >/dev/null; done
- uv run python scripts/validate_dependency_consistency.py
- git diff --check

Notes
- Profiles do not store secrets, OAuth callbacks, passwords, cloud tokens, or approval tokens.
- The dry-run remediation profile exposes `iam-departures-aws` in the effective allowlist, but the graph still blocks until `DEMO_APPROVE=yes` / approval context is present.
