### PR TITLE
feat(examples): add LangGraph checkpoint replay

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -72,6 +72,21 @@ The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `audit-writer`. Each run carries an authority label plus input/output hashes
 so replay can detect drift without trusting prompt text.
 
+The same example can persist a checkpoint artifact after writeback:
+
+```bash
+DEMO_CHECKPOINT_PATH=artifacts/langgraph-checkpoint.json \
+python examples/agents/langgraph_security_graph.py
+
+DEMO_REPLAY_CHECKPOINT=artifacts/langgraph-checkpoint.json \
+python examples/agents/langgraph_security_graph.py
+```
+
+The artifact stores `schema_version=langgraph-soc-checkpoint-v1`, final graph
+state, `state_hash`, `summary_hash`, and `checkpoint_hash`. Replay verifies
+those hashes before returning the operator-facing summary and does not re-run
+graph nodes or tool calls.
+
 Eval fixtures live under
 [`examples/agents/evals/`](../examples/agents/evals/). The offline gate
 replays golden profile and triage cases through the same graph, checks bounded

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -134,6 +134,13 @@ DEMO_APPROVE=yes \
 DEMO_API_ERROR_STATUS=429 \
 python examples/agents/langgraph_security_graph.py
 
+# Checkpoint artifact: persist the final graph state with stable hashes,
+# then replay the same summary offline without re-running graph nodes.
+DEMO_CHECKPOINT_PATH=artifacts/langgraph-checkpoint.json \
+python examples/agents/langgraph_security_graph.py
+DEMO_REPLAY_CHECKPOINT=artifacts/langgraph-checkpoint.json \
+python examples/agents/langgraph_security_graph.py
+
 # Offline eval gate: replay golden profile, triage, integrity,
 # idempotency, and API-error cases and fail on drift.
 python examples/agents/eval_langgraph_harness.py --check
@@ -160,6 +167,9 @@ Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
 graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation
 enters graph state.
+Checkpoint artifacts use `langgraph-soc-checkpoint-v1`, include the final
+state, `state_hash`, `summary_hash`, and `checkpoint_hash`, and replay only
+after those hashes verify.
 
 Profile examples live under
 [`harness_profiles/`](harness_profiles/):

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -21,6 +21,8 @@ Run:
     python examples/agents/langgraph_security_graph.py
     DEMO_APPROVE=yes python examples/agents/langgraph_security_graph.py
     DEMO_LANGGRAPH_RUNTIME=yes python examples/agents/langgraph_security_graph.py
