### PR TITLE
feat(examples): emit LangGraph agent policy report

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -111,6 +111,10 @@ agent keeps `no_tool_writes` with an empty skill scope, while remediation
 planning keeps `dry_run_write_planning` and requires human approval. Each run
 carries an authority label plus input/output hashes so replay can detect drift
 without trusting prompt text.
+The summary also emits `agent_policy`, a compiled effective-grants report that
+intersects each agent's roster skill scope with the profile allowlist. It shows
+granted skills, denied skills, model tier, write policy, approval satisfaction,
+and a stable `policy_hash` copied into audit.
 The operator-facing summary also emits `pipeline_contract`, a code-backed list
 of nodes, edges, route conditions, skills, input/output state keys, and
 guardrails for approval, dry-run remediation, retries, idempotency, and audit
@@ -168,8 +172,8 @@ small triage tasks stay on tiny/small model tiers, oversized context falls back
 deterministically, and write-capable stages remain deterministic plus HITL.
 Closed JSON Schema contracts live under
 [`examples/agents/schemas/`](../examples/agents/schemas/) for harness
-profiles, LLM adapter recommendation payloads, and the emitted
-`pipeline_contract` topology. Checkpoint artifacts have a closed schema
+profiles, LLM adapter recommendation payloads, emitted `agent_policy`, and the
+emitted `pipeline_contract` topology. Checkpoint artifacts have a closed schema
 envelope for replay persistence, and eval reports use a shared schema for
 both JSON output and JSONL history rows.
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -106,6 +106,7 @@ DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/readonly-soc.json \
 python examples/agents/langgraph_security_graph.py
 
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
+DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json \
 DEMO_APPROVE=yes \
 DEMO_APPROVER=reviewer@example.com \
 DEMO_TICKET=SEC-LANGGRAPH-1 \
@@ -174,7 +175,8 @@ The LangGraph summary includes `integrity.evidence_hash`,
 retryable-vs-terminal API error classification. It also includes the
 `profile`, `effective_allowed_skills`, `harness` provider/model/mode/model
 policy/token budget, `agents` manifest, `pipeline_contract`, `agent_runs`
-ledger, compact LLM evidence cards, token budget usage, and bounded
+ledger, `agent_policy` effective grants report, compact LLM evidence cards,
+token budget usage, and bounded
 `agent_recommendations` so
 operators can see which role and model would have drafted the analyst note
 without letting that model set policy, mappings, approvals, or audit facts. Use
@@ -191,6 +193,9 @@ Profiles can also carry concise `agent_roster` overrides. The loader preserves
 fixed graph ownership and re-applies safety boundaries, so an operator can set
 the triage model tier or document remediation posture without granting the LLM
 agent tool-write scope or bypassing HITL.
