### PR TITLE
feat(examples): add LangGraph harness preflight inspector

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -61,6 +61,23 @@ print(summary["harness_runtime"]["validation_status"])
 PY
 ```
 
+Inspect a profile before running the graph:
+
+```bash
+python examples/agents/inspect_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/readonly-soc.json
+
+python examples/agents/inspect_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/dry-run-remediation.json \
+  --approval-context-present \
+  --require-remediation-ready
+```
+
+The preflight inspector emits the same `agent_policy` effective-grants report
+without replaying evidence, calling a model, reading credentials, or executing
+remediation. `--require-remediation-ready` fails closed unless the remediation
+skill is granted and an approval context is represented.
+
 `HARNESS.md` is therefore the readable operator contract; the graph nodes,
 adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are
 the executable harness.

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -105,6 +105,14 @@ python examples/agents/langgraph_security_graph.py
 DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/readonly-soc.json \
 python examples/agents/langgraph_security_graph.py
 
+# Preflight profile grants before graph execution.
+python examples/agents/inspect_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/readonly-soc.json
+python examples/agents/inspect_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/dry-run-remediation.json \
+  --approval-context-present \
+  --require-remediation-ready
+
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
 DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json \
 DEMO_APPROVE=yes \
@@ -196,6 +204,8 @@ agent tool-write scope or bypassing HITL.
 `agent_policy` is the compiled view of those choices: per-agent requested
 skills, effective grants, denied skills, model tier, write policy, approval
 state, and decision.
+`inspect_langgraph_harness.py` emits that policy without running graph nodes,
+calling a model, reading credentials, or executing remediation.
 Importable harness wrapper:
 
 ```bash

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -22,6 +22,13 @@ python examples/agents/configure_langgraph_harness.py \
   --output-env artifacts/acme-remediation-dryrun.env
 ```
 
+Inspect a profile before running the graph:
+
+```bash
+python examples/agents/inspect_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/readonly-soc.json
+```
+
 The generated dotenv file points `CLOUD_SECURITY_HARNESS_PROFILE` and
 `DEMO_HARNESS_PROFILE` at the profile. It does not duplicate provider/model as
 env overrides, and it intentionally omits `DEMO_APPROVE`; approval still has

--- a/examples/agents/inspect_langgraph_harness.py
+++ b/examples/agents/inspect_langgraph_harness.py
@@ -1,0 +1,64 @@
+"""Inspect a LangGraph SOC harness profile before running the graph.
+
+The inspector loads metadata only. It does not read cloud credentials, replay
+evidence, call a model, request approval, or execute remediation.
+
+Run:
+
+    python examples/agents/inspect_langgraph_harness.py \
+      --profile examples/agents/harness_profiles/readonly-soc.json
+
+    python examples/agents/inspect_langgraph_harness.py \
+      --profile examples/agents/harness_profiles/dry-run-remediation.json \
+      --approval-context-present \
+      --require-remediation-ready
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from langgraph_security_graph import load_harness_profile, preview_agent_policy
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", type=Path, help="Harness profile JSON path")
+    parser.add_argument(
+        "--approval-context-present",
+        action="store_true",
+        help="Preview policy as if an external approval context is present",
+    )
+    parser.add_argument(
+        "--require-remediation-ready",
+        action="store_true",
+        help="Exit nonzero unless dry-run remediation would be allowed",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON output path")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    profile = load_harness_profile(str(args.profile) if args.profile else None)
+    report = preview_agent_policy(
+        profile,
+        approval_context_present=args.approval_context_present,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    if args.require_remediation_ready and not report["remediation_preflight"]["would_plan_dry_run"]:
+        sys.stderr.write("remediation preflight is not ready for dry-run planning\n")
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -811,6 +811,63 @@ def effective_agent_policy(state: GraphState) -> dict[str, Any]:
     }
 
 
+def preview_agent_policy(
+    profile: HarnessProfile,
+    *,
+    approval_context_present: bool = False,
+) -> dict[str, Any]:
+    """Build a metadata-only policy preview without running graph nodes."""
+    state: GraphState = {
+        "harness_profile": profile,
+        "caller_context": profile["caller_context"],
+        "raw_events": [],
+    }
+    state["effective_allowed_skills"] = _effective_allowed_skills(profile)
+    state["agent_manifest"] = _agent_manifest(state)
+    state["harness_config"] = _agent_harness_config(state)
+    if approval_context_present:
+        state["review_decision"] = {
+            "status": "approved",
+            "reason": "preflight approval context supplied",
+            "approval": {
+                "approver_id": "preflight",
+                "ticket_id": "PREFLIGHT",
+                "approval_timestamp": "1970-01-01T00:00:00+00:00",
+            },
+        }
+    else:
+        state["review_decision"] = {
+            "status": "blocked",
+            "reason": "preflight only; approval context not supplied",
+            "approval": None,
+        }
+    agent_policy = effective_agent_policy(state)
+    remediation_entry = next(
+        entry for entry in agent_policy["entries"]
+        if entry["agent_id"] == "remediation-planner"
+    )
+    remediation_skill_granted = ALLOWED_SKILLS_REMEDIATION in remediation_entry["effective_skill_grants"]
+    return {
+        "schema_version": "langgraph-harness-preflight-v1",
+        "profile_id": profile["profile_id"],
+        "secrets_loaded": False,
+        "cloud_calls_made": False,
+        "approval_context_present": approval_context_present,
+        "harness": state["harness_config"],
+        "effective_allowed_skills": state["effective_allowed_skills"],
+        "agent_policy": agent_policy,
+        "remediation_preflight": {
+            "skill": ALLOWED_SKILLS_REMEDIATION,
+            "skill_granted": remediation_skill_granted,
+            "approval_satisfied": remediation_entry["approval_satisfied"],
+            "decision": remediation_entry["decision"],
+            "write_policy": remediation_entry["write_policy"],
+            "would_plan_dry_run": remediation_skill_granted and approval_context_present,
+            "apply_supported": False,
+        },
+    }
+
+
 def _record_agent_run(
     state: GraphState,
     *,

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -1301,6 +1301,88 @@ class TestLangGraphHarnessSetup:
         assert "unknown example skill" in result.stderr
 
 
+class TestLangGraphHarnessPreflight:
+    """Preflight inspector coverage for profile grants before graph execution."""
+
+    SCRIPT = EXAMPLES / "inspect_langgraph_harness.py"
+    PROFILES = EXAMPLES / "harness_profiles"
+
+    def test_readonly_profile_reports_denied_remediation_without_cloud_calls(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--profile",
+                str(self.PROFILES / "readonly-soc.json"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["schema_version"] == "langgraph-harness-preflight-v1"
+        assert report["secrets_loaded"] is False
+        assert report["cloud_calls_made"] is False
+        assert report["remediation_preflight"]["would_plan_dry_run"] is False
+        assert report["remediation_preflight"]["skill_granted"] is False
+
+        entries = {
+            entry["agent_id"]: entry
+            for entry in report["agent_policy"]["entries"]
+        }
+        assert entries["triage-agent"]["decision"] == "no_direct_tools"
+        assert entries["remediation-planner"]["denied_skill_scope"] == ["iam-departures-aws"]
+        assert entries["remediation-planner"]["decision"] == "blocked_by_allowlist"
+
+    def test_dry_run_profile_can_require_remediation_ready(self, tmp_path: Path):
+        output = tmp_path / "preflight.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--profile",
+                str(self.PROFILES / "dry-run-remediation.json"),
+                "--approval-context-present",
+                "--require-remediation-ready",
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == ""
+        report = json.loads(output.read_text(encoding="utf-8"))
+        assert report["approval_context_present"] is True
+        assert report["remediation_preflight"]["skill_granted"] is True
+        assert report["remediation_preflight"]["would_plan_dry_run"] is True
+        assert report["remediation_preflight"]["apply_supported"] is False
+
+    def test_require_remediation_ready_fails_closed_for_readonly_profile(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--profile",
+                str(self.PROFILES / "readonly-soc.json"),
+                "--approval-context-present",
+                "--require-remediation-ready",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 3
+        assert "remediation preflight is not ready" in result.stderr
+        report = json.loads(result.stdout)
+        assert report["remediation_preflight"]["skill_granted"] is False
+
+
 class TestLangGraphPipelineDiagram:
     """Regression coverage for the code-backed LangGraph Mermaid diagram."""
 


### PR DESCRIPTION
Summary
- Add a metadata-only LangGraph harness preflight inspector for profile grants, model policy, HITL state, and remediation readiness.
- Expose `preview_agent_policy()` so operators can inspect effective grants without graph execution, model calls, credentials, or remediation.
- Add tests and docs for readonly denied remediation, dry-run remediation readiness, and fail-closed `--require-remediation-ready`.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/inspect_langgraph_harness.py
- uv run make agent-evals
- git diff --check

Notes
- Existing untracked duplicate files ending in ` 2` were left untouched.