### PR TITLE
feat(examples): add LangGraph harness runner

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -78,6 +78,31 @@ without replaying evidence, calling a model, reading credentials, or executing
 remediation. `--require-remediation-ready` fails closed unless the remediation
 skill is granted and an approval context is represented.
 
+Run the executable harness wrapper:
+
+```bash
+python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/readonly-soc.json \
+  --raw-events artifacts/events.jsonl \
+  --caller-context '{"email":"analyst@example.com","session_id":"SEC-123"}'
+
+python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/dry-run-remediation.json \
+  --approve \
+  --approver reviewer@example.com \
+  --ticket SEC-123 \
+  --checkpoint artifacts/langgraph-checkpoint.json
+
+python examples/agents/run_langgraph_harness.py \
+  --replay-checkpoint artifacts/langgraph-checkpoint.json
+```
+
+The runner calls the same importable wrapper used by CI or SOAR integrations,
+keeps validation on by default, and accepts `--langgraph-runtime` when the
+optional LangGraph dependency is installed. `--approve` only supplies demo
+HITL metadata; remediation still requires the profile allowlist and remains
+dry-run only.
+
 `HARNESS.md` is therefore the readable operator contract; the graph nodes,
 adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are
 the executable harness.

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -113,6 +113,20 @@ python examples/agents/inspect_langgraph_harness.py \
   --approval-context-present \
   --require-remediation-ready
 
+# Operator-facing harness runner: profile + optional evidence fixture
+# through the importable runtime wrapper, with validation enabled by default.
+python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/readonly-soc.json \
+  --raw-events /path/to/events.jsonl \
+  --caller-context '{"email":"analyst@example.com","session_id":"SEC-123"}'
+
+# HITL-gated dry-run planning through the same runner.
+python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/dry-run-remediation.json \
+  --approve \
+  --approver reviewer@example.com \
+  --ticket SEC-LANGGRAPH-1
+
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
 DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json \
 DEMO_APPROVE=yes \
@@ -223,6 +237,10 @@ PY
 Use this wrapper from CI, MCP, SOAR, or a customer-owned LangGraph app when
 the workflow should run as code. `docs/HARNESS.md` remains the readable
 operator contract, not the implementation body.
+`run_langgraph_harness.py` is the CLI over that wrapper: it accepts profile
+paths, raw-event fixtures, caller-context overrides, LangGraph runtime
+selection, checkpoint write/replay, JSON output, and explicit demo approval
+metadata without duplicating graph logic.
 Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
 graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation

