### PR TITLE
test(examples): add LangGraph adapter eval cases

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -73,7 +73,8 @@ Eval fixtures live under
 [`examples/agents/evals/`](../examples/agents/evals/). The offline gate
 replays golden profile and triage cases through the same graph, checks bounded
 recommendation shape, HITL routing, allowlist intersection, and remediation
-blocking, then emits a pass-rate report:
+blocking, and covers both accepted and rejected LLM adapter output, then emits
+a pass-rate report:
 
 ```bash
 python examples/agents/eval_langgraph_harness.py --check

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -151,8 +151,9 @@ Profile examples live under
 
 Eval fixtures live under [`evals/`](evals/). The eval runner is deterministic:
 it replays profile/triage cases, checks recommendation shape, HITL routing,
-allowlist behavior, and remediation blocking, then emits a pass-rate report.
-It does not call a live model and does not use an LLM-as-judge.
+allowlist behavior, LLM adapter schema acceptance/rejection, and remediation
+blocking, then emits a pass-rate report. It does not call a live model and
+does not use an LLM-as-judge.
 
 See each example file's module-level docstring for framework-specific
 prerequisites.

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -15,6 +15,7 @@ import argparse
 import hashlib
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,15 @@ from langgraph_security_graph import load_harness_profile, run_graph, summarize
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DATASET = Path(__file__).with_name("evals") / "langgraph_triage_golden.json"
+ENV_KEYS = [
+    "DEMO_APPROVE",
+    "DEMO_APPROVER",
+    "DEMO_TICKET",
+    "DEMO_EXTERNAL_LLM_ALLOWED",
+    "DEMO_LLM_PROVIDER",
+    "DEMO_LLM_MODEL",
+    "DEMO_LLM_ADAPTER_FIXTURE",
+]
 
 
 def _stable_hash(payload: Any) -> str:
@@ -34,12 +44,8 @@ def _resolve(path_text: str) -> Path:
     return path if path.is_absolute() else REPO_ROOT / path
 
 
-def _without_approval_env() -> dict[str, str | None]:
-    saved = {
-        "DEMO_APPROVE": os.environ.get("DEMO_APPROVE"),
-        "DEMO_APPROVER": os.environ.get("DEMO_APPROVER"),
-        "DEMO_TICKET": os.environ.get("DEMO_TICKET"),
-    }
+def _without_case_env() -> dict[str, str | None]:
+    saved = {key: os.environ.get(key) for key in ENV_KEYS}
     for key in saved:
         os.environ.pop(key, None)
     return saved
@@ -67,6 +73,38 @@ def _triage_agent(summary: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _first_finding_uid(case: dict[str, Any]) -> str:
+    raw_events = case.get("raw_events") or [{"source": "demo"}]
+    return f"det-evt-{_stable_hash(raw_events[0])[:12]}"
+
+
+def _replace_placeholders(payload: Any, replacements: dict[str, str]) -> Any:
+    if isinstance(payload, str):
+        rendered = payload
+        for key, value in replacements.items():
+            rendered = rendered.replace(f"{{{{{key}}}}}", value)
+        return rendered
+    if isinstance(payload, list):
+        return [_replace_placeholders(item, replacements) for item in payload]
+    if isinstance(payload, dict):
+        return {
+            key: _replace_placeholders(value, replacements)
+            for key, value in payload.items()
+        }
+    return payload
+
+
+def _write_adapter_fixture(case: dict[str, Any]) -> Path | None:
+    fixture = case.get("llm_adapter_fixture")
+    if not fixture:
+        return None
+    rendered = _replace_placeholders(fixture, {"finding_uid": _first_finding_uid(case)})
+    handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False)
+    with handle:
+        json.dump(rendered, handle, sort_keys=True)
+    return Path(handle.name)
+
+
 def _check(name: str, actual: Any, expected: Any) -> dict[str, Any]:
     return {
         "name": name,
@@ -77,8 +115,13 @@ def _check(name: str, actual: Any, expected: Any) -> dict[str, Any]:
 
 
 def run_case(case: dict[str, Any]) -> dict[str, Any]:
-    saved_env = _without_approval_env()
+    saved_env = _without_case_env()
+    fixture_path = _write_adapter_fixture(case)
     try:
+        for key, value in (case.get("env") or {}).items():
+            os.environ[key] = str(value)
+        if fixture_path:
+            os.environ["DEMO_LLM_ADAPTER_FIXTURE"] = str(fixture_path)
         profile = load_harness_profile(str(_resolve(case["profile"])))
         initial = {
             "harness_profile": profile,
@@ -87,6 +130,8 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
         }
         summary = summarize(run_graph(initial))
     finally:
+        if fixture_path:
+            fixture_path.unlink(missing_ok=True)
         _restore_env(saved_env)
 
     expected = case["expected"]
@@ -108,6 +153,31 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
             "recommendation_generated_by",
             recommendation.get("generated_by"),
             expected["recommendation_generated_by"],
+        ))
+
+    if "llm_validation_status" in expected:
+        validation = (summary.get("llm_validation") or [{}])[0]
+        checks.append(_check(
+            "llm_validation_status",
+            validation.get("status"),
+            expected["llm_validation_status"],
+        ))
+        checks.append(_check(
+            "llm_validation_reason",
+            validation.get("reason"),
+            expected["llm_validation_reason"],
+        ))
+
+    if "llm_adapter_accepted" in expected:
+        checks.append(_check(
+            "llm_adapter_accepted",
+            summary["audit"]["llm_adapter_accepted"],
+            expected["llm_adapter_accepted"],
+        ))
+        checks.append(_check(
+            "llm_adapter_rejected",
+            summary["audit"]["llm_adapter_rejected"],
+            expected["llm_adapter_rejected"],
         ))
 
     for skill in expected.get("effective_allowed_includes", []):
@@ -142,6 +212,7 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
             "remediation": summary["remediation"],
             "route": summary["audit"]["route"],
             "effective_allowed_skills": summary["effective_allowed_skills"],
+            "llm_validation": summary.get("llm_validation"),
         })[:16],
         "checks": checks,
     }

--- a/examples/agents/evals/langgraph_triage_golden.json
+++ b/examples/agents/evals/langgraph_triage_golden.json
@@ -71,6 +71,92 @@
         "effective_allowed_includes": ["iam-departures-aws"],
         "planned_steps_absent": true
       }
+    },
+    {
+      "case_id": "llm_adapter_accepts_bounded_triage",
+      "profile": "examples/agents/harness_profiles/analyst-triage.json",
+      "env": {
+        "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+        "DEMO_LLM_PROVIDER": "fixture",
+        "DEMO_LLM_MODEL": "triage-fixture-v1"
+      },
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "llm_adapter_fixture": {
+        "recommendations": [
+          {
+            "finding_uid": "{{finding_uid}}",
+            "priority": "critical",
+            "recommended_action": "request_approval",
+            "rationale": "Fixture model ranks the finding for immediate analyst review."
+          }
+        ]
+      },
+      "expected": {
+        "profile_id": "analyst-triage",
+        "harness_mode": "external_llm_optional",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "critical",
+        "recommendation_generated_by": "fixture:triage-fixture-v1",
+        "llm_validation_status": "accepted",
+        "llm_validation_reason": "schema_valid",
+        "llm_adapter_accepted": 1,
+        "llm_adapter_rejected": 0,
+        "review_status": "blocked",
+        "remediation_status": "skipped",
+        "route_after_review": "writeback",
+        "planned_steps_absent": true
+      }
+    },
+    {
+      "case_id": "llm_adapter_rejects_forbidden_security_facts",
+      "profile": "examples/agents/harness_profiles/analyst-triage.json",
+      "env": {
+        "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+        "DEMO_LLM_PROVIDER": "fixture",
+        "DEMO_LLM_MODEL": "triage-fixture-v1"
+      },
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "llm_adapter_fixture": {
+        "recommendations": [
+          {
+            "finding_uid": "{{finding_uid}}",
+            "priority": "low",
+            "recommended_action": "close",
+            "rationale": "This output should not be trusted.",
+            "approval": {"approver_id": "model"},
+            "cvss": {"base_score": 0.0}
+          }
+        ]
+      },
+      "expected": {
+        "profile_id": "analyst-triage",
+        "harness_mode": "external_llm_optional",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "recommendation_generated_by": "fixture:triage-fixture-v1",
+        "llm_validation_status": "rejected",
+        "llm_validation_reason": "forbidden_output:approval,cvss",
+        "llm_adapter_accepted": 0,
+        "llm_adapter_rejected": 1,
+        "review_status": "blocked",
+        "remediation_status": "skipped",
+        "route_after_review": "writeback",
+        "planned_steps_absent": true
+      }
     }
   ]
 }

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -588,17 +588,19 @@ class TestLangGraphHarnessEvals:
         report = json.loads(result.stdout)
         assert report["event"] == "langgraph_agent_harness_eval"
         assert report["dataset_version"] == "langgraph-agent-harness-golden-v1"
-        assert report["cases_total"] == 3
-        assert report["passed"] == 3
+        assert report["cases_total"] == 5
+        assert report["passed"] == 5
         assert report["failed"] == 0
         assert report["pass_rate"] == 1.0
         assert {case["case_id"] for case in report["results"]} == {
             "readonly_soc_blocks_remediation",
             "analyst_triage_records_model_metadata",
             "remediation_profile_does_not_approve_itself",
+            "llm_adapter_accepts_bounded_triage",
+            "llm_adapter_rejects_forbidden_security_facts",
         }
 
     def test_golden_dataset_is_valid_json(self):
         payload = json.loads(self.DATASET.read_text(encoding="utf-8"))
         assert payload["dataset_version"] == "langgraph-agent-harness-golden-v1"
-        assert len(payload["cases"]) == 3
+        assert len(payload["cases"]) == 5


### PR DESCRIPTION
## Summary
- Extend the offline LangGraph harness eval runner so cases can set isolated env and temporary adapter fixtures.
- Add golden eval cases for accepted bounded adapter output and rejected forbidden security-fact output.
- Update eval tests and docs so adapter schema acceptance/rejection is part of the pass-rate contract.

## Verification
- `python examples/agents/eval_langgraph_harness.py --check`
- `python -m json.tool examples/agents/evals/langgraph_triage_golden.json >/dev/null`
- `uv run make agent-evals`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `uv run python scripts/validate_dependency_consistency.py`
- `git diff --check`

## Notes
- The eval runner still does not call a live model or use an LLM-as-judge.
- Local duplicate `* 2.*` files remain untracked and are not part of this PR.