### PR TITLE
feat(examples): expose LangGraph pipeline contract

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -71,6 +71,10 @@ The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `remediation-planner`, `retry-coordinator`, `escalation-agent`, and
 `audit-writer`. Each run carries an authority label plus input/output hashes
 so replay can detect drift without trusting prompt text.
+The operator-facing summary also emits `pipeline_contract`, a code-backed list
+of nodes, edges, route conditions, skills, input/output state keys, and
+guardrails for approval, dry-run remediation, retries, idempotency, and audit
+writeback.
 
 The same example can persist a checkpoint artifact after writeback:
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -167,7 +167,8 @@ The LangGraph summary includes `integrity.evidence_hash`,
 `integrity.state_hash`, stable workflow/remediation idempotency keys, and
 retryable-vs-terminal API error classification. It also includes the
 `profile`, `effective_allowed_skills`, `harness` provider/model/mode, `agents`
-manifest, `agent_runs` ledger, and bounded `agent_recommendations` so
+manifest, `pipeline_contract`, `agent_runs` ledger, and bounded
+`agent_recommendations` so
 operators can see which role and model would have drafted the analyst note
 without letting that model set policy, mappings, approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
@@ -175,6 +176,9 @@ without letting that model set policy, mappings, approvals, or audit facts. Use
 replaced by deterministic fallback. The eval runner can write a point-in-time
 JSON report and append timestamped JSONL rows so CI or operators can track
 pass-rate drift across harness, profile, and adapter changes.
+`pipeline_contract` is code-backed topology metadata: node ownership, skills,
+input/output state keys, conditional edges, and guardrails for dry-run,
+approval, retries, idempotency, and audit writeback.
 Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
 graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -156,6 +156,21 @@ class AgentDefinition(TypedDict):
     forbidden_outputs: list[str]
 
 
+class PipelineNodeContract(TypedDict):
+    node: WorkflowStage
+    agent_id: str
+    skills: list[str]
+    inputs: list[str]
+    outputs: list[str]
+    guardrails: list[str]
+
+
+class PipelineEdgeContract(TypedDict):
+    source: WorkflowStage
+    target: WorkflowStage
+    condition: str
+
+
 class AgentRunRecord(TypedDict):
     run_id: str
     agent_id: str
@@ -391,6 +406,142 @@ def _agent_manifest() -> list[AgentDefinition]:
             "forbidden_outputs": ["overwrite_history", "remove_agent_run"],
         },
     ]