--- a/examples/agents/run_langgraph_harness.py
+++ b/examples/agents/run_langgraph_harness.py
@@ -1,0 +1,152 @@
+"""Run the LangGraph SOC harness through the importable runtime wrapper.
+
+This is the operator-facing CLI for the executable harness. It loads profile
+metadata, optional evidence fixtures, optional caller context overrides, then
+runs either the deterministic route mirror or the real LangGraph StateGraph.
+
+The runner does not read cloud credentials or call live models. Approval flags
+only populate the demo approval context consumed by the graph; remediation
+still requires the profile allowlist and remains dry-run only.
+
+Run:
+
+    python examples/agents/run_langgraph_harness.py \
+      --profile examples/agents/harness_profiles/readonly-soc.json
+
+    python examples/agents/run_langgraph_harness.py \
+      --profile examples/agents/harness_profiles/dry-run-remediation.json \
+      --approve --approver reviewer@example.com --ticket SEC-123
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from harness_runtime import HarnessRunConfig, run_harness_summary
+
+
+def _load_json_or_jsonl(path: Path) -> Any:
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        raise ValueError(f"{path} is empty")
+    if text[0] in "[{":
+        return json.loads(text)
+    rows = [json.loads(line) for line in text.splitlines() if line.strip()]
+    return rows
+
+
+def _load_mapping_argument(value: str | None, *, label: str) -> dict[str, Any] | None:
+    if not value:
+        return None
+    candidate = Path(value)
+    payload = _load_json_or_jsonl(candidate) if candidate.exists() else json.loads(value)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return payload
+
+
+def _load_raw_events(path: Path | None) -> tuple[Mapping[str, Any], ...] | None:
+    if not path:
+        return None
+    payload = _load_json_or_jsonl(path)
+    if isinstance(payload, dict):
+        payload = [payload]
+    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+        raise ValueError("--raw-events must be a JSON object, JSON array of objects, or JSONL objects")
+    return tuple(payload)
+
+
+@contextmanager
+def _temporary_demo_approval(args: argparse.Namespace) -> Iterator[None]:
+    keys = ("DEMO_APPROVE", "DEMO_APPROVER", "DEMO_TICKET")
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        if args.approve:
+            os.environ["DEMO_APPROVE"] = "yes"
+            os.environ["DEMO_APPROVER"] = args.approver
+            os.environ["DEMO_TICKET"] = args.ticket
+        elif args.clear_approval_env:
+            for key in keys:
+                os.environ.pop(key, None)
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", type=Path, help="Harness profile JSON path")
+    parser.add_argument(
+        "--raw-events",
+        type=Path,
+        help="Optional JSON object, JSON array, or JSONL evidence fixture",
+    )
+    parser.add_argument(
+        "--caller-context",
+        help="JSON object or path to a JSON object merged over profile caller_context",
+    )
+    parser.add_argument(
+        "--langgraph-runtime",
+        action="store_true",
+        help="Run through compiled LangGraph StateGraph instead of the deterministic mirror",
+    )
+    parser.add_argument("--checkpoint", type=Path, help="Write a replay checkpoint artifact")
+    parser.add_argument("--replay-checkpoint", type=Path, help="Replay a checkpoint without running nodes")
+    parser.add_argument("--output", type=Path, help="Optional JSON summary output path")
+    parser.add_argument("--no-check", action="store_true", help="Emit summary even if wrapper validation fails")
+    parser.add_argument(
+        "--approve",
+        action="store_true",
+        help="Populate demo approval context for HITL-gated dry-run planning",
+    )
+    parser.add_argument("--approver", default="operator@example.com", help="Approver identity for --approve")
+    parser.add_argument("--ticket", default="SEC-LANGGRAPH-1", help="Ticket id for --approve")
+    parser.add_argument(
+        "--clear-approval-env",
+        action="store_true",
+        help="Ignore inherited DEMO_APPROVE/DEMO_APPROVER/DEMO_TICKET values for this run",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.checkpoint and args.replay_checkpoint:
+        sys.stderr.write("--checkpoint and --replay-checkpoint are mutually exclusive\n")
+        return 2
+    try:
+        config = HarnessRunConfig(
+            profile_path=args.profile,
+            raw_events=_load_raw_events(args.raw_events),
+            caller_context=_load_mapping_argument(args.caller_context, label="--caller-context"),
+            use_langgraph_runtime=args.langgraph_runtime,
+            checkpoint_path=args.checkpoint,
+            replay_checkpoint_path=args.replay_checkpoint,
+        )
+        with _temporary_demo_approval(args):
+            summary = run_harness_summary(config, check=not args.no_check)
+    except Exception as exc:
+        sys.stderr.write(f"langgraph harness run failed: {exc}\n")
+        return 1
+
+    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -28,6 +28,7 @@ SCRIPTS = [
     EXAMPLES / "anthropic_sdk_security_agent.py",
     EXAMPLES / "openai_sdk_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
+    EXAMPLES / "run_langgraph_harness.py",
 ]
 
 JSON_TYPE_MAP = {
@@ -303,6 +304,141 @@ class TestLangGraphHarnessRuntime:
         assert replayed.runtime["execution_mode"] == "checkpoint_replay"
         assert replayed.runtime["replayed"] is True
         assert replayed.summary["integrity"]["state_hash"] == first.summary["integrity"]["state_hash"]
+
+
+class TestLangGraphHarnessRunner:
+    """CLI coverage for the operator-facing harness runner."""
+
+    SCRIPT = EXAMPLES / "run_langgraph_harness.py"
+
+    def _run(
+        self,
+        *args: str,
+        env: dict[str, str] | None = None,
+    ) -> tuple[dict, subprocess.CompletedProcess[str]]:
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env={**os.environ, **(env or {})},
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout), result
+
+    def test_runner_executes_readonly_profile(self):
+        summary, result = self._run(
+            "--profile",
+            str(EXAMPLES / "harness_profiles" / "readonly-soc.json"),
+            "--clear-approval-env",
+        )
+
+        assert summary["harness_runtime"]["schema_version"] == "langgraph-soc-harness-runtime-v1"
+        assert summary["harness_runtime"]["execution_mode"] == "deterministic_runner"
+        assert summary["harness_runtime"]["validation_status"] == "pass"
+        assert summary["profile"]["profile_id"] == "readonly-soc"
+        assert summary["review"]["status"] == "blocked"
+        assert summary["remediation"]["status"] == "skipped"
+        assert '"node": "ingest"' in result.stderr
+
+    def test_runner_accepts_raw_events_and_caller_context(self, tmp_path: Path):
+        raw_events = tmp_path / "events.jsonl"
+        raw_events.write_text(
+            "\n".join([
+                json.dumps({
+                    "source": "cloudtrail",
+                    "event_name": "CreateAccessKey",
+                    "actor_uid": "AIDARUNNER",
+                    "resource_uid": "arn:aws:iam::111122223333:user/runner",
+                }),
+            ]) + "\n",
+            encoding="utf-8",
+        )
+        caller_context = {
+            "email": "runner@example.com",
+            "session_id": "runner-session",
+        }
+
+        summary, _ = self._run(
+            "--profile",
+            str(EXAMPLES / "harness_profiles" / "readonly-soc.json"),
+            "--raw-events",
+            str(raw_events),
+            "--caller-context",
+            json.dumps(caller_context),
+            "--clear-approval-env",
+        )
+
+        assert summary["caller_context"]["email"] == "runner@example.com"
+        assert summary["audit"]["correlation_id"] == "runner-session"
+        assert summary["findings_count"] == 1
+
+    def test_runner_approval_reaches_dry_run_only(self):
+        summary, _ = self._run(
+            "--profile",
+            str(EXAMPLES / "harness_profiles" / "dry-run-remediation.json"),
+            "--approve",
+            "--approver",
+            "reviewer@example.com",
+            "--ticket",
+            "SEC-RUNNER-1",
+        )
+
+        assert summary["review"]["status"] == "approved"
+        assert summary["review"]["approval"]["ticket_id"] == "SEC-RUNNER-1"
+        assert summary["remediation"]["status"] == "dry_run"
+        assert summary["remediation"]["dry_run"] is True
+
+    def test_runner_writes_output_and_replays_checkpoint(self, tmp_path: Path):
+        checkpoint = tmp_path / "checkpoint.json"
+        output = tmp_path / "summary.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--checkpoint",
+                str(checkpoint),
+                "--output",
+                str(output),
+                "--clear-approval-env",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        original = json.loads(output.read_text(encoding="utf-8"))
+        assert checkpoint.exists()
+
+        replayed, _ = self._run("--replay-checkpoint", str(checkpoint))
+
+        assert replayed["harness_runtime"]["execution_mode"] == "checkpoint_replay"
+        assert replayed["harness_runtime"]["replayed"] is True
+        assert replayed["integrity"]["state_hash"] == original["integrity"]["state_hash"]
+
+    def test_runner_fails_closed_on_invalid_raw_event_shape(self, tmp_path: Path):
+        raw_events = tmp_path / "bad-events.json"
+        raw_events.write_text(json.dumps(["not-an-object"]), encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--raw-events",
+                str(raw_events),
+                "--clear-approval-env",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 1
+        assert "langgraph harness run failed" in result.stderr
+        assert "--raw-events must be a JSON object" in result.stderr
 
 
 class TestLangGraphSocWorkflow:


### PR DESCRIPTION
Summary
- Add an operator-facing CLI over the importable LangGraph SOC harness runtime.
- Support profiles, raw event fixtures, caller-context overrides, deterministic vs StateGraph runtime selection, checkpoint write/replay, JSON output, and explicit demo HITL metadata.
- Document the runner in HARNESS.md and the agent examples README; add subprocess coverage for success, dry-run, checkpoint replay, and fail-closed input validation.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/run_langgraph_harness.py examples/agents/harness_runtime.py examples/agents/langgraph_security_graph.py
- uv run make agent-evals
- git diff --check