+`agent_policy` is the compiled view of those choices: per-agent requested
+skills, effective grants, denied skills, model tier, write policy, approval
+state, and decision.
 Importable harness wrapper:
 
 ```bash

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -153,6 +153,13 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
     model_policy = (summary.get("harness") or {}).get("model_policy") or {}
     agents = {agent.get("agent_id"): agent for agent in summary.get("agents") or []}
     remediation_agent = agents.get("remediation-planner") or {}
+    agent_policy = summary.get("agent_policy") or {}
+    policy_entries = {
+        entry.get("agent_id"): entry
+        for entry in agent_policy.get("entries") or []
+    }
+    triage_policy = policy_entries.get("triage-agent") or {}
+    remediation_policy = policy_entries.get("remediation-planner") or {}
     checks.extend([
         _check("token_budget_status_present", token_usage.get("status") in {"within_budget", "fallback"}, True),
         _check(
@@ -192,6 +199,11 @@ def run_case(case: dict[str, Any]) -> dict[str, Any]:
         ),
         _check("remediation_agent_requires_hitl", remediation_agent.get("requires_human_approval"), True),
         _check("remediation_agent_dry_run_boundary", remediation_agent.get("privilege_boundary"), "dry_run_write_planning"),
+        _check("agent_policy_schema_version", agent_policy.get("schema_version"), "langgraph-agent-policy-v1"),
+        _check("agent_policy_hash_present", bool(agent_policy.get("policy_hash")), True),
+        _check("triage_policy_grants_no_skills", triage_policy.get("effective_skill_grants"), []),
+        _check("triage_policy_decision_no_direct_tools", triage_policy.get("decision"), "no_direct_tools"),
+        _check("remediation_policy_write_boundary", remediation_policy.get("write_policy"), "dry_run_only_after_hitl"),
     ])
 
     if "recommendation_generated_by" in expected:

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -47,6 +47,11 @@ Profiles control:
 - `approval_policy`: documentation of the HITL source; profiles never grant
   approval by themselves.
 
+At runtime the harness emits `agent_policy`, which intersects the roster skill
+scope with `allowed_skills`. Approval alone is not enough to reach dry-run
+remediation; the remediation skill must also be present in the effective
+allowlist.
+
 Included profiles:
 
 | Profile | Use |

--- a/examples/agents/harness_runtime.py
+++ b/examples/agents/harness_runtime.py
@@ -130,6 +130,24 @@ def validate_harness_summary(summary: Mapping[str, Any]) -> tuple[str, ...]:
     if remediation_agent.get("privilege_boundary") != "dry_run_write_planning":
         errors.append("remediation-planner must stay dry-run write planning only")
 
+    agent_policy = summary.get("agent_policy") or {}
+    if agent_policy.get("schema_version") != "langgraph-agent-policy-v1":
+        errors.append("agent policy report must use langgraph-agent-policy-v1")
+    if not agent_policy.get("policy_hash"):
+        errors.append("agent policy report must include policy_hash")
+    policy_entries = {
+        entry.get("agent_id"): entry
+        for entry in agent_policy.get("entries") or []
+    }
+    triage_policy = policy_entries.get("triage-agent") or {}
+    if triage_policy.get("effective_skill_grants") not in ((), []):
+        errors.append("triage-agent policy must not grant tool skills")
+    if triage_policy.get("decision") != "no_direct_tools":
+        errors.append("triage-agent policy decision must be no_direct_tools")
+    remediation_policy = policy_entries.get("remediation-planner") or {}
+    if remediation_policy.get("write_policy") != "dry_run_only_after_hitl":
+        errors.append("remediation-planner policy must stay dry-run-only after HITL")
+
     review = summary.get("review") or {}
     remediation = summary.get("remediation") or {}
     if remediation.get("status") == "dry_run" and review.get("status") != "approved":

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -191,6 +191,22 @@ class AgentRunRecord(TypedDict, total=False):
     token_budget: dict[str, Any]
 
 
+class AgentPolicyEntry(TypedDict):
+    agent_id: str
+    kind: AgentKind
+    privilege_boundary: str
+    owns: list[WorkflowStage]
+    requested_skill_scope: list[str]
+    effective_skill_grants: list[str]
+    denied_skill_scope: list[str]
+    model_tier: str
+    model_policy_tier: str
+    requires_human_approval: bool
+    approval_satisfied: bool
+    write_policy: str
+    decision: str
+
+
 class AgentRecommendation(TypedDict):
     finding_uid: str
     priority: Literal["critical", "high", "medium", "low"]
@@ -267,6 +283,7 @@ class GraphState(TypedDict, total=False):
     framework_maps: list[FrameworkMap]
     harness_config: AgentHarnessConfig
     agent_manifest: list[AgentDefinition]
+    agent_policy: dict[str, Any]
     agent_runs: list[AgentRunRecord]
     agent_recommendations: list[AgentRecommendation]
     llm_validation: list[LlmValidationRecord]
@@ -715,6 +732,82 @@ def pipeline_contract(state: GraphState | None = None) -> dict[str, Any]:
             "API errors route to retry_queue only when classified retryable",
             "audit/eval writeback records state_hash and idempotency keys",
         ],
+    }
+
+
+def _agent_write_policy(agent: AgentDefinition) -> str:
+    if agent["agent_id"] == "remediation-planner":
+        return "dry_run_only_after_hitl"
+    if agent["agent_id"] == "audit-writer":
+        return "append_only_audit_eval"
+    return "none"
+
+
+def _agent_policy_decision(
+    *,
+    agent: AgentDefinition,
+    effective_grants: list[str],
+    denied_scope: list[str],
+    approval_satisfied: bool,
+) -> str:
+    if agent["agent_id"] == "triage-agent":
+        return "no_direct_tools"
+    if denied_scope:
+        return "blocked_by_allowlist"
+    if agent["requires_human_approval"] and not approval_satisfied:
+        return "requires_human_approval"
+    if effective_grants or agent["kind"] in {"human_gate", "governance"}:
+        return "ready"
+    return "metadata_only"
+
+
+def effective_agent_policy(state: GraphState) -> dict[str, Any]:
+    """Compile profile, roster, and allowlist into per-agent grants."""
+    profile = state.get("harness_profile") or {}
+    effective_allowed = list(state.get("effective_allowed_skills") or _effective_allowed_skills(profile))
+    allowed_set = set(effective_allowed)
+    harness_config = state.get("harness_config") or _agent_harness_config(state)
+    selected_model_tier = (harness_config.get("model_policy") or {}).get("selected_model_tier")
+    review_status = (state.get("review_decision") or {}).get("status")
+    entries: list[AgentPolicyEntry] = []
+    for agent in state.get("agent_manifest") or _agent_manifest(state):
+        requested_scope = list(agent["skill_scope"])
+        effective_grants = [skill for skill in requested_scope if skill in allowed_set]
+        denied_scope = [skill for skill in requested_scope if skill not in allowed_set]
+        approval_satisfied = (
+            not agent["requires_human_approval"]
+            or review_status == "approved"
+        )
+        model_policy_tier = selected_model_tier if agent["kind"] == "llm_optional" else "none"
+        entries.append({
+            "agent_id": agent["agent_id"],
+            "kind": agent["kind"],
+            "privilege_boundary": agent["privilege_boundary"],
+            "owns": list(agent["owns"]),
+            "requested_skill_scope": requested_scope,
+            "effective_skill_grants": effective_grants,
+            "denied_skill_scope": denied_scope,
+            "model_tier": agent["model_tier"],
+            "model_policy_tier": model_policy_tier,
+            "requires_human_approval": agent["requires_human_approval"],
+            "approval_satisfied": approval_satisfied,
+            "write_policy": _agent_write_policy(agent),
+            "decision": _agent_policy_decision(
+                agent=agent,
+                effective_grants=effective_grants,
+                denied_scope=denied_scope,
+                approval_satisfied=approval_satisfied,
+            ),
+        })
+    payload = {
+        "schema_version": "langgraph-agent-policy-v1",
+        "profile_id": profile.get("profile_id"),
+        "effective_allowed_skills": effective_allowed,
+        "entries": entries,
+    }
+    return {
+        **payload,
+        "policy_hash": _stable_hash(payload)[:16],
     }
 
 
@@ -1206,6 +1299,23 @@ def dry_run_remediation_node(state: GraphState) -> GraphState:
         _emit_node("remediate", status="skipped", reason="hitl_not_approved")
         return state
 
+    if ALLOWED_SKILLS_REMEDIATION not in set(state.get("effective_allowed_skills") or []):
+        state["remediation_result"] = {
+            "status": "skipped",
+            "skill": ALLOWED_SKILLS_REMEDIATION,
+            "reason": "remediation skill not in effective allowlist",
+            "approval": approval,
+        }
+        _record_agent_run(
+            state,
+            agent_id="remediation-planner",
+            stage="remediate",
+            inputs={"review_decision": decision, "effective_allowed_skills": state.get("effective_allowed_skills")},
+            outputs=state["remediation_result"],
+        )
+        _emit_node("remediate", status="skipped", reason="skill_not_allowed")
+        return state
+
     finding_uids = sorted(finding["uid"] for finding in state.get("findings") or [])
     approved_payload = {
         "approval_ticket": approval["ticket_id"],
@@ -1379,6 +1489,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         },
         outputs={"writeback": "audit_eval_pending"},
     )
+    state["agent_policy"] = effective_agent_policy(state)
     summary_payload = {
         "caller_context": state.get("caller_context"),
         "harness_profile": {
@@ -1393,6 +1504,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "harness_config": state.get("harness_config"),
         "token_budget_usage": state.get("token_budget_usage"),
         "agent_manifest": state.get("agent_manifest"),
+        "agent_policy": state.get("agent_policy"),
         "agent_runs": state.get("agent_runs"),
         "agent_recommendations": state.get("agent_recommendations"),
         "llm_validation": state.get("llm_validation"),
@@ -1425,6 +1537,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "idempotency_key": idempotency.get("remediation_key") or idempotency.get("workflow_key"),
         "api_error_count": len(api_errors),
         "agent_run_count": len(state.get("agent_runs") or []),
+        "agent_policy_hash": (state.get("agent_policy") or {}).get("policy_hash"),
         "llm_adapter_accepted": sum(1 for record in llm_validation if record["status"] == "accepted"),
         "llm_adapter_rejected": sum(1 for record in llm_validation if record["status"] == "rejected"),
         "llm_token_budget_status": (state.get("token_budget_usage") or {}).get("status"),
@@ -1576,6 +1689,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "harness": final.get("harness_config"),
         "pipeline_contract": pipeline_contract(final),
         "agents": final.get("agent_manifest"),
+        "agent_policy": final.get("agent_policy"),
         "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),
         "llm_validation": final.get("llm_validation"),

--- a/examples/agents/schemas/agent_policy.schema.json
+++ b/examples/agents/schemas/agent_policy.schema.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/agent_policy.schema.json",
+  "title": "LangGraph SOC effective agent policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_id",
+    "effective_allowed_skills",
+    "entries",
+    "policy_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "langgraph-agent-policy-v1"
+    },
+    "profile_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "effective_allowed_skills": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "agent_id",
+          "kind",
+          "privilege_boundary",
+          "owns",
+          "requested_skill_scope",
+          "effective_skill_grants",
+          "denied_skill_scope",
+          "model_tier",
+          "model_policy_tier",
+          "requires_human_approval",
+          "approval_satisfied",
+          "write_policy",
+          "decision"
+        ],
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "deterministic_skill",
+              "llm_optional",
+              "human_gate",
+              "governance"
+            ]
+          },
+          "privilege_boundary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owns": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "requested_skill_scope": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "effective_skill_grants": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "denied_skill_scope": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "model_tier": {
+            "type": "string",
+            "enum": [
+              "none",
+              "tiny",
+              "small",
+              "large"
+            ]
+          },
+          "model_policy_tier": {
+            "type": "string",
+            "enum": [
+              "none",
+              "tiny",
+              "small",
+              "large"
+            ]
+          },
+          "requires_human_approval": {
+            "type": "boolean"
+          },
+          "approval_satisfied": {
+            "type": "boolean"
+          },
+          "write_policy": {
+            "type": "string",
+            "enum": [
+              "none",
+              "dry_run_only_after_hitl",
+              "append_only_audit_eval"
+            ]
+          },
+          "decision": {
+            "type": "string",
+            "enum": [
+              "no_direct_tools",
+              "blocked_by_allowlist",
+              "requires_human_approval",
+              "ready",
+              "metadata_only"
+            ]
+          }
+        }
+      }
+    },
+    "policy_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{16}$"
+    }
+  }
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -223,7 +223,11 @@ class TestHitlGateReachable:
         assert "remediation_dry_run" in result.stdout or "reconciler" in (result.stdout + result.stderr)
 
     def test_langgraph_reaches_remediation_with_approval(self):
-        env = {**os.environ, "DEMO_APPROVE": "yes"}
+        env = {
+            **os.environ,
+            "DEMO_APPROVE": "yes",
+            "DEMO_HARNESS_PROFILE": str(EXAMPLES / "harness_profiles" / "dry-run-remediation.json"),
+        }
         result = subprocess.run(
             [sys.executable, str(EXAMPLES / "langgraph_security_graph.py")],
             capture_output=True,
@@ -405,6 +409,16 @@ class TestLangGraphSocWorkflow:
         remediation_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "remediation-planner")
         assert remediation_agent["requires_human_approval"] is True
         assert remediation_agent["privilege_boundary"] == "dry_run_write_planning"
+        assert summary["agent_policy"]["schema_version"] == "langgraph-agent-policy-v1"
+        assert summary["agent_policy"]["policy_hash"] == summary["audit"]["agent_policy_hash"]
+        policy_entries = {
+            entry["agent_id"]: entry
+            for entry in summary["agent_policy"]["entries"]
+        }
+        assert policy_entries["triage-agent"]["decision"] == "no_direct_tools"
+        assert policy_entries["triage-agent"]["effective_skill_grants"] == []
+        assert policy_entries["remediation-planner"]["denied_skill_scope"] == ["iam-departures-aws"]
+        assert policy_entries["remediation-planner"]["decision"] == "blocked_by_allowlist"
         assert [run["agent_id"] for run in summary["agent_runs"]] == [
             "evidence-agent",
             "risk-map-agent",
@@ -490,8 +504,25 @@ class TestLangGraphSocWorkflow:
         assert summary["integrity"]["state_hash"] == summary["audit"]["state_hash"]
         assert summary["idempotency"]["workflow_key"].startswith("wf-")
 
-    def test_approval_allows_dry_run_only(self):
+    def test_approval_without_remediation_skill_does_not_create_write_intent(self):
         summary, _ = self._run(approved=True)
+        assert summary["trace"] == self.EXPECTED_APPROVED_TRACE
+        assert summary["review"]["status"] == "approved"
+        assert summary["remediation"]["status"] == "skipped"
+        assert summary["remediation"]["reason"] == "remediation skill not in effective allowlist"
+        assert "planned_steps" not in summary["remediation"]
+        remediation_policy = next(
+            entry for entry in summary["agent_policy"]["entries"]
+            if entry["agent_id"] == "remediation-planner"
+        )
+        assert remediation_policy["denied_skill_scope"] == ["iam-departures-aws"]
+        assert remediation_policy["decision"] == "blocked_by_allowlist"
+
+    def test_approval_allows_dry_run_only(self):
+        summary, _ = self._run(
+            approved=True,
+            extra_env={"DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json")},
+        )
         assert summary["trace"] == self.EXPECTED_APPROVED_TRACE
         assert summary["review"]["status"] == "approved"
         assert summary["review"]["approval"]["ticket_id"] == "SEC-LANGGRAPH-1"
@@ -506,6 +537,13 @@ class TestLangGraphSocWorkflow:
             "after_review": "remediate",
             "after_remediation": "writeback",
         }
+        policy_entries = {
+            entry["agent_id"]: entry
+            for entry in summary["agent_policy"]["entries"]
+        }
+        assert policy_entries["remediation-planner"]["effective_skill_grants"] == ["iam-departures-aws"]
+        assert policy_entries["remediation-planner"]["denied_skill_scope"] == []
+        assert policy_entries["remediation-planner"]["decision"] == "ready"
         assert [run["agent_id"] for run in summary["agent_runs"]] == [
             "evidence-agent",
             "risk-map-agent",
@@ -714,11 +752,17 @@ class TestLangGraphSocWorkflow:
         assert first["agent_runs"] == second["agent_runs"]
 
     def test_duplicate_remediation_key_suppresses_write_intent(self):
-        approved, _ = self._run(approved=True)
+        approved, _ = self._run(
+            approved=True,
+            extra_env={"DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json")},
+        )
         remediation_key = approved["remediation"]["idempotency_key"]
         replay, _ = self._run(
             approved=True,
-            extra_env={"DEMO_SEEN_IDEMPOTENCY_KEYS": remediation_key},
+            extra_env={
+                "DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json"),
+                "DEMO_SEEN_IDEMPOTENCY_KEYS": remediation_key,
+            },
         )
         assert replay["remediation"]["status"] == "skipped"
         assert replay["remediation"]["reason"] == "duplicate idempotency key; write intent suppressed"
@@ -739,7 +783,10 @@ class TestLangGraphSocWorkflow:
     def test_retryable_api_error_reuses_idempotency_key_when_approved(self):
         summary, _ = self._run(
             approved=True,
-            extra_env={"DEMO_API_ERROR_STATUS": "429"},
+            extra_env={
+                "DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json"),
+                "DEMO_API_ERROR_STATUS": "429",
+            },
         )
         assert summary["trace"] == [
             *self.EXPECTED_APPROVED_TRACE[:-1],
@@ -767,7 +814,10 @@ class TestLangGraphSocWorkflow:
     def test_terminal_api_error_blocks_write_intent(self):
         summary, _ = self._run(
             approved=True,
-            extra_env={"DEMO_API_ERROR_STATUS": "403"},
+            extra_env={
+                "DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json"),
+                "DEMO_API_ERROR_STATUS": "403",
+            },
         )
         assert summary["trace"] == [
             *self.EXPECTED_APPROVED_TRACE[:-1],
@@ -813,6 +863,7 @@ class TestLangGraphSocWorkflow:
             **os.environ,
             "DEMO_LANGGRAPH_RUNTIME": "yes",
             "DEMO_APPROVE": "yes",
+            "DEMO_HARNESS_PROFILE": str(self.PROFILES / "dry-run-remediation.json"),
             "DEMO_API_ERROR_STATUS": "429",
         }
         result = subprocess.run(
@@ -909,6 +960,7 @@ class TestLangGraphContractSchemas:
     PROFILE_SCHEMA = SCHEMAS / "harness_profile.schema.json"
     ADAPTER_SCHEMA = SCHEMAS / "llm_adapter_recommendations.schema.json"
     PIPELINE_SCHEMA = SCHEMAS / "pipeline_contract.schema.json"
+    AGENT_POLICY_SCHEMA = SCHEMAS / "agent_policy.schema.json"
     CHECKPOINT_SCHEMA = SCHEMAS / "checkpoint.schema.json"
     EVAL_REPORT_SCHEMA = SCHEMAS / "eval_report.schema.json"
     GRAPH = EXAMPLES / "langgraph_security_graph.py"
@@ -920,6 +972,7 @@ class TestLangGraphContractSchemas:
             self.PROFILE_SCHEMA,
             self.ADAPTER_SCHEMA,
             self.PIPELINE_SCHEMA,
+            self.AGENT_POLICY_SCHEMA,
             self.CHECKPOINT_SCHEMA,
             self.EVAL_REPORT_SCHEMA,
         ]:
@@ -1018,6 +1071,30 @@ class TestLangGraphContractSchemas:
             node for node in contract["nodes"] if node["node"] == "llm_triage"
         )
         assert triage_node["skills"] == []
+
+    def test_emitted_agent_policy_matches_schema_and_known_boundaries(self):
+        result = subprocess.run(
+            [sys.executable, str(self.GRAPH)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        summary = json.loads(result.stdout)
+        agent_policy = summary["agent_policy"]
+        schema = json.loads(self.AGENT_POLICY_SCHEMA.read_text(encoding="utf-8"))
+        assert _schema_errors(schema, agent_policy) == []
+        assert agent_policy["policy_hash"] == summary["audit"]["agent_policy_hash"]
+
+        entries = {
+            entry["agent_id"]: entry
+            for entry in agent_policy["entries"]
+        }
+        assert entries["triage-agent"]["effective_skill_grants"] == []
+        assert entries["triage-agent"]["decision"] == "no_direct_tools"
+        assert entries["remediation-planner"]["write_policy"] == "dry_run_only_after_hitl"
+        assert entries["remediation-planner"]["denied_skill_scope"] == ["iam-departures-aws"]
 
 
 class TestLangGraphHarnessSetup:


### PR DESCRIPTION
Summary
- Emit a `langgraph-agent-policy-v1` effective policy report that intersects each agent roster skill scope with the profile allowlist.
- Enforce that approval alone is not enough for remediation; the dry-run remediation skill must also be present in the effective allowlist.
- Add runtime/eval/schema/test coverage for per-agent grants, denied skills, model tier, HITL state, write policy, and audit policy hash linkage.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_runtime.py examples/agents/eval_langgraph_harness.py
- python -m json.tool examples/agents/schemas/agent_policy.schema.json
- uv run make agent-evals
- git diff --check

Notes
- Existing untracked duplicate files ending in ` 2` were left untouched.