### PR TITLE
feat(examples): add LangGraph token budget policy

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -53,13 +53,14 @@ python examples/agents/render_langgraph_pipeline_diagram.py \
   --output docs/diagrams/langgraph-agent-harness.mmd
 ```
 
-The LLM/agent harness records provider/model/mode in state and audit output.
-Its allowed outputs are intentionally narrow: rank findings, summarize
-evidence, draft analyst notes, and request human review. It cannot set CVSS,
-MITRE, EPSS, KEV, tenant scope, idempotency keys, HITL approval, dry-run state,
-or audit-chain facts. The compiled LangGraph path uses conditional edges for
-HITL, retryable API errors, terminal API errors, duplicate write suppression,
-and audit/eval writeback; the offline runner mirrors those routes for tests.
+The LLM/agent harness records provider/model/mode and token-budget policy in
+state and audit output. Its allowed outputs are intentionally narrow: rank
+findings, summarize evidence, draft analyst notes, and request human review.
+It cannot set CVSS, MITRE, EPSS, KEV, tenant scope, idempotency keys, HITL
+approval, dry-run state, or audit-chain facts. The compiled LangGraph path
+uses conditional edges for HITL, retryable API errors, terminal API errors,
+duplicate write suppression, and audit/eval writeback; the offline runner
+mirrors those routes for tests.
 
 Model-backed triage plugs in through a bounded adapter contract in
 [`examples/agents/harness_adapters.py`](../examples/agents/harness_adapters.py).
@@ -71,6 +72,11 @@ LangChain chat-message fixture, then accepts only `finding_uid`, `priority`,
 and audit record expose `llm_validation` plus accepted/rejected counts so
 operators can see whether model output influenced triage without letting it
 mutate facts.
+Before an optional adapter sees anything, the graph compacts deterministic
+findings, confidence, framework mappings, and evidence references into small
+cards. The run ledger records estimated raw input tokens, compact input tokens,
+output tokens, compression ratio, model tier, cache key, and deterministic
+fallback when the budget is exceeded.
 
 The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `evidence-agent`, `risk-map-agent`, `triage-agent`, `review-gate`,
@@ -128,6 +134,8 @@ LLM provider/model metadata, and approval-policy documentation. They do not
 store cloud secrets and they do not grant approval. A remediation profile can
 make a dry-run skill visible, but the graph still needs `_approval_context`
 from the operator's IDP or ticketing workflow before routing to remediation.
+Profiles can also declare `token_budget` limits so small triage tasks stay on
+tiny/small model tiers and oversized context falls back deterministically.
 Closed JSON Schema contracts live under
 [`examples/agents/schemas/`](../examples/agents/schemas/) for harness
 profiles, LLM adapter recommendation payloads, and the emitted

--- a/docs/diagrams/langgraph-agent-harness.mmd
+++ b/docs/diagrams/langgraph-agent-harness.mmd
@@ -19,7 +19,7 @@ flowchart LR
     end
 
     subgraph LLM["Optional model node: bounded triage only"]
-        TRIAGE["llm triage<br/>agent: triage-agent<br/>skills: none<br/>guards: closed_adapter_schema · rank_summarize_draft_only +1"]:::agent
+        TRIAGE["llm triage<br/>agent: triage-agent<br/>skills: none<br/>guards: closed_adapter_schema · rank_summarize_draft_only +3"]:::agent
     end
 
     subgraph GOV["Governance nodes: approval, dry-run, retry, escalation, audit"]

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -171,9 +171,9 @@ python examples/agents/render_langgraph_pipeline_diagram.py \
 The LangGraph summary includes `integrity.evidence_hash`,
 `integrity.state_hash`, stable workflow/remediation idempotency keys, and
 retryable-vs-terminal API error classification. It also includes the
-`profile`, `effective_allowed_skills`, `harness` provider/model/mode, `agents`
-manifest, `pipeline_contract`, `agent_runs` ledger, and bounded
-`agent_recommendations` so
+`profile`, `effective_allowed_skills`, `harness` provider/model/mode/token
+budget, `agents` manifest, `pipeline_contract`, `agent_runs` ledger, compact
+LLM evidence cards, token budget usage, and bounded `agent_recommendations` so
 operators can see which role and model would have drafted the analyst note
 without letting that model set policy, mappings, approvals, or audit facts. Use
 `DEMO_API_ERROR_STATUS=429` for retryable errors or `403` for terminal errors.
@@ -189,6 +189,10 @@ Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
 graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation
 enters graph state.
+The graph sends compact finding cards to the optional adapter, not raw events
+or full OCSF payloads. Each triage run records estimated raw and compact input
+tokens, output tokens, compression ratio, cache key, model tier, and fallback
+reason when a budget is exceeded.
 Checkpoint artifacts use `langgraph-soc-checkpoint-v1`, include the final
 state, `state_hash`, `summary_hash`, and `checkpoint_hash`, match a closed
 schema envelope, and replay only after those hashes verify.
@@ -212,8 +216,8 @@ customizing the harness for a buyer or internal environment. It asks for role,
 operator identity, cloud identity hints, allowed example skills, and
 provider/model metadata, then writes a schema-shaped profile plus a dotenv file.
 The generated runtime keeps `dry_run_default=true`, `apply_supported=false`,
-and `remediation_requires_approval_context=true`; setting a remediation-capable
-role exposes dry-run planning only, not approval.
+`remediation_requires_approval_context=true`, and a token budget policy;
+setting a remediation-capable role exposes dry-run planning only, not approval.
 
 Eval fixtures live under [`evals/`](evals/). The eval runner is deterministic:
 it replays profile/triage cases, checks recommendation shape, HITL routing,

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -25,6 +25,7 @@ from typing import Any, Literal
 from langgraph_security_graph import (
     ALLOWED_SKILLS_READ_ONLY_LIST,
     ALLOWED_SKILLS_REMEDIATION,
+    DEFAULT_TOKEN_BUDGET,
 )
 
 HarnessRole = Literal["readonly-soc", "analyst-triage", "dry-run-remediation"]
@@ -107,6 +108,10 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
             "mode": llm_mode,
             "provider": args.llm_provider,
             "model": args.llm_model,
+        },
+        "token_budget": {
+            **DEFAULT_TOKEN_BUDGET,
+            "model_tier": "small" if args.external_llm else "tiny",
         },
         "approval_policy": {
             "remediation_requires_approval_context": True,

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -148,6 +148,29 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
         _check("route_after_review", summary["audit"]["route"]["after_review"], expected["route_after_review"]),
         _check("planned_steps_absent", "planned_steps" not in summary["remediation"], expected["planned_steps_absent"]),
     ]
+    token_usage = summary.get("token_budget_usage") or {}
+    token_budget = (summary.get("harness") or {}).get("token_budget") or {}
+    checks.extend([
+        _check("token_budget_status_present", token_usage.get("status") in {"within_budget", "fallback"}, True),
+        _check(
+            "token_budget_input_within_limit_or_fallback",
+            token_usage.get("compact_input_tokens_estimate", 0) <= token_budget.get("max_input_tokens", 0)
+            or token_usage.get("status") == "fallback",
+            True,
+        ),
+        _check(
+            "token_budget_evidence_within_limit_or_fallback",
+            token_usage.get("compact_evidence_chars", 0) <= token_budget.get("max_evidence_chars", 0)
+            or token_usage.get("status") == "fallback",
+            True,
+        ),
+        _check("token_budget_model_tier_bounded", token_budget.get("model_tier") in {"tiny", "small"}, True),
+        _check(
+            "llm_evidence_cards_compact",
+            all("raw_events" not in card and "ocsf_events" not in card for card in summary.get("llm_evidence_cards") or []),
+            True,
+        ),
+    ])
 
     if "recommendation_generated_by" in expected:
         checks.append(_check(
@@ -331,6 +354,7 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
             "api_errors": summary.get("api_errors"),
             "retry": summary.get("retry"),
             "escalation": summary.get("escalation"),
+            "token_budget_usage": summary.get("token_budget_usage"),
         })[:16],
         "checks": checks,
     }

--- a/examples/agents/harness_adapters.py
+++ b/examples/agents/harness_adapters.py
@@ -49,10 +49,12 @@ def stable_hash(payload: Any) -> str:
 def build_harness_config(
     *,
     profile_llm: Mapping[str, str] | None,
+    profile_token_budget: Mapping[str, Any] | None = None,
     environ: Mapping[str, str] = os.environ,
 ) -> dict[str, Any]:
     """Describe the LLM/agent harness without requiring a live model."""
     profile_llm = profile_llm or {}
+    token_budget = dict(profile_token_budget or {})
     mode: LlmMode = (
         "external_llm_optional"
         if environ.get("DEMO_EXTERNAL_LLM_ALLOWED") == "yes"
@@ -61,6 +63,10 @@ def build_harness_config(
     )
     provider = environ.get("DEMO_LLM_PROVIDER") or profile_llm.get("provider", "deterministic-local")
     model = environ.get("DEMO_LLM_MODEL") or profile_llm.get("model", "policy-bounded-triage-v1")
+    if environ.get("DEMO_TOKEN_MAX_INPUT_TOKENS"):
+        token_budget["max_input_tokens"] = int(environ["DEMO_TOKEN_MAX_INPUT_TOKENS"])
+    if environ.get("DEMO_TOKEN_MAX_TOTAL_TOKENS"):
+        token_budget["max_total_tokens"] = int(environ["DEMO_TOKEN_MAX_TOTAL_TOKENS"])
     allowed_outputs = [
         "rank_findings",
         "summarize_evidence",
@@ -71,6 +77,7 @@ def build_harness_config(
         "mode": mode,
         "provider": provider,
         "model": model,
+        "token_budget": token_budget,
         "allowed_outputs": allowed_outputs,
         "prompt_hash": stable_hash({
             "system": "llm may rank, summarize, and draft only",

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -35,6 +35,9 @@ Profiles control:
   human; credentials stay in the provider CLI/SDK chain.
 - `llm`: provider/model metadata for bounded triage; model output can only
   rank, summarize, draft, or request human review.
+- `token_budget`: model tier and hard estimated token caps; the harness sends
+  compact evidence cards only and falls back deterministically when a request
+  would exceed budget.
 - `approval_policy`: documentation of the HITL source; profiles never grant
   approval by themselves.
 

--- a/examples/agents/harness_profiles/analyst-triage.json
+++ b/examples/agents/harness_profiles/analyst-triage.json
@@ -28,6 +28,18 @@
     "provider": "openai",
     "model": "gpt-4.1-mini"
   },
+  "token_budget": {
+    "policy_version": "langgraph-token-budget-v1",
+    "task_class": "triage_summary",
+    "model_tier": "small",
+    "max_input_tokens": 1200,
+    "max_output_tokens": 256,
+    "max_total_tokens": 1600,
+    "max_findings_per_call": 5,
+    "max_evidence_chars": 1800,
+    "compression_required": true,
+    "fallback_on_budget_exceeded": true
+  },
   "approval_policy": {
     "remediation_requires_approval_context": true,
     "approval_source": "operator_idp_or_ticketing_system"

--- a/examples/agents/harness_profiles/dry-run-remediation.json
+++ b/examples/agents/harness_profiles/dry-run-remediation.json
@@ -28,6 +28,18 @@
     "provider": "deterministic-local",
     "model": "policy-bounded-triage-v1"
   },
+  "token_budget": {
+    "policy_version": "langgraph-token-budget-v1",
+    "task_class": "triage_summary",
+    "model_tier": "tiny",
+    "max_input_tokens": 1200,
+    "max_output_tokens": 256,
+    "max_total_tokens": 1600,
+    "max_findings_per_call": 5,
+    "max_evidence_chars": 1800,
+    "compression_required": true,
+    "fallback_on_budget_exceeded": true
+  },
   "approval_policy": {
     "remediation_requires_approval_context": true,
     "approval_source": "operator_idp_or_ticketing_system",

--- a/examples/agents/harness_profiles/readonly-soc.json
+++ b/examples/agents/harness_profiles/readonly-soc.json
@@ -29,6 +29,18 @@
     "provider": "deterministic-local",
     "model": "policy-bounded-triage-v1"
   },
+  "token_budget": {
+    "policy_version": "langgraph-token-budget-v1",
+    "task_class": "triage_summary",
+    "model_tier": "tiny",
+    "max_input_tokens": 1200,
+    "max_output_tokens": 256,
+    "max_total_tokens": 1600,
+    "max_findings_per_call": 5,
+    "max_evidence_chars": 1800,
+    "compression_required": true,
+    "fallback_on_budget_exceeded": true
+  },
   "approval_policy": {
     "remediation_requires_approval_context": true,
     "approval_source": "not_enabled_for_this_profile"

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import sys
 from datetime import UTC, datetime
@@ -145,6 +146,7 @@ class AgentHarnessConfig(TypedDict):
     model: str
     allowed_outputs: list[str]
     prompt_hash: str
+    token_budget: dict[str, Any]
 
 
 class AgentDefinition(TypedDict):
@@ -171,13 +173,14 @@ class PipelineEdgeContract(TypedDict):
     condition: str
 
 
-class AgentRunRecord(TypedDict):
+class AgentRunRecord(TypedDict, total=False):
     run_id: str
     agent_id: str
     stage: WorkflowStage
     authority: str
     input_hash: str
     output_hash: str
+    token_budget: dict[str, Any]
 
 
 class AgentRecommendation(TypedDict):
@@ -267,6 +270,8 @@ class GraphState(TypedDict, total=False):
     idempotency: IdempotencyRecord
     api_errors: list[ApiErrorRecord]
     seen_idempotency_keys: list[str]
+    llm_evidence_cards: list[dict[str, Any]]
+    token_budget_usage: dict[str, Any]
     audit_record: dict[str, Any]
     eval_record: EvalRecord
     trace: list[WorkflowStage]
@@ -280,6 +285,20 @@ def _emit_node(stage: WorkflowStage, **payload: Any) -> None:
 def _stable_hash(payload: Any) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+DEFAULT_TOKEN_BUDGET = {
+    "policy_version": "langgraph-token-budget-v1",
+    "task_class": "triage_summary",
+    "model_tier": "tiny",
+    "max_input_tokens": 1200,
+    "max_output_tokens": 256,
+    "max_total_tokens": 1600,
+    "max_findings_per_call": 5,
+    "max_evidence_chars": 1800,
+    "compression_required": True,
+    "fallback_on_budget_exceeded": True,
+}
 
 
 def _default_harness_profile() -> HarnessProfile:
@@ -303,6 +322,7 @@ def _default_harness_profile() -> HarnessProfile:
             "provider": "deterministic-local",
             "model": "policy-bounded-triage-v1",
         },
+        "token_budget": DEFAULT_TOKEN_BUDGET,
         "approval_policy": {
             "remediation_requires_approval_context": True,
             "approval_source": "operator_idp_or_ticketing_system",
@@ -329,6 +349,10 @@ def load_harness_profile(path_text: str | None = None) -> HarnessProfile:
     profile["llm"] = {
         **default["llm"],
         **payload.get("llm", {}),
+    }
+    profile["token_budget"] = {
+        **default["token_budget"],
+        **payload.get("token_budget", {}),
     }
     return profile
 
@@ -462,9 +486,15 @@ def _pipeline_node_contracts() -> list[PipelineNodeContract]:
             "node": "llm_triage",
             "agent_id": "triage-agent",
             "skills": [],
-            "inputs": ["framework_maps", "confidence_scores", "harness_profile.llm"],
-            "outputs": ["agent_recommendations", "llm_validation", "agent_runs"],
-            "guardrails": ["closed_adapter_schema", "rank_summarize_draft_only", "fallback_closed"],
+            "inputs": ["framework_maps", "confidence_scores", "harness_profile.llm", "token_budget"],
+            "outputs": ["agent_recommendations", "llm_validation", "agent_runs", "token_budget_usage"],
+            "guardrails": [
+                "closed_adapter_schema",
+                "rank_summarize_draft_only",
+                "compact_evidence_only",
+                "token_budget_enforced",
+                "fallback_closed",
+            ],
         },
         {
             "node": "review",
@@ -558,24 +588,126 @@ def _record_agent_run(
     stage: WorkflowStage,
     inputs: Any,
     outputs: Any,
+    token_budget: dict[str, Any] | None = None,
 ) -> None:
     state.setdefault("agent_manifest", _agent_manifest())
     agent = _agent_by_id(agent_id)
     runs = state.setdefault("agent_runs", [])
-    runs.append({
+    record: AgentRunRecord = {
         "run_id": f"run-{len(runs) + 1:02d}-{agent_id}",
         "agent_id": agent_id,
         "stage": stage,
         "authority": agent["authority"],
         "input_hash": _stable_hash(inputs)[:16],
         "output_hash": _stable_hash(outputs)[:16],
-    })
+    }
+    if token_budget is not None:
+        record["token_budget"] = token_budget
+    runs.append(record)
 
 
 def _agent_harness_config(state: GraphState) -> AgentHarnessConfig:
     """Describe the LLM/agent harness without requiring a live model."""
-    profile_llm = (state.get("harness_profile") or {}).get("llm", {})
-    return build_harness_config(profile_llm=profile_llm, environ=os.environ)
+    profile = state.get("harness_profile") or {}
+    profile_llm = profile.get("llm", {})
+    return build_harness_config(
+        profile_llm=profile_llm,
+        profile_token_budget=profile.get("token_budget", DEFAULT_TOKEN_BUDGET),
+        environ=os.environ,
+    )
+
+
+def _estimate_tokens(payload: Any) -> int:
+    """Cheap deterministic estimate: compact JSON chars divided by four."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return max(1, math.ceil(len(encoded) / 4))
+
+
+def _compact_json_chars(payload: Any) -> int:
+    return len(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def _compact_evidence_cards(state: GraphState, budget: dict[str, Any]) -> list[dict[str, Any]]:
+    confidence_by_uid = {
+        score["finding_uid"]: score
+        for score in state.get("confidence_scores") or []
+    }
+    findings_by_uid = {
+        finding["uid"]: finding
+        for finding in state.get("findings") or []
+    }
+    cards = []
+    max_cards = int(budget["max_findings_per_call"])
+    max_card_chars = max(160, int(budget["max_evidence_chars"]) // max_cards)
+    for mapped in (state.get("framework_maps") or [])[:max_cards]:
+        finding_uid = mapped["finding_uid"]
+        finding = findings_by_uid.get(finding_uid, {})
+        confidence = confidence_by_uid.get(finding_uid, {})
+        cards.append({
+            "finding_uid": finding_uid,
+            "title": str(finding.get("title", "security finding"))[:max_card_chars],
+            "severity": finding.get("severity", mapped["cvss"]["severity"]),
+            "confidence": confidence.get("score", 0.0),
+            "reason_codes": [str(reason)[:80] for reason in confidence.get("reason_codes", [])[:6]],
+            "mitre_attack": mapped["mitre_attack"],
+            "mitre_atlas": mapped["mitre_atlas"],
+            "cvss": {
+                "base_score": mapped["cvss"]["base_score"],
+                "severity": mapped["cvss"]["severity"],
+            },
+            "epss_percentile": mapped["epss_percentile"],
+            "kev_listed": mapped["kev_listed"],
+            "evidence_refs": [
+                f"finding_uid:{finding_uid}",
+                f"resource_uid:{finding.get('resource_uid', 'unknown')}",
+            ],
+        })
+    return cards
+
+
+def _token_budget_usage(
+    *,
+    state: GraphState,
+    harness_config: AgentHarnessConfig,
+    evidence_cards: list[dict[str, Any]],
+    recommendations: list[AgentRecommendation] | None = None,
+) -> dict[str, Any]:
+    budget = harness_config["token_budget"]
+    raw_payload = {
+        "raw_events": state.get("raw_events") or [],
+        "ocsf_events": state.get("ocsf_events") or [],
+        "framework_maps": state.get("framework_maps") or [],
+        "confidence_scores": state.get("confidence_scores") or [],
+    }
+    raw_tokens = _estimate_tokens(raw_payload)
+    compact_tokens = _estimate_tokens(evidence_cards)
+    output_tokens = _estimate_tokens(recommendations or [])
+    compact_chars = _compact_json_chars(evidence_cards)
+    over_budget = (
+        compact_tokens > budget["max_input_tokens"]
+        or output_tokens > budget["max_output_tokens"]
+        or compact_tokens + output_tokens > budget["max_total_tokens"]
+        or compact_chars > budget["max_evidence_chars"]
+    )
+    return {
+        "policy_version": budget["policy_version"],
+        "task_class": budget["task_class"],
+        "model_tier": budget["model_tier"],
+        "model": harness_config["model"],
+        "raw_input_tokens_estimate": raw_tokens,
+        "compact_input_tokens_estimate": compact_tokens,
+        "output_tokens_estimate": output_tokens,
+        "max_input_tokens": budget["max_input_tokens"],
+        "max_output_tokens": budget["max_output_tokens"],
+        "max_total_tokens": budget["max_total_tokens"],
+        "compact_evidence_chars": compact_chars,
+        "max_evidence_chars": budget["max_evidence_chars"],
+        "compression_required": budget["compression_required"],
+        "compression_ratio": round(raw_tokens / compact_tokens, 2) if compact_tokens else 1.0,
+        "cache_key": f"triage-{_stable_hash({'model': harness_config['model'], 'evidence': evidence_cards})[:16]}",
+        "status": "fallback" if over_budget and budget["fallback_on_budget_exceeded"] else "within_budget",
+        "fallback_reason": "token_budget_exceeded" if over_budget else None,
+    }
 
 
 def _classify_api_error(status_code: int) -> ApiErrorClassification:
@@ -791,12 +923,20 @@ def llm_triage_node(state: GraphState) -> GraphState:
     """Bounded agent layer: rank and summarize only, never decide facts."""
     _append_trace(state, "llm_triage")
     harness_config = _agent_harness_config(state)
+    evidence_cards = _compact_evidence_cards(state, harness_config["token_budget"])
+    initial_budget_usage = _token_budget_usage(
+        state=state,
+        harness_config=harness_config,
+        evidence_cards=evidence_cards,
+    )
     adapter = select_triage_adapter(harness_config=harness_config, environ=os.environ)
-    adapter_recommendations = {
-        recommendation.get("finding_uid"): recommendation
-        for recommendation in adapter.recommendations()
-        if isinstance(recommendation, dict)
-    }
+    adapter_recommendations = {}
+    if initial_budget_usage["status"] != "fallback":
+        adapter_recommendations = {
+            recommendation.get("finding_uid"): recommendation
+            for recommendation in adapter.recommendations()
+            if isinstance(recommendation, dict)
+        }
     confidence_by_uid = {
         score["finding_uid"]: score["score"]
         for score in state.get("confidence_scores") or []
@@ -819,9 +959,25 @@ def llm_triage_node(state: GraphState) -> GraphState:
             harness_config=harness_config,
             adapter_id=adapter.adapter_id,
         )
+        if initial_budget_usage["status"] == "fallback":
+            validation = {
+                "finding_uid": finding_uid,
+                "adapter": "deterministic_fallback",
+                "status": "fallback",
+                "reason": initial_budget_usage["fallback_reason"],
+                "output_hash": fallback["output_hash"],
+            }
         recommendations.append(recommendation)
         validation_records.append(validation)
+    budget_usage = _token_budget_usage(
+        state=state,
+        harness_config=harness_config,
+        evidence_cards=evidence_cards,
+        recommendations=recommendations,
+    )
     state["harness_config"] = harness_config
+    state["llm_evidence_cards"] = evidence_cards
+    state["token_budget_usage"] = budget_usage
     state["agent_recommendations"] = recommendations
     state["llm_validation"] = validation_records
     _record_agent_run(
@@ -829,14 +985,14 @@ def llm_triage_node(state: GraphState) -> GraphState:
         agent_id="triage-agent",
         stage="llm_triage",
         inputs={
-            "confidence_scores": state.get("confidence_scores"),
-            "framework_maps": state.get("framework_maps"),
+            "compact_evidence_cards": evidence_cards,
             "harness_config": harness_config,
         },
         outputs={
             "agent_recommendations": recommendations,
             "llm_validation": validation_records,
         },
+        token_budget=budget_usage,
     )
     _emit_node(
         "llm_triage",
@@ -846,6 +1002,8 @@ def llm_triage_node(state: GraphState) -> GraphState:
         recommendations=len(recommendations),
         accepted=sum(1 for record in validation_records if record["status"] == "accepted"),
         rejected=sum(1 for record in validation_records if record["status"] == "rejected"),
+        token_status=budget_usage["status"],
+        input_tokens=budget_usage["compact_input_tokens_estimate"],
         authority="rank_summarize_draft_only",
     )
     return state
@@ -1094,6 +1252,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "trace": state.get("trace"),
         "findings": state.get("findings"),
         "harness_config": state.get("harness_config"),
+        "token_budget_usage": state.get("token_budget_usage"),
         "agent_manifest": state.get("agent_manifest"),
         "agent_runs": state.get("agent_runs"),
         "agent_recommendations": state.get("agent_recommendations"),
@@ -1129,6 +1288,8 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "agent_run_count": len(state.get("agent_runs") or []),
         "llm_adapter_accepted": sum(1 for record in llm_validation if record["status"] == "accepted"),
         "llm_adapter_rejected": sum(1 for record in llm_validation if record["status"] == "rejected"),
+        "llm_token_budget_status": (state.get("token_budget_usage") or {}).get("status"),
+        "llm_compact_input_tokens": (state.get("token_budget_usage") or {}).get("compact_input_tokens_estimate"),
         "retryable_api_error_count": sum(
             1 for error in api_errors if error["classification"] == "retryable"
         ),
@@ -1154,6 +1315,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "api_error_classification",
             "llm_harness_bounded",
             "llm_adapter_schema_gate",
+            "llm_token_budget_gate",
             "multi_agent_ledger",
             "conditional_edges",
         ],
@@ -1278,6 +1440,8 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),
         "llm_validation": final.get("llm_validation"),
+        "llm_evidence_cards": final.get("llm_evidence_cards"),
+        "token_budget_usage": final.get("token_budget_usage"),
         "review": final.get("review_decision"),
         "remediation": final.get("remediation_result"),
         "retry": final.get("retry_record"),

--- a/examples/agents/schemas/harness_profile.schema.json
+++ b/examples/agents/schemas/harness_profile.schema.json
@@ -103,6 +103,68 @@
         }
       }
     },
+    "token_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_version",
+        "task_class",
+        "model_tier",
+        "max_input_tokens",
+        "max_output_tokens",
+        "max_total_tokens",
+        "max_findings_per_call",
+        "max_evidence_chars",
+        "compression_required",
+        "fallback_on_budget_exceeded"
+      ],
+      "properties": {
+        "policy_version": {
+          "type": "string",
+          "const": "langgraph-token-budget-v1"
+        },
+        "task_class": {
+          "type": "string",
+          "const": "triage_summary"
+        },
+        "model_tier": {
+          "type": "string",
+          "enum": [
+            "tiny",
+            "small",
+            "large"
+          ]
+        },
+        "max_input_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_output_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_total_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_findings_per_call": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_evidence_chars": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "compression_required": {
+          "type": "boolean",
+          "const": true
+        },
+        "fallback_on_budget_exceeded": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
     "approval_policy": {
       "type": "object",
       "additionalProperties": false,

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -318,6 +318,16 @@ class TestLangGraphSocWorkflow:
             "draft_analyst_note",
             "request_human_review",
         ]
+        assert summary["harness"]["token_budget"]["policy_version"] == "langgraph-token-budget-v1"
+        assert summary["harness"]["token_budget"]["model_tier"] == "tiny"
+        assert summary["token_budget_usage"]["status"] == "within_budget"
+        assert summary["token_budget_usage"]["compact_input_tokens_estimate"] <= summary["harness"]["token_budget"]["max_input_tokens"]
+        assert summary["token_budget_usage"]["compact_evidence_chars"] <= summary["harness"]["token_budget"]["max_evidence_chars"]
+        assert summary["audit"]["llm_token_budget_status"] == "within_budget"
+        assert summary["audit"]["llm_compact_input_tokens"] == summary["token_budget_usage"]["compact_input_tokens_estimate"]
+        assert summary["llm_evidence_cards"]
+        assert all("raw_events" not in card for card in summary["llm_evidence_cards"])
+        assert all("ocsf_events" not in card for card in summary["llm_evidence_cards"])
         assert [agent["agent_id"] for agent in summary["agents"]] == self.EXPECTED_AGENT_IDS
         assert [run["agent_id"] for run in summary["agent_runs"]] == [
             "evidence-agent",
@@ -379,6 +389,8 @@ class TestLangGraphSocWorkflow:
         triage_node = next(node for node in contract["nodes"] if node["node"] == "llm_triage")
         assert triage_node["skills"] == []
         assert "closed_adapter_schema" in triage_node["guardrails"]
+        assert "token_budget_enforced" in triage_node["guardrails"]
+        assert "compact_evidence_only" in triage_node["guardrails"]
         assert "LLM adapters can rank, summarize, draft, or request review only" in contract["invariants"]
 
     def test_no_approval_blocks_remediation_but_writes_audit_and_eval(self):
@@ -439,6 +451,7 @@ class TestLangGraphSocWorkflow:
         assert summary["harness"]["mode"] == "external_llm_optional"
         assert summary["harness"]["provider"] == "openai"
         assert summary["harness"]["model"] == "gpt-4.1-mini"
+        assert summary["harness"]["token_budget"]["model_tier"] == "tiny"
         assert "call_write_tools" not in summary["harness"]["allowed_outputs"]
         assert summary["agent_recommendations"][0]["generated_by"] == "openai:gpt-4.1-mini"
         assert summary["remediation"]["status"] == "skipped"
@@ -447,6 +460,22 @@ class TestLangGraphSocWorkflow:
         assert "write_intent" in triage_agent["forbidden_outputs"]
         assert summary["llm_validation"][0]["status"] == "fallback"
         assert summary["llm_validation"][0]["reason"] == "no_adapter_output"
+
+    def test_token_budget_overage_uses_deterministic_fallback(self):
+        summary, _ = self._run(extra_env={
+            "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+            "DEMO_LLM_PROVIDER": "fixture",
+            "DEMO_LLM_MODEL": "oversized-context-fixture",
+            "DEMO_TOKEN_MAX_INPUT_TOKENS": "1",
+        })
+        assert summary["token_budget_usage"]["status"] == "fallback"
+        assert summary["token_budget_usage"]["fallback_reason"] == "token_budget_exceeded"
+        assert summary["llm_validation"][0]["status"] == "fallback"
+        assert summary["llm_validation"][0]["reason"] == "token_budget_exceeded"
+        triage_run = next(run for run in summary["agent_runs"] if run["agent_id"] == "triage-agent")
+        assert triage_run["token_budget"]["status"] == "fallback"
+        assert triage_run["token_budget"]["cache_key"].startswith("triage-")
+        assert summary["audit"]["llm_token_budget_status"] == "fallback"
 
     def test_llm_adapter_accepts_bounded_triage_output(self, tmp_path: Path):
         baseline, _ = self._run()
@@ -825,6 +854,9 @@ class TestLangGraphContractSchemas:
             )
             assert profile["approval_policy"]["remediation_requires_approval_context"] is True
             assert profile["runtime"]["dry_run_default"] is True
+            if "token_budget" in profile:
+                assert profile["token_budget"]["compression_required"] is True
+                assert profile["token_budget"]["fallback_on_budget_exceeded"] is True
 
     def test_llm_adapter_eval_fixtures_match_expected_schema_outcome(self):
         schema = json.loads(self.ADAPTER_SCHEMA.read_text(encoding="utf-8"))
@@ -965,6 +997,9 @@ class TestLangGraphHarnessSetup:
             "provider": "openai",
             "model": "gpt-4.1-mini",
         }
+        assert profile["token_budget"]["policy_version"] == "langgraph-token-budget-v1"
+        assert profile["token_budget"]["model_tier"] == "small"
+        assert profile["token_budget"]["compression_required"] is True
         assert "iam-departures-aws" not in profile["allowed_skills"]
 
         dotenv = env_path.read_text(encoding="utf-8")
@@ -985,6 +1020,7 @@ class TestLangGraphHarnessSetup:
         assert summary["profile"]["profile_id"] == "acme-soc-triage"
         assert summary["harness"]["mode"] == "external_llm_optional"
         assert summary["harness"]["provider"] == "openai"
+        assert summary["harness"]["token_budget"]["model_tier"] == "small"
         assert summary["review"]["status"] == "blocked"
 
     def test_setup_generator_dry_run_profile_still_requires_approval(self, tmp_path: Path):
@@ -1016,6 +1052,7 @@ class TestLangGraphHarnessSetup:
         assert profile["runtime"]["dry_run_default"] is True
         assert profile["runtime"]["apply_supported"] is False
         assert profile["approval_policy"]["remediation_requires_approval_context"] is True
+        assert profile["token_budget"]["model_tier"] == "tiny"
 
         blocked = subprocess.run(
             [sys.executable, str(self.GRAPH)],


### PR DESCRIPTION
Summary
- Add token-budget policy to LangGraph harness profiles and generated setup output.
- Compact LLM triage inputs into bounded evidence cards with token and character accounting, cache keys, and deterministic fallback on budget overflow.
- Carry token-budget status through agent runs, audit/eval writeback, docs, schema, and regression checks.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_adapters.py examples/agents/eval_langgraph_harness.py examples/agents/configure_langgraph_harness.py examples/agents/render_langgraph_pipeline_diagram.py
- uv run make agent-evals
- git diff --check

Notes
- Existing untracked duplicate files with ` 2` suffixes were left untouched and are not part of this PR.