### PR TITLE
feat(examples): add LangGraph harness runtime wrapper

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -44,6 +44,27 @@ ingest -> normalize -> enrich -> correlate -> confidence -> map
    blocked  -> writeback
 ```
 
+The importable wrapper is
+[`examples/agents/harness_runtime.py`](../examples/agents/harness_runtime.py).
+Use it when another runner wants the harness as code instead of shelling out
+to the demo script:
+
+```bash
+PYTHONPATH=examples/agents python - <<'PY'
+from harness_runtime import HarnessRunConfig, run_harness_summary
+
+summary = run_harness_summary(HarnessRunConfig(
+    profile_path="examples/agents/harness_profiles/readonly-soc.json",
+    raw_events=({"source": "cloudtrail", "event_name": "CreateAccessKey"},),
+))
+print(summary["harness_runtime"]["validation_status"])
+PY
+```
+
+`HARNESS.md` is therefore the readable operator contract; the graph nodes,
+adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are
+the executable harness.
+
 Diagram source:
 [`docs/diagrams/langgraph-agent-harness.mmd`](diagrams/langgraph-agent-harness.mmd).
 It is generated from the code-backed `pipeline_contract()`:
@@ -231,8 +252,8 @@ To stop redundancy creep, we draw the line clearly.
 | **TLS termination** | speak HTTP behind a WAF | operator's API gateway / WAF |
 | **Multi-tenancy** | one process = one tenant | operator routes per-tenant via separate processes / containers |
 | **Secret management** | read env vars | operator's KMS / Vault / sealed-secrets |
-| **Workflow orchestration** | spec in `examples/workflows/` | operator's SOAR / Step Function / LangGraph |
-| **State persistence (dedupe, checkpoint)** | — | runners own state, skills are stateless |
+| **Workflow orchestration** | reference harness in `examples/agents/` plus specs in `examples/workflows/` | operator's production SOAR / Step Function / LangGraph |
+| **State persistence (dedupe, checkpoint)** | reference checkpoint artifacts only | runners own production state, skills are stateless |
 | **Rate limiting incoming traffic** | — | operator's API gateway |
 | **Authorization to remediate** | enforce HITL gate | operator's IDP attests `_approval_context` |
 
@@ -245,7 +266,9 @@ something the SDK / IDP / WAF / agent already does:
   database table to hold them, that work belongs upstream of the
   wrapper.
 - **Never speak SAML / OIDC as a client.** The cloud CLI does that.
-- **Never run a workflow engine.** Workflows are markdown specs.
+- **Never ship a hosted workflow engine by default.** Reference harnesses can
+  show LangGraph/SOAR composition, but production orchestration remains
+  operator-owned.
 - **Never proxy traffic to the cloud.** The skill calls the cloud SDK
   directly; latency, retries, and TLS are the SDK's concern.
 - **Never persist user state between calls.** Skills are pure

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -185,6 +185,23 @@ forms share a closed schema contract under [`schemas/`](schemas/).
 `pipeline_contract` is code-backed topology metadata: node ownership, skills,
 input/output state keys, conditional edges, and guardrails for dry-run,
 approval, retries, idempotency, and audit writeback.
+Importable harness wrapper:
+
+```bash
+PYTHONPATH=examples/agents python - <<'PY'
+from harness_runtime import HarnessRunConfig, run_harness
+
+result = run_harness(HarnessRunConfig(
+    profile_path="examples/agents/harness_profiles/readonly-soc.json",
+    raw_events=({"source": "cloudtrail", "event_name": "CreateAccessKey"},),
+))
+assert result.runtime["validation_status"] == "pass"
+PY
+```
+
+Use this wrapper from CI, MCP, SOAR, or a customer-owned LangGraph app when
+the workflow should run as code. `docs/HARNESS.md` remains the readable
+operator contract, not the implementation body.
 Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
 graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation

--- a/examples/agents/harness_runtime.py
+++ b/examples/agents/harness_runtime.py
@@ -1,0 +1,191 @@
+"""Importable runtime wrapper for the LangGraph SOC harness example.
+
+`docs/HARNESS.md` is the operator contract. This module is the small code
+surface a CI job, MCP wrapper, SOAR playbook, or customer-owned LangGraph app
+can import when it wants the demo harness behavior without shelling out to the
+example CLI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from langgraph_security_graph import (
+    CHECKPOINT_SCHEMA_VERSION,
+    GraphState,
+    load_checkpoint,
+    load_harness_profile,
+    run_graph,
+    run_langgraph,
+    summarize,
+    write_checkpoint,
+)
+
+HARNESS_RUNTIME_VERSION = "langgraph-soc-harness-runtime-v1"
+
+
+@dataclass(frozen=True)
+class HarnessRunConfig:
+    """Operator-owned run settings for the example harness wrapper."""
+
+    profile_path: str | Path | None = None
+    raw_events: tuple[Mapping[str, Any], ...] | None = None
+    caller_context: Mapping[str, Any] | None = None
+    use_langgraph_runtime: bool = False
+    checkpoint_path: str | Path | None = None
+    replay_checkpoint_path: str | Path | None = None
+
+
+@dataclass(frozen=True)
+class HarnessRunResult:
+    """Structured result returned by `run_harness`."""
+
+    runtime: dict[str, Any]
+    final_state: GraphState
+    summary: dict[str, Any]
+    checkpoint: dict[str, Any] | None
+    validation_errors: tuple[str, ...]
+
+
+def build_initial_state(config: HarnessRunConfig | None = None) -> GraphState:
+    """Create initial graph state from an operator profile and evidence rows."""
+    config = config or HarnessRunConfig()
+    profile_path = str(config.profile_path) if config.profile_path else None
+    profile = load_harness_profile(profile_path)
+    caller_context = dict(profile["caller_context"])
+    if config.caller_context:
+        caller_context.update(config.caller_context)
+    raw_events = [dict(event) for event in (config.raw_events or ({"source": "demo"},))]
+    return {
+        "harness_profile": profile,
+        "caller_context": caller_context,
+        "raw_events": raw_events,
+    }
+
+
+def validate_harness_summary(summary: Mapping[str, Any]) -> tuple[str, ...]:
+    """Validate wrapper-level invariants without re-running graph nodes."""
+    errors: list[str] = []
+    trace = list(summary.get("trace") or [])
+    if not trace or trace[0] != "ingest" or trace[-1] != "writeback":
+        errors.append("trace must run from ingest to writeback")
+
+    harness = summary.get("harness") or {}
+    allowed_outputs = set(harness.get("allowed_outputs") or [])
+    forbidden_harness_outputs = {
+        "approval",
+        "cvss",
+        "mitre",
+        "epss",
+        "kev",
+        "tenant_scope",
+        "idempotency_key",
+        "write_intent",
+        "call_write_tools",
+    }
+    if allowed_outputs.intersection(forbidden_harness_outputs):
+        errors.append("llm harness exposes forbidden authoritative outputs")
+
+    token_usage = summary.get("token_budget_usage") or {}
+    token_budget = harness.get("token_budget") or {}
+    if token_usage.get("status") not in {"within_budget", "fallback"}:
+        errors.append("token budget status must be within_budget or fallback")
+    if (
+        token_usage.get("status") == "within_budget"
+        and token_usage.get("compact_input_tokens_estimate", 0) > token_budget.get("max_input_tokens", 0)
+    ):
+        errors.append("compact LLM input exceeds max_input_tokens")
+    if (
+        token_usage.get("status") == "within_budget"
+        and token_usage.get("compact_evidence_chars", 0) > token_budget.get("max_evidence_chars", 0)
+    ):
+        errors.append("compact LLM evidence exceeds max_evidence_chars")
+
+    for card in summary.get("llm_evidence_cards") or []:
+        if "raw_events" in card or "ocsf_events" in card:
+            errors.append("llm evidence cards must not include raw or full OCSF events")
+            break
+
+    review = summary.get("review") or {}
+    remediation = summary.get("remediation") or {}
+    if remediation.get("status") == "dry_run" and review.get("status") != "approved":
+        errors.append("dry-run remediation requires approved review state")
+
+    integrity = summary.get("integrity") or {}
+    audit = summary.get("audit") or {}
+    if integrity.get("state_hash") != audit.get("state_hash"):
+        errors.append("audit state_hash must match integrity state_hash")
+
+    contract = summary.get("pipeline_contract") or {}
+    triage_nodes = [
+        node
+        for node in contract.get("nodes") or []
+        if node.get("node") == "llm_triage"
+    ]
+    if not triage_nodes:
+        errors.append("pipeline contract must include llm_triage node")
+    else:
+        guardrails = set(triage_nodes[0].get("guardrails") or [])
+        for required in ("closed_adapter_schema", "compact_evidence_only", "token_budget_enforced"):
+            if required not in guardrails:
+                errors.append(f"llm_triage guardrail missing: {required}")
+
+    return tuple(errors)
+
+
+def run_harness(config: HarnessRunConfig | None = None, *, check: bool = True) -> HarnessRunResult:
+    """Run or replay the example harness and return state plus summary.
+
+    Set `use_langgraph_runtime=True` to execute through a compiled LangGraph
+    StateGraph. The default deterministic runner mirrors the same route
+    decisions and keeps local/CI runs dependency-light.
+    """
+    config = config or HarnessRunConfig()
+    checkpoint: dict[str, Any] | None = None
+    replayed = bool(config.replay_checkpoint_path)
+    if config.replay_checkpoint_path:
+        final = load_checkpoint(Path(config.replay_checkpoint_path))
+        execution_mode = "checkpoint_replay"
+    else:
+        initial = build_initial_state(config)
+        if config.use_langgraph_runtime:
+            final = run_langgraph(initial)
+            execution_mode = "langgraph_stategraph"
+        else:
+            final = run_graph(initial)
+            execution_mode = "deterministic_runner"
+        if config.checkpoint_path:
+            checkpoint = write_checkpoint(final, Path(config.checkpoint_path))
+
+    summary = summarize(final)
+    validation_errors = validate_harness_summary(summary)
+    if check and validation_errors:
+        raise ValueError("; ".join(validation_errors))
+
+    runtime = {
+        "schema_version": HARNESS_RUNTIME_VERSION,
+        "checkpoint_schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "execution_mode": execution_mode,
+        "replayed": replayed,
+        "profile_id": (summary.get("profile") or {}).get("profile_id"),
+        "trace": summary.get("trace"),
+        "validation_status": "pass" if not validation_errors else "fail",
+    }
+    return HarnessRunResult(
+        runtime=runtime,
+        final_state=final,
+        summary=summary,
+        checkpoint=checkpoint,
+        validation_errors=validation_errors,
+    )
+
+
+def run_harness_summary(config: HarnessRunConfig | None = None, *, check: bool = True) -> dict[str, Any]:
+    """Return the operator-facing summary with wrapper runtime metadata."""
+    result = run_harness(config, check=check)
+    return {
+        "harness_runtime": result.runtime,
+        **result.summary,
+    }

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -236,6 +236,71 @@ class TestHitlGateReachable:
         assert '"dry_run"' in result.stdout
 
 
+class TestLangGraphHarnessRuntime:
+    """Importable wrapper coverage for embedding the LangGraph harness."""
+
+    def _runtime_module(self):
+        if str(EXAMPLES) not in sys.path:
+            sys.path.insert(0, str(EXAMPLES))
+        import harness_runtime
+
+        return harness_runtime
+
+    def test_runtime_wrapper_runs_without_shelling_out(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("DEMO_APPROVE", raising=False)
+        runtime = self._runtime_module()
+
+        summary = runtime.run_harness_summary()
+
+        assert summary["harness_runtime"]["schema_version"] == "langgraph-soc-harness-runtime-v1"
+        assert summary["harness_runtime"]["execution_mode"] == "deterministic_runner"
+        assert summary["harness_runtime"]["validation_status"] == "pass"
+        assert summary["trace"][0] == "ingest"
+        assert summary["trace"][-1] == "writeback"
+        assert summary["review"]["status"] == "blocked"
+        assert summary["remediation"]["status"] == "skipped"
+
+    def test_runtime_wrapper_accepts_profile_caller_and_events(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("DEMO_APPROVE", raising=False)
+        runtime = self._runtime_module()
+        config = runtime.HarnessRunConfig(
+            profile_path=EXAMPLES / "harness_profiles" / "readonly-soc.json",
+            caller_context={
+                "session_id": "wrapper-test-session",
+                "email": "wrapper@example.com",
+            },
+            raw_events=(
+                {
+                    "source": "cloudtrail",
+                    "event_name": "CreateAccessKey",
+                    "actor_uid": "AIDAWRAPPER",
+                    "resource_uid": "arn:aws:iam::111122223333:user/wrapper",
+                },
+            ),
+        )
+
+        result = runtime.run_harness(config)
+
+        assert result.validation_errors == ()
+        assert result.runtime["profile_id"] == "readonly-soc"
+        assert result.summary["caller_context"]["session_id"] == "wrapper-test-session"
+        assert result.summary["audit"]["correlation_id"] == "wrapper-test-session"
+        assert result.summary["findings_count"] == 1
+
+    def test_runtime_wrapper_replays_checkpoint(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("DEMO_APPROVE", raising=False)
+        runtime = self._runtime_module()
+        checkpoint_path = tmp_path / "langgraph-checkpoint.json"
+
+        first = runtime.run_harness(runtime.HarnessRunConfig(checkpoint_path=checkpoint_path))
+        replayed = runtime.run_harness(runtime.HarnessRunConfig(replay_checkpoint_path=checkpoint_path))
+
+        assert first.checkpoint["path"] == str(checkpoint_path)
+        assert replayed.runtime["execution_mode"] == "checkpoint_replay"
+        assert replayed.runtime["replayed"] is True
+        assert replayed.summary["integrity"]["state_hash"] == first.summary["integrity"]["state_hash"]
+
+
 class TestLangGraphSocWorkflow:
     """Regression coverage for the expanded SOC workflow graph."""
 


### PR DESCRIPTION
Summary
- Add an importable `harness_runtime.py` wrapper for running, checkpointing, replaying, and validating the LangGraph SOC harness as code.
- Document that `docs/HARNESS.md` is the operator contract while graph nodes, adapters, wrapper, schemas, checkpoints, and evals are the executable harness.
- Add regression coverage for direct wrapper imports, operator profile/caller overrides, raw event input, and checkpoint replay.

Verification
- PYTHONPATH=examples/agents python - <<'PY' ... wrapper import smoke ... PY
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/harness_runtime.py
- uv run make agent-evals
- git diff --check

Notes
- Existing untracked duplicate files with ` 2` suffixes were left untouched and are not part of this PR.