### PR TITLE
feat(examples): add LangGraph harness adapters

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -55,13 +55,16 @@ or audit-chain facts. The compiled LangGraph path uses conditional edges for
 HITL, retryable API errors, terminal API errors, duplicate write suppression,
 and audit/eval writeback; the offline runner mirrors those routes for tests.
 
-Model-backed triage plugs in through a bounded adapter contract. The example
-accepts only `finding_uid`, `priority`, `recommended_action`, and `rationale`
-from an optional adapter fixture; forbidden fields such as `approval`, `cvss`,
-`mitre`, `epss`, `kev`, `tenant_scope`, `idempotency_key`, or `write_intent`
-are rejected and replaced by deterministic fallback. The summary and audit
-record expose `llm_validation` plus accepted/rejected counts so operators can
-see whether model output influenced triage without letting it mutate facts.
+Model-backed triage plugs in through a bounded adapter contract in
+[`examples/agents/harness_adapters.py`](../examples/agents/harness_adapters.py).
+The graph can select deterministic fallback, a JSON fixture, or an optional
+LangChain chat-message fixture, then accepts only `finding_uid`, `priority`,
+`recommended_action`, and `rationale`; forbidden fields such as `approval`,
+`cvss`, `mitre`, `epss`, `kev`, `tenant_scope`, `idempotency_key`, or
+`write_intent` are rejected and replaced by deterministic fallback. The summary
+and audit record expose `llm_validation` plus accepted/rejected counts so
+operators can see whether model output influenced triage without letting it
+mutate facts.
 
 The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `evidence-agent`, `risk-map-agent`, `triage-agent`, `review-gate`,

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -119,6 +119,15 @@ DEMO_LLM_MODEL=triage-fixture-v1 \
 DEMO_LLM_ADAPTER_FIXTURE=/path/to/recommendations.json \
 python examples/agents/langgraph_security_graph.py
 
+# Optional LangChain adapter fixture: parses a LangChain AIMessage payload,
+# then applies the same bounded recommendation schema gate.
+uv sync --group dev --group langgraph
+DEMO_EXTERNAL_LLM_ALLOWED=yes \
+DEMO_LLM_PROVIDER=langchain \
+DEMO_LLM_MODEL=chat-model-fixture-v1 \
+DEMO_LANGCHAIN_ADAPTER_FIXTURE=/path/to/langchain-message.json \
+python examples/agents/langgraph_security_graph.py
+
 # Retryable API error path: no write intent is created without approval;
 # approved retries reuse the same remediation idempotency key.
 DEMO_APPROVE=yes \
@@ -147,6 +156,10 @@ without letting that model set policy, mappings, approvals, or audit facts. Use
 replaced by deterministic fallback. The eval runner can write a point-in-time
 JSON report and append timestamped JSONL rows so CI or operators can track
 pass-rate drift across harness, profile, and adapter changes.
+Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
+graph selects deterministic fallback, JSON fixture, or optional LangChain chat
+fixture adapters, then applies one closed schema gate before any recommendation
+enters graph state.
 
 Profile examples live under
 [`harness_profiles/`](harness_profiles/):

