### PR TITLE
feat(examples): add LangGraph checkpoint schema

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -93,9 +93,9 @@ python examples/agents/langgraph_security_graph.py
 ```
 
 The artifact stores `schema_version=langgraph-soc-checkpoint-v1`, final graph
-state, `state_hash`, `summary_hash`, and `checkpoint_hash`. Replay verifies
-those hashes before returning the operator-facing summary and does not re-run
-graph nodes or tool calls.
+state, `state_hash`, `summary_hash`, and `checkpoint_hash`, and matches a
+closed schema envelope. Replay verifies those hashes before returning the
+operator-facing summary and does not re-run graph nodes or tool calls.
 
 Eval fixtures live under
 [`examples/agents/evals/`](../examples/agents/evals/). The offline gate
@@ -130,7 +130,8 @@ from the operator's IDP or ticketing workflow before routing to remediation.
 Closed JSON Schema contracts live under
 [`examples/agents/schemas/`](../examples/agents/schemas/) for harness
 profiles, LLM adapter recommendation payloads, and the emitted
-`pipeline_contract` topology.
+`pipeline_contract` topology. Checkpoint artifacts have a closed schema
+envelope for replay persistence.
 
 ## Customization knobs
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -189,8 +189,8 @@ graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation
 enters graph state.
 Checkpoint artifacts use `langgraph-soc-checkpoint-v1`, include the final
-state, `state_hash`, `summary_hash`, and `checkpoint_hash`, and replay only
-after those hashes verify.
+state, `state_hash`, `summary_hash`, and `checkpoint_hash`, match a closed
+schema envelope, and replay only after those hashes verify.
 
 Profile examples live under
 [`harness_profiles/`](harness_profiles/):
@@ -203,7 +203,8 @@ Profile examples live under
 
 Contract schemas live under [`schemas/`](schemas/). They define the closed
 shape for harness profiles, the LLM adapter recommendation payload accepted by
-the reference graph, and the emitted `pipeline_contract` topology.
+the reference graph, the emitted `pipeline_contract` topology, and checkpoint
+artifact envelopes.
 
 Use [`configure_langgraph_harness.py`](configure_langgraph_harness.py) when
 customizing the harness for a buyer or internal environment. It asks for role,

--- a/examples/agents/schemas/checkpoint.schema.json
+++ b/examples/agents/schemas/checkpoint.schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/checkpoint.schema.json",
+  "title": "LangGraph SOC checkpoint artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event",
+    "schema_version",
+    "profile_id",
+    "trace",
+    "state_hash",
+    "summary_hash",
+    "state",
+    "checkpoint_hash"
+  ],
+  "properties": {
+    "event": {
+      "type": "string",
+      "const": "langgraph_soc_checkpoint"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "langgraph-soc-checkpoint-v1"
+    },
+    "profile_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "ingest",
+          "normalize",
+          "enrich",
+          "correlate",
+          "confidence",
+          "map",
+          "llm_triage",
+          "review",
+          "remediate",
+          "retry_queue",
+          "escalate",
+          "writeback"
+        ]
+      }
+    },
+    "state_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "summary_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "state": {
+      "type": "object",
+      "required": [
+        "harness_profile",
+        "caller_context",
+        "effective_allowed_skills",
+        "trace",
+        "raw_events",
+        "ocsf_events",
+        "findings",
+        "enrichments",
+        "correlations",
+        "confidence_scores",
+        "framework_maps",
+        "harness_config",
+        "agent_manifest",
+        "agent_runs",
+        "agent_recommendations",
+        "llm_validation",
+        "integrity",
+        "idempotency",
+        "review_decision",
+        "remediation_result",
+        "audit_record",
+        "eval_record"
+      ],
+      "properties": {
+        "trace": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "integrity": {
+          "type": "object",
+          "required": [
+            "evidence_hash",
+            "state_hash"
+          ],
+          "properties": {
+            "evidence_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "state_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        },
+        "idempotency": {
+          "type": "object",
+          "required": [
+            "workflow_key",
+            "duplicate_write_suppressed"
+          ],
+          "properties": {
+            "workflow_key": {
+              "type": "string",
+              "pattern": "^wf-[0-9a-f]{16}$"
+            },
+            "duplicate_write_suppressed": {
+              "type": "boolean"
+            }
+          }
+        },
+        "audit_record": {
+          "type": "object",
+          "required": [
+            "event",
+            "chain_hash",
+            "state_hash",
+            "idempotency_key",
+            "route"
+          ],
+          "properties": {
+            "event": {
+              "type": "string",
+              "const": "agentic_soc_workflow"
+            },
+            "chain_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "state_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "idempotency_key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "route": {
+              "type": "object"
+            }
+          }
+        },
+        "eval_record": {
+          "type": "object",
+          "required": [
+            "dataset_version",
+            "model_policy",
+            "prompt_hash",
+            "cases",
+            "status"
+          ],
+          "properties": {
+            "dataset_version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "model_policy": {
+              "type": "string",
+              "const": "llm_may_rank_summarize_draft_only"
+            },
+            "prompt_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{16}$"
+            },
+            "cases": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "blocked"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "checkpoint_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -239,6 +239,7 @@ class TestLangGraphSocWorkflow:
     """Regression coverage for the expanded SOC workflow graph."""
 
     SCRIPT = EXAMPLES / "langgraph_security_graph.py"
+    CHECKPOINT_SCHEMA = SCHEMAS / "checkpoint.schema.json"
     PROFILES = EXAMPLES / "harness_profiles"
     EXPECTED_AGENT_IDS = [
         "evidence-agent",
@@ -727,9 +728,14 @@ class TestLangGraphSocWorkflow:
         assert result.returncode == 0, result.stderr
         original_summary = json.loads(result.stdout)
         payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+        schema = json.loads(self.CHECKPOINT_SCHEMA.read_text(encoding="utf-8"))
+        assert _schema_errors(schema, payload) == []
         assert payload["event"] == "langgraph_soc_checkpoint"
         assert payload["schema_version"] == "langgraph-soc-checkpoint-v1"
         assert payload["state_hash"] == original_summary["integrity"]["state_hash"]
+        assert payload["state"]["integrity"]["state_hash"] == payload["state_hash"]
+        assert payload["state"]["audit_record"]["state_hash"] == payload["state_hash"]
+        assert payload["state"]["audit_record"]["chain_hash"] == payload["state_hash"]
         assert payload["checkpoint_hash"]
         assert payload["summary_hash"]
 
@@ -789,12 +795,18 @@ class TestLangGraphContractSchemas:
     PROFILE_SCHEMA = SCHEMAS / "harness_profile.schema.json"
     ADAPTER_SCHEMA = SCHEMAS / "llm_adapter_recommendations.schema.json"
     PIPELINE_SCHEMA = SCHEMAS / "pipeline_contract.schema.json"
+    CHECKPOINT_SCHEMA = SCHEMAS / "checkpoint.schema.json"
     GRAPH = EXAMPLES / "langgraph_security_graph.py"
     PROFILES = EXAMPLES / "harness_profiles"
     DATASET = EXAMPLES / "evals" / "langgraph_triage_golden.json"
 
     def test_schema_files_are_closed_json_schema_documents(self):
-        for schema_path in [self.PROFILE_SCHEMA, self.ADAPTER_SCHEMA, self.PIPELINE_SCHEMA]:
+        for schema_path in [
+            self.PROFILE_SCHEMA,
+            self.ADAPTER_SCHEMA,
+            self.PIPELINE_SCHEMA,
+            self.CHECKPOINT_SCHEMA,
+        ]:
             schema = json.loads(schema_path.read_text(encoding="utf-8"))
             assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
             assert schema["type"] == "object"


### PR DESCRIPTION
Summary
- Add a closed JSON Schema envelope for LangGraph checkpoint artifacts.
- Validate live checkpoint output against the schema and assert state/audit hash consistency.
- Document checkpoint schema coverage in the agent examples and harness guide.

Verification
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_adapters.py examples/agents/eval_langgraph_harness.py examples/agents/configure_langgraph_harness.py examples/agents/render_langgraph_pipeline_diagram.py`
- `uv run make agent-evals`
- `git diff --check`

Notes
- Local duplicate `" 2"` files remain untracked and are not part of this PR.