### PR TITLE
feat(examples): bound LangGraph LLM adapter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Profiles set allowlists, caller context, identity hints, and model metadata;
 they never store secrets or grant approval.
 Golden eval fixtures in [`examples/agents/evals/`](examples/agents/evals/)
 replay those routes offline and emit a pass-rate report for harness drift.
+The optional LLM adapter path is schema-gated: model output can rank and draft
+triage rationale, but attempts to set approvals, CVSS/MITRE/EPSS/KEV facts,
+tenant scope, idempotency keys, or write intent are rejected and fall back to
+deterministic triage.
 
 ![Optional agentic SOC orchestrator: LangGraph or LangChain controls the workflow DAG and LLM/model choice, while cloud-ai-security-skills owns deterministic ingest, normalize, enrich, correlate, map, review, audit, eval artifacts, sandbox/RLIMIT, allowlist, dry-run, HITL, and HMAC audit rails.](docs/images/agentic-soc-orchestrator.svg)
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -55,6 +55,14 @@ or audit-chain facts. The compiled LangGraph path uses conditional edges for
 HITL, retryable API errors, terminal API errors, duplicate write suppression,
 and audit/eval writeback; the offline runner mirrors those routes for tests.
 
+Model-backed triage plugs in through a bounded adapter contract. The example
+accepts only `finding_uid`, `priority`, `recommended_action`, and `rationale`
+from an optional adapter fixture; forbidden fields such as `approval`, `cvss`,
+`mitre`, `epss`, `kev`, `tenant_scope`, `idempotency_key`, or `write_intent`
+are rejected and replaced by deterministic fallback. The summary and audit
+record expose `llm_validation` plus accepted/rejected counts so operators can
+see whether model output influenced triage without letting it mutate facts.
+
 The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `evidence-agent`, `risk-map-agent`, `triage-agent`, `review-gate`,
 `remediation-planner`, `retry-coordinator`, `escalation-agent`, and

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -111,6 +111,14 @@ DEMO_LLM_PROVIDER=openai \
 DEMO_LLM_MODEL=gpt-4.1-mini \
 python examples/agents/langgraph_security_graph.py
 
+# Optional adapter fixture: accepts only finding_uid, priority,
+# recommended_action, and rationale; forbidden security facts fall back closed.
+DEMO_EXTERNAL_LLM_ALLOWED=yes \
+DEMO_LLM_PROVIDER=fixture \
+DEMO_LLM_MODEL=triage-fixture-v1 \
+DEMO_LLM_ADAPTER_FIXTURE=/path/to/recommendations.json \
+python examples/agents/langgraph_security_graph.py
+
 # Retryable API error path: no write intent is created without approval;
 # approved retries reuse the same remediation idempotency key.
 DEMO_APPROVE=yes \
@@ -129,6 +137,8 @@ manifest, `agent_runs` ledger, and bounded `agent_recommendations` so
 operators can see which role and model would have drafted the analyst note
 without letting that model set policy, mappings, approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
+`llm_validation` records whether an adapter output was accepted, rejected, or
+replaced by deterministic fallback.
 
 Profile examples live under
 [`harness_profiles/`](harness_profiles/):

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -164,6 +164,14 @@ class AgentRecommendation(TypedDict):
     output_hash: str
 
 
+class LlmValidationRecord(TypedDict):
+    finding_uid: str
+    adapter: str
+    status: Literal["accepted", "fallback", "rejected"]
+    reason: str
+    output_hash: str
+
+
 class ReviewDecision(TypedDict):
     status: Literal["approved", "blocked"]
     reason: str
@@ -225,6 +233,7 @@ class GraphState(TypedDict, total=False):
     agent_manifest: list[AgentDefinition]
     agent_runs: list[AgentRunRecord]
     agent_recommendations: list[AgentRecommendation]
+    llm_validation: list[LlmValidationRecord]
     review_decision: ReviewDecision
     remediation_result: RemediationResult
     retry_record: dict[str, Any]
@@ -435,6 +444,162 @@ def _agent_harness_config(state: GraphState) -> AgentHarnessConfig:
             ],
             "allowed_outputs": allowed_outputs,
         })[:16],
