### PR TITLE
feat(examples): add LangGraph harness evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Operator customization is profile-based: see
 read-only SOC, analyst triage, and HITL-gated dry-run remediation profiles.
 Profiles set allowlists, caller context, identity hints, and model metadata;
 they never store secrets or grant approval.
+Golden eval fixtures in [`examples/agents/evals/`](examples/agents/evals/)
+replay those routes offline and emit a pass-rate report for harness drift.
 
 ![Optional agentic SOC orchestrator: LangGraph or LangChain controls the workflow DAG and LLM/model choice, while cloud-ai-security-skills owns deterministic ingest, normalize, enrich, correlate, map, review, audit, eval artifacts, sandbox/RLIMIT, allowlist, dry-run, HITL, and HMAC audit rails.](docs/images/agentic-soc-orchestrator.svg)
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -61,6 +61,20 @@ The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `audit-writer`. Each run carries an authority label plus input/output hashes
 so replay can detect drift without trusting prompt text.
 
+Eval fixtures live under
+[`examples/agents/evals/`](../examples/agents/evals/). The offline gate
+replays golden profile and triage cases through the same graph, checks bounded
+recommendation shape, HITL routing, allowlist intersection, and remediation
+blocking, then emits a pass-rate report:
+
+```bash
+python examples/agents/eval_langgraph_harness.py --check
+```
+
+This is regression tracking for orchestrator behavior, not an LLM-as-judge.
+It does not call a live model; live model quality checks can be layered on top
+later with the same dataset/version/report contract.
+
 Operator profiles live under
 [`examples/agents/harness_profiles/`](../examples/agents/harness_profiles/).
 They are JSON metadata only: allowed skills, caller context, identity hints,

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -116,6 +116,9 @@ python examples/agents/langgraph_security_graph.py
 DEMO_APPROVE=yes \
 DEMO_API_ERROR_STATUS=429 \
 python examples/agents/langgraph_security_graph.py