+
+
+def _pipeline_node_contracts() -> list[PipelineNodeContract]:
+    return [
+        {
+            "node": "ingest",
+            "agent_id": "evidence-agent",
+            "skills": ["ingest-cloudtrail-ocsf", "source-snowflake-query"],
+            "inputs": ["harness_profile", "caller_context", "raw_events"],
+            "outputs": ["effective_allowed_skills", "raw_events"],
+            "guardrails": ["allowlist_intersection", "no_credentials_in_profile"],
+        },
+        {
+            "node": "normalize",
+            "agent_id": "evidence-agent",
+            "skills": ["ingest-cloudtrail-ocsf"],
+            "inputs": ["raw_events"],
+            "outputs": ["ocsf_events", "integrity.evidence_hash", "idempotency.workflow_key"],
+            "guardrails": ["ocsf_1_8_shape", "stable_event_uid", "state_hash_input"],
+        },
+        {
+            "node": "enrich",
+            "agent_id": "evidence-agent",
+            "skills": ["detect-lateral-movement"],
+            "inputs": ["ocsf_events"],
+            "outputs": ["findings", "enrichments"],
+            "guardrails": ["deterministic_finding_uid", "no_llm_security_facts"],
+        },
+        {
+            "node": "correlate",
+            "agent_id": "evidence-agent",
+            "skills": ["discover-control-evidence"],
+            "inputs": ["raw_events", "ocsf_events", "findings"],
+            "outputs": ["correlations", "agent_runs"],
+            "guardrails": ["identity_resource_join", "agent_run_hashes"],
+        },
+        {
+            "node": "confidence",
+            "agent_id": "risk-map-agent",
+            "skills": ["detect-lateral-movement"],
+            "inputs": ["findings", "enrichments"],
+            "outputs": ["confidence_scores"],
+            "guardrails": ["deterministic_reason_codes", "no_model_belief_score"],
+        },
+        {
+            "node": "map",
+            "agent_id": "risk-map-agent",
+            "skills": ["cspm-aws-cis-benchmark"],
+            "inputs": ["findings", "enrichments"],
+            "outputs": ["framework_maps"],
+            "guardrails": ["mitre_cvss_epss_kev_from_rules", "no_llm_mapping_mutation"],
+        },
+        {
+            "node": "llm_triage",
+            "agent_id": "triage-agent",
+            "skills": [],
+            "inputs": ["framework_maps", "confidence_scores", "harness_profile.llm"],
+            "outputs": ["agent_recommendations", "llm_validation", "agent_runs"],
+            "guardrails": ["closed_adapter_schema", "rank_summarize_draft_only", "fallback_closed"],
+        },
+        {
+            "node": "review",
+            "agent_id": "review-gate",
+            "skills": [],
+            "inputs": ["agent_recommendations", "approval_context"],
+            "outputs": ["review_decision"],
+            "guardrails": ["human_gate_required", "no_model_attested_approval"],
+        },
+        {
+            "node": "remediate",
+            "agent_id": "remediation-planner",
+            "skills": [ALLOWED_SKILLS_REMEDIATION],
+            "inputs": ["review_decision", "framework_maps", "confidence_scores", "idempotency"],
+            "outputs": ["remediation_result", "api_errors", "idempotency.remediation_key"],
+            "guardrails": ["dry_run_default", "approval_context_required", "stable_idempotency_key"],
+        },
+        {
+            "node": "retry_queue",
+            "agent_id": "retry-coordinator",
+            "skills": [],
+            "inputs": ["api_errors", "remediation_result"],
+            "outputs": ["retry_record", "agent_runs"],
+            "guardrails": ["bounded_retries", "reuse_idempotency_key", "retryable_errors_only"],
+        },
+        {
+            "node": "escalate",
+            "agent_id": "escalation-agent",
+            "skills": [],
+            "inputs": ["api_errors", "remediation_result"],
+            "outputs": ["escalation_record", "agent_runs"],
+            "guardrails": ["terminal_errors_to_human_queue", "no_auto_apply"],
+        },
+        {
+            "node": "writeback",
+            "agent_id": "audit-writer",
+            "skills": ["convert-ocsf-to-sarif"],
+            "inputs": ["trace", "agent_runs", "integrity", "idempotency", "api_errors"],
+            "outputs": ["audit_record", "eval_record", "integrity.state_hash"],
+            "guardrails": ["append_only_audit", "state_hash", "eval_writeback"],
+        },
+    ]
+
+
+def _pipeline_edge_contracts() -> list[PipelineEdgeContract]:
+    return [
+        {"source": "ingest", "target": "normalize", "condition": "always"},
+        {"source": "normalize", "target": "enrich", "condition": "always"},
+        {"source": "enrich", "target": "correlate", "condition": "always"},
+        {"source": "correlate", "target": "confidence", "condition": "always"},
+        {"source": "confidence", "target": "map", "condition": "always"},
+        {"source": "map", "target": "llm_triage", "condition": "always"},
+        {"source": "llm_triage", "target": "review", "condition": "always"},
+        {"source": "review", "target": "remediate", "condition": "route_after_review == remediate"},
+        {"source": "review", "target": "writeback", "condition": "route_after_review == writeback"},
+        {"source": "remediate", "target": "retry_queue", "condition": "route_after_remediation == retry_queue"},
+        {"source": "remediate", "target": "escalate", "condition": "route_after_remediation == escalate"},
+        {"source": "remediate", "target": "writeback", "condition": "route_after_remediation == writeback"},
+        {"source": "retry_queue", "target": "writeback", "condition": "always"},
+        {"source": "escalate", "target": "writeback", "condition": "always"},
+    ]
+
+
+def pipeline_contract() -> dict[str, Any]:
+    return {
+        "schema_version": "langgraph-soc-pipeline-contract-v1",
+        "description": "Code-backed LangGraph SOC workflow contract for nodes, edges, skills, and guardrails.",
+        "nodes": _pipeline_node_contracts(),
+        "edges": _pipeline_edge_contracts(),
+        "invariants": [
+            "skills own facts; LangGraph owns routing and state",
+            "LLM adapters can rank, summarize, draft, or request review only",
+            "remediation is dry-run-only and requires human approval context",
+            "API errors route to retry_queue only when classified retryable",
+            "audit/eval writeback records state_hash and idempotency keys",
+        ],
+    }
 
 
 def _agent_by_id(agent_id: str) -> AgentDefinition:
