### PR TITLE
feat(examples): add LangGraph agent roster policy

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -104,8 +104,13 @@ fallback when the budget is exceeded.
 The example exposes a concrete `agents` manifest and `agent_runs` ledger:
 `evidence-agent`, `risk-map-agent`, `triage-agent`, `review-gate`,
 `remediation-planner`, `retry-coordinator`, `escalation-agent`, and
-`audit-writer`. Each run carries an authority label plus input/output hashes
-so replay can detect drift without trusting prompt text.
+`audit-writer`. Profiles can declare concise `agent_roster` overrides for
+model tier, privilege boundary, skill scope, and HITL posture. Runtime loading
+then re-applies fixed graph ownership and safety boundaries: the LLM triage
+agent keeps `no_tool_writes` with an empty skill scope, while remediation
+planning keeps `dry_run_write_planning` and requires human approval. Each run
+carries an authority label plus input/output hashes so replay can detect drift
+without trusting prompt text.
 The operator-facing summary also emits `pipeline_contract`, a code-backed list
 of nodes, edges, route conditions, skills, input/output state keys, and
 guardrails for approval, dry-run remediation, retries, idempotency, and audit
@@ -153,13 +158,14 @@ share a closed eval-report schema.
 Operator profiles live under
 [`examples/agents/harness_profiles/`](../examples/agents/harness_profiles/).
 They are JSON metadata only: allowed skills, caller context, identity hints,
-LLM provider/model metadata, model-policy selection, token-budget limits, and
-approval-policy documentation. They do not store cloud secrets and they do not
-grant approval. A remediation profile can make a dry-run skill visible, but
-the graph still needs `_approval_context` from the operator's IDP or ticketing
-workflow before routing to remediation. Profiles can declare `model_policy`
-and `token_budget` together so small triage tasks stay on tiny/small model
-tiers and oversized context falls back deterministically.
+LLM provider/model metadata, model-policy selection, token-budget limits,
+agent-roster overrides, and approval-policy documentation. They do not store
+cloud secrets and they do not grant approval. A remediation profile can make a
+dry-run skill visible, but the graph still needs `_approval_context` from the
+operator's IDP or ticketing workflow before routing to remediation. Profiles
+can declare `model_policy`, `token_budget`, and `agent_roster` together so
+small triage tasks stay on tiny/small model tiers, oversized context falls back
+deterministically, and write-capable stages remain deterministic plus HITL.
 Closed JSON Schema contracts live under
 [`examples/agents/schemas/`](../examples/agents/schemas/) for harness
 profiles, LLM adapter recommendation payloads, and the emitted

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -187,6 +187,10 @@ forms share a closed schema contract under [`schemas/`](schemas/).
 `pipeline_contract` is code-backed topology metadata: node ownership, skills,
 input/output state keys, conditional edges, and guardrails for dry-run,
 approval, retries, idempotency, and audit writeback.