+
+# Offline eval gate: replay golden profile/triage cases and fail on drift.
+python examples/agents/eval_langgraph_harness.py --check
 ```
 
 The LangGraph summary includes `integrity.evidence_hash`,
@@ -135,6 +138,11 @@ Profile examples live under
 | `readonly-soc.json` | read-only SOC replay and triage |
 | `analyst-triage.json` | optional external-model metadata for bounded drafting |
 | `dry-run-remediation.json` | exposes remediation planning, but still requires `DEMO_APPROVE=yes` / approval context |
+
+Eval fixtures live under [`evals/`](evals/). The eval runner is deterministic:
+it replays profile/triage cases, checks recommendation shape, HITL routing,
+allowlist behavior, and remediation blocking, then emits a pass-rate report.
+It does not call a live model and does not use an LLM-as-judge.
 
 See each example file's module-level docstring for framework-specific
 prerequisites.

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -1,0 +1,183 @@
+"""Offline eval runner for the LangGraph agent harness example.
+
+This is intentionally not an LLM-as-judge. It replays golden cases through the
+same deterministic graph and checks bounded agent outputs, HITL routing, model
+metadata, idempotency, and profile allowlist behavior.
+
+Run:
+
+    python examples/agents/eval_langgraph_harness.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from langgraph_security_graph import load_harness_profile, run_graph, summarize
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATASET = Path(__file__).with_name("evals") / "langgraph_triage_golden.json"
+
+
+def _stable_hash(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _resolve(path_text: str) -> Path:
+    path = Path(path_text)
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def _without_approval_env() -> dict[str, str | None]:
+    saved = {
+        "DEMO_APPROVE": os.environ.get("DEMO_APPROVE"),
+        "DEMO_APPROVER": os.environ.get("DEMO_APPROVER"),
+        "DEMO_TICKET": os.environ.get("DEMO_TICKET"),
+    }
+    for key in saved:
+        os.environ.pop(key, None)
+    return saved
+
+
+def _restore_env(saved: dict[str, str | None]) -> None:
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _first_recommendation(summary: dict[str, Any]) -> dict[str, Any]:
+    recommendations = summary.get("agent_recommendations") or []
+    if not recommendations:
+        return {}
+    return recommendations[0]
+
+
+def _triage_agent(summary: dict[str, Any]) -> dict[str, Any]:
+    for agent in summary.get("agents") or []:
+        if agent.get("agent_id") == "triage-agent":
+            return agent
+    return {}
+
+
+def _check(name: str, actual: Any, expected: Any) -> dict[str, Any]:
+    return {
+        "name": name,
+        "actual": actual,
+        "expected": expected,
+        "passed": actual == expected,
+    }
+
+
+def run_case(case: dict[str, Any]) -> dict[str, Any]:
+    saved_env = _without_approval_env()
+    try:
+        profile = load_harness_profile(str(_resolve(case["profile"])))
+        initial = {
+            "harness_profile": profile,
+            "caller_context": profile["caller_context"],
+            "raw_events": case.get("raw_events") or [{"source": "demo"}],
+        }
+        summary = summarize(run_graph(initial))
+    finally:
+        _restore_env(saved_env)
+
+    expected = case["expected"]
+    recommendation = _first_recommendation(summary)
+    triage_agent = _triage_agent(summary)
+    checks = [
+        _check("profile_id", summary["profile"]["profile_id"], expected["profile_id"]),
+        _check("harness_mode", summary["harness"]["mode"], expected["harness_mode"]),
+        _check("recommendation_action", recommendation.get("recommended_action"), expected["recommendation_action"]),
+        _check("recommendation_priority", recommendation.get("priority"), expected["recommendation_priority"]),
+        _check("review_status", summary["review"]["status"], expected["review_status"]),
+        _check("remediation_status", summary["remediation"]["status"], expected["remediation_status"]),
+        _check("route_after_review", summary["audit"]["route"]["after_review"], expected["route_after_review"]),
+        _check("planned_steps_absent", "planned_steps" not in summary["remediation"], expected["planned_steps_absent"]),
+    ]
+
+    if "recommendation_generated_by" in expected:
+        checks.append(_check(
+            "recommendation_generated_by",
+            recommendation.get("generated_by"),
+            expected["recommendation_generated_by"],
+        ))
+
+    for skill in expected.get("effective_allowed_includes", []):
+        checks.append(_check(
+            f"effective_allowed_includes:{skill}",
+            skill in summary["effective_allowed_skills"],
+            True,
+        ))
+
+    for skill in expected.get("effective_allowed_excludes", []):
+        checks.append(_check(
+            f"effective_allowed_excludes:{skill}",
+            skill not in summary["effective_allowed_skills"],
+            True,
+        ))
+
+    for field in expected.get("triage_forbidden_outputs", []):
+        checks.append(_check(
+            f"triage_forbidden_output:{field}",
+            field in triage_agent.get("forbidden_outputs", []),
+            True,
+        ))
+
+    passed = all(check["passed"] for check in checks)
+    return {
+        "case_id": case["case_id"],
+        "status": "pass" if passed else "fail",
+        "output_hash": _stable_hash({
+            "profile": summary["profile"]["profile_id"],
+            "recommendation": recommendation,
+            "review": summary["review"],
+            "remediation": summary["remediation"],
+            "route": summary["audit"]["route"],
+            "effective_allowed_skills": summary["effective_allowed_skills"],
+        })[:16],
+        "checks": checks,
+    }
+
+
+def run_dataset(dataset_path: Path) -> dict[str, Any]:
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    results = [run_case(case) for case in dataset["cases"]]
+    passed = sum(1 for result in results if result["status"] == "pass")
+    total = len(results)
+    return {
+        "event": "langgraph_agent_harness_eval",
+        "dataset_version": dataset["dataset_version"],
+        "dataset_hash": _stable_hash(dataset)[:16],
+        "cases_total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "pass_rate": passed / total if total else 0.0,
+        "model_policy": "llm_may_rank_summarize_draft_only",
+        "results": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
+    parser.add_argument("--min-pass-rate", type=float, default=1.0)
+    parser.add_argument("--check", action="store_true", help="exit nonzero when pass rate is below threshold")
+    args = parser.parse_args()
+
+    report = run_dataset(args.dataset)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.check and report["pass_rate"] < args.min_pass_rate:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/evals/langgraph_triage_golden.json
+++ b/examples/agents/evals/langgraph_triage_golden.json
@@ -1,0 +1,76 @@
+{
+  "dataset_version": "langgraph-agent-harness-golden-v1",
+  "description": "Offline regression cases for bounded LangGraph agent recommendations, profile loading, HITL routing, and remediation guardrails.",
+  "cases": [
+    {
+      "case_id": "readonly_soc_blocks_remediation",
+      "profile": "examples/agents/harness_profiles/readonly-soc.json",
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "expected": {
+        "profile_id": "readonly-soc",
+        "harness_mode": "deterministic_offline",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "review_status": "blocked",
+        "remediation_status": "skipped",
+        "route_after_review": "writeback",
+        "effective_allowed_excludes": ["iam-departures-aws"],
+        "triage_forbidden_outputs": ["approval", "write_intent", "audit_chain_mutation"],
+        "planned_steps_absent": true
+      }
+    },
+    {
+      "case_id": "analyst_triage_records_model_metadata",
+      "profile": "examples/agents/harness_profiles/analyst-triage.json",
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "expected": {
+        "profile_id": "analyst-triage",
+        "harness_mode": "external_llm_optional",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "recommendation_generated_by": "openai:gpt-4.1-mini",
+        "review_status": "blocked",
+        "remediation_status": "skipped",
+        "route_after_review": "writeback",
+        "planned_steps_absent": true
+      }
+    },
+    {
+      "case_id": "remediation_profile_does_not_approve_itself",
+      "profile": "examples/agents/harness_profiles/dry-run-remediation.json",
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "expected": {
+        "profile_id": "dry-run-remediation",
+        "harness_mode": "deterministic_offline",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "review_status": "blocked",
+        "remediation_status": "skipped",
+        "route_after_review": "writeback",
+        "effective_allowed_includes": ["iam-departures-aws"],
+        "planned_steps_absent": true
+      }
+    }
+  ]
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -501,3 +501,37 @@ class TestLangGraphSocWorkflow:
         assert "route_after_remediation" in text
         assert 'graph.add_node("llm_triage", llm_triage_node)' in text
         assert "DEMO_LANGGRAPH_RUNTIME" in text
+
+
+class TestLangGraphHarnessEvals:
+    """Regression coverage for profile/triage eval tracking."""
+
+    SCRIPT = EXAMPLES / "eval_langgraph_harness.py"
+    DATASET = EXAMPLES / "evals" / "langgraph_triage_golden.json"
+
+    def test_golden_eval_report_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT), "--check"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["event"] == "langgraph_agent_harness_eval"
+        assert report["dataset_version"] == "langgraph-agent-harness-golden-v1"
+        assert report["cases_total"] == 3
+        assert report["passed"] == 3
+        assert report["failed"] == 0
+        assert report["pass_rate"] == 1.0
+        assert {case["case_id"] for case in report["results"]} == {
+            "readonly_soc_blocks_remediation",
+            "analyst_triage_records_model_metadata",
+            "remediation_profile_does_not_approve_itself",
+        }
+
+    def test_golden_dataset_is_valid_json(self):
+        payload = json.loads(self.DATASET.read_text(encoding="utf-8"))
+        assert payload["dataset_version"] == "langgraph-agent-harness-golden-v1"
+        assert len(payload["cases"]) == 3


### PR DESCRIPTION
## Summary
- Add an offline LangGraph harness eval runner that replays golden profile and triage cases through the existing graph.
- Add a golden dataset covering read-only SOC, analyst triage model metadata, and dry-run remediation guardrails.
- Document the eval gate in the agent examples, harness docs, and top-level agentic SOC section.

## Verification
- `python examples/agents/eval_langgraph_harness.py --check`
- `python -m json.tool examples/agents/evals/langgraph_triage_golden.json >/dev/null`
- `uv run pytest examples/agents/tests/test_examples.py -q`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `uv run python scripts/validate_dependency_consistency.py`
- `git diff --check`

## Notes
- The eval runner is deterministic and does not call a live model or use an LLM-as-judge.
- Local duplicate `* 2.*` files remain untracked and are not part of this PR.