### PR TITLE
test(examples): add LangGraph contract schemas

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -91,6 +91,9 @@ LLM provider/model metadata, and approval-policy documentation. They do not
 store cloud secrets and they do not grant approval. A remediation profile can
 make a dry-run skill visible, but the graph still needs `_approval_context`
 from the operator's IDP or ticketing workflow before routing to remediation.
+Closed JSON Schema contracts live under
+[`examples/agents/schemas/`](../examples/agents/schemas/) for both harness
+profiles and LLM adapter recommendation payloads.
 
 ## Customization knobs
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -149,6 +149,10 @@ Profile examples live under
 | `analyst-triage.json` | optional external-model metadata for bounded drafting |
 | `dry-run-remediation.json` | exposes remediation planning, but still requires `DEMO_APPROVE=yes` / approval context |
 
+Contract schemas live under [`schemas/`](schemas/). They define the closed
+shape for harness profiles and the LLM adapter recommendation payload accepted
+by the reference graph.
+
 Eval fixtures live under [`evals/`](evals/). The eval runner is deterministic:
 it replays profile/triage cases, checks recommendation shape, HITL routing,
 allowlist behavior, LLM adapter schema acceptance/rejection, and remediation

--- a/examples/agents/schemas/harness_profile.schema.json
+++ b/examples/agents/schemas/harness_profile.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/harness_profile.schema.json",
+  "title": "LangGraph SOC harness profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile_id",
+    "description",
+    "allowed_skills",
+    "caller_context",
+    "cloud_identity_hints",
+    "llm",
+    "approval_policy",
+    "runtime"
+  ],
+  "properties": {
+    "profile_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_skills": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "caller_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "user_id",
+        "email",
+        "session_id",
+        "roles",
+        "allowed_skills"
+      ],
+      "properties": {
+        "user_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "minLength": 3
+        },
+        "session_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "roles": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allowed_skills": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "cloud_identity_hints": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "llm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "provider",
+        "model"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "deterministic_offline",
+            "external_llm_optional"
+          ]
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "approval_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "remediation_requires_approval_context",
+        "approval_source"
+      ],
+      "properties": {
+        "remediation_requires_approval_context": {
+          "type": "boolean",
+          "const": true
+        },
+        "approval_source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "min_approvers": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "langgraph_runtime_optional",
+        "dry_run_default"
+      ],
+      "properties": {
+        "langgraph_runtime_optional": {
+          "type": "boolean",
+          "const": true
+        },
+        "dry_run_default": {
+          "type": "boolean",
+          "const": true
+        },
+        "apply_supported": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/examples/agents/schemas/llm_adapter_recommendations.schema.json
+++ b/examples/agents/schemas/llm_adapter_recommendations.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/llm_adapter_recommendations.schema.json",
+  "title": "LangGraph SOC LLM adapter recommendations",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "recommendations"
+  ],
+  "properties": {
+    "recommendations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "finding_uid",
+          "priority",
+          "recommended_action",
+          "rationale"
+        ],
+        "properties": {
+          "finding_uid": {
+            "type": "string",
+            "minLength": 1
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "recommended_action": {
+            "type": "string",
+            "enum": [
+              "request_approval",
+              "investigate",
+              "close"
+            ]
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -20,12 +21,93 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 EXAMPLES = REPO_ROOT / "examples" / "agents"
+SCHEMAS = EXAMPLES / "schemas"
 
 SCRIPTS = [
     EXAMPLES / "anthropic_sdk_security_agent.py",
     EXAMPLES / "openai_sdk_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
 ]
+
+JSON_TYPE_MAP = {
+    "array": list,
+    "boolean": bool,
+    "integer": int,
+    "object": dict,
+    "string": str,
+}
+
+
+def _schema_errors(schema: dict, value, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    schema_type = schema.get("type")
+    if schema_type:
+        expected_type = JSON_TYPE_MAP[schema_type]
+        if not isinstance(value, expected_type) or (
+            schema_type == "integer" and isinstance(value, bool)
+        ):
+            return [f"{path}: expected {schema_type}"]
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}")
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']!r}")
+    if schema_type == "string":
+        if len(value) < schema.get("minLength", 0):
+            errors.append(f"{path}: shorter than minLength")
+        if pattern := schema.get("pattern"):
+            if not re.match(pattern, value):
+                errors.append(f"{path}: does not match pattern")
+    if schema_type == "integer" and "minimum" in schema and value < schema["minimum"]:
+        errors.append(f"{path}: below minimum")
+
+    if schema_type == "array":
+        if len(value) < schema.get("minItems", 0):
+            errors.append(f"{path}: shorter than minItems")
+        if schema.get("uniqueItems"):
+            stable = [json.dumps(item, sort_keys=True) for item in value]
+            if len(stable) != len(set(stable)):
+                errors.append(f"{path}: duplicate array item")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(value):
+                errors.extend(_schema_errors(item_schema, item, f"{path}[{index}]"))
+
+    if schema_type == "object":
+        required = set(schema.get("required", []))
+        missing = sorted(required - set(value))
+        for key in missing:
+            errors.append(f"{path}: missing required property {key}")
+        properties = schema.get("properties", {})
+        extra = sorted(set(value) - set(properties))
+        additional = schema.get("additionalProperties", True)
+        if additional is False:
+            for key in extra:
+                errors.append(f"{path}: additional property {key}")
+        elif isinstance(additional, dict):
+            for key in extra:
+                errors.extend(_schema_errors(additional, value[key], f"{path}.{key}"))
+        for key, child_schema in properties.items():
+            if key in value:
+                errors.extend(_schema_errors(child_schema, value[key], f"{path}.{key}"))
+
+    return errors
+
+
+def _render_fixture(payload, replacements: dict[str, str]):
+    if isinstance(payload, str):
+        rendered = payload
+        for key, value in replacements.items():
+            rendered = rendered.replace(f"{{{{{key}}}}}", value)
+        return rendered
+    if isinstance(payload, list):
+        return [_render_fixture(item, replacements) for item in payload]
+    if isinstance(payload, dict):
+        return {
+            key: _render_fixture(value, replacements)
+            for key, value in payload.items()
+        }
+    return payload
 
 
 @pytest.mark.parametrize("script", SCRIPTS, ids=lambda p: p.name)
@@ -568,6 +650,58 @@ class TestLangGraphSocWorkflow:
         assert "route_after_remediation" in text
         assert 'graph.add_node("llm_triage", llm_triage_node)' in text
         assert "DEMO_LANGGRAPH_RUNTIME" in text
+
+
+class TestLangGraphContractSchemas:
+    """Contract coverage for harness profile and LLM adapter JSON schemas."""
+
+    PROFILE_SCHEMA = SCHEMAS / "harness_profile.schema.json"
+    ADAPTER_SCHEMA = SCHEMAS / "llm_adapter_recommendations.schema.json"
+    PROFILES = EXAMPLES / "harness_profiles"
+    DATASET = EXAMPLES / "evals" / "langgraph_triage_golden.json"
+
+    def test_schema_files_are_closed_json_schema_documents(self):
+        for schema_path in [self.PROFILE_SCHEMA, self.ADAPTER_SCHEMA]:
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+            assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+            assert schema["type"] == "object"
+            assert schema["additionalProperties"] is False
+
+    def test_harness_profiles_match_schema_and_intersect_allowlists(self):
+        schema = json.loads(self.PROFILE_SCHEMA.read_text(encoding="utf-8"))
+        for profile_path in sorted(self.PROFILES.glob("*.json")):
+            profile = json.loads(profile_path.read_text(encoding="utf-8"))
+            assert _schema_errors(schema, profile) == []
+            assert set(profile["caller_context"]["allowed_skills"]).issubset(
+                set(profile["allowed_skills"])
+            )
+            assert profile["approval_policy"]["remediation_requires_approval_context"] is True
+            assert profile["runtime"]["dry_run_default"] is True
+
+    def test_llm_adapter_eval_fixtures_match_expected_schema_outcome(self):
+        schema = json.loads(self.ADAPTER_SCHEMA.read_text(encoding="utf-8"))
+        dataset = json.loads(self.DATASET.read_text(encoding="utf-8"))
+        adapter_cases = [
+            case for case in dataset["cases"]
+            if "llm_adapter_fixture" in case
+        ]
+        assert {case["case_id"] for case in adapter_cases} == {
+            "llm_adapter_accepts_bounded_triage",
+            "llm_adapter_rejects_forbidden_security_facts",
+        }
+
+        for case in adapter_cases:
+            rendered = _render_fixture(
+                case["llm_adapter_fixture"],
+                {"finding_uid": "det-evt-schema-test"},
+            )
+            errors = _schema_errors(schema, rendered)
+            if case["expected"]["llm_validation_status"] == "accepted":
+                assert errors == []
+            else:
+                assert errors
+                assert any("additional property approval" in error for error in errors)
+                assert any("additional property cvss" in error for error in errors)
 
 
 class TestLangGraphHarnessEvals:


### PR DESCRIPTION
## Summary
- Add closed JSON Schema documents for LangGraph harness profiles and LLM adapter recommendation payloads.
- Validate shipped harness profiles and adapter eval fixtures in the agent example tests without adding a new dependency.
- Document the schema location in the harness and example docs.

## Verification
- `uv run make agent-evals`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `python -m json.tool examples/agents/schemas/harness_profile.schema.json >/dev/null`
- `python -m json.tool examples/agents/schemas/llm_adapter_recommendations.schema.json >/dev/null`
- `uv run ruff check examples/agents`
- `uv run python scripts/validate_dependency_consistency.py`
- `git diff --check`

## Notes
- This keeps schema validation dependency-free for CI by using a small test-local validator over the schema subset these contracts use.
- Local duplicate `* 2.*` files remain untracked and are not part of this PR.