### PR TITLE
ci(examples): gate LangGraph harness evals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,26 @@ jobs:
           packages: mypy
       - run: bash scripts/run_mypy.sh
 
+  agent-examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: lockfile
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: "3.11"
+          packages: pytest ruff
+      - run: ruff check examples/agents --config pyproject.toml
+      - name: Run dependency-light agent examples
+        run: pytest examples/agents/tests/test_examples.py -q
+      - name: Run LangGraph harness eval gate
+        run: python examples/agents/eval_langgraph_harness.py --check
+      - name: Install optional LangGraph runtime
+        run: python -m pip install "langgraph>=1.2,<2"
+      - name: Run examples with real LangGraph runtime available
+        run: pytest examples/agents/tests/test_examples.py -q
+
   safe-skill-bar:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ## file — every command below has a direct shell-script equivalent
 ## documented in `CONTRIBUTING.md`.
 
-.PHONY: help docs-regen docs-check validate test ruff demo
+.PHONY: help docs-regen docs-check validate test ruff agent-evals demo
 
 help:
 	@echo "Common targets:"
@@ -12,6 +12,7 @@ help:
 	@echo "  make validate    — run every shared validator under scripts/"
 	@echo "  make test        — pytest repo-wide"
 	@echo "  make ruff        — lint everything CI lints"
+	@echo "  make agent-evals — run agent example tests and LangGraph harness evals"
 
 demo:
 	@echo "Running 3-step ingest -> detect -> view pipeline on a captured CloudTrail fixture..."
@@ -59,3 +60,8 @@ test:
 
 ruff:
 	ruff check skills/ tests/ mcp-server/ scripts/ --config pyproject.toml
+
+agent-evals:
+	ruff check examples/agents --config pyproject.toml
+	python -m pytest examples/agents/tests/test_examples.py -q
+	python examples/agents/eval_langgraph_harness.py --check


### PR DESCRIPTION
## Summary
- Add an `agent-examples` CI job that lints and tests `examples/agents`.
- Run the LangGraph harness eval gate in CI with `python examples/agents/eval_langgraph_harness.py --check`.
- Re-run the agent example tests after installing the optional real `langgraph` runtime.
- Add `make agent-evals` as the local equivalent for contributors.

## Verification
- `uv run make agent-evals`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run python scripts/validate_dependency_consistency.py`
- `git diff --check`

## Notes
- This PR does not change harness behavior; it locks the merged eval runner into CI.
- Local duplicate `* 2.*` files remain untracked and are not part of this PR.