@@ -1122,6 +1273,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "confidence_scores": final.get("confidence_scores"),
         "framework_maps": final.get("framework_maps"),
         "harness": final.get("harness_config"),
+        "pipeline_contract": pipeline_contract(),
         "agents": final.get("agent_manifest"),
         "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -338,6 +338,46 @@ class TestLangGraphSocWorkflow:
         assert framework_map["epss_percentile"] == 0.91
         assert framework_map["kev_listed"] is False
 
+    def test_pipeline_contract_exposes_nodes_edges_and_guardrails(self):
+        summary, _ = self._run()
+        contract = summary["pipeline_contract"]
+        assert contract["schema_version"] == "langgraph-soc-pipeline-contract-v1"
+        node_names = [node["node"] for node in contract["nodes"]]
+        assert node_names == [
+            "ingest",
+            "normalize",
+            "enrich",
+            "correlate",
+            "confidence",
+            "map",
+            "llm_triage",
+            "review",
+            "remediate",
+            "retry_queue",
+            "escalate",
+            "writeback",
+        ]
+        assert {node["agent_id"] for node in contract["nodes"]} == set(self.EXPECTED_AGENT_IDS)
+        assert all(node["guardrails"] for node in contract["nodes"])
+
+        edge_pairs = {
+            (edge["source"], edge["target"], edge["condition"])
+            for edge in contract["edges"]
+        }
+        assert ("review", "remediate", "route_after_review == remediate") in edge_pairs
+        assert ("review", "writeback", "route_after_review == writeback") in edge_pairs
+        assert ("remediate", "retry_queue", "route_after_remediation == retry_queue") in edge_pairs
+        assert ("remediate", "escalate", "route_after_remediation == escalate") in edge_pairs
+        assert ("remediate", "writeback", "route_after_remediation == writeback") in edge_pairs
+
+        remediation_node = next(node for node in contract["nodes"] if node["node"] == "remediate")
+        assert remediation_node["skills"] == ["iam-departures-aws"]
+        assert "dry_run_default" in remediation_node["guardrails"]
+        triage_node = next(node for node in contract["nodes"] if node["node"] == "llm_triage")
+        assert triage_node["skills"] == []
+        assert "closed_adapter_schema" in triage_node["guardrails"]
+        assert "LLM adapters can rank, summarize, draft, or request review only" in contract["invariants"]
+
     def test_no_approval_blocks_remediation_but_writes_audit_and_eval(self):
         summary, result = self._run()
         assert summary["review"]["status"] == "blocked"


### PR DESCRIPTION
Summary
- Add a code-backed LangGraph SOC pipeline contract with node ownership, skills, state inputs/outputs, guardrails, and conditional edges.
- Emit the contract in the operator-facing summary so diagrams and docs can be checked against runnable code.
- Document the contract and add regression coverage for nodes, edge conditions, and guardrails.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_adapters.py examples/agents/eval_langgraph_harness.py examples/agents/configure_langgraph_harness.py
- uv run make agent-evals
- git diff --check

Notes
- Unrelated duplicate local files ending in " 2" are not included.