+    }
+
+
+LLM_ADAPTER_ALLOWED_KEYS = {"finding_uid", "priority", "recommended_action", "rationale"}
+LLM_ADAPTER_FORBIDDEN_KEYS = {
+    "approval",
+    "audit_chain_mutation",
+    "cvss",
+    "epss",
+    "idempotency_key",
+    "kev",
+    "mitre",
+    "tenant_scope",
+    "write_intent",
+}
+LLM_ADAPTER_PRIORITIES = {"critical", "high", "medium", "low"}
+LLM_ADAPTER_ACTIONS = {"request_approval", "investigate", "close"}
+
+
+def _load_llm_adapter_recommendations() -> list[dict[str, Any]]:
+    """Load an optional model-output fixture without requiring a live model."""
+    fixture_path = os.environ.get("DEMO_LLM_ADAPTER_FIXTURE")
+    if not fixture_path:
+        return []
+    payload = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        recommendations = payload.get("recommendations", [])
+        return recommendations if isinstance(recommendations, list) else []
+    return []
+
+
+def _deterministic_triage_recommendation(
+    *,
+    finding_uid: str,
+    mapped: FrameworkMap,
+    confidence: float,
+    harness_config: AgentHarnessConfig,
+) -> AgentRecommendation:
+    recommended_action: Literal["request_approval", "investigate", "close"] = (
+        "request_approval" if confidence >= 0.90 else "investigate"
+    )
+    priority: Literal["critical", "high", "medium", "low"] = (
+        "high" if mapped["cvss"]["base_score"] >= 7.0 else "medium"
+    )
+    recommendation_payload = {
+        "finding_uid": finding_uid,
+        "priority": priority,
+        "recommended_action": recommended_action,
+        "confidence": confidence,
+        "provider": harness_config["provider"],
+        "model": harness_config["model"],
+    }
+    return {
+        "finding_uid": finding_uid,
+        "priority": priority,
+        "recommended_action": recommended_action,
+        "rationale": "Deterministic triage from rule confidence, CVSS, EPSS, and mapping coverage.",
+        "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
+        "output_hash": _stable_hash(recommendation_payload)[:16],
+    }
+
+
+def _validate_llm_adapter_recommendation(
+    *,
+    candidate: dict[str, Any] | None,
+    fallback: AgentRecommendation,
+    finding_uid: str,
+    harness_config: AgentHarnessConfig,
+) -> tuple[AgentRecommendation, LlmValidationRecord]:
+    if not candidate:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "deterministic_fallback",
+            "status": "fallback",
+            "reason": "no_adapter_output",
+            "output_hash": fallback["output_hash"],
+        }
+
+    output_hash = _stable_hash(candidate)[:16]
+    forbidden = sorted(key for key in candidate if key in LLM_ADAPTER_FORBIDDEN_KEYS)
+    extra = sorted(key for key in candidate if key not in LLM_ADAPTER_ALLOWED_KEYS)
+    if forbidden:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "fixture_llm_adapter",
+            "status": "rejected",
+            "reason": f"forbidden_output:{','.join(forbidden)}",
+            "output_hash": output_hash,
+        }
+    if extra:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "fixture_llm_adapter",
+            "status": "rejected",
+            "reason": f"unknown_output:{','.join(extra)}",
+            "output_hash": output_hash,
+        }
+    if candidate.get("finding_uid") != finding_uid:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "fixture_llm_adapter",
+            "status": "rejected",
+            "reason": "finding_uid_mismatch",
+            "output_hash": output_hash,
+        }
+    if candidate.get("priority") not in LLM_ADAPTER_PRIORITIES:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "fixture_llm_adapter",
+            "status": "rejected",
+            "reason": "invalid_priority",
+            "output_hash": output_hash,
+        }
+    if candidate.get("recommended_action") not in LLM_ADAPTER_ACTIONS:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "fixture_llm_adapter",
+            "status": "rejected",
+            "reason": "invalid_recommended_action",
+            "output_hash": output_hash,
+        }
+
+    rationale = str(candidate.get("rationale") or "").strip()
+    if not rationale:
+        return fallback, {
+            "finding_uid": finding_uid,
+            "adapter": "fixture_llm_adapter",
+            "status": "rejected",
+            "reason": "missing_rationale",
+            "output_hash": output_hash,
+        }
+
+    recommendation_payload = {
+        "finding_uid": finding_uid,
+        "priority": candidate["priority"],
+        "recommended_action": candidate["recommended_action"],
+        "rationale": rationale,
+        "provider": harness_config["provider"],
+        "model": harness_config["model"],
+    }
+    accepted: AgentRecommendation = {
+        "finding_uid": finding_uid,
+        "priority": candidate["priority"],
+        "recommended_action": candidate["recommended_action"],
+        "rationale": rationale,
+        "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
+        "output_hash": _stable_hash(recommendation_payload)[:16],
+    }
+    return accepted, {
+        "finding_uid": finding_uid,
+        "adapter": "fixture_llm_adapter",
+        "status": "accepted",
+        "reason": "schema_valid",
+        "output_hash": output_hash,
     }
 
 
