### PR TITLE
feat(examples): add LangGraph harness drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
         run: pytest examples/agents/tests/test_examples.py -q
       - name: Run LangGraph harness eval gate
         run: python examples/agents/eval_langgraph_harness.py --check
+      - name: Check LangGraph harness drift
+        run: python examples/agents/check_langgraph_harness_drift.py
       - name: Install optional LangGraph runtime
         run: python -m pip install "langgraph>=1.2,<2"
       - name: Run examples with real LangGraph runtime available

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -122,6 +122,19 @@ python examples/agents/render_langgraph_pipeline_diagram.py \
   --output docs/diagrams/langgraph-agent-harness.mmd
 ```
 
+Drift check:
+
+```bash
+python examples/agents/check_langgraph_harness_drift.py
+```
+
+The drift checker regenerates the diagram from `pipeline_contract()` in memory,
+validates closed schemas and stock profiles, verifies metadata-only preflight
+policy, runs the importable wrapper validation path, checks harness docs/CI
+references, and scans the harness docs/profiles for PAT/API-key/password
+literals. It remains offline: no cloud credentials, model calls, approval
+tokens, cloud APIs, or remediation execution.
+
 The LLM/agent harness records provider/model/mode, model-policy selection, and
 token-budget policy in state and audit output. `model_policy` selects the
 configured provider/model tier for the triage task; `token_budget` caps input,

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -195,6 +195,10 @@ python examples/agents/eval_langgraph_harness.py --check \
 # from the code-backed pipeline_contract().
 python examples/agents/render_langgraph_pipeline_diagram.py \
   --output docs/diagrams/langgraph-agent-harness.mmd
+
+# Drift doctor: verify schemas, profiles, generated diagram, docs/CI
+# references, preflight safety, and wrapper validation stay aligned.
+python examples/agents/check_langgraph_harness_drift.py
 ```
 
 The LangGraph summary includes `integrity.evidence_hash`,
@@ -273,6 +277,10 @@ Contract schemas live under [`schemas/`](schemas/). They define the closed
 shape for harness profiles, the LLM adapter recommendation payload accepted by
 the reference graph, the emitted `pipeline_contract` topology, and checkpoint
 artifact and eval-report envelopes.