--- a/examples/agents/harness_adapters.py
+++ b/examples/agents/harness_adapters.py
@@ -1,0 +1,281 @@
+"""Bounded model adapters for the LangGraph SOC harness example.
+
+Adapters may rank, summarize, and draft triage recommendations. They do not
+own security facts, mappings, approval, idempotency, or audit state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Literal, Mapping, Protocol
+
+LlmMode = Literal["deterministic_offline", "external_llm_optional"]
+Priority = Literal["critical", "high", "medium", "low"]
+RecommendedAction = Literal["request_approval", "investigate", "close"]
+
+ADAPTER_ALLOWED_KEYS = {"finding_uid", "priority", "recommended_action", "rationale"}
+ADAPTER_FORBIDDEN_KEYS = {
+    "approval",
+    "audit_chain_mutation",
+    "cvss",
+    "epss",
+    "idempotency_key",
+    "kev",
+    "mitre",
+    "tenant_scope",
+    "write_intent",
+}
+ADAPTER_PRIORITIES = {"critical", "high", "medium", "low"}
+ADAPTER_ACTIONS = {"request_approval", "investigate", "close"}
+
+
+class TriageAdapter(Protocol):
+    """Adapter contract for optional model-backed triage."""
+
+    adapter_id: str
+
+    def recommendations(self) -> list[dict[str, Any]]:
+        """Return untrusted candidate recommendations."""
+
+
+def stable_hash(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_harness_config(
+    *,
+    profile_llm: Mapping[str, str] | None,
+    environ: Mapping[str, str] = os.environ,
+) -> dict[str, Any]:
+    """Describe the LLM/agent harness without requiring a live model."""
+    profile_llm = profile_llm or {}
+    mode: LlmMode = (
+        "external_llm_optional"
+        if environ.get("DEMO_EXTERNAL_LLM_ALLOWED") == "yes"
+        or profile_llm.get("mode") == "external_llm_optional"
+        else "deterministic_offline"
+    )
+    provider = environ.get("DEMO_LLM_PROVIDER") or profile_llm.get("provider", "deterministic-local")
+    model = environ.get("DEMO_LLM_MODEL") or profile_llm.get("model", "policy-bounded-triage-v1")
+    allowed_outputs = [
+        "rank_findings",
+        "summarize_evidence",
+        "draft_analyst_note",
+        "request_human_review",
+    ]
+    return {
+        "mode": mode,
+        "provider": provider,
+        "model": model,
+        "allowed_outputs": allowed_outputs,
+        "prompt_hash": stable_hash({
+            "system": "llm may rank, summarize, and draft only",
+            "forbidden": [
+                "approve",
+                "set_security_facts",
+                "change_cvss_mitre_epss_kev",
+                "call_write_tools",
+                "write_audit",
+            ],
+            "allowed_outputs": allowed_outputs,
+        })[:16],
+    }
+
+
+class DeterministicFallbackAdapter:
+    adapter_id = "deterministic_fallback"
+
+    def recommendations(self) -> list[dict[str, Any]]:
+        return []
+
+
+class FixtureTriageAdapter:
+    adapter_id = "fixture_llm_adapter"
+
+    def __init__(self, fixture_path: Path) -> None:
+        self.fixture_path = fixture_path
+
+    def recommendations(self) -> list[dict[str, Any]]:
+        payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            recommendations = payload.get("recommendations", [])
+            return [item for item in recommendations if isinstance(item, dict)]
+        return []
+
+
+class LangChainChatFixtureAdapter:
+    """Parse a LangChain chat-message fixture without calling a live model."""
+
+    adapter_id = "langchain_chat_adapter"
+
+    def __init__(self, fixture_path: Path) -> None:
+        self.fixture_path = fixture_path
+
+    def recommendations(self) -> list[dict[str, Any]]:
+        try:
+            from langchain_core.messages import AIMessage
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional group
+            raise RuntimeError(
+                "LangChain adapter requires `uv sync --group langgraph` "
+                "so langchain-core is available."
+            ) from exc
+
+        message = AIMessage(content=self.fixture_path.read_text(encoding="utf-8"))
+        payload = json.loads(str(message.content))
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            recommendations = payload.get("recommendations", [])
+            return [item for item in recommendations if isinstance(item, dict)]
+        return []
+
+
+def select_triage_adapter(
+    *,
+    harness_config: Mapping[str, Any],
+    environ: Mapping[str, str] = os.environ,
+) -> TriageAdapter:
+    """Select the optional adapter without granting it extra authority."""
+    langchain_fixture = environ.get("DEMO_LANGCHAIN_ADAPTER_FIXTURE")
+    if langchain_fixture:
+        return LangChainChatFixtureAdapter(Path(langchain_fixture))
+
+    fixture_path = environ.get("DEMO_LLM_ADAPTER_FIXTURE")
+    if fixture_path:
+        return FixtureTriageAdapter(Path(fixture_path))
+
+    if harness_config.get("provider") == "langchain":
+        return DeterministicFallbackAdapter()
+
+    return DeterministicFallbackAdapter()
+
+
+def deterministic_triage_recommendation(
+    *,
+    finding_uid: str,
+    mapped: Mapping[str, Any],
+    confidence: float,
+    harness_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    recommended_action: RecommendedAction = (
+        "request_approval" if confidence >= 0.90 else "investigate"
+    )
+    priority: Priority = "high" if mapped["cvss"]["base_score"] >= 7.0 else "medium"
+    recommendation_payload = {
+        "finding_uid": finding_uid,
+        "priority": priority,
+        "recommended_action": recommended_action,
+        "confidence": confidence,
+        "provider": harness_config["provider"],
+        "model": harness_config["model"],
+    }
+    return {
+        "finding_uid": finding_uid,
+        "priority": priority,
+        "recommended_action": recommended_action,
+        "rationale": "Deterministic triage from rule confidence, CVSS, EPSS, and mapping coverage.",
+        "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
+        "output_hash": stable_hash(recommendation_payload)[:16],
+    }
+
+
+def validate_adapter_recommendation(
+    *,
+    candidate: Mapping[str, Any] | None,
+    fallback: Mapping[str, Any],
+    finding_uid: str,
+    harness_config: Mapping[str, Any],
+    adapter_id: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not candidate:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": "deterministic_fallback",
+            "status": "fallback",
+            "reason": "no_adapter_output",
+            "output_hash": fallback["output_hash"],
+        }
+
+    output_hash = stable_hash(candidate)[:16]
+    forbidden = sorted(key for key in candidate if key in ADAPTER_FORBIDDEN_KEYS)
+    extra = sorted(key for key in candidate if key not in ADAPTER_ALLOWED_KEYS)
+    if forbidden:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": adapter_id,
+            "status": "rejected",
+            "reason": f"forbidden_output:{','.join(forbidden)}",
+            "output_hash": output_hash,
+        }
+    if extra:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": adapter_id,
+            "status": "rejected",
+            "reason": f"unknown_output:{','.join(extra)}",
+            "output_hash": output_hash,
+        }
+    if candidate.get("finding_uid") != finding_uid:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": adapter_id,
+            "status": "rejected",
+            "reason": "finding_uid_mismatch",
+            "output_hash": output_hash,
+        }
+    if candidate.get("priority") not in ADAPTER_PRIORITIES:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": adapter_id,
+            "status": "rejected",
+            "reason": "invalid_priority",
+            "output_hash": output_hash,
+        }
+    if candidate.get("recommended_action") not in ADAPTER_ACTIONS:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": adapter_id,
+            "status": "rejected",
+            "reason": "invalid_recommended_action",
+            "output_hash": output_hash,
+        }
+
+    rationale = str(candidate.get("rationale") or "").strip()
+    if not rationale:
+        return dict(fallback), {
+            "finding_uid": finding_uid,
+            "adapter": adapter_id,
+            "status": "rejected",
+            "reason": "missing_rationale",
+            "output_hash": output_hash,
+        }
+
+    recommendation_payload = {
+        "finding_uid": finding_uid,
+        "priority": candidate["priority"],
+        "recommended_action": candidate["recommended_action"],
+        "rationale": rationale,
+        "provider": harness_config["provider"],
+        "model": harness_config["model"],
+    }
+    accepted = {
+        "finding_uid": finding_uid,
+        "priority": candidate["priority"],
+        "recommended_action": candidate["recommended_action"],
+        "rationale": rationale,
+        "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
+        "output_hash": stable_hash(recommendation_payload)[:16],
+    }
+    return accepted, {
+        "finding_uid": finding_uid,
+        "adapter": adapter_id,
+        "status": "accepted",
+        "reason": "schema_valid",
+        "output_hash": output_hash,
+    }

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -33,6 +33,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
+from harness_adapters import (
+    build_harness_config,
+    deterministic_triage_recommendation,
+    select_triage_adapter,
+    validate_adapter_recommendation,
+)
+
 ALLOWED_SKILLS_READ_ONLY_LIST = [
     "ingest-cloudtrail-ocsf",
     "source-snowflake-query",
@@ -414,193 +421,7 @@ def _record_agent_run(
 def _agent_harness_config(state: GraphState) -> AgentHarnessConfig:
     """Describe the LLM/agent harness without requiring a live model."""
     profile_llm = (state.get("harness_profile") or {}).get("llm", {})
-    mode: LlmMode = (
-        "external_llm_optional"
-        if os.environ.get("DEMO_EXTERNAL_LLM_ALLOWED") == "yes"
-        or profile_llm.get("mode") == "external_llm_optional"
-        else "deterministic_offline"
-    )
-    provider = os.environ.get("DEMO_LLM_PROVIDER") or profile_llm.get("provider", "deterministic-local")
-    model = os.environ.get("DEMO_LLM_MODEL") or profile_llm.get("model", "policy-bounded-triage-v1")
-    allowed_outputs = [
-        "rank_findings",
-        "summarize_evidence",
-        "draft_analyst_note",
-        "request_human_review",
-    ]
-    return {
-        "mode": mode,
-        "provider": provider,
-        "model": model,
-        "allowed_outputs": allowed_outputs,
-        "prompt_hash": _stable_hash({
-            "system": "llm may rank, summarize, and draft only",
-            "forbidden": [
-                "approve",
-                "set_security_facts",
-                "change_cvss_mitre_epss_kev",
-                "call_write_tools",
-                "write_audit",
-            ],
-            "allowed_outputs": allowed_outputs,
-        })[:16],
-    }
-
-
-LLM_ADAPTER_ALLOWED_KEYS = {"finding_uid", "priority", "recommended_action", "rationale"}
-LLM_ADAPTER_FORBIDDEN_KEYS = {
-    "approval",
-    "audit_chain_mutation",
-    "cvss",
-    "epss",
-    "idempotency_key",
-    "kev",
-    "mitre",
-    "tenant_scope",
-    "write_intent",
-}
-LLM_ADAPTER_PRIORITIES = {"critical", "high", "medium", "low"}
-LLM_ADAPTER_ACTIONS = {"request_approval", "investigate", "close"}
-
-
-def _load_llm_adapter_recommendations() -> list[dict[str, Any]]:
-    """Load an optional model-output fixture without requiring a live model."""
-    fixture_path = os.environ.get("DEMO_LLM_ADAPTER_FIXTURE")
-    if not fixture_path:
-        return []
-    payload = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
-    if isinstance(payload, list):
-        return payload
-    if isinstance(payload, dict):
-        recommendations = payload.get("recommendations", [])
-        return recommendations if isinstance(recommendations, list) else []
-    return []
-
-
-def _deterministic_triage_recommendation(
-    *,
-    finding_uid: str,
-    mapped: FrameworkMap,
-    confidence: float,
-    harness_config: AgentHarnessConfig,
-) -> AgentRecommendation:
-    recommended_action: Literal["request_approval", "investigate", "close"] = (
-        "request_approval" if confidence >= 0.90 else "investigate"
-    )
-    priority: Literal["critical", "high", "medium", "low"] = (
-        "high" if mapped["cvss"]["base_score"] >= 7.0 else "medium"
-    )
-    recommendation_payload = {
-        "finding_uid": finding_uid,
-        "priority": priority,
-        "recommended_action": recommended_action,
-        "confidence": confidence,
-        "provider": harness_config["provider"],
-        "model": harness_config["model"],
-    }
-    return {
-        "finding_uid": finding_uid,
-        "priority": priority,
-        "recommended_action": recommended_action,
-        "rationale": "Deterministic triage from rule confidence, CVSS, EPSS, and mapping coverage.",
-        "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
-        "output_hash": _stable_hash(recommendation_payload)[:16],
-    }
-
-
-def _validate_llm_adapter_recommendation(
-    *,
-    candidate: dict[str, Any] | None,
-    fallback: AgentRecommendation,
-    finding_uid: str,
-    harness_config: AgentHarnessConfig,
-) -> tuple[AgentRecommendation, LlmValidationRecord]:
-    if not candidate:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "deterministic_fallback",
-            "status": "fallback",
-            "reason": "no_adapter_output",
-            "output_hash": fallback["output_hash"],
-        }
-
-    output_hash = _stable_hash(candidate)[:16]
-    forbidden = sorted(key for key in candidate if key in LLM_ADAPTER_FORBIDDEN_KEYS)
-    extra = sorted(key for key in candidate if key not in LLM_ADAPTER_ALLOWED_KEYS)
-    if forbidden:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "fixture_llm_adapter",
-            "status": "rejected",
-            "reason": f"forbidden_output:{','.join(forbidden)}",
-            "output_hash": output_hash,
-        }
-    if extra:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "fixture_llm_adapter",
-            "status": "rejected",
-            "reason": f"unknown_output:{','.join(extra)}",
-            "output_hash": output_hash,
-        }
-    if candidate.get("finding_uid") != finding_uid:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "fixture_llm_adapter",
-            "status": "rejected",
-            "reason": "finding_uid_mismatch",
-            "output_hash": output_hash,
-        }
-    if candidate.get("priority") not in LLM_ADAPTER_PRIORITIES:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "fixture_llm_adapter",
-            "status": "rejected",
-            "reason": "invalid_priority",
-            "output_hash": output_hash,
-        }
-    if candidate.get("recommended_action") not in LLM_ADAPTER_ACTIONS:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "fixture_llm_adapter",
-            "status": "rejected",
-            "reason": "invalid_recommended_action",
-            "output_hash": output_hash,
-        }
-
-    rationale = str(candidate.get("rationale") or "").strip()
-    if not rationale:
-        return fallback, {
-            "finding_uid": finding_uid,
-            "adapter": "fixture_llm_adapter",
-            "status": "rejected",
-            "reason": "missing_rationale",
-            "output_hash": output_hash,
-        }
-
-    recommendation_payload = {
-        "finding_uid": finding_uid,
-        "priority": candidate["priority"],
-        "recommended_action": candidate["recommended_action"],
-        "rationale": rationale,
-        "provider": harness_config["provider"],
-        "model": harness_config["model"],
-    }
-    accepted: AgentRecommendation = {
-        "finding_uid": finding_uid,
-        "priority": candidate["priority"],
-        "recommended_action": candidate["recommended_action"],
-        "rationale": rationale,
-        "generated_by": f"{harness_config['provider']}:{harness_config['model']}",
-        "output_hash": _stable_hash(recommendation_payload)[:16],
-    }
-    return accepted, {
-        "finding_uid": finding_uid,
-        "adapter": "fixture_llm_adapter",
-        "status": "accepted",
-        "reason": "schema_valid",
-        "output_hash": output_hash,
-    }
+    return build_harness_config(profile_llm=profile_llm, environ=os.environ)
 
 
 def _classify_api_error(status_code: int) -> ApiErrorClassification:
@@ -816,9 +637,10 @@ def llm_triage_node(state: GraphState) -> GraphState:
     """Bounded agent layer: rank and summarize only, never decide facts."""
     _append_trace(state, "llm_triage")
     harness_config = _agent_harness_config(state)
+    adapter = select_triage_adapter(harness_config=harness_config, environ=os.environ)
     adapter_recommendations = {
         recommendation.get("finding_uid"): recommendation
-        for recommendation in _load_llm_adapter_recommendations()
+        for recommendation in adapter.recommendations()
         if isinstance(recommendation, dict)
     }
     confidence_by_uid = {
@@ -830,17 +652,18 @@ def llm_triage_node(state: GraphState) -> GraphState:
     for mapped in state.get("framework_maps") or []:
         finding_uid = mapped["finding_uid"]
         confidence = confidence_by_uid.get(finding_uid, 0.0)
-        fallback = _deterministic_triage_recommendation(
+        fallback = deterministic_triage_recommendation(
             finding_uid=finding_uid,
             mapped=mapped,
             confidence=confidence,
             harness_config=harness_config,
         )
-        recommendation, validation = _validate_llm_adapter_recommendation(
+        recommendation, validation = validate_adapter_recommendation(
             candidate=adapter_recommendations.get(finding_uid),
             fallback=fallback,
             finding_uid=finding_uid,
             harness_config=harness_config,
+            adapter_id=adapter.adapter_id,
         )
         recommendations.append(recommendation)
         validation_records.append(validation)

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -437,6 +437,36 @@ class TestLangGraphSocWorkflow:
         assert summary["audit"]["llm_adapter_accepted"] == 1
         assert summary["audit"]["llm_adapter_rejected"] == 0
 
+    def test_langchain_adapter_accepts_bounded_chat_message(self, tmp_path: Path):
+        pytest.importorskip("langchain_core.messages")
+        baseline, _ = self._run()
+        finding_uid = baseline["framework_maps"][0]["finding_uid"]
+        fixture = tmp_path / "langchain-message-output.json"
+        fixture.write_text(json.dumps({
+            "recommendations": [
+                {
+                    "finding_uid": finding_uid,
+                    "priority": "critical",
+                    "recommended_action": "request_approval",
+                    "rationale": "LangChain fixture ranks this for immediate analyst review.",
+                },
+            ],
+        }), encoding="utf-8")
+
+        summary, _ = self._run(extra_env={
+            "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+            "DEMO_LLM_PROVIDER": "langchain",
+            "DEMO_LLM_MODEL": "chat-model-fixture-v1",
+            "DEMO_LANGCHAIN_ADAPTER_FIXTURE": str(fixture),
+        })
+
+        recommendation = summary["agent_recommendations"][0]
+        assert recommendation["priority"] == "critical"
+        assert recommendation["generated_by"] == "langchain:chat-model-fixture-v1"
+        assert summary["llm_validation"][0]["adapter"] == "langchain_chat_adapter"
+        assert summary["llm_validation"][0]["status"] == "accepted"
+        assert summary["audit"]["llm_adapter_accepted"] == 1
+
     def test_llm_adapter_rejects_forbidden_security_facts(self, tmp_path: Path):
         baseline, _ = self._run()
         finding_uid = baseline["framework_maps"][0]["finding_uid"]


### PR DESCRIPTION
Summary
- Extracts bounded triage/model plumbing into examples/agents/harness_adapters.py.
- Adds deterministic fallback, JSON fixture, and optional LangChain chat-message fixture adapters behind one selector.
- Keeps the LangGraph node focused on orchestration and runs every adapter candidate through the same closed recommendation schema gate.
- Documents the LangChain adapter fixture path and adds regression coverage.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python examples/agents/eval_langgraph_harness.py --check --output /tmp/langgraph-harness-adapters-eval.json --append-jsonl /tmp/langgraph-harness-adapters-eval-history.jsonl
- uv run make agent-evals
- uv run python scripts/validate_dependency_consistency.py
- git diff --check
- python -m py_compile examples/agents/harness_adapters.py examples/agents/langgraph_security_graph.py examples/agents/eval_langgraph_harness.py

Notes
- No new dependency is added; the optional LangChain fixture path uses langchain-core from the existing langgraph dependency group.
- Unrelated local duplicate files with " 2" names were left untracked and are not part of this PR.