@@ -651,38 +816,37 @@ def llm_triage_node(state: GraphState) -> GraphState:
     """Bounded agent layer: rank and summarize only, never decide facts."""
     _append_trace(state, "llm_triage")
     harness_config = _agent_harness_config(state)
+    adapter_recommendations = {
+        recommendation.get("finding_uid"): recommendation
+        for recommendation in _load_llm_adapter_recommendations()
+        if isinstance(recommendation, dict)
+    }
     confidence_by_uid = {
         score["finding_uid"]: score["score"]
         for score in state.get("confidence_scores") or []
     }
     recommendations = []
+    validation_records = []
     for mapped in state.get("framework_maps") or []:
         finding_uid = mapped["finding_uid"]
         confidence = confidence_by_uid.get(finding_uid, 0.0)
-        recommended_action: Literal["request_approval", "investigate", "close"] = (
-            "request_approval" if confidence >= 0.90 else "investigate"
+        fallback = _deterministic_triage_recommendation(
+            finding_uid=finding_uid,
+            mapped=mapped,
+            confidence=confidence,
+            harness_config=harness_config,
         )
-        priority: Literal["critical", "high", "medium", "low"] = (
-            "high" if mapped["cvss"]["base_score"] >= 7.0 else "medium"
+        recommendation, validation = _validate_llm_adapter_recommendation(
+            candidate=adapter_recommendations.get(finding_uid),
+            fallback=fallback,
+            finding_uid=finding_uid,
+            harness_config=harness_config,
         )
-        recommendation_payload = {
-            "finding_uid": finding_uid,
-            "priority": priority,
-            "recommended_action": recommended_action,
-            "confidence": confidence,
-            "provider": harness_config["provider"],
-            "model": harness_config["model"],
-        }
-        recommendations.append({
-            "finding_uid": finding_uid,
-            "priority": priority,
-            "recommended_action": recommended_action,
-            "rationale": "Deterministic triage from rule confidence, CVSS, EPSS, and mapping coverage.",
-            "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
-            "output_hash": _stable_hash(recommendation_payload)[:16],
-        })
+        recommendations.append(recommendation)
+        validation_records.append(validation)
     state["harness_config"] = harness_config
     state["agent_recommendations"] = recommendations
+    state["llm_validation"] = validation_records
     _record_agent_run(
         state,
         agent_id="triage-agent",
@@ -692,7 +856,10 @@ def llm_triage_node(state: GraphState) -> GraphState:
             "framework_maps": state.get("framework_maps"),
             "harness_config": harness_config,
         },
-        outputs={"agent_recommendations": recommendations},
+        outputs={
+            "agent_recommendations": recommendations,
+            "llm_validation": validation_records,
+        },
     )
     _emit_node(
         "llm_triage",
@@ -700,6 +867,8 @@ def llm_triage_node(state: GraphState) -> GraphState:
         provider=harness_config["provider"],
         model=harness_config["model"],
         recommendations=len(recommendations),
+        accepted=sum(1 for record in validation_records if record["status"] == "accepted"),
+        rejected=sum(1 for record in validation_records if record["status"] == "rejected"),
         authority="rank_summarize_draft_only",
     )
     return state
@@ -951,6 +1120,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "agent_manifest": state.get("agent_manifest"),
         "agent_runs": state.get("agent_runs"),
         "agent_recommendations": state.get("agent_recommendations"),
+        "llm_validation": state.get("llm_validation"),
         "integrity": {
             key: value
             for key, value in (state.get("integrity") or {}).items()
@@ -969,6 +1139,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
     state["integrity"] = integrity
     idempotency = state.get("idempotency") or {}
     api_errors = state.get("api_errors") or []
+    llm_validation = state.get("llm_validation") or []
     audit_record = {
         "event": "agentic_soc_workflow",
         "correlation_id": state.get("caller_context", {}).get("session_id", "graph-demo-1"),
@@ -979,6 +1150,8 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "idempotency_key": idempotency.get("remediation_key") or idempotency.get("workflow_key"),
         "api_error_count": len(api_errors),
         "agent_run_count": len(state.get("agent_runs") or []),
+        "llm_adapter_accepted": sum(1 for record in llm_validation if record["status"] == "accepted"),
+        "llm_adapter_rejected": sum(1 for record in llm_validation if record["status"] == "rejected"),
         "retryable_api_error_count": sum(
             1 for error in api_errors if error["classification"] == "retryable"
         ),
@@ -1003,6 +1176,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "idempotency_key_stable",
             "api_error_classification",
             "llm_harness_bounded",
+            "llm_adapter_schema_gate",
             "multi_agent_ledger",
             "conditional_edges",
         ],
@@ -1125,6 +1299,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "agents": final.get("agent_manifest"),
         "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),
+        "llm_validation": final.get("llm_validation"),
         "review": final.get("review_decision"),
         "remediation": final.get("remediation_result"),
         "retry": final.get("retry_record"),

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -320,6 +320,73 @@ class TestLangGraphSocWorkflow:
         triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
         assert "approval" in triage_agent["forbidden_outputs"]
         assert "write_intent" in triage_agent["forbidden_outputs"]
+        assert summary["llm_validation"][0]["status"] == "fallback"
+        assert summary["llm_validation"][0]["reason"] == "no_adapter_output"
+
+    def test_llm_adapter_accepts_bounded_triage_output(self, tmp_path: Path):
+        baseline, _ = self._run()
+        finding_uid = baseline["framework_maps"][0]["finding_uid"]
+        fixture = tmp_path / "accepted-llm-output.json"
+        fixture.write_text(json.dumps({
+            "recommendations": [
+                {
+                    "finding_uid": finding_uid,
+                    "priority": "critical",
+                    "recommended_action": "request_approval",
+                    "rationale": "Fixture model ranks the finding for immediate analyst review.",
+                },
+            ],
+        }), encoding="utf-8")
+
+        summary, _ = self._run(extra_env={
+            "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+            "DEMO_LLM_PROVIDER": "fixture",
+            "DEMO_LLM_MODEL": "triage-fixture-v1",
+            "DEMO_LLM_ADAPTER_FIXTURE": str(fixture),
+        })
+
+        recommendation = summary["agent_recommendations"][0]
+        assert recommendation["priority"] == "critical"
+        assert recommendation["recommended_action"] == "request_approval"
+        assert recommendation["rationale"] == "Fixture model ranks the finding for immediate analyst review."
+        assert recommendation["generated_by"] == "fixture:triage-fixture-v1"
+        assert summary["llm_validation"][0]["status"] == "accepted"
+        assert summary["llm_validation"][0]["reason"] == "schema_valid"
+        assert summary["audit"]["llm_adapter_accepted"] == 1
+        assert summary["audit"]["llm_adapter_rejected"] == 0
+
+    def test_llm_adapter_rejects_forbidden_security_facts(self, tmp_path: Path):
+        baseline, _ = self._run()
+        finding_uid = baseline["framework_maps"][0]["finding_uid"]
+        fixture = tmp_path / "forbidden-llm-output.json"
+        fixture.write_text(json.dumps({
+            "recommendations": [
+                {
+                    "finding_uid": finding_uid,
+                    "priority": "low",
+                    "recommended_action": "close",
+                    "rationale": "This output should not be trusted.",
+                    "approval": {"approver_id": "model"},
+                    "cvss": {"base_score": 0.0},
+                },
+            ],
+        }), encoding="utf-8")
+
+        summary, _ = self._run(extra_env={
+            "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+            "DEMO_LLM_PROVIDER": "fixture",
+            "DEMO_LLM_MODEL": "triage-fixture-v1",
+            "DEMO_LLM_ADAPTER_FIXTURE": str(fixture),
+        })
+
+        recommendation = summary["agent_recommendations"][0]
+        assert recommendation["priority"] == "high"
+        assert recommendation["recommended_action"] == "request_approval"
+        assert recommendation["rationale"].startswith("Deterministic triage")
+        assert summary["llm_validation"][0]["status"] == "rejected"
+        assert summary["llm_validation"][0]["reason"] == "forbidden_output:approval,cvss"
+        assert summary["audit"]["llm_adapter_accepted"] == 0
+        assert summary["audit"]["llm_adapter_rejected"] == 1
 
     def test_profile_loads_caller_context_and_allowed_skills(self):
         summary, _ = self._run(extra_env={


### PR DESCRIPTION
## Summary
- Add a bounded LLM adapter contract to the LangGraph SOC example.
- Accept only triage-safe fields from optional adapter output: `finding_uid`, `priority`, `recommended_action`, and `rationale`.
- Reject forbidden model outputs such as approval, CVSS/MITRE/EPSS/KEV facts, tenant scope, idempotency keys, and write intent, then fall back to deterministic triage.
- Expose `llm_validation` and accepted/rejected counts in the summary/audit path.

## Verification
- `uv run make agent-evals`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `uv run python scripts/validate_dependency_consistency.py`
- `python -m py_compile examples/agents/langgraph_security_graph.py`
- `git diff --check`

## Notes
- This remains offline by default; the fixture-backed adapter models the schema gate a live provider adapter must satisfy.
- Local duplicate `* 2.*` files remain untracked and are not part of this PR.