### PR TITLE
feat(examples): guard LangGraph harness secret inputs

### DIFF
--- a/examples/agents/anthropic_sdk_security_agent.py
+++ b/examples/agents/anthropic_sdk_security_agent.py
@@ -13,7 +13,7 @@ The example is runnable offline: the CSPM scan calls `moto` fixtures
 Prerequisites:
 
     uv sync --group dev --extra aws
-    export ANTHROPIC_API_KEY=sk-...  # only if you want to actually run
+    Configure Anthropic SDK credentials outside this repo if you run live SDK calls.
 
 Run:
 

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -50,6 +50,28 @@ ROLE_DEFAULTS: dict[HarnessRole, dict[str, Any]] = {
 }
 
 PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,63}$")
+SECRET_FIELD_RE = re.compile(
+    r"(?i)(password|passwd|pwd|pat|personal[_-]?access[_-]?token|api[_-]?key|"
+    r"secret|private[_-]?key|access[_-]?key|session[_-]?token|bearer)"
+)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)(ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|"
+    r"sk-[A-Za-z0-9_-]{20,}|AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+)
+
+
+def _assert_no_secret_material(payload: Any, *, path: str) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            key_text = str(key)
+            if SECRET_FIELD_RE.search(key_text):
+                raise ValueError(f"{path}.{key_text} must not contain passwords, PATs, tokens, or secrets")
+            _assert_no_secret_material(value, path=f"{path}.{key_text}")
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            _assert_no_secret_material(value, path=f"{path}[{index}]")
+    elif isinstance(payload, str) and (SECRET_FIELD_RE.search(payload) or SECRET_VALUE_RE.search(payload)):
+        raise ValueError(f"{path} must not contain password, PAT, token, or secret material")
 
 
 def _parse_cloud_hint(values: list[str]) -> dict[str, str]:
@@ -62,6 +84,7 @@ def _parse_cloud_hint(values: list[str]) -> dict[str, str]:
         hint = hint.strip()
         if not provider or not hint:
             raise ValueError("cloud hints require a provider and hint")
+        _assert_no_secret_material({provider: hint}, path="cloud_identity_hints")
         hints[provider] = hint
     if hints:
         return hints
@@ -108,7 +131,7 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
             "skill_scope": [ALLOWED_SKILLS_REMEDIATION] if ROLE_DEFAULTS[role]["include_remediation"] else [],
         },
     ]
-    return {
+    profile = {
         "profile_id": args.profile_id,
         "description": args.description or ROLE_DEFAULTS[role]["description"],
         "allowed_skills": allowed_skills,
@@ -153,6 +176,8 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
             "apply_supported": False,
         },
     }
