### PR TITLE
feat(examples): add LangGraph pipeline contract schema

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -128,8 +128,9 @@ store cloud secrets and they do not grant approval. A remediation profile can
 make a dry-run skill visible, but the graph still needs `_approval_context`
 from the operator's IDP or ticketing workflow before routing to remediation.
 Closed JSON Schema contracts live under
-[`examples/agents/schemas/`](../examples/agents/schemas/) for both harness
-profiles and LLM adapter recommendation payloads.
+[`examples/agents/schemas/`](../examples/agents/schemas/) for harness
+profiles, LLM adapter recommendation payloads, and the emitted
+`pipeline_contract` topology.
 
 ## Customization knobs
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -202,8 +202,8 @@ Profile examples live under
 | `dry-run-remediation.json` | exposes remediation planning, but still requires `DEMO_APPROVE=yes` / approval context |
 
 Contract schemas live under [`schemas/`](schemas/). They define the closed
-shape for harness profiles and the LLM adapter recommendation payload accepted
-by the reference graph.
+shape for harness profiles, the LLM adapter recommendation payload accepted by
+the reference graph, and the emitted `pipeline_contract` topology.
 
 Use [`configure_langgraph_harness.py`](configure_langgraph_harness.py) when
 customizing the harness for a buyer or internal environment. It asks for role,

--- a/examples/agents/schemas/pipeline_contract.schema.json
+++ b/examples/agents/schemas/pipeline_contract.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/pipeline_contract.schema.json",
+  "title": "LangGraph SOC pipeline contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "description",
+    "nodes",
+    "edges",
+    "invariants"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "langgraph-soc-pipeline-contract-v1"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "node",
+          "agent_id",
+          "skills",
+          "inputs",
+          "outputs",
+          "guardrails"
+        ],
+        "properties": {
+          "node": {
+            "type": "string",
+            "enum": [
+              "ingest",
+              "normalize",
+              "enrich",
+              "correlate",
+              "confidence",
+              "map",
+              "llm_triage",
+              "review",
+              "remediate",
+              "retry_queue",
+              "escalate",
+              "writeback"
+            ]
+          },
+          "agent_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "skills": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "inputs": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "guardrails": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "edges": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source",
+          "target",
+          "condition"
+        ],
+        "properties": {
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1
+          },
+          "condition": {
+            "type": "string",
+            "enum": [
+              "always",
+              "route_after_review == remediate",
+              "route_after_review == writeback",
+              "route_after_remediation == retry_queue",
+              "route_after_remediation == escalate",
+              "route_after_remediation == writeback"
+            ]
+          }
+        }
+      }
+    },
+    "invariants": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -788,11 +788,13 @@ class TestLangGraphContractSchemas:
 
     PROFILE_SCHEMA = SCHEMAS / "harness_profile.schema.json"
     ADAPTER_SCHEMA = SCHEMAS / "llm_adapter_recommendations.schema.json"
+    PIPELINE_SCHEMA = SCHEMAS / "pipeline_contract.schema.json"
+    GRAPH = EXAMPLES / "langgraph_security_graph.py"
     PROFILES = EXAMPLES / "harness_profiles"
     DATASET = EXAMPLES / "evals" / "langgraph_triage_golden.json"
 
     def test_schema_files_are_closed_json_schema_documents(self):
-        for schema_path in [self.PROFILE_SCHEMA, self.ADAPTER_SCHEMA]:
+        for schema_path in [self.PROFILE_SCHEMA, self.ADAPTER_SCHEMA, self.PIPELINE_SCHEMA]:
             schema = json.loads(schema_path.read_text(encoding="utf-8"))
             assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
             assert schema["type"] == "object"
@@ -833,6 +835,48 @@ class TestLangGraphContractSchemas:
                 assert errors
                 assert any("additional property approval" in error for error in errors)
                 assert any("additional property cvss" in error for error in errors)
+
+    def test_emitted_pipeline_contract_matches_schema_and_known_topology(self):
+        result = subprocess.run(
+            [sys.executable, str(self.GRAPH)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        contract = json.loads(result.stdout)["pipeline_contract"]
+        schema = json.loads(self.PIPELINE_SCHEMA.read_text(encoding="utf-8"))
+        assert _schema_errors(schema, contract) == []
+
+        node_names = {node["node"] for node in contract["nodes"]}
+        assert node_names == {
+            "ingest",
+            "normalize",
+            "enrich",
+            "correlate",
+            "confidence",
+            "map",
+            "llm_triage",
+            "review",
+            "remediate",
+            "retry_queue",
+            "escalate",
+            "writeback",
+        }
+        for edge in contract["edges"]:
+            assert edge["source"] in node_names
+            assert edge["target"] in node_names
+        assert len(contract["edges"]) == 14
+
+        remediation_node = next(
+            node for node in contract["nodes"] if node["node"] == "remediate"
+        )
+        assert remediation_node["skills"] == ["iam-departures-aws"]
+        triage_node = next(
+            node for node in contract["nodes"] if node["node"] == "llm_triage"
+        )
+        assert triage_node["skills"] == []
 
 
 class TestLangGraphHarnessSetup:


### PR DESCRIPTION
Summary
- Add a closed JSON Schema for the emitted LangGraph SOC `pipeline_contract`.
- Validate the live example summary against that schema, including node set, edge references, edge count, and skill boundaries.
- Document that harness profiles, adapter payloads, and pipeline topology all have closed schema contracts.

Verification
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_adapters.py examples/agents/eval_langgraph_harness.py examples/agents/configure_langgraph_harness.py examples/agents/render_langgraph_pipeline_diagram.py`
- `uv run make agent-evals`
- `git diff --check`

Notes
- Local duplicate `" 2"` files remain untracked and are not part of this PR.