+    DEMO_CHECKPOINT_PATH=/tmp/langgraph-checkpoint.json python examples/agents/langgraph_security_graph.py
+    DEMO_REPLAY_CHECKPOINT=/tmp/langgraph-checkpoint.json python examples/agents/langgraph_security_graph.py
 """
 
 from __future__ import annotations
@@ -70,6 +72,7 @@ LlmMode = Literal["deterministic_offline", "external_llm_optional"]
 ReviewRoute = Literal["remediate", "writeback"]
 RemediationRoute = Literal["retry_queue", "escalate", "writeback"]
 AgentKind = Literal["deterministic_skill", "llm_optional", "human_gate", "governance"]
+CHECKPOINT_SCHEMA_VERSION = "langgraph-soc-checkpoint-v1"
 
 
 class CallerContext(TypedDict):
@@ -1135,17 +1138,77 @@ def summarize(final: GraphState) -> dict[str, Any]:
     }
 
 
-def main() -> int:
-    profile = load_harness_profile()
-    initial: GraphState = {
-        "harness_profile": profile,
-        "caller_context": profile["caller_context"],
-        "raw_events": [{"source": "demo"}],
+def _checkpoint_payload(final: GraphState) -> dict[str, Any]:
+    """Build a replayable state artifact with stable hashes."""
+    summary = summarize(final)
+    state = dict(final)
+    payload = {
+        "event": "langgraph_soc_checkpoint",
+        "schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "profile_id": (final.get("harness_profile") or {}).get("profile_id"),
+        "trace": final.get("trace"),
+        "state_hash": (final.get("integrity") or {}).get("state_hash"),
+        "summary_hash": _stable_hash(summary),
+        "state": state,
     }
-    if os.environ.get("DEMO_LANGGRAPH_RUNTIME") == "yes":
-        final = run_langgraph(initial)
+    payload["checkpoint_hash"] = _stable_hash(payload)
+    return payload
+
+
+def write_checkpoint(final: GraphState, checkpoint_path: Path) -> dict[str, Any]:
+    """Persist a replay artifact for offline audit and regression checks."""
+    payload = _checkpoint_payload(final)
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {
+        "path": str(checkpoint_path),
+        "checkpoint_hash": payload["checkpoint_hash"],
+        "state_hash": payload["state_hash"],
+        "summary_hash": payload["summary_hash"],
+    }
+
+
+def load_checkpoint(checkpoint_path: Path) -> GraphState:
+    """Load and verify a checkpoint artifact without re-running graph nodes."""
+    payload = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    expected_hash = payload.get("checkpoint_hash")
+    unsigned_payload = dict(payload)
+    unsigned_payload.pop("checkpoint_hash", None)
+    if payload.get("event") != "langgraph_soc_checkpoint":
+        raise ValueError("checkpoint event must be langgraph_soc_checkpoint")
+    if payload.get("schema_version") != CHECKPOINT_SCHEMA_VERSION:
+        raise ValueError(f"unsupported checkpoint schema: {payload.get('schema_version')}")
+    if _stable_hash(unsigned_payload) != expected_hash:
+        raise ValueError("checkpoint_hash mismatch")
+    state = payload.get("state")
+    if not isinstance(state, dict):
+        raise ValueError("checkpoint state must be an object")
+    summary_hash = _stable_hash(summarize(state))
+    if summary_hash != payload.get("summary_hash"):
+        raise ValueError("checkpoint summary_hash mismatch")
+    state_hash = (state.get("integrity") or {}).get("state_hash")
+    if state_hash != payload.get("state_hash"):
+        raise ValueError("checkpoint state_hash mismatch")
+    return state
+
+
+def main() -> int:
+    replay_path = os.environ.get("DEMO_REPLAY_CHECKPOINT")
+    if replay_path:
+        final = load_checkpoint(Path(replay_path))
     else:
-        final = run_graph(initial)
+        profile = load_harness_profile()
+        initial: GraphState = {
+            "harness_profile": profile,
+            "caller_context": profile["caller_context"],
+            "raw_events": [{"source": "demo"}],
+        }
+        if os.environ.get("DEMO_LANGGRAPH_RUNTIME") == "yes":
+            final = run_langgraph(initial)
+        else:
+            final = run_graph(initial)
+        if checkpoint_path := os.environ.get("DEMO_CHECKPOINT_PATH"):
+            write_checkpoint(final, Path(checkpoint_path))
     print(json.dumps(summarize(final), indent=2))
     return 0
 

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -672,6 +672,66 @@ class TestLangGraphSocWorkflow:
         assert "retry_queue" in summary["trace"]
         assert summary["audit"]["route"]["after_remediation"] == "retry_queue"
 
+    def test_checkpoint_artifact_replays_same_summary(self, tmp_path: Path):
+        checkpoint = tmp_path / "langgraph-checkpoint.json"
+        env = {**os.environ, "DEMO_CHECKPOINT_PATH": str(checkpoint)}
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        original_summary = json.loads(result.stdout)
+        payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+        assert payload["event"] == "langgraph_soc_checkpoint"
+        assert payload["schema_version"] == "langgraph-soc-checkpoint-v1"
+        assert payload["state_hash"] == original_summary["integrity"]["state_hash"]
+        assert payload["checkpoint_hash"]
+        assert payload["summary_hash"]
+
+        replay_env = {**os.environ, "DEMO_REPLAY_CHECKPOINT": str(checkpoint)}
+        replay = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=replay_env,
+        )
+        assert replay.returncode == 0, replay.stderr
+        assert json.loads(replay.stdout) == original_summary
+        assert replay.stderr == ""
+
+    def test_checkpoint_replay_rejects_tampered_state(self, tmp_path: Path):
+        checkpoint = tmp_path / "langgraph-checkpoint.json"
+        env = {**os.environ, "DEMO_CHECKPOINT_PATH": str(checkpoint)}
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+        payload["state"]["trace"].append("tampered")
+        checkpoint.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        replay = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env={**os.environ, "DEMO_REPLAY_CHECKPOINT": str(checkpoint)},
+        )
+        assert replay.returncode != 0
+        assert "checkpoint_hash mismatch" in replay.stderr
+
     def test_stategraph_builder_is_present_without_importing_dependency(self):
         text = self.SCRIPT.read_text(encoding="utf-8")
         assert "StateGraph(GraphState)" in text


### PR DESCRIPTION
Summary
- Add signed LangGraph SOC checkpoint artifacts with stable state, summary, and checkpoint hashes.
- Add offline replay mode that verifies checkpoint integrity before returning the summary without re-running graph nodes.
- Document checkpoint/replay commands in the harness and examples docs.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/harness_adapters.py examples/agents/langgraph_security_graph.py examples/agents/eval_langgraph_harness.py
- DEMO_CHECKPOINT_PATH=/tmp/langgraph-checkpoint.json python examples/agents/langgraph_security_graph.py; DEMO_REPLAY_CHECKPOINT=/tmp/langgraph-checkpoint.json python examples/agents/langgraph_security_graph.py; semantic JSON summaries match
- uv run make agent-evals
- uv run python scripts/validate_dependency_consistency.py
- git diff --check

Notes
- Unrelated duplicate local files ending in " 2" are not included.