+    _assert_no_secret_material(profile, path="profile")
+    return profile
 
 
 def write_dotenv(

--- a/examples/agents/openai_sdk_security_agent.py
+++ b/examples/agents/openai_sdk_security_agent.py
@@ -13,7 +13,7 @@ demonstrates the wiring without pinning the SDK as a repo dep.
 Prerequisites:
 
     uv sync --group dev --extra aws
-    export OPENAI_API_KEY=sk-...   # only if you want to actually run
+    Configure OpenAI SDK credentials outside this repo if you run live SDK calls.
 
 Run:
 

--- a/examples/agents/run_langgraph_harness.py
+++ b/examples/agents/run_langgraph_harness.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from contextlib import contextmanager
 from datetime import UTC, datetime
@@ -30,6 +31,29 @@ from pathlib import Path
 from typing import Any, Iterator, Mapping
 
 from harness_runtime import HarnessRunConfig, run_harness_summary
+
+SECRET_FIELD_RE = re.compile(
+    r"(?i)(password|passwd|pwd|pat|personal[_-]?access[_-]?token|api[_-]?key|"
+    r"secret|private[_-]?key|access[_-]?key|session[_-]?token|bearer)"
+)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)(ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|"
+    r"sk-[A-Za-z0-9_-]{20,}|AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+)
+
+
+def _assert_no_secret_material(payload: Any, *, path: str) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            key_text = str(key)
+            if SECRET_FIELD_RE.search(key_text):
+                raise ValueError(f"{path}.{key_text} must not contain passwords, PATs, tokens, or secrets")
+            _assert_no_secret_material(value, path=f"{path}.{key_text}")
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            _assert_no_secret_material(value, path=f"{path}[{index}]")
+    elif isinstance(payload, str) and (SECRET_FIELD_RE.search(payload) or SECRET_VALUE_RE.search(payload)):
+        raise ValueError(f"{path} must not contain password, PAT, token, or secret material")
 
 
 def _load_json_or_jsonl(path: Path) -> Any:
@@ -66,6 +90,7 @@ def _load_raw_events(path: Path | None) -> tuple[Mapping[str, Any], ...] | None:
 def _approval_context_from_args(args: argparse.Namespace) -> dict[str, Any] | None:
     explicit = _load_mapping_argument(args.approval_context, label="--approval-context")
     if explicit:
+        _assert_no_secret_material(explicit, path="approval_context")
         return explicit
     if not args.approve:
         return None

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -460,6 +460,34 @@ class TestLangGraphHarnessRunner:
         assert replayed["harness_runtime"]["replayed"] is True
         assert replayed["integrity"]["state_hash"] == original["integrity"]["state_hash"]
 
+    def test_runner_rejects_secret_material_in_approval_context(self, tmp_path: Path):
+        approval_context = tmp_path / "approval.json"
+        synthetic_pat = "ghp_" + ("a" * 36)
+        approval_context.write_text(json.dumps({
+            "approver_id": "reviewer@example.com",
+            "ticket_id": "SEC-RUNNER-SECRET-1",
+            "approval_timestamp": "2026-06-23T00:00:00+00:00",
+            "notes": synthetic_pat,
+        }), encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--profile",
+                str(EXAMPLES / "harness_profiles" / "dry-run-remediation.json"),
+                "--approval-context",
+                str(approval_context),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 1
+        assert "must not contain password, PAT, token, or secret material" in result.stderr
+
     def test_runner_fails_closed_on_invalid_raw_event_shape(self, tmp_path: Path):
         raw_events = tmp_path / "bad-events.json"
         raw_events.write_text(json.dumps(["not-an-object"]), encoding="utf-8")
@@ -1453,6 +1481,38 @@ class TestLangGraphHarnessSetup:
         assert approved_summary["remediation"]["status"] == "dry_run"
         assert approved_summary["remediation"]["dry_run"] is True
         assert approved_summary["audit"]["route"]["after_review"] == "remediate"
+
+    def test_setup_generator_rejects_secret_material_in_cloud_hints(self, tmp_path: Path):
+        profile_path = tmp_path / "bad-profile.json"
+        env_path = tmp_path / "bad.env"
+        credential_hint = "SNOWFLAKE_" + "PASSWORD=not-for-profile"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--role",
+                "readonly-soc",
+                "--profile-id",
+                "bad-secret-profile",
+                "--email",
+                "analyst@example.com",
+                "--cloud-hint",
+                f"snowflake={credential_hint}",
+                "--output-profile",
+                str(profile_path),
+                "--output-env",
+                str(env_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 2
+        assert "must not contain password, PAT, token, or secret material" in result.stderr
+        assert not profile_path.exists()
+        assert not env_path.exists()
 
     def test_setup_generator_rejects_unknown_example_skill(self, tmp_path: Path):
         result = subprocess.run(


### PR DESCRIPTION
Summary
- Reject password/PAT/token/API-key/private-key material in generated LangGraph harness profiles and runner approval-context input.
- Keep synthetic PAT regression values generated at runtime instead of storing PAT-shaped literals in the harness examples.
- Remove key-shaped SDK placeholder exports from the Anthropic/OpenAI example docstrings.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- uv run ruff check examples/agents
- python -m py_compile examples/agents/configure_langgraph_harness.py examples/agents/run_langgraph_harness.py examples/agents/anthropic_sdk_security_agent.py examples/agents/openai_sdk_security_agent.py
- uv run make agent-evals
- git diff --check
- git grep -n -I -E 'ghp_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]+|SNOWFLAKE_PASSWORD|OPENAI_API_KEY=|ANTHROPIC_API_KEY=|sk-[A-Za-z0-9_-]{20,}' -- examples/agents docs/HARNESS.md || true