+Use [`check_langgraph_harness_drift.py`](check_langgraph_harness_drift.py) to
+fail closed when the generated diagram, profiles, schemas, docs, CI command
+references, metadata-only preflight, or wrapper validation drift away from the
+code-backed harness.
 
 Use [`configure_langgraph_harness.py`](configure_langgraph_harness.py) when
 customizing the harness for a buyer or internal environment. It asks for role,

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -1,0 +1,374 @@
+"""Check that the LangGraph SOC harness docs and contracts match the code.
+
+This command is intentionally offline. It does not load credentials, call a
+model, execute cloud APIs, or run remediation. It compares generated artifacts
+and profile/schema contracts against the runnable harness surfaces.
+
+Run:
+
+    python examples/agents/check_langgraph_harness_drift.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from harness_runtime import HarnessRunConfig, run_harness_summary
+from langgraph_security_graph import load_harness_profile, pipeline_contract, preview_agent_policy
+from render_langgraph_pipeline_diagram import render_mermaid
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO_ROOT / "examples" / "agents"
+SCHEMAS = EXAMPLES / "schemas"
+PROFILES = EXAMPLES / "harness_profiles"
+DIAGRAM = REPO_ROOT / "docs" / "diagrams" / "langgraph-agent-harness.mmd"
+HARNESS_DOC = REPO_ROOT / "docs" / "HARNESS.md"
+EXAMPLES_README = EXAMPLES / "README.md"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+EXPECTED_SCHEMAS = [
+    SCHEMAS / "harness_profile.schema.json",
+    SCHEMAS / "llm_adapter_recommendations.schema.json",
+    SCHEMAS / "pipeline_contract.schema.json",
+    SCHEMAS / "agent_policy.schema.json",
+    SCHEMAS / "checkpoint.schema.json",
+    SCHEMAS / "eval_report.schema.json",
+]
+
+REQUIRED_DOC_TOKENS = [
+    "inspect_langgraph_harness.py",
+    "run_langgraph_harness.py",
+    "eval_langgraph_harness.py --check",
+    "render_langgraph_pipeline_diagram.py",
+    "check_langgraph_harness_drift.py",
+]
+
+SECRET_PATTERNS = [
+    re.compile(r"ghp_[A-Za-z0-9_]{36,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]+"),
+    re.compile(r"sk-[A-Za-z0-9_-]{20,}"),
+    re.compile(
+        r"(?i)\b(?:openai_api_key|anthropic_api_key|github_token|"
+        r"snowflake_password|secret_access_key)\b\s*[:=]\s*[\"'][^\"']{4,}[\"']"
+    ),
+]
+
+JSON_TYPE_MAP = {
+    "array": list,
+    "boolean": bool,
+    "integer": int,
+    "number": (int, float),
+    "object": dict,
+    "string": str,
+}
+
+
+@dataclass(frozen=True)
+class DriftCheck:
+    name: str
+    passed: bool
+    details: Any
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": "pass" if self.passed else "fail",
+            "details": self.details,
+        }
+
+
+def _schema_errors(schema: dict[str, Any], value: Any, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    schema_type = schema.get("type")
+    if schema_type:
+        expected_type = JSON_TYPE_MAP[schema_type]
+        if not isinstance(value, expected_type) or (
+            schema_type in {"integer", "number"} and isinstance(value, bool)
+        ):
+            return [f"{path}: expected {schema_type}"]
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}")
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']!r}")
+    if schema_type == "string":
+        if len(value) < schema.get("minLength", 0):
+            errors.append(f"{path}: shorter than minLength")
+        if pattern := schema.get("pattern"):
+            if not re.match(pattern, value):
+                errors.append(f"{path}: does not match pattern")
+    if schema_type == "integer" and "minimum" in schema and value < schema["minimum"]:
+        errors.append(f"{path}: below minimum")
+
+    if schema_type == "array":
+        if len(value) < schema.get("minItems", 0):
+            errors.append(f"{path}: shorter than minItems")
+        if schema.get("uniqueItems"):
+            stable = [json.dumps(item, sort_keys=True) for item in value]
+            if len(stable) != len(set(stable)):
+                errors.append(f"{path}: duplicate array item")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(value):
+                errors.extend(_schema_errors(item_schema, item, f"{path}[{index}]"))
+
+    if schema_type == "object":
+        required = set(schema.get("required", []))
+        for key in sorted(required - set(value)):
+            errors.append(f"{path}: missing required property {key}")
+        properties = schema.get("properties", {})
+        extra = sorted(set(value) - set(properties))
+        additional = schema.get("additionalProperties", True)
+        if additional is False:
+            for key in extra:
+                errors.append(f"{path}: additional property {key}")
+        elif isinstance(additional, dict):
+            for key in extra:
+                errors.extend(_schema_errors(additional, value[key], f"{path}.{key}"))
+        for key, child_schema in properties.items():
+            if key in value:
+                errors.extend(_schema_errors(child_schema, value[key], f"{path}.{key}"))
+
+    return errors
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _check_schema_documents() -> DriftCheck:
+    failures: list[str] = []
+    for schema_path in EXPECTED_SCHEMAS:
+        if not schema_path.exists():
+            failures.append(f"{schema_path.relative_to(REPO_ROOT)} missing")
+            continue
+        schema = _load_json(schema_path)
+        if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            failures.append(f"{schema_path.name}: unsupported $schema")
+        if schema.get("type") != "object":
+            failures.append(f"{schema_path.name}: root type must be object")
+        if schema.get("additionalProperties") is not False:
+            failures.append(f"{schema_path.name}: root must be closed")
+    return DriftCheck(
+        "schema_documents_closed",
+        not failures,
+        "all expected schemas are closed draft 2020-12 objects" if not failures else failures,
+    )
+
+
+def _check_pipeline_contract() -> DriftCheck:
+    schema = _load_json(SCHEMAS / "pipeline_contract.schema.json")
+    contract = pipeline_contract()
+    errors = _schema_errors(schema, contract)
+    node_names = {node["node"] for node in contract.get("nodes", [])}
+    for edge in contract.get("edges", []):
+        if edge.get("source") not in node_names or edge.get("target") not in node_names:
+            errors.append(f"edge references unknown node: {edge}")
+    return DriftCheck(
+        "pipeline_contract_schema",
+        not errors,
+        {
+            "nodes": len(contract.get("nodes", [])),
+            "edges": len(contract.get("edges", [])),
+            "errors": errors,
+        },
+    )
+
+
+def _check_diagram(update_diagram: bool) -> DriftCheck:
+    rendered = render_mermaid() + "\n"
+    existing = DIAGRAM.read_text(encoding="utf-8") if DIAGRAM.exists() else ""
+    if existing != rendered and update_diagram:
+        DIAGRAM.parent.mkdir(parents=True, exist_ok=True)
+        DIAGRAM.write_text(rendered, encoding="utf-8")
+        existing = rendered
+    return DriftCheck(
+        "pipeline_diagram_generated",
+        existing == rendered,
+        {
+            "path": str(DIAGRAM.relative_to(REPO_ROOT)),
+            "source": "pipeline_contract()",
+            "updated": update_diagram and existing == rendered,
+        },
+    )
+
+
+def _check_profiles() -> DriftCheck:
+    schema = _load_json(SCHEMAS / "harness_profile.schema.json")
+    failures: list[str] = []
+    profile_names: list[str] = []
+    for profile_path in sorted(PROFILES.glob("*.json")):
+        profile_names.append(profile_path.name)
+        profile = _load_json(profile_path)
+        errors = _schema_errors(schema, profile)
+        if errors:
+            failures.extend(f"{profile_path.name}: {error}" for error in errors)
+            continue
+        if not set(profile["caller_context"]["allowed_skills"]).issubset(profile["allowed_skills"]):
+            failures.append(f"{profile_path.name}: caller_context skills exceed profile allowlist")
+        if profile["runtime"].get("dry_run_default") is not True:
+            failures.append(f"{profile_path.name}: dry_run_default must stay true")
+        if profile["runtime"].get("apply_supported", False) is not False:
+            failures.append(f"{profile_path.name}: apply_supported must stay false")
+        if profile["approval_policy"].get("remediation_requires_approval_context") is not True:
+            failures.append(f"{profile_path.name}: remediation must require approval context")
+        if profile["token_budget"].get("fallback_on_budget_exceeded") is not True:
+            failures.append(f"{profile_path.name}: token overage must fall back closed")
+        if profile["token_budget"].get("model_tier") not in profile["model_policy"].get(
+            "allowed_model_tiers",
+            [],
+        ):
+            failures.append(f"{profile_path.name}: token model tier not allowed by model policy")
+    return DriftCheck(
+        "harness_profiles_safe",
+        not failures,
+        {"profiles": profile_names, "errors": failures},
+    )
+
+
+def _check_preflight_policy() -> DriftCheck:
+    failures: list[str] = []
+    for profile_path in sorted(PROFILES.glob("*.json")):
+        profile = load_harness_profile(str(profile_path))
+        without_approval = preview_agent_policy(profile, approval_context_present=False)
+        with_approval = preview_agent_policy(profile, approval_context_present=True)
+        for report in [without_approval, with_approval]:
+            if report.get("secrets_loaded") is not False:
+                failures.append(f"{profile_path.name}: preflight loaded secrets")
+            if report.get("cloud_calls_made") is not False:
+                failures.append(f"{profile_path.name}: preflight made cloud calls")
+            if report["remediation_preflight"].get("apply_supported") is not False:
+                failures.append(f"{profile_path.name}: preflight reports apply support")
+            triage = next(
+                entry for entry in report["agent_policy"]["entries"]
+                if entry["agent_id"] == "triage-agent"
+            )
+            if triage.get("effective_skill_grants") != []:
+                failures.append(f"{profile_path.name}: triage-agent has tool grants")
+        if without_approval["remediation_preflight"].get("would_plan_dry_run") is not False:
+            failures.append(f"{profile_path.name}: remediation ready without approval context")
+    return DriftCheck(
+        "preflight_policy_safe",
+        not failures,
+        "preflight stays metadata-only and approval-gated" if not failures else failures,
+    )
+
+
+def _check_runtime_wrapper() -> DriftCheck:
+    summary = run_harness_summary(
+        HarnessRunConfig(profile_path=PROFILES / "readonly-soc.json"),
+    )
+    errors: list[str] = []
+    if summary["harness_runtime"]["validation_status"] != "pass":
+        errors.append("runtime wrapper validation did not pass")
+    if summary["trace"][0] != "ingest" or summary["trace"][-1] != "writeback":
+        errors.append("runtime trace must start at ingest and end at writeback")
+    if summary["harness"].get("mode") not in {
+        "deterministic_offline",
+        "external_llm_metadata",
+    }:
+        errors.append("unexpected harness mode")
+    return DriftCheck(
+        "runtime_wrapper_validates",
+        not errors,
+        {
+            "profile_id": summary["profile"]["profile_id"],
+            "execution_mode": summary["harness_runtime"]["execution_mode"],
+            "errors": errors,
+        },
+    )
+
+
+def _check_docs_wired() -> DriftCheck:
+    docs = {
+        str(HARNESS_DOC.relative_to(REPO_ROOT)): HARNESS_DOC.read_text(encoding="utf-8"),
+        str(EXAMPLES_README.relative_to(REPO_ROOT)): EXAMPLES_README.read_text(encoding="utf-8"),
+        str(CI_WORKFLOW.relative_to(REPO_ROOT)): CI_WORKFLOW.read_text(encoding="utf-8"),
+    }
+    failures: list[str] = []
+    for token in REQUIRED_DOC_TOKENS:
+        if not any(token in text for text in docs.values()):
+            failures.append(f"missing reference: {token}")
+    return DriftCheck(
+        "docs_and_ci_reference_harness_commands",
+        not failures,
+        "docs and CI reference harness commands" if not failures else failures,
+    )
+
+
+def _check_no_harness_secret_literals() -> DriftCheck:
+    paths = [
+        HARNESS_DOC,
+        EXAMPLES_README,
+        EXAMPLES / "configure_langgraph_harness.py",
+        EXAMPLES / "inspect_langgraph_harness.py",
+        EXAMPLES / "run_langgraph_harness.py",
+        *sorted(PROFILES.glob("*.json")),
+    ]
+    findings: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for pattern in SECRET_PATTERNS:
+            for match in pattern.finditer(text):
+                findings.append(f"{path.relative_to(REPO_ROOT)}:{match.start()}: {match.group(0)[:32]}")
+    return DriftCheck(
+        "harness_docs_have_no_secret_literals",
+        not findings,
+        "no PAT/API-key/password literals in harness docs or profiles" if not findings else findings,
+    )
+
+
+def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
+    return [
+        _check_schema_documents(),
+        _check_pipeline_contract(),
+        _check_diagram(update_diagram),
+        _check_profiles(),
+        _check_preflight_policy(),
+        _check_runtime_wrapper(),
+        _check_docs_wired(),
+        _check_no_harness_secret_literals(),
+    ]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update-diagram",
+        action="store_true",
+        help="Rewrite docs/diagrams/langgraph-agent-harness.mmd if it drifted.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON report path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    checks = run_checks(update_diagram=args.update_diagram)
+    failed = [check for check in checks if not check.passed]
+    report = {
+        "event": "langgraph_harness_drift_check",
+        "schema_version": "langgraph-harness-drift-check-v1",
+        "status": "fail" if failed else "pass",
+        "checks_total": len(checks),
+        "passed": len(checks) - len(failed),
+        "failed": len(failed),
+        "checks": [check.to_json() for check in checks],
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -1642,6 +1642,31 @@ class TestLangGraphPipelineDiagram:
         assert "REM -- retryable API error --> RETRY" in result.stdout
 
 
+class TestLangGraphHarnessDriftCheck:
+    """Regression coverage for the operator-facing harness drift checker."""
+
+    SCRIPT = EXAMPLES / "check_langgraph_harness_drift.py"
+
+    def test_harness_drift_check_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["event"] == "langgraph_harness_drift_check"
+        assert report["schema_version"] == "langgraph-harness-drift-check-v1"
+        assert report["status"] == "pass"
+        assert report["failed"] == 0
+        check_names = {check["name"] for check in report["checks"]}
+        assert "pipeline_diagram_generated" in check_names
+        assert "preflight_policy_safe" in check_names
+        assert "harness_docs_have_no_secret_literals" in check_names
+
+
 class TestLangGraphHarnessEvals:
     """Regression coverage for profile/triage eval tracking."""
 


### PR DESCRIPTION
Summary
- Add an offline LangGraph harness drift checker for generated diagram, closed schemas, stock profiles, metadata-only preflight, runtime wrapper validation, docs/CI references, and harness secret literals.
- Wire the drift checker into agent-example CI.
- Document the drift doctor command in `docs/HARNESS.md` and `examples/agents/README.md`.

Verification
- `python examples/agents/check_langgraph_harness_drift.py`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `python -m py_compile examples/agents/check_langgraph_harness_drift.py`
- `uv run make agent-evals`
- `git diff --check`
- `git grep -n -I -E 'ghp_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]+|SNOWFLAKE_PASSWORD|OPENAI_API_KEY=|ANTHROPIC_API_KEY=|sk-[A-Za-z0-9_-]{20,}' -- examples/agents docs/HARNESS.md || true`

Notes
- The checker is offline and does not read credentials, call models, call cloud APIs, or execute remediation.
