### PR TITLE
feat(examples): add LangGraph eval history store

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -78,11 +78,17 @@ a pass-rate report:
 
 ```bash
 python examples/agents/eval_langgraph_harness.py --check
+
+python examples/agents/eval_langgraph_harness.py --check \
+  --output artifacts/langgraph-harness-eval.json \
+  --append-jsonl artifacts/langgraph-harness-eval-history.jsonl
 ```
 
 This is regression tracking for orchestrator behavior, not an LLM-as-judge.
 It does not call a live model; live model quality checks can be layered on top
-later with the same dataset/version/report contract.
+later with the same dataset/version/report contract. The JSON report captures
+the latest run, while the JSONL history gives CI, release checks, or customer
+forks an append-only pass-rate trail for harness drift.
 
 Operator profiles live under
 [`examples/agents/harness_profiles/`](../examples/agents/harness_profiles/).

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -127,6 +127,11 @@ python examples/agents/langgraph_security_graph.py
 
 # Offline eval gate: replay golden profile/triage cases and fail on drift.
 python examples/agents/eval_langgraph_harness.py --check
+
+# Eval artifact store: keep the latest JSON report and append pass-rate history.
+python examples/agents/eval_langgraph_harness.py --check \
+  --output artifacts/langgraph-harness-eval.json \
+  --append-jsonl artifacts/langgraph-harness-eval-history.jsonl
 ```
 
 The LangGraph summary includes `integrity.evidence_hash`,
@@ -138,7 +143,9 @@ operators can see which role and model would have drafted the analyst note
 without letting that model set policy, mappings, approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
 `llm_validation` records whether an adapter output was accepted, rejected, or
-replaced by deterministic fallback.
+replaced by deterministic fallback. The eval runner can write a point-in-time
+JSON report and append timestamped JSONL rows so CI or operators can track
+pass-rate drift across harness, profile, and adapter changes.
 
 Profile examples live under
 [`harness_profiles/`](harness_profiles/):

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import os
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -236,15 +237,56 @@ def run_dataset(dataset_path: Path) -> dict[str, Any]:
     }
 
 
+def _encoded_report(report: dict[str, Any]) -> str:
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+
+def _write_json(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload, encoding="utf-8")
+
+
+def _append_history(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    recorded_at = (
+        datetime.now(UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    record = {
+        "recorded_at": recorded_at,
+        "report_hash": _stable_hash(report)[:16],
+        **report,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
     parser.add_argument("--min-pass-rate", type=float, default=1.0)
     parser.add_argument("--check", action="store_true", help="exit nonzero when pass rate is below threshold")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write the JSON eval report to this path",
+    )
+    parser.add_argument(
+        "--append-jsonl",
+        type=Path,
+        help="append a timestamped eval report row to this JSONL history",
+    )
     args = parser.parse_args()
 
     report = run_dataset(args.dataset)
-    print(json.dumps(report, indent=2, sort_keys=True))
+    encoded = _encoded_report(report)
+    print(encoded, end="")
+    if args.output:
+        _write_json(args.output, encoded)
+    if args.append_jsonl:
+        _append_history(args.append_jsonl, report)
     if args.check and report["pass_rate"] < args.min_pass_rate:
         return 1
     return 0

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -738,3 +738,36 @@ class TestLangGraphHarnessEvals:
         payload = json.loads(self.DATASET.read_text(encoding="utf-8"))
         assert payload["dataset_version"] == "langgraph-agent-harness-golden-v1"
         assert len(payload["cases"]) == 5
+
+    def test_eval_report_can_be_written_and_appended(self, tmp_path):
+        report_path = tmp_path / "langgraph-harness-eval.json"
+        history_path = tmp_path / "langgraph-harness-eval-history.jsonl"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--check",
+                "--output",
+                str(report_path),
+                "--append-jsonl",
+                str(history_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        stdout_report = json.loads(result.stdout)
+        file_report = json.loads(report_path.read_text(encoding="utf-8"))
+        history_rows = [
+            json.loads(line)
+            for line in history_path.read_text(encoding="utf-8").splitlines()
+        ]
+        assert file_report == stdout_report
+        assert len(history_rows) == 1
+        assert history_rows[0]["event"] == "langgraph_agent_harness_eval"
+        assert history_rows[0]["dataset_hash"] == stdout_report["dataset_hash"]
+        assert history_rows[0]["pass_rate"] == 1.0
+        assert history_rows[0]["report_hash"]
+        assert history_rows[0]["recorded_at"].endswith("Z")


### PR DESCRIPTION
Summary
- Adds --output and --append-jsonl to the LangGraph harness eval runner so operators can keep a latest JSON report and append pass-rate history.
- Records timestamped JSONL rows with a stable report hash while keeping the eval itself offline and deterministic.
- Documents the artifact command and adds regression coverage for report/history writes.

Verification
- python examples/agents/eval_langgraph_harness.py --check --output /tmp/langgraph-harness-eval.json --append-jsonl /tmp/langgraph-harness-eval-history.jsonl
- python -m json.tool examples/agents/evals/langgraph_triage_golden.json >/dev/null
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- uv run make agent-evals
- uv run python scripts/validate_dependency_consistency.py
- git diff --check

Notes
- Unrelated local duplicate files with " 2" names were left untracked and are not part of this PR.