### PR TITLE
feat(examples): make LangGraph approval context stateful

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -94,6 +94,10 @@ python examples/agents/run_langgraph_harness.py \
   --checkpoint artifacts/langgraph-checkpoint.json
 
 python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/dry-run-remediation.json \
+  --approval-context artifacts/approval-context.json
+
+python examples/agents/run_langgraph_harness.py \
   --replay-checkpoint artifacts/langgraph-checkpoint.json
 ```
 
@@ -101,7 +105,9 @@ The runner calls the same importable wrapper used by CI or SOAR integrations,
 keeps validation on by default, and accepts `--langgraph-runtime` when the
 optional LangGraph dependency is installed. `--approve` only supplies demo
 HITL metadata; remediation still requires the profile allowlist and remains
-dry-run only.
+dry-run only. Embedded callers should pass `approval_context` directly to
+`HarnessRunConfig`; the older `DEMO_APPROVE` environment variables remain a
+compatibility path for the original example script.
 
 `HARNESS.md` is therefore the readable operator contract; the graph nodes,
 adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -127,6 +127,11 @@ python examples/agents/run_langgraph_harness.py \
   --approver reviewer@example.com \
   --ticket SEC-LANGGRAPH-1
 
+# Embedded/SOAR-style approval metadata can also come from JSON, not env vars.
+python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/dry-run-remediation.json \
+  --approval-context /path/to/approval-context.json
+
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
 DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json \
 DEMO_APPROVE=yes \
@@ -240,7 +245,9 @@ operator contract, not the implementation body.
 `run_langgraph_harness.py` is the CLI over that wrapper: it accepts profile
 paths, raw-event fixtures, caller-context overrides, LangGraph runtime
 selection, checkpoint write/replay, JSON output, and explicit demo approval
-metadata without duplicating graph logic.
+metadata without duplicating graph logic. `HarnessRunConfig` also accepts
+stateful `approval_context`, so CI, SOAR, ticketing, or MCP wrappers do not
+need to rely on process-wide approval env vars.
 Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
 graph selects deterministic fallback, JSON fixture, or optional LangChain chat
 fixture adapters, then applies one closed schema gate before any recommendation

--- a/examples/agents/harness_runtime.py
+++ b/examples/agents/harness_runtime.py
@@ -33,6 +33,7 @@ class HarnessRunConfig:
     profile_path: str | Path | None = None
     raw_events: tuple[Mapping[str, Any], ...] | None = None
     caller_context: Mapping[str, Any] | None = None
+    approval_context: Mapping[str, Any] | None = None
     use_langgraph_runtime: bool = False
     checkpoint_path: str | Path | None = None
     replay_checkpoint_path: str | Path | None = None
@@ -58,11 +59,14 @@ def build_initial_state(config: HarnessRunConfig | None = None) -> GraphState:
     if config.caller_context:
         caller_context.update(config.caller_context)
     raw_events = [dict(event) for event in (config.raw_events or ({"source": "demo"},))]
-    return {
+    state: GraphState = {
         "harness_profile": profile,
         "caller_context": caller_context,
         "raw_events": raw_events,
     }
+    if config.approval_context:
+        state["approval_context"] = dict(config.approval_context)
+    return state
 
 
 def validate_harness_summary(summary: Mapping[str, Any]) -> tuple[str, ...]:

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -272,6 +272,7 @@ class EvalRecord(TypedDict):
 
 class GraphState(TypedDict, total=False):
     caller_context: CallerContext
+    approval_context: ApprovalContext
     harness_profile: HarnessProfile
     effective_allowed_skills: list[str]
     raw_events: list[dict[str, Any]]
@@ -1301,15 +1302,22 @@ def llm_triage_node(state: GraphState) -> GraphState:
 def analyst_review_node(state: GraphState) -> GraphState:
     """Hard pause. No auto-approval and no hallucinated approval context."""
     _append_trace(state, "review")
-    if os.environ.get("DEMO_APPROVE") == "yes":
-        approval: ApprovalContext | None = {
+    approval: ApprovalContext | None = state.get("approval_context")
+    if approval:
+        decision: ReviewDecision = {
+            "status": "approved",
+            "reason": "operator approval context present",
+            "approval": approval,
+        }
+    elif os.environ.get("DEMO_APPROVE") == "yes":
+        approval = {
             "approver_id": os.environ.get("DEMO_APPROVER", "operator@example.com"),
             "ticket_id": os.environ.get("DEMO_TICKET", "SEC-GRAPH-1"),
             "approval_timestamp": datetime.now(UTC).replace(microsecond=0).isoformat(),
         }
         decision: ReviewDecision = {
             "status": "approved",
-            "reason": "operator approval present",
+            "reason": "operator approval env present",
             "approval": approval,
         }
     else:
@@ -1737,6 +1745,9 @@ def summarize(final: GraphState) -> dict[str, Any]:
     """Strip state to a stable operator-facing summary."""
     return {
         "caller_context": final.get("caller_context"),
+        "approval_context_present": bool(
+            final.get("approval_context") or (final.get("review_decision") or {}).get("approval")
+        ),
         "profile": final.get("harness_profile"),
         "effective_allowed_skills": final.get("effective_allowed_skills"),
         "trace": final.get("trace"),

--- a/examples/agents/run_langgraph_harness.py
+++ b/examples/agents/run_langgraph_harness.py
@@ -4,9 +4,9 @@ This is the operator-facing CLI for the executable harness. It loads profile
 metadata, optional evidence fixtures, optional caller context overrides, then
 runs either the deterministic route mirror or the real LangGraph StateGraph.
 
-The runner does not read cloud credentials or call live models. Approval flags
-only populate the demo approval context consumed by the graph; remediation
-still requires the profile allowlist and remains dry-run only.
+The runner does not read cloud credentials or call live models. Approval
+metadata is carried in graph state; remediation still requires the profile
+allowlist and remains dry-run only.
 
 Run:
 
@@ -25,6 +25,7 @@ import json
 import os
 import sys
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Iterator, Mapping
 
@@ -62,15 +63,27 @@ def _load_raw_events(path: Path | None) -> tuple[Mapping[str, Any], ...] | None:
     return tuple(payload)
 
 
+def _approval_context_from_args(args: argparse.Namespace) -> dict[str, Any] | None:
+    explicit = _load_mapping_argument(args.approval_context, label="--approval-context")
+    if explicit:
+        return explicit
+    if not args.approve:
+        return None
+    return {
+        "approver_id": args.approver,
+        "ticket_id": args.ticket,
+        "approval_timestamp": datetime.now(UTC).replace(microsecond=0).isoformat(),
+    }
+
+
 @contextmanager
 def _temporary_demo_approval(args: argparse.Namespace) -> Iterator[None]:
     keys = ("DEMO_APPROVE", "DEMO_APPROVER", "DEMO_TICKET")
     previous = {key: os.environ.get(key) for key in keys}
     try:
         if args.approve:
-            os.environ["DEMO_APPROVE"] = "yes"
-            os.environ["DEMO_APPROVER"] = args.approver
-            os.environ["DEMO_TICKET"] = args.ticket
+            for key in keys:
+                os.environ.pop(key, None)
         elif args.clear_approval_env:
             for key in keys:
                 os.environ.pop(key, None)
@@ -105,6 +118,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--output", type=Path, help="Optional JSON summary output path")
     parser.add_argument("--no-check", action="store_true", help="Emit summary even if wrapper validation fails")
     parser.add_argument(
+        "--approval-context",
+        help="JSON object or path with approver_id, ticket_id, and approval_timestamp",
+    )
+    parser.add_argument(
         "--approve",
         action="store_true",
         help="Populate demo approval context for HITL-gated dry-run planning",
@@ -129,6 +146,7 @@ def main(argv: list[str] | None = None) -> int:
             profile_path=args.profile,
             raw_events=_load_raw_events(args.raw_events),
             caller_context=_load_mapping_argument(args.caller_context, label="--caller-context"),
+            approval_context=_approval_context_from_args(args),
             use_langgraph_runtime=args.langgraph_runtime,
             checkpoint_path=args.checkpoint,
             replay_checkpoint_path=args.replay_checkpoint,

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -305,6 +305,26 @@ class TestLangGraphHarnessRuntime:
         assert replayed.runtime["replayed"] is True
         assert replayed.summary["integrity"]["state_hash"] == first.summary["integrity"]["state_hash"]
 
+    def test_runtime_wrapper_accepts_stateful_approval_context(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("DEMO_APPROVE", raising=False)
+        runtime = self._runtime_module()
+        config = runtime.HarnessRunConfig(
+            profile_path=EXAMPLES / "harness_profiles" / "dry-run-remediation.json",
+            approval_context={
+                "approver_id": "reviewer@example.com",
+                "ticket_id": "SEC-RUNTIME-1",
+                "approval_timestamp": "2026-06-23T00:00:00+00:00",
+            },
+        )
+
+        result = runtime.run_harness(config)
+
+        assert result.validation_errors == ()
+        assert result.summary["approval_context_present"] is True
+        assert result.summary["review"]["status"] == "approved"
+        assert result.summary["review"]["reason"] == "operator approval context present"
+        assert result.summary["remediation"]["status"] == "dry_run"
+
 
 class TestLangGraphHarnessRunner:
     """CLI coverage for the operator-facing harness runner."""
@@ -386,9 +406,31 @@ class TestLangGraphHarnessRunner:
         )
 
         assert summary["review"]["status"] == "approved"
+        assert summary["approval_context_present"] is True
+        assert summary["review"]["reason"] == "operator approval context present"
         assert summary["review"]["approval"]["ticket_id"] == "SEC-RUNNER-1"
         assert summary["remediation"]["status"] == "dry_run"
         assert summary["remediation"]["dry_run"] is True
+
+    def test_runner_accepts_explicit_approval_context_file(self, tmp_path: Path):
+        approval_context = tmp_path / "approval.json"
+        approval_context.write_text(json.dumps({
+            "approver_id": "reviewer@example.com",
+            "ticket_id": "SEC-RUNNER-FILE-1",
+            "approval_timestamp": "2026-06-23T00:00:00+00:00",
+        }), encoding="utf-8")
+
+        summary, _ = self._run(
+            "--profile",
+            str(EXAMPLES / "harness_profiles" / "dry-run-remediation.json"),
+            "--approval-context",
+            str(approval_context),
+            "--clear-approval-env",
+        )
+
+        assert summary["approval_context_present"] is True
+        assert summary["review"]["approval"]["ticket_id"] == "SEC-RUNNER-FILE-1"
+        assert summary["remediation"]["status"] == "dry_run"
 
     def test_runner_writes_output_and_replays_checkpoint(self, tmp_path: Path):
         checkpoint = tmp_path / "checkpoint.json"


### PR DESCRIPTION
Summary
- Add first-class approval_context state to the LangGraph SOC harness and runtime wrapper.
- Let the harness runner accept --approval-context JSON/path or derive stateful approval metadata from --approve without relying on process-wide approval env vars.
- Keep DEMO_APPROVE compatibility for the original example script and document the preferred stateful path.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/langgraph_security_graph.py examples/agents/harness_runtime.py examples/agents/run_langgraph_harness.py
- uv run make agent-evals
- git diff --check