### PR TITLE
test(examples): expand LangGraph operational evals

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -73,8 +73,10 @@ Eval fixtures live under
 [`examples/agents/evals/`](../examples/agents/evals/). The offline gate
 replays golden profile and triage cases through the same graph, checks bounded
 recommendation shape, HITL routing, allowlist intersection, and remediation
-blocking, and covers both accepted and rejected LLM adapter output, then emits
-a pass-rate report:
+blocking, and covers both accepted and rejected LLM adapter output. It also
+checks integrity hashes, remediation idempotency keys, retryable API errors,
+terminal API errors, retry queue routing, and human escalation routing, then
+emits a pass-rate report:
 
 ```bash
 python examples/agents/eval_langgraph_harness.py --check

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -125,7 +125,8 @@ DEMO_APPROVE=yes \
 DEMO_API_ERROR_STATUS=429 \
 python examples/agents/langgraph_security_graph.py
 
-# Offline eval gate: replay golden profile/triage cases and fail on drift.
+# Offline eval gate: replay golden profile, triage, integrity,
+# idempotency, and API-error cases and fail on drift.
 python examples/agents/eval_langgraph_harness.py --check
 
 # Eval artifact store: keep the latest JSON report and append pass-rate history.

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -181,6 +181,118 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
             expected["llm_adapter_rejected"],
         ))
 
+    for key in expected.get("integrity_keys_present", []):
+        checks.append(_check(
+            f"integrity_key_present:{key}",
+            bool((summary.get("integrity") or {}).get(key)),
+            True,
+        ))
+
+    for key in expected.get("idempotency_keys_present", []):
+        checks.append(_check(
+            f"idempotency_key_present:{key}",
+            bool((summary.get("idempotency") or {}).get(key)),
+            True,
+        ))
+
+    if "idempotency_duplicate_write_suppressed" in expected:
+        checks.append(_check(
+            "idempotency_duplicate_write_suppressed",
+            (summary.get("idempotency") or {}).get("duplicate_write_suppressed"),
+            expected["idempotency_duplicate_write_suppressed"],
+        ))
+
+    if "remediation_dry_run" in expected:
+        checks.append(_check(
+            "remediation_dry_run",
+            summary["remediation"].get("dry_run"),
+            expected["remediation_dry_run"],
+        ))
+
+    if expected.get("remediation_key_matches_idempotency"):
+        checks.append(_check(
+            "remediation_key_matches_idempotency",
+            summary["remediation"].get("idempotency_key"),
+            (summary.get("idempotency") or {}).get("remediation_key"),
+        ))
+
+    if expected.get("audit_key_matches_remediation"):
+        checks.append(_check(
+            "audit_key_matches_remediation",
+            summary["audit"].get("idempotency_key"),
+            summary["remediation"].get("idempotency_key"),
+        ))
+
+    if "route_after_remediation" in expected:
+        checks.append(_check(
+            "route_after_remediation",
+            summary["audit"]["route"]["after_remediation"],
+            expected["route_after_remediation"],
+        ))
+
+    if "eval_status" in expected:
+        checks.append(_check(
+            "eval_status",
+            summary["eval"]["status"],
+            expected["eval_status"],
+        ))
+
+    if "audit_api_error_count" in expected:
+        checks.append(_check(
+            "audit_api_error_count",
+            summary["audit"]["api_error_count"],
+            expected["audit_api_error_count"],
+        ))
+        checks.append(_check(
+            "audit_retryable_api_error_count",
+            summary["audit"]["retryable_api_error_count"],
+            expected.get("audit_retryable_api_error_count", 0),
+        ))
+
+    if "api_error_classification" in expected:
+        api_error = (summary.get("api_errors") or [{}])[0]
+        checks.append(_check(
+            "api_error_classification",
+            api_error.get("classification"),
+            expected["api_error_classification"],
+        ))
+        checks.append(_check(
+            "api_error_status_code",
+            api_error.get("status_code"),
+            expected["api_error_status_code"],
+        ))
+
+    if "retry_status" in expected:
+        checks.append(_check(
+            "retry_status",
+            (summary.get("retry") or {}).get("status"),
+            expected["retry_status"],
+        ))
+        checks.append(_check(
+            "retry_policy",
+            (summary.get("retry") or {}).get("policy"),
+            expected["retry_policy"],
+        ))
+
+    if expected.get("retry_key_matches_remediation"):
+        checks.append(_check(
+            "retry_key_matches_remediation",
+            (summary.get("retry") or {}).get("idempotency_key"),
+            summary["remediation"].get("idempotency_key"),
+        ))
+
+    if "escalation_status" in expected:
+        checks.append(_check(
+            "escalation_status",
+            (summary.get("escalation") or {}).get("status"),
+            expected["escalation_status"],
+        ))
+        checks.append(_check(
+            "escalation_reason",
+            (summary.get("escalation") or {}).get("reason"),
+            expected["escalation_reason"],
+        ))
+
     for skill in expected.get("effective_allowed_includes", []):
         checks.append(_check(
             f"effective_allowed_includes:{skill}",
@@ -214,6 +326,11 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
             "route": summary["audit"]["route"],
             "effective_allowed_skills": summary["effective_allowed_skills"],
             "llm_validation": summary.get("llm_validation"),
+            "integrity": summary.get("integrity"),
+            "idempotency": summary.get("idempotency"),
+            "api_errors": summary.get("api_errors"),
+            "retry": summary.get("retry"),
+            "escalation": summary.get("escalation"),
         })[:16],
         "checks": checks,
     }

--- a/examples/agents/evals/langgraph_triage_golden.json
+++ b/examples/agents/evals/langgraph_triage_golden.json
@@ -1,6 +1,6 @@
 {
   "dataset_version": "langgraph-agent-harness-golden-v1",
-  "description": "Offline regression cases for bounded LangGraph agent recommendations, profile loading, HITL routing, and remediation guardrails.",
+  "description": "Offline regression cases for bounded LangGraph agent recommendations, profile loading, HITL routing, remediation guardrails, integrity, idempotency, and API error routing.",
   "cases": [
     {
       "case_id": "readonly_soc_blocks_remediation",
@@ -69,6 +69,123 @@
         "remediation_status": "skipped",
         "route_after_review": "writeback",
         "effective_allowed_includes": ["iam-departures-aws"],
+        "planned_steps_absent": true
+      }
+    },
+    {
+      "case_id": "approved_dry_run_records_integrity_idempotency",
+      "profile": "examples/agents/harness_profiles/dry-run-remediation.json",
+      "env": {
+        "DEMO_APPROVE": "yes",
+        "DEMO_APPROVER": "reviewer@example.com",
+        "DEMO_TICKET": "SEC-LANGGRAPH-DRYRUN"
+      },
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "expected": {
+        "profile_id": "dry-run-remediation",
+        "harness_mode": "deterministic_offline",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "review_status": "approved",
+        "remediation_status": "dry_run",
+        "remediation_dry_run": true,
+        "route_after_review": "remediate",
+        "route_after_remediation": "writeback",
+        "eval_status": "pass",
+        "effective_allowed_includes": ["iam-departures-aws"],
+        "integrity_keys_present": ["evidence_hash", "approved_payload_hash", "state_hash"],
+        "idempotency_keys_present": ["workflow_key", "remediation_key"],
+        "idempotency_duplicate_write_suppressed": false,
+        "remediation_key_matches_idempotency": true,
+        "audit_key_matches_remediation": true,
+        "planned_steps_absent": false
+      }
+    },
+    {
+      "case_id": "retryable_api_error_reuses_idempotency_key",
+      "profile": "examples/agents/harness_profiles/dry-run-remediation.json",
+      "env": {
+        "DEMO_APPROVE": "yes",
+        "DEMO_APPROVER": "reviewer@example.com",
+        "DEMO_TICKET": "SEC-LANGGRAPH-RETRY",
+        "DEMO_API_ERROR_STATUS": "429"
+      },
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "expected": {
+        "profile_id": "dry-run-remediation",
+        "harness_mode": "deterministic_offline",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "review_status": "approved",
+        "remediation_status": "skipped",
+        "route_after_review": "remediate",
+        "route_after_remediation": "retry_queue",
+        "eval_status": "blocked",
+        "audit_api_error_count": 1,
+        "audit_retryable_api_error_count": 1,
+        "api_error_classification": "retryable",
+        "api_error_status_code": 429,
+        "retry_status": "scheduled",
+        "retry_policy": "bounded_retry_same_idempotency_key",
+        "retry_key_matches_remediation": true,
+        "integrity_keys_present": ["approved_payload_hash", "state_hash"],
+        "idempotency_keys_present": ["remediation_key"],
+        "remediation_key_matches_idempotency": true,
+        "audit_key_matches_remediation": true,
+        "planned_steps_absent": true
+      }
+    },
+    {
+      "case_id": "terminal_api_error_escalates_to_human_queue",
+      "profile": "examples/agents/harness_profiles/dry-run-remediation.json",
+      "env": {
+        "DEMO_APPROVE": "yes",
+        "DEMO_APPROVER": "reviewer@example.com",
+        "DEMO_TICKET": "SEC-LANGGRAPH-ESCALATE",
+        "DEMO_API_ERROR_STATUS": "403"
+      },
+      "raw_events": [
+        {
+          "source": "cloudtrail",
+          "event_name": "CreateAccessKey",
+          "actor_uid": "AIDAEXAMPLE",
+          "resource_uid": "arn:aws:iam::111122223333:user/build-bot"
+        }
+      ],
+      "expected": {
+        "profile_id": "dry-run-remediation",
+        "harness_mode": "deterministic_offline",
+        "recommendation_action": "request_approval",
+        "recommendation_priority": "high",
+        "review_status": "approved",
+        "remediation_status": "skipped",
+        "route_after_review": "remediate",
+        "route_after_remediation": "escalate",
+        "eval_status": "blocked",
+        "audit_api_error_count": 1,
+        "audit_retryable_api_error_count": 0,
+        "api_error_classification": "terminal",
+        "api_error_status_code": 403,
+        "escalation_status": "queued",
+        "escalation_reason": "terminal_api_error",
+        "integrity_keys_present": ["approved_payload_hash", "state_hash"],
+        "idempotency_keys_present": ["remediation_key"],
+        "remediation_key_matches_idempotency": true,
+        "audit_key_matches_remediation": true,
         "planned_steps_absent": true
       }
     },

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -722,14 +722,17 @@ class TestLangGraphHarnessEvals:
         report = json.loads(result.stdout)
         assert report["event"] == "langgraph_agent_harness_eval"
         assert report["dataset_version"] == "langgraph-agent-harness-golden-v1"
-        assert report["cases_total"] == 5
-        assert report["passed"] == 5
+        assert report["cases_total"] == 8
+        assert report["passed"] == 8
         assert report["failed"] == 0
         assert report["pass_rate"] == 1.0
         assert {case["case_id"] for case in report["results"]} == {
             "readonly_soc_blocks_remediation",
             "analyst_triage_records_model_metadata",
             "remediation_profile_does_not_approve_itself",
+            "approved_dry_run_records_integrity_idempotency",
+            "retryable_api_error_reuses_idempotency_key",
+            "terminal_api_error_escalates_to_human_queue",
             "llm_adapter_accepts_bounded_triage",
             "llm_adapter_rejects_forbidden_security_facts",
         }
@@ -737,7 +740,7 @@ class TestLangGraphHarnessEvals:
     def test_golden_dataset_is_valid_json(self):
         payload = json.loads(self.DATASET.read_text(encoding="utf-8"))
         assert payload["dataset_version"] == "langgraph-agent-harness-golden-v1"
-        assert len(payload["cases"]) == 5
+        assert len(payload["cases"]) == 8
 
     def test_eval_report_can_be_written_and_appended(self, tmp_path):
         report_path = tmp_path / "langgraph-harness-eval.json"


### PR DESCRIPTION
Summary
- Expands the LangGraph harness golden dataset from 5 to 8 cases.
- Adds eval checks for integrity hashes, remediation idempotency keys, approved dry-run routing, retryable API errors, terminal API errors, retry queue routing, and human escalation.
- Updates harness docs and example README to describe the expanded offline eval coverage.

Verification
- python examples/agents/eval_langgraph_harness.py --check --output /tmp/langgraph-harness-operational-eval.json --append-jsonl /tmp/langgraph-harness-operational-eval-history.jsonl
- python -m json.tool examples/agents/evals/langgraph_triage_golden.json >/dev/null
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- uv run make agent-evals
- uv run python scripts/validate_dependency_consistency.py
- git diff --check

Notes
- Unrelated local duplicate files with " 2" names were left untracked and are not part of this PR.