+Profiles can also carry concise `agent_roster` overrides. The loader preserves
+fixed graph ownership and re-applies safety boundaries, so an operator can set
+the triage model tier or document remediation posture without granting the LLM
+agent tool-write scope or bypassing HITL.
 Importable harness wrapper:
 
 ```bash

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -94,6 +94,20 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
     session_id = args.session_id or f"{args.profile_id}-session"
     user_id = args.user_id or args.email.split("@", 1)[0]
     model_tier = "small" if args.external_llm else "tiny"
+    agent_roster = [
+        {
+            "agent_id": "triage-agent",
+            "model_tier": model_tier,
+            "privilege_boundary": "no_tool_writes",
+            "skill_scope": [],
+        },
+        {
+            "agent_id": "remediation-planner",
+            "requires_human_approval": True,
+            "privilege_boundary": "dry_run_write_planning",
+            "skill_scope": [ALLOWED_SKILLS_REMEDIATION] if ROLE_DEFAULTS[role]["include_remediation"] else [],
+        },
+    ]
     return {
         "profile_id": args.profile_id,
         "description": args.description or ROLE_DEFAULTS[role]["description"],
@@ -127,6 +141,7 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
                 },
             },
         },
+        "agent_roster": agent_roster,
         "approval_policy": {
             "remediation_requires_approval_context": True,
             "approval_source": args.approval_source,

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -151,6 +151,8 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
     token_usage = summary.get("token_budget_usage") or {}
     token_budget = (summary.get("harness") or {}).get("token_budget") or {}
     model_policy = (summary.get("harness") or {}).get("model_policy") or {}
+    agents = {agent.get("agent_id"): agent for agent in summary.get("agents") or []}
+    remediation_agent = agents.get("remediation-planner") or {}
     checks.extend([
         _check("token_budget_status_present", token_usage.get("status") in {"within_budget", "fallback"}, True),
         _check(
@@ -181,6 +183,15 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
             all("raw_events" not in card and "ocsf_events" not in card for card in summary.get("llm_evidence_cards") or []),
             True,
         ),
+        _check("triage_agent_no_write_privilege", triage_agent.get("privilege_boundary"), "no_tool_writes"),
+        _check("triage_agent_no_skill_scope", triage_agent.get("skill_scope"), []),
+        _check(
+            "triage_agent_model_tier_allowed",
+            triage_agent.get("model_tier") in set(model_policy.get("allowed_model_tiers") or []),
+            True,
+        ),
+        _check("remediation_agent_requires_hitl", remediation_agent.get("requires_human_approval"), True),
+        _check("remediation_agent_dry_run_boundary", remediation_agent.get("privilege_boundary"), "dry_run_write_planning"),
     ])
 
     if "recommendation_generated_by" in expected:

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -41,6 +41,9 @@ Profiles control:
 - `token_budget`: model tier and hard estimated token caps; the harness sends
   compact evidence cards only and falls back deterministically when a request
   would exceed budget.
+- `agent_roster`: concise per-agent overrides for model tier, privilege
+  boundary, skill scope, and HITL posture. The loader keeps the graph topology
+  fixed and re-applies no-write/HITL guardrails.
 - `approval_policy`: documentation of the HITL source; profiles never grant
   approval by themselves.
 

--- a/examples/agents/harness_profiles/analyst-triage.json
+++ b/examples/agents/harness_profiles/analyst-triage.json
@@ -68,6 +68,14 @@
       "model": "policy-bounded-triage-v1"
     }
   },
+  "agent_roster": [
+    {
+      "agent_id": "triage-agent",
+      "model_tier": "small",
+      "privilege_boundary": "no_tool_writes",
+      "skill_scope": []
+    }
+  ],
   "approval_policy": {
     "remediation_requires_approval_context": true,
     "approval_source": "operator_idp_or_ticketing_system"

--- a/examples/agents/harness_profiles/dry-run-remediation.json
+++ b/examples/agents/harness_profiles/dry-run-remediation.json
@@ -67,6 +67,22 @@
       "model": "policy-bounded-triage-v1"
     }
   },
+  "agent_roster": [
+    {
+      "agent_id": "triage-agent",
+      "model_tier": "tiny",
+      "privilege_boundary": "no_tool_writes",
+      "skill_scope": []
+    },
+    {
+      "agent_id": "remediation-planner",
+      "requires_human_approval": true,
+      "privilege_boundary": "dry_run_write_planning",
+      "skill_scope": [
+        "iam-departures-aws"
+      ]
+    }
+  ],
   "approval_policy": {
     "remediation_requires_approval_context": true,
     "approval_source": "operator_idp_or_ticketing_system",

--- a/examples/agents/harness_profiles/readonly-soc.json
+++ b/examples/agents/harness_profiles/readonly-soc.json
@@ -68,6 +68,14 @@
       "model": "policy-bounded-triage-v1"
     }
   },
+  "agent_roster": [
+    {
+      "agent_id": "triage-agent",
+      "model_tier": "tiny",
+      "privilege_boundary": "no_tool_writes",
+      "skill_scope": []
+    }
+  ],
   "approval_policy": {
     "remediation_requires_approval_context": true,
     "approval_source": "not_enabled_for_this_profile"

--- a/examples/agents/harness_runtime.py
+++ b/examples/agents/harness_runtime.py
@@ -113,6 +113,23 @@ def validate_harness_summary(summary: Mapping[str, Any]) -> tuple[str, ...]:
             errors.append("llm evidence cards must not include raw or full OCSF events")
             break
 
+    agents = {agent.get("agent_id"): agent for agent in summary.get("agents") or []}
+    triage_agent = agents.get("triage-agent") or {}
+    if triage_agent.get("privilege_boundary") != "no_tool_writes":
+        errors.append("triage-agent must use no_tool_writes privilege boundary")
+    if triage_agent.get("skill_scope") not in ((), []):
+        errors.append("triage-agent must not have direct skill scope")
+    if {"approval", "write_intent"} - set(triage_agent.get("forbidden_outputs") or []):
+        errors.append("triage-agent must forbid approval and write_intent outputs")
+    if triage_agent.get("model_tier") not in set(model_policy.get("allowed_model_tiers") or []):
+        errors.append("triage-agent model tier must be allowed by model policy")
+
+    remediation_agent = agents.get("remediation-planner") or {}
+    if remediation_agent.get("requires_human_approval") is not True:
+        errors.append("remediation-planner must require human approval")
+    if remediation_agent.get("privilege_boundary") != "dry_run_write_planning":
+        errors.append("remediation-planner must stay dry-run write planning only")
+
     review = summary.get("review") or {}
     remediation = summary.get("remediation") or {}
     if remediation.get("status") == "dry_run" and review.get("status") != "approved":

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -93,6 +93,7 @@ class HarnessProfile(TypedDict, total=False):
     llm: dict[str, str]
     approval_policy: dict[str, Any]
     model_policy: dict[str, Any]
+    agent_roster: list[dict[str, Any]]
     runtime: dict[str, Any]
 
 
@@ -156,6 +157,11 @@ class AgentDefinition(TypedDict):
     kind: AgentKind
     owns: list[WorkflowStage]
     authority: str
+    privilege_boundary: str
+    skill_scope: list[str]
+    model_tier: str
+    requires_human_approval: bool
+    failure_route: str
     allowed_outputs: list[str]
     forbidden_outputs: list[str]
 
@@ -329,6 +335,118 @@ DEFAULT_MODEL_POLICY = {
     },
 }
 
+DEFAULT_AGENT_ROSTER: list[AgentDefinition] = [
+    {
+        "agent_id": "evidence-agent",
+        "kind": "deterministic_skill",
+        "owns": ["ingest", "normalize", "enrich", "correlate"],
+        "authority": "read_only_evidence_collection",
+        "privilege_boundary": "read_only",
+        "skill_scope": [
+            "ingest-cloudtrail-ocsf",
+            "source-snowflake-query",
+            "detect-lateral-movement",
+            "discover-control-evidence",
+        ],
+        "model_tier": "none",
+        "requires_human_approval": False,
+        "failure_route": "writeback",
+        "allowed_outputs": ["raw_events", "ocsf_events", "findings", "correlations"],
+        "forbidden_outputs": ["approval", "write_intent", "policy_override"],
+    },
+    {
+        "agent_id": "risk-map-agent",
+        "kind": "deterministic_skill",
+        "owns": ["confidence", "map"],
+        "authority": "deterministic_security_facts",
+        "privilege_boundary": "read_only",
+        "skill_scope": ["detect-lateral-movement", "cspm-aws-cis-benchmark"],
+        "model_tier": "none",
+        "requires_human_approval": False,
+        "failure_route": "writeback",
+        "allowed_outputs": ["confidence_scores", "framework_maps"],
+        "forbidden_outputs": ["approval", "write_intent", "audit_chain_mutation"],
+    },
+    {
+        "agent_id": "triage-agent",
+        "kind": "llm_optional",
+        "owns": ["llm_triage"],
+        "authority": "rank_summarize_draft_only",
+        "privilege_boundary": "no_tool_writes",
+        "skill_scope": [],
+        "model_tier": "tiny",
+        "requires_human_approval": False,
+        "failure_route": "deterministic_fallback",
+        "allowed_outputs": ["rank_findings", "summarize_evidence", "draft_analyst_note", "request_human_review"],
+        "forbidden_outputs": ["approval", "cvss", "mitre", "epss", "kev", "write_intent", "audit_chain_mutation"],
+    },
+    {
+        "agent_id": "review-gate",
+        "kind": "human_gate",
+        "owns": ["review"],
+        "authority": "operator_attested_approval_only",
+        "privilege_boundary": "approval_context_only",
+        "skill_scope": [],
+        "model_tier": "none",
+        "requires_human_approval": True,
+        "failure_route": "writeback",
+        "allowed_outputs": ["approved", "blocked", "approval_context"],
+        "forbidden_outputs": ["synthetic_approval", "model_attested_approval"],
+    },
+    {
+        "agent_id": "remediation-planner",
+        "kind": "deterministic_skill",
+        "owns": ["remediate"],
+        "authority": "dry_run_after_hitl_only",
+        "privilege_boundary": "dry_run_write_planning",
+        "skill_scope": [ALLOWED_SKILLS_REMEDIATION],
+        "model_tier": "none",
+        "requires_human_approval": True,
+        "failure_route": "retry_or_escalate",
+        "allowed_outputs": ["dry_run_plan", "idempotency_key", "retry_decision"],
+        "forbidden_outputs": ["apply", "ungated_write", "new_idempotency_key_on_retry"],
+    },
+    {
+        "agent_id": "retry-coordinator",
+        "kind": "governance",
+        "owns": ["retry_queue"],
+        "authority": "bounded_retry_same_idempotency_key",
+        "privilege_boundary": "retry_metadata_only",
+        "skill_scope": [],
+        "model_tier": "none",
+        "requires_human_approval": True,
+        "failure_route": "writeback",
+        "allowed_outputs": ["retry_record"],
+        "forbidden_outputs": ["new_write_intent", "approval_bypass"],
+    },
+    {
+        "agent_id": "escalation-agent",
+        "kind": "governance",
+        "owns": ["escalate"],
+        "authority": "terminal_error_human_queue",
+        "privilege_boundary": "queue_metadata_only",
+        "skill_scope": [],
+        "model_tier": "none",
+        "requires_human_approval": True,
+        "failure_route": "writeback",
+        "allowed_outputs": ["escalation_record"],
+        "forbidden_outputs": ["auto_apply", "silent_drop"],
+    },
+    {
+        "agent_id": "audit-writer",
+        "kind": "deterministic_skill",
+        "owns": ["writeback"],
+        "authority": "append_only_audit_eval",
+        "privilege_boundary": "append_only",
+        "skill_scope": ["convert-ocsf-to-sarif"],
+        "model_tier": "none",
+        "requires_human_approval": False,
+        "failure_route": "fail_closed",
+        "allowed_outputs": ["audit_record", "eval_record", "state_hash"],
+        "forbidden_outputs": ["overwrite_history", "remove_agent_run"],
+    },
+]
+
 
 def _default_harness_profile() -> HarnessProfile:
     return {
@@ -353,6 +471,7 @@ def _default_harness_profile() -> HarnessProfile:
         },
         "token_budget": DEFAULT_TOKEN_BUDGET,
         "model_policy": DEFAULT_MODEL_POLICY,
+        "agent_roster": DEFAULT_AGENT_ROSTER,
         "approval_policy": {
             "remediation_requires_approval_context": True,
             "approval_source": "operator_idp_or_ticketing_system",
@@ -362,6 +481,49 @@ def _default_harness_profile() -> HarnessProfile:
             "dry_run_default": True,
         },
     }
+
+
+def _merge_agent_roster(profile_roster: list[dict[str, Any]] | None) -> list[AgentDefinition]:
+    if not profile_roster:
+        return [dict(agent) for agent in DEFAULT_AGENT_ROSTER]
+    merged: list[AgentDefinition] = []
+    for default in DEFAULT_AGENT_ROSTER:
+        override = next(
+            (agent for agent in profile_roster if agent.get("agent_id") == default["agent_id"]),
+            {},
+        )
+        candidate = {**default, **override}
+        if candidate["agent_id"] != default["agent_id"]:
+            candidate["agent_id"] = default["agent_id"]
+        if candidate["kind"] != default["kind"]:
+            candidate["kind"] = default["kind"]
+        if candidate["owns"] != default["owns"]:
+            candidate["owns"] = default["owns"]
+        if candidate["authority"] != default["authority"]:
+            candidate["authority"] = default["authority"]
+        if candidate["agent_id"] == "triage-agent":
+            candidate["privilege_boundary"] = "no_tool_writes"
+            candidate["skill_scope"] = []
+            candidate["requires_human_approval"] = False
+            candidate["forbidden_outputs"] = sorted({
+                *default["forbidden_outputs"],
+                *candidate.get("forbidden_outputs", []),
+                "approval",
+                "write_intent",
+                "audit_chain_mutation",
+            })
+        if candidate["agent_id"] == "remediation-planner":
+            candidate["requires_human_approval"] = True
+            candidate["privilege_boundary"] = "dry_run_write_planning"
+            candidate["skill_scope"] = [ALLOWED_SKILLS_REMEDIATION]
+            candidate["forbidden_outputs"] = sorted({
+                *default["forbidden_outputs"],
+                *candidate.get("forbidden_outputs", []),
+                "apply",
+                "ungated_write",
+            })
+        merged.append(candidate)  # type: ignore[arg-type]
+    return merged
 
 
 def load_harness_profile(path_text: str | None = None) -> HarnessProfile:
@@ -396,6 +558,7 @@ def load_harness_profile(path_text: str | None = None) -> HarnessProfile:
         **default["model_policy"]["fallback"],
         **payload.get("model_policy", {}).get("fallback", {}),
     }
+    profile["agent_roster"] = _merge_agent_roster(payload.get("agent_roster"))
     return profile
 
 
@@ -405,76 +568,15 @@ def _effective_allowed_skills(profile: HarnessProfile) -> list[str]:
     return [skill for skill in requested if skill in safe_surface]
 
 
-def _agent_manifest() -> list[AgentDefinition]:
-    return [
-        {
-            "agent_id": "evidence-agent",
-            "kind": "deterministic_skill",
-            "owns": ["ingest", "normalize", "enrich", "correlate"],
-            "authority": "read_only_evidence_collection",
-            "allowed_outputs": ["raw_events", "ocsf_events", "findings", "correlations"],
-            "forbidden_outputs": ["approval", "write_intent", "policy_override"],
-        },
-        {
-            "agent_id": "risk-map-agent",
-            "kind": "deterministic_skill",
-            "owns": ["confidence", "map"],
-            "authority": "deterministic_security_facts",
-            "allowed_outputs": ["confidence_scores", "framework_maps"],
-            "forbidden_outputs": ["approval", "write_intent", "audit_chain_mutation"],
-        },
-        {
-            "agent_id": "triage-agent",
-            "kind": "llm_optional",
-            "owns": ["llm_triage"],
-            "authority": "rank_summarize_draft_only",
-            "allowed_outputs": ["rank_findings", "summarize_evidence", "draft_analyst_note", "request_human_review"],
-            "forbidden_outputs": ["approval", "cvss", "mitre", "epss", "kev", "write_intent", "audit_chain_mutation"],
-        },
-        {
-            "agent_id": "review-gate",
-            "kind": "human_gate",
-            "owns": ["review"],
-            "authority": "operator_attested_approval_only",
-            "allowed_outputs": ["approved", "blocked", "approval_context"],
-            "forbidden_outputs": ["synthetic_approval", "model_attested_approval"],
-        },
-        {
-            "agent_id": "remediation-planner",
-            "kind": "deterministic_skill",
-            "owns": ["remediate"],
-            "authority": "dry_run_after_hitl_only",
-            "allowed_outputs": ["dry_run_plan", "idempotency_key", "retry_decision"],
-            "forbidden_outputs": ["apply", "ungated_write", "new_idempotency_key_on_retry"],
-        },
-        {
-            "agent_id": "retry-coordinator",
-            "kind": "governance",
-            "owns": ["retry_queue"],
-            "authority": "bounded_retry_same_idempotency_key",
-            "allowed_outputs": ["retry_record"],
-            "forbidden_outputs": ["new_write_intent", "approval_bypass"],
-        },
-        {
-            "agent_id": "escalation-agent",
-            "kind": "governance",
-            "owns": ["escalate"],
-            "authority": "terminal_error_human_queue",
-            "allowed_outputs": ["escalation_record"],
-            "forbidden_outputs": ["auto_apply", "silent_drop"],
-        },
-        {
-            "agent_id": "audit-writer",
-            "kind": "deterministic_skill",
-            "owns": ["writeback"],
-            "authority": "append_only_audit_eval",
-            "allowed_outputs": ["audit_record", "eval_record", "state_hash"],
-            "forbidden_outputs": ["overwrite_history", "remove_agent_run"],
-        },
-    ]
+def _agent_manifest(state: GraphState | None = None) -> list[AgentDefinition]:
+    profile = (state or {}).get("harness_profile") if state else None
+    if profile and profile.get("agent_roster"):
+        return _merge_agent_roster(profile.get("agent_roster"))
+    return [dict(agent) for agent in DEFAULT_AGENT_ROSTER]
 
 
-def _pipeline_node_contracts() -> list[PipelineNodeContract]:
+def _pipeline_node_contracts(state: GraphState | None = None) -> list[PipelineNodeContract]:
+    agent_by_id = {agent["agent_id"]: agent for agent in _agent_manifest(state)}
     return [
         {
             "node": "ingest",
@@ -549,7 +651,7 @@ def _pipeline_node_contracts() -> list[PipelineNodeContract]:
         {
             "node": "remediate",
             "agent_id": "remediation-planner",
-            "skills": [ALLOWED_SKILLS_REMEDIATION],
+            "skills": agent_by_id["remediation-planner"]["skill_scope"],
             "inputs": ["review_decision", "framework_maps", "confidence_scores", "idempotency"],
             "outputs": ["remediation_result", "api_errors", "idempotency.remediation_key"],
             "guardrails": ["dry_run_default", "approval_context_required", "stable_idempotency_key"],
@@ -600,11 +702,11 @@ def _pipeline_edge_contracts() -> list[PipelineEdgeContract]:
     ]
 
 
-def pipeline_contract() -> dict[str, Any]:
+def pipeline_contract(state: GraphState | None = None) -> dict[str, Any]:
     return {
         "schema_version": "langgraph-soc-pipeline-contract-v1",
         "description": "Code-backed LangGraph SOC workflow contract for nodes, edges, skills, and guardrails.",
-        "nodes": _pipeline_node_contracts(),
+        "nodes": _pipeline_node_contracts(state),
         "edges": _pipeline_edge_contracts(),
         "invariants": [
             "skills own facts; LangGraph owns routing and state",
@@ -616,13 +718,6 @@ def pipeline_contract() -> dict[str, Any]:
     }
 
 
-def _agent_by_id(agent_id: str) -> AgentDefinition:
-    for agent in _agent_manifest():
-        if agent["agent_id"] == agent_id:
-            return agent
-    raise KeyError(agent_id)
-
-
 def _record_agent_run(
     state: GraphState,
     *,
@@ -632,8 +727,9 @@ def _record_agent_run(
     outputs: Any,
     token_budget: dict[str, Any] | None = None,
 ) -> None:
-    state.setdefault("agent_manifest", _agent_manifest())
-    agent = _agent_by_id(agent_id)
+    state.setdefault("agent_manifest", _agent_manifest(state))
+    agent_by_id = {agent["agent_id"]: agent for agent in state["agent_manifest"]}
+    agent = agent_by_id[agent_id]
     runs = state.setdefault("agent_runs", [])
     record: AgentRunRecord = {
         "run_id": f"run-{len(runs) + 1:02d}-{agent_id}",
@@ -803,8 +899,8 @@ def route_after_remediation(state: GraphState) -> RemediationRoute:
 def ingest_node(state: GraphState) -> GraphState:
     """Collect raw evidence from an approved source surface."""
     _append_trace(state, "ingest")
-    state.setdefault("agent_manifest", _agent_manifest())
     profile = state.setdefault("harness_profile", _default_harness_profile())
+    state["agent_manifest"] = _agent_manifest(state)
     effective_skills = _effective_allowed_skills(profile)
     state["effective_allowed_skills"] = effective_skills
     raw_events = state.get("raw_events") or [{
@@ -1478,7 +1574,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "confidence_scores": final.get("confidence_scores"),
         "framework_maps": final.get("framework_maps"),
         "harness": final.get("harness_config"),
-        "pipeline_contract": pipeline_contract(),
+        "pipeline_contract": pipeline_contract(final),
         "agents": final.get("agent_manifest"),
         "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),

--- a/examples/agents/schemas/harness_profile.schema.json
+++ b/examples/agents/schemas/harness_profile.schema.json
@@ -237,6 +237,14 @@
         }
       }
     },
+    "agent_roster": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/agent_roster_entry"
+      }
+    },
     "approval_policy": {
       "type": "object",
       "additionalProperties": false,
@@ -298,6 +306,120 @@
         "model": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "agent_roster_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent_id"
+      ],
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "enum": [
+            "evidence-agent",
+            "risk-map-agent",
+            "triage-agent",
+            "review-gate",
+            "remediation-planner",
+            "retry-coordinator",
+            "escalation-agent",
+            "audit-writer"
+          ]
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "deterministic_skill",
+            "llm_optional",
+            "human_gate",
+            "governance"
+          ]
+        },
+        "owns": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "ingest",
+              "normalize",
+              "enrich",
+              "correlate",
+              "confidence",
+              "map",
+              "llm_triage",
+              "review",
+              "remediate",
+              "retry_queue",
+              "escalate",
+              "writeback"
+            ]
+          }
+        },
+        "authority": {
+          "type": "string",
+          "minLength": 1
+        },
+        "privilege_boundary": {
+          "type": "string",
+          "enum": [
+            "read_only",
+            "no_tool_writes",
+            "approval_context_only",
+            "dry_run_write_planning",
+            "retry_metadata_only",
+            "queue_metadata_only",
+            "append_only"
+          ]
+        },
+        "skill_scope": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "model_tier": {
+          "type": "string",
+          "enum": [
+            "none",
+            "tiny",
+            "small",
+            "large"
+          ]
+        },
+        "requires_human_approval": {
+          "type": "boolean"
+        },
+        "failure_route": {
+          "type": "string",
+          "enum": [
+            "writeback",
+            "deterministic_fallback",
+            "retry_or_escalate",
+            "fail_closed"
+          ]
+        },
+        "allowed_outputs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "forbidden_outputs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     }

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -397,6 +397,14 @@ class TestLangGraphSocWorkflow:
         assert all("raw_events" not in card for card in summary["llm_evidence_cards"])
         assert all("ocsf_events" not in card for card in summary["llm_evidence_cards"])
         assert [agent["agent_id"] for agent in summary["agents"]] == self.EXPECTED_AGENT_IDS
+        triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
+        assert triage_agent["privilege_boundary"] == "no_tool_writes"
+        assert triage_agent["skill_scope"] == []
+        assert triage_agent["model_tier"] == "tiny"
+        assert "approval" in triage_agent["forbidden_outputs"]
+        remediation_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "remediation-planner")
+        assert remediation_agent["requires_human_approval"] is True
+        assert remediation_agent["privilege_boundary"] == "dry_run_write_planning"
         assert [run["agent_id"] for run in summary["agent_runs"]] == [
             "evidence-agent",
             "risk-map-agent",
@@ -669,6 +677,10 @@ class TestLangGraphSocWorkflow:
         assert summary["harness"]["model"] == "gpt-4.1-mini"
         assert summary["harness"]["model_policy"]["selected_model_tier"] == "small"
         assert summary["harness"]["model_policy"]["selection_source"] == "profile_model_policy"
+        triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
+        assert triage_agent["model_tier"] == "small"
+        assert triage_agent["privilege_boundary"] == "no_tool_writes"
+        assert triage_agent["skill_scope"] == []
         assert summary["agent_recommendations"][0]["generated_by"] == "openai:gpt-4.1-mini"
         assert summary["review"]["status"] == "blocked"
 
@@ -932,6 +944,13 @@ class TestLangGraphContractSchemas:
             assert profile["model_policy"]["policy_version"] == "langgraph-model-policy-v1"
             assert profile["model_policy"]["selection_strategy"] == "smallest_sufficient"
             assert profile["token_budget"]["model_tier"] in profile["model_policy"]["allowed_model_tiers"]
+            if profile.get("agent_roster"):
+                roster = {agent["agent_id"]: agent for agent in profile["agent_roster"]}
+                if "triage-agent" in roster:
+                    assert roster["triage-agent"]["privilege_boundary"] == "no_tool_writes"
+                    assert roster["triage-agent"]["skill_scope"] == []
+                if "remediation-planner" in roster:
+                    assert roster["remediation-planner"]["requires_human_approval"] is True
 
     def test_llm_adapter_eval_fixtures_match_expected_schema_outcome(self):
         schema = json.loads(self.ADAPTER_SCHEMA.read_text(encoding="utf-8"))
@@ -1081,6 +1100,13 @@ class TestLangGraphHarnessSetup:
             "provider": "openai",
             "model": "gpt-4.1-mini",
         }
+        roster = {agent["agent_id"]: agent for agent in profile["agent_roster"]}
+        assert roster["triage-agent"] == {
+            "agent_id": "triage-agent",
+            "model_tier": "small",
+            "privilege_boundary": "no_tool_writes",
+            "skill_scope": [],
+        }
         assert "iam-departures-aws" not in profile["allowed_skills"]
 
         dotenv = env_path.read_text(encoding="utf-8")
@@ -1107,6 +1133,9 @@ class TestLangGraphHarnessSetup:
         assert summary["harness"]["token_budget"]["model_tier"] == "small"
         assert summary["harness"]["model_policy"]["selected_model_tier"] == "small"
         assert summary["harness"]["model_policy"]["selection_source"] == "profile_model_policy"
+        triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
+        assert triage_agent["model_tier"] == "small"
+        assert triage_agent["skill_scope"] == []
         assert summary["review"]["status"] == "blocked"
 
     def test_setup_generator_dry_run_profile_still_requires_approval(self, tmp_path: Path):
@@ -1140,6 +1169,9 @@ class TestLangGraphHarnessSetup:
         assert profile["approval_policy"]["remediation_requires_approval_context"] is True
         assert profile["token_budget"]["model_tier"] == "tiny"
         assert profile["model_policy"]["allowed_model_tiers"] == ["tiny"]
+        roster = {agent["agent_id"]: agent for agent in profile["agent_roster"]}
+        assert roster["remediation-planner"]["requires_human_approval"] is True
+        assert roster["remediation-planner"]["privilege_boundary"] == "dry_run_write_planning"
 
         blocked = subprocess.run(
             [sys.executable, str(self.GRAPH)],


### PR DESCRIPTION
Summary
- Add a profile-backed LangGraph agent roster policy for model tier, privilege boundary, skill scope, HITL posture, and failure routing.
- Enforce no-write LLM triage and HITL dry-run remediation boundaries in the runtime wrapper, eval gate, schema, and tests.
- Document the roster customization surface and add concise roster overrides to shipped/generated harness profiles.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/configure_langgraph_harness.py examples/agents/harness_runtime.py examples/agents/eval_langgraph_harness.py
- python -m json.tool examples/agents/schemas/harness_profile.schema.json and shipped harness profiles
- uv run make agent-evals
- git diff --check

Notes
- Existing untracked duplicate files ending in ` 2` were left untouched.