### PR TITLE
feat(examples): add LangGraph eval report schema

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -118,7 +118,8 @@ This is regression tracking for orchestrator behavior, not an LLM-as-judge.
 It does not call a live model; live model quality checks can be layered on top
 later with the same dataset/version/report contract. The JSON report captures
 the latest run, while the JSONL history gives CI, release checks, or customer
-forks an append-only pass-rate trail for harness drift.
+forks an append-only pass-rate trail for harness drift. Both output forms
+share a closed eval-report schema.
 
 Operator profiles live under
 [`examples/agents/harness_profiles/`](../examples/agents/harness_profiles/).
@@ -131,7 +132,8 @@ Closed JSON Schema contracts live under
 [`examples/agents/schemas/`](../examples/agents/schemas/) for harness
 profiles, LLM adapter recommendation payloads, and the emitted
 `pipeline_contract` topology. Checkpoint artifacts have a closed schema
-envelope for replay persistence.
+envelope for replay persistence, and eval reports use a shared schema for
+both JSON output and JSONL history rows.
 
 ## Customization knobs
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -180,7 +180,8 @@ without letting that model set policy, mappings, approvals, or audit facts. Use
 `llm_validation` records whether an adapter output was accepted, rejected, or
 replaced by deterministic fallback. The eval runner can write a point-in-time
 JSON report and append timestamped JSONL rows so CI or operators can track
-pass-rate drift across harness, profile, and adapter changes.
+pass-rate drift across harness, profile, and adapter changes. Both report
+forms share a closed schema contract under [`schemas/`](schemas/).
 `pipeline_contract` is code-backed topology metadata: node ownership, skills,
 input/output state keys, conditional edges, and guardrails for dry-run,
 approval, retries, idempotency, and audit writeback.
@@ -204,7 +205,7 @@ Profile examples live under
 Contract schemas live under [`schemas/`](schemas/). They define the closed
 shape for harness profiles, the LLM adapter recommendation payload accepted by
 the reference graph, the emitted `pipeline_contract` topology, and checkpoint
-artifact envelopes.
+artifact and eval-report envelopes.
 
 Use [`configure_langgraph_harness.py`](configure_langgraph_harness.py) when
 customizing the harness for a buyer or internal environment. It asks for role,

--- a/examples/agents/schemas/eval_report.schema.json
+++ b/examples/agents/schemas/eval_report.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/eval_report.schema.json",
+  "title": "LangGraph SOC harness eval report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event",
+    "dataset_version",
+    "dataset_hash",
+    "cases_total",
+    "passed",
+    "failed",
+    "pass_rate",
+    "model_policy",
+    "results"
+  ],
+  "properties": {
+    "recorded_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+    },
+    "report_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$"
+    },
+    "event": {
+      "type": "string",
+      "const": "langgraph_agent_harness_eval"
+    },
+    "dataset_version": {
+      "type": "string",
+      "const": "langgraph-agent-harness-golden-v1"
+    },
+    "dataset_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$"
+    },
+    "cases_total": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pass_rate": {
+      "type": "number",
+      "minimum": 0
+    },
+    "model_policy": {
+      "type": "string",
+      "const": "llm_may_rank_summarize_draft_only"
+    },
+    "results": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "case_id",
+          "status",
+          "output_hash",
+          "checks"
+        ],
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail"
+            ]
+          },
+          "output_hash": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{16}$"
+          },
+          "checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "actual",
+                "expected",
+                "passed"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "actual": {},
+                "expected": {},
+                "passed": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -34,6 +34,7 @@ JSON_TYPE_MAP = {
     "array": list,
     "boolean": bool,
     "integer": int,
+    "number": (int, float),
     "object": dict,
     "string": str,
 }
@@ -45,7 +46,7 @@ def _schema_errors(schema: dict, value, path: str = "$") -> list[str]:
     if schema_type:
         expected_type = JSON_TYPE_MAP[schema_type]
         if not isinstance(value, expected_type) or (
-            schema_type == "integer" and isinstance(value, bool)
+            schema_type in {"integer", "number"} and isinstance(value, bool)
         ):
             return [f"{path}: expected {schema_type}"]
 
@@ -796,6 +797,7 @@ class TestLangGraphContractSchemas:
     ADAPTER_SCHEMA = SCHEMAS / "llm_adapter_recommendations.schema.json"
     PIPELINE_SCHEMA = SCHEMAS / "pipeline_contract.schema.json"
     CHECKPOINT_SCHEMA = SCHEMAS / "checkpoint.schema.json"
+    EVAL_REPORT_SCHEMA = SCHEMAS / "eval_report.schema.json"
     GRAPH = EXAMPLES / "langgraph_security_graph.py"
     PROFILES = EXAMPLES / "harness_profiles"
     DATASET = EXAMPLES / "evals" / "langgraph_triage_golden.json"
@@ -806,6 +808,7 @@ class TestLangGraphContractSchemas:
             self.ADAPTER_SCHEMA,
             self.PIPELINE_SCHEMA,
             self.CHECKPOINT_SCHEMA,
+            self.EVAL_REPORT_SCHEMA,
         ]:
             schema = json.loads(schema_path.read_text(encoding="utf-8"))
             assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
@@ -1091,6 +1094,7 @@ class TestLangGraphHarnessEvals:
 
     SCRIPT = EXAMPLES / "eval_langgraph_harness.py"
     DATASET = EXAMPLES / "evals" / "langgraph_triage_golden.json"
+    SCHEMA = SCHEMAS / "eval_report.schema.json"
 
     def test_golden_eval_report_passes(self):
         result = subprocess.run(
@@ -1102,6 +1106,8 @@ class TestLangGraphHarnessEvals:
         )
         assert result.returncode == 0, result.stderr
         report = json.loads(result.stdout)
+        schema = json.loads(self.SCHEMA.read_text(encoding="utf-8"))
+        assert _schema_errors(schema, report) == []
         assert report["event"] == "langgraph_agent_harness_eval"
         assert report["dataset_version"] == "langgraph-agent-harness-golden-v1"
         assert report["cases_total"] == 8
@@ -1150,7 +1156,10 @@ class TestLangGraphHarnessEvals:
             for line in history_path.read_text(encoding="utf-8").splitlines()
         ]
         assert file_report == stdout_report
+        schema = json.loads(self.SCHEMA.read_text(encoding="utf-8"))
+        assert _schema_errors(schema, stdout_report) == []
         assert len(history_rows) == 1
+        assert _schema_errors(schema, history_rows[0]) == []
         assert history_rows[0]["event"] == "langgraph_agent_harness_eval"
         assert history_rows[0]["dataset_hash"] == stdout_report["dataset_hash"]
         assert history_rows[0]["pass_rate"] == 1.0


### PR DESCRIPTION
Summary
- Add a closed JSON Schema for LangGraph harness eval reports and JSONL history rows.
- Validate both stdout/file reports and appended history rows against the schema.
- Document eval-report schema coverage in the examples README and harness guide.

Verification
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_adapters.py examples/agents/eval_langgraph_harness.py examples/agents/configure_langgraph_harness.py examples/agents/render_langgraph_pipeline_diagram.py`
- `uv run make agent-evals`
- `git diff --check`

Notes
- Local duplicate `" 2"` files remain untracked and are not part of this PR.