### PR TITLE
feat(examples): plan LangGraph MCP data sources

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -109,6 +109,17 @@ dry-run only. Embedded callers should pass `approval_context` directly to
 `HarnessRunConfig`; the older `DEMO_APPROVE` environment variables remain a
 compatibility path for the original example script.
 
+Each profile also declares `runtime.security_data_source`, so the harness does
+not guess whether a tenant/account needs raw ingest or security-lake replay.
+Use `mode=raw_ingest` with `source_skill=ingest-cloudtrail-ocsf` when evidence
+arrives as raw vendor events. Use `mode=security_lake_replay` with
+`source-snowflake-query`, `source-clickhouse-query`, or
+`source-databricks-query` when OCSF or raw rows already live in the customer
+lake. `records_format=ocsf` tells the MCP call planner to skip the raw
+normalizer; `records_format=raw_vendor` keeps the source query followed by the
+ingest/normalize skill. Queries stay read-only and credentials remain outside
+the profile.
+
 `HARNESS.md` is therefore the readable operator contract; the graph nodes,
 adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are
 the executable harness.

--- a/docs/diagrams/langgraph-agent-harness.mmd
+++ b/docs/diagrams/langgraph-agent-harness.mmd
@@ -10,7 +10,7 @@ flowchart LR
     classDef audit fill:#1f2937,stroke:#94a3b8,color:#f8fafc
 
     subgraph FACTS["Deterministic skill nodes: evidence and security facts"]
-        ING["ingest<br/>agent: evidence-agent<br/>skills: ingest-cloudtrail-ocsf · source-snowflake-query<br/>guards: allowlist_intersection · no_credentials_in_profile"]:::fact
+        ING["ingest<br/>agent: evidence-agent<br/>skills: ingest-cloudtrail-ocsf · source-snowflake-query +2<br/>guards: allowlist_intersection · no_credentials_in_profile"]:::fact
         NORM["normalize<br/>agent: evidence-agent<br/>skills: ingest-cloudtrail-ocsf<br/>guards: ocsf_1_8_shape · stable_event_uid +1"]:::fact
         ENR["enrich<br/>agent: evidence-agent<br/>skills: detect-lateral-movement<br/>guards: deterministic_finding_uid · no_llm_security_facts"]:::fact
         COR["correlate<br/>agent: evidence-agent<br/>skills: discover-control-evidence<br/>guards: identity_resource_join · agent_run_hashes"]:::fact

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -98,6 +98,17 @@ python examples/agents/configure_langgraph_harness.py \
   --output-profile artifacts/acme-soc-triage.json \
   --output-env artifacts/acme-soc-triage.env
 
+# Existing security lake: replay read-only rows instead of raw ingest.
+python examples/agents/configure_langgraph_harness.py \
+  --role readonly-soc \
+  --profile-id acme-clickhouse-replay \
+  --email analyst@example.com \
+  --data-source-mode security-lake-replay \
+  --lake-backend clickhouse \
+  --lake-query "SELECT payload FROM security.events_sink LIMIT 100" \
+  --output-profile artifacts/acme-clickhouse-replay.json \
+  --output-env artifacts/acme-clickhouse-replay.env
+
 # Blocked path: no approval context, no remediation action.
 python examples/agents/langgraph_security_graph.py
 
@@ -204,8 +215,9 @@ python examples/agents/check_langgraph_harness_drift.py
 The LangGraph summary includes `integrity.evidence_hash`,
 `integrity.state_hash`, stable workflow/remediation idempotency keys, and
 retryable-vs-terminal API error classification. It also includes the
-`profile`, `effective_allowed_skills`, `harness` provider/model/mode/model
-policy/token budget, `agents` manifest, `pipeline_contract`, `agent_runs`
+`profile`, `effective_allowed_skills`, `data_source`, `harness`
+provider/model/mode/model policy/token budget, `agents` manifest,
+`pipeline_contract`, `mcp_call_plan`, `agent_runs`
 ledger, `agent_policy` effective grants report, compact LLM evidence cards,
 token budget usage, and bounded
 `agent_recommendations` so

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -216,6 +216,16 @@ def _check_profiles() -> DriftCheck:
             failures.append(f"{profile_path.name}: dry_run_default must stay true")
         if profile["runtime"].get("apply_supported", False) is not False:
             failures.append(f"{profile_path.name}: apply_supported must stay false")
+        data_source = profile["runtime"].get("security_data_source") or {}
+        if data_source.get("mode") not in {"raw_ingest", "security_lake_replay"}:
+            failures.append(f"{profile_path.name}: security_data_source mode is invalid")
+        if data_source.get("mode") == "raw_ingest" and data_source.get("source_skill") != "ingest-cloudtrail-ocsf":
+            failures.append(f"{profile_path.name}: raw_ingest must use ingest-cloudtrail-ocsf")
+        if data_source.get("mode") == "security_lake_replay":
+            if not str(data_source.get("source_skill", "")).startswith("source-"):
+                failures.append(f"{profile_path.name}: lake replay must use a source-* query skill")
+            if data_source.get("backend") not in {"snowflake", "clickhouse", "databricks"}:
+                failures.append(f"{profile_path.name}: lake replay backend must be a shipped warehouse source")
         if profile["approval_policy"].get("remediation_requires_approval_context") is not True:
             failures.append(f"{profile_path.name}: remediation must require approval context")
         if profile["token_budget"].get("fallback_on_budget_exceeded") is not True:

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -30,6 +30,11 @@ from langgraph_security_graph import (
 )
 
 HarnessRole = Literal["readonly-soc", "analyst-triage", "dry-run-remediation"]
+LAKE_SOURCE_SKILLS = {
+    "snowflake": "source-snowflake-query",
+    "clickhouse": "source-clickhouse-query",
+    "databricks": "source-databricks-query",
+}
 
 ROLE_DEFAULTS: dict[HarnessRole, dict[str, Any]] = {
     "readonly-soc": {
@@ -108,6 +113,27 @@ def _profile_allowed_skills(role: HarnessRole, extra_skills: list[str]) -> list[
     return allowed
 
 
+def _security_data_source(args: argparse.Namespace) -> dict[str, str]:
+    if args.data_source_mode == "raw-ingest":
+        return {
+            "mode": "raw_ingest",
+            "backend": "inline_events",
+            "source_skill": "ingest-cloudtrail-ocsf",
+            "records_format": "raw_vendor",
+            "query": "",
+        }
+    source_skill = LAKE_SOURCE_SKILLS[args.lake_backend]
+    query = args.lake_query or "SELECT payload FROM security.events_sink LIMIT 100"
+    _assert_no_secret_material({"lake_query": query}, path="runtime.security_data_source")
+    return {
+        "mode": "security_lake_replay",
+        "backend": args.lake_backend,
+        "source_skill": source_skill,
+        "records_format": args.lake_records_format,
+        "query": query,
+    }
+
+
 def build_profile(args: argparse.Namespace) -> dict[str, Any]:
     role: HarnessRole = args.role
     if not PROFILE_ID_RE.match(args.profile_id):
@@ -174,6 +200,7 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
             "langgraph_runtime_optional": True,
             "dry_run_default": True,
             "apply_supported": False,
+            "security_data_source": _security_data_source(args),
         },
     }
     _assert_no_secret_material(profile, path="profile")
@@ -212,6 +239,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--roles")
     parser.add_argument("--cloud-hint", action="append", default=[], help="provider=credential-hint")
     parser.add_argument("--allowed-skill", action="append", default=[], help="additional known example skill")
+    parser.add_argument(
+        "--data-source-mode",
+        choices=["raw-ingest", "security-lake-replay"],
+        default="raw-ingest",
+        help="Whether this harness should ingest raw events or replay an existing security data lake",
+    )
+    parser.add_argument(
+        "--lake-backend",
+        choices=sorted(LAKE_SOURCE_SKILLS),
+        default="snowflake",
+        help="Security lake backend when --data-source-mode=security-lake-replay",
+    )
+    parser.add_argument(
+        "--lake-records-format",
+        choices=["raw_vendor", "ocsf"],
+        default="ocsf",
+        help="Shape returned by the lake replay query",
+    )
+    parser.add_argument("--lake-query", help="Read-only SELECT/WITH/SHOW/DESCRIBE query for lake replay")
     parser.add_argument("--external-llm", action="store_true")
     parser.add_argument("--llm-provider", default="deterministic-local")
     parser.add_argument("--llm-model", default="policy-bounded-triage-v1")

--- a/examples/agents/harness_mcp_bridge.py
+++ b/examples/agents/harness_mcp_bridge.py
@@ -1,0 +1,276 @@
+"""MCP call planner for the LangGraph SOC harness example.
+
+The live MCP wrapper owns execution, subprocess sandboxing, timeouts, HMAC
+audit, and dry-run/HITL enforcement. This module keeps the LangGraph example
+aligned to that wrapper by building the exact `tools/call` JSON-RPC payloads
+the graph would send, while staying offline for tests and docs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+CALLER_CONTEXT_KEYS = frozenset({
+    "user_id",
+    "email",
+    "session_id",
+    "roles",
+    "allowed_skills",
+})
+
+APPROVAL_CONTEXT_KEYS = frozenset({
+    "approver_id",
+    "approver_email",
+    "ticket_id",
+    "approval_timestamp",
+    "approver_ids",
+    "approver_emails",
+})
+
+READ_ONLY_SKILLS = {
+    "ingest-cloudtrail-ocsf",
+    "source-snowflake-query",
+    "source-clickhouse-query",
+    "source-databricks-query",
+    "detect-lateral-movement",
+    "cspm-aws-cis-benchmark",
+    "discover-control-evidence",
+    "convert-ocsf-to-sarif",
+}
+
+REMEDIATION_SKILLS = {"iam-departures-aws"}
+SOURCE_SKILLS = {
+    "ingest-cloudtrail-ocsf",
+    "source-snowflake-query",
+    "source-clickhouse-query",
+    "source-databricks-query",
+}
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _validate_context(
+    context: Mapping[str, Any] | None,
+    *,
+    allowed_keys: frozenset[str],
+    label: str,
+) -> dict[str, Any] | None:
+    if context is None:
+        return None
+    validated: dict[str, Any] = {}
+    for key, value in context.items():
+        if key not in allowed_keys:
+            raise ValueError(f"{label}.{key} is not accepted by the MCP wrapper")
+        if isinstance(value, str):
+            validated[key] = value
+        elif isinstance(value, list) and all(isinstance(item, str) for item in value):
+            validated[key] = list(value)
+        else:
+            raise ValueError(f"{label}.{key} must be a string or array of strings")
+    return validated
+
+
+def _caller_context(raw: Mapping[str, Any] | None, allowed_skills: list[str]) -> dict[str, Any]:
+    caller = _validate_context(raw, allowed_keys=CALLER_CONTEXT_KEYS, label="_caller_context") or {}
+    profile_allowed = {skill for skill in allowed_skills if isinstance(skill, str) and skill.strip()}
+    raw_caller_allowed = caller.get("allowed_skills")
+    if isinstance(raw_caller_allowed, str):
+        caller_allowed = {part.strip() for part in raw_caller_allowed.split(",") if part.strip()}
+    elif isinstance(raw_caller_allowed, list):
+        caller_allowed = {skill.strip() for skill in raw_caller_allowed if skill.strip()}
+    else:
+        caller_allowed = profile_allowed
+    caller["allowed_skills"] = sorted(profile_allowed & caller_allowed)
+    return caller
+
+
+def _approval_context(raw: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    return _validate_context(raw, allowed_keys=APPROVAL_CONTEXT_KEYS, label="_approval_context")
+
+
+def _cloudtrail_input(state: Mapping[str, Any]) -> str:
+    rows = state.get("raw_events") or []
+    return "\n".join(_stable_json(row) for row in rows if isinstance(row, dict)) + "\n"
+
+
+def _ocsf_input(state: Mapping[str, Any]) -> str:
+    rows = state.get("ocsf_events") or []
+    return "\n".join(_stable_json(row) for row in rows if isinstance(row, dict)) + "\n"
+
+
+def _finding_username(resource_uid: str) -> str:
+    if "/" in resource_uid:
+        return resource_uid.rsplit("/", 1)[-1] or "unknown"
+    return "unknown"
+
+
+def _finding_account_id(resource_uid: str) -> str:
+    parts = resource_uid.split(":")
+    if len(parts) > 4 and parts[4].isdigit() and len(parts[4]) == 12:
+        return parts[4]
+    return "111122223333"
+
+
+def _remediation_manifest_input(state: Mapping[str, Any]) -> str:
+    """Build a dry-run IAM departure manifest row from current findings.
+
+    The shipped `iam-departures-aws` MCP entrypoint consumes newline-delimited
+    manifest entries and is dry-run by default. The harness uses stable,
+    non-secret identity fields derived from the finding resource ARN where
+    available.
+    """
+    findings = state.get("findings") or []
+    terminated_at = "2026-01-01T00:00:00+00:00"
+    rows: list[dict[str, Any]] = []
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            continue
+        resource_uid = str(finding.get("resource_uid") or "")
+        username = _finding_username(resource_uid)
+        rows.append({
+            "email": f"{username or 'user'}@example.invalid",
+            "recipient_account_id": _finding_account_id(resource_uid),
+            "iam_username": username or f"user-{index}",
+            "terminated_at": terminated_at,
+        })
+    return "\n".join(_stable_json(row) for row in rows) + ("\n" if rows else "")
+
+
+def _skill_arguments(skill: str, state: Mapping[str, Any]) -> dict[str, Any]:
+    source_decision = state.get("data_source_decision") or {}
+    if skill == "ingest-cloudtrail-ocsf":
+        return {
+            "args": [],
+            "input": _cloudtrail_input(state),
+            "output_format": "ocsf",
+        }
+    if skill in {"source-snowflake-query", "source-clickhouse-query", "source-databricks-query"}:
+        query = str(source_decision.get("query") or "SELECT payload FROM security.events_sink LIMIT 100")
+        return {
+            "args": ["--query", query],
+            "input": "",
+            "output_format": "raw",
+        }
+    if skill in {"detect-lateral-movement", "convert-ocsf-to-sarif"}:
+        return {
+            "args": [],
+            "input": _ocsf_input(state),
+            "output_format": "ocsf",
+        }
+    if skill == "iam-departures-aws":
+        return {
+            "args": [],
+            "input": _remediation_manifest_input(state),
+        }
+    return {
+        "args": [],
+        "input": "",
+    }
+
+
+def build_tools_call(
+    *,
+    skill: str,
+    state: Mapping[str, Any],
+    request_id: str,
+    caller_context: Mapping[str, Any],
+    approval_context: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    arguments = _skill_arguments(skill, state)
+    arguments["_caller_context"] = dict(caller_context)
+    if approval_context:
+        arguments["_approval_context"] = dict(approval_context)
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": skill,
+            "arguments": arguments,
+        },
+    }
+
+
+def _request_id(state: Mapping[str, Any], node: str, skill: str) -> str:
+    idempotency = state.get("idempotency") or {}
+    workflow_key = idempotency.get("workflow_key") or "wf-preview"
+    return f"{workflow_key}:{node}:{skill}"
+
+
+def build_mcp_call_plan(
+    *,
+    state: Mapping[str, Any],
+    pipeline_contract: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return planned MCP calls for skill-backed graph nodes.
+
+    The plan is not an execution result. It lets operators and CI verify that
+    LangGraph node ownership, caller scope, approval context, and dry-run write
+    posture line up with the repo MCP wrapper before any stdio transport is
+    invoked.
+    """
+    effective_allowed = list(state.get("effective_allowed_skills") or [])
+    effective_allowed_set = set(effective_allowed)
+    source_decision = state.get("data_source_decision") or {}
+    selected_source_skill = source_decision.get("source_skill") or "ingest-cloudtrail-ocsf"
+    records_format = source_decision.get("records_format") or "raw_vendor"
+    caller = _caller_context(state.get("caller_context"), effective_allowed)
+    caller_allowed_set = set(caller.get("allowed_skills") or [])
+    approval = _approval_context(
+        state.get("approval_context")
+        or (state.get("review_decision") or {}).get("approval")
+    )
+    plan: list[dict[str, Any]] = []
+    for node in pipeline_contract.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        node_name = str(node.get("node") or "")
+        for skill in node.get("skills") or []:
+            if node_name == "ingest" and skill in SOURCE_SKILLS and skill != selected_source_skill:
+                status = "not_required"
+                reason = f"data source mode selected {selected_source_skill}"
+                request = None
+            elif (
+                skill == "ingest-cloudtrail-ocsf"
+                and source_decision.get("mode") == "security_lake_replay"
+                and records_format == "ocsf"
+            ):
+                status = "not_required"
+                reason = "security data lake rows are already OCSF"
+                request = None
+            elif skill not in effective_allowed_set or skill not in caller_allowed_set:
+                status = "blocked_by_allowlist"
+                reason = "skill is outside effective profile/caller allowlist"
+                request = None
+            elif skill in REMEDIATION_SKILLS and approval is None:
+                status = "blocked_by_hitl"
+                reason = "write-capable skill requires approval context"
+                request = None
+            else:
+                status = "planned"
+                reason = "ready for MCP wrapper dry-run gate"
+                request = build_tools_call(
+                    skill=skill,
+                    state=state,
+                    request_id=_request_id(state, node_name, skill),
+                    caller_context=caller,
+                    approval_context=approval if skill in REMEDIATION_SKILLS else None,
+                )
+            plan.append({
+                "node": node_name,
+                "agent_id": node.get("agent_id"),
+                "skill": skill,
+                "status": status,
+                "reason": reason,
+                "read_only": skill in READ_ONLY_SKILLS,
+                "write_capable": skill in REMEDIATION_SKILLS,
+                "requires_approval_context": skill in REMEDIATION_SKILLS,
+                "approval_context_attached": bool(request and skill in REMEDIATION_SKILLS),
+                "caller_allowed_skill_count": len(caller.get("allowed_skills") or []),
+                "transport": "mcp_stdio_jsonrpc",
+                "request": request,
+            })
+    return plan

--- a/examples/agents/harness_profiles/analyst-triage.json
+++ b/examples/agents/harness_profiles/analyst-triage.json
@@ -14,6 +14,7 @@
     "session_id": "analyst-triage-demo",
     "roles": "security_analyst",
     "allowed_skills": [
+      "ingest-cloudtrail-ocsf",
       "detect-lateral-movement",
       "discover-control-evidence",
       "convert-ocsf-to-sarif"
@@ -82,6 +83,13 @@
   },
   "runtime": {
     "langgraph_runtime_optional": true,
-    "dry_run_default": true
+    "dry_run_default": true,
+    "security_data_source": {
+      "mode": "raw_ingest",
+      "backend": "inline_events",
+      "source_skill": "ingest-cloudtrail-ocsf",
+      "records_format": "raw_vendor",
+      "query": ""
+    }
   }
 }

--- a/examples/agents/harness_profiles/dry-run-remediation.json
+++ b/examples/agents/harness_profiles/dry-run-remediation.json
@@ -14,8 +14,10 @@
     "session_id": "dry-run-remediation-demo",
     "roles": "security_engineer",
     "allowed_skills": [
+      "ingest-cloudtrail-ocsf",
       "detect-lateral-movement",
       "discover-control-evidence",
+      "convert-ocsf-to-sarif",
       "iam-departures-aws"
     ]
   },
@@ -91,6 +93,13 @@
   "runtime": {
     "langgraph_runtime_optional": true,
     "dry_run_default": true,
-    "apply_supported": false
+    "apply_supported": false,
+    "security_data_source": {
+      "mode": "raw_ingest",
+      "backend": "inline_events",
+      "source_skill": "ingest-cloudtrail-ocsf",
+      "records_format": "raw_vendor",
+      "query": ""
+    }
   }
 }

--- a/examples/agents/harness_profiles/readonly-soc.json
+++ b/examples/agents/harness_profiles/readonly-soc.json
@@ -82,6 +82,13 @@
   },
   "runtime": {
     "langgraph_runtime_optional": true,
-    "dry_run_default": true
+    "dry_run_default": true,
+    "security_data_source": {
+      "mode": "security_lake_replay",
+      "backend": "snowflake",
+      "source_skill": "source-snowflake-query",
+      "records_format": "ocsf",
+      "query": "SELECT payload FROM security.events_sink WHERE class_uid = 6003 LIMIT 100"
+    }
   }
 }

--- a/examples/agents/harness_runtime.py
+++ b/examples/agents/harness_runtime.py
@@ -157,10 +157,36 @@ def validate_harness_summary(summary: Mapping[str, Any]) -> tuple[str, ...]:
     if remediation.get("status") == "dry_run" and review.get("status") != "approved":
         errors.append("dry-run remediation requires approved review state")
 
+    mcp_call_plan = list(summary.get("mcp_call_plan") or [])
+    if not mcp_call_plan:
+        errors.append("summary must include MCP call plan")
+    planned_mcp_calls = [call for call in mcp_call_plan if call.get("status") == "planned"]
+    for call in planned_mcp_calls:
+        request = call.get("request") or {}
+        params = request.get("params") or {}
+        arguments = params.get("arguments") or {}
+        if request.get("method") != "tools/call":
+            errors.append("planned MCP call must use tools/call")
+        if params.get("name") != call.get("skill"):
+            errors.append("planned MCP call name must match skill")
+        caller_context = arguments.get("_caller_context") or {}
+        caller_allowed = set(caller_context.get("allowed_skills") or [])
+        if call.get("skill") not in caller_allowed:
+            errors.append("planned MCP call skill must be in caller allowed_skills")
+        if call.get("write_capable") and not arguments.get("_approval_context"):
+            errors.append("planned write-capable MCP call must attach approval context")
+        if call.get("write_capable") and "--apply" in set(arguments.get("args") or []):
+            errors.append("planned write-capable MCP call must not include --apply")
+    for call in mcp_call_plan:
+        if str(call.get("status", "")).startswith("blocked_") and call.get("request") is not None:
+            errors.append("blocked MCP calls must not carry executable requests")
+
     integrity = summary.get("integrity") or {}
     audit = summary.get("audit") or {}
     if integrity.get("state_hash") != audit.get("state_hash"):
         errors.append("audit state_hash must match integrity state_hash")
+    if audit.get("mcp_planned_call_count") != len(planned_mcp_calls):
+        errors.append("audit MCP planned call count must match call plan")
 
     contract = summary.get("pipeline_contract") or {}
     triage_nodes = [

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -42,10 +42,13 @@ from harness_adapters import (
     select_triage_adapter,
     validate_adapter_recommendation,
 )
+from harness_mcp_bridge import build_mcp_call_plan
 
 ALLOWED_SKILLS_READ_ONLY_LIST = [
     "ingest-cloudtrail-ocsf",
     "source-snowflake-query",
+    "source-clickhouse-query",
+    "source-databricks-query",
     "detect-lateral-movement",
     "cspm-aws-cis-benchmark",
     "discover-control-evidence",
@@ -298,6 +301,8 @@ class GraphState(TypedDict, total=False):
     seen_idempotency_keys: list[str]
     llm_evidence_cards: list[dict[str, Any]]
     token_budget_usage: dict[str, Any]
+    data_source_decision: dict[str, Any]
+    mcp_call_plan: list[dict[str, Any]]
     audit_record: dict[str, Any]
     eval_record: EvalRecord
     trace: list[WorkflowStage]
@@ -497,6 +502,13 @@ def _default_harness_profile() -> HarnessProfile:
         "runtime": {
             "langgraph_runtime_optional": True,
             "dry_run_default": True,
+            "security_data_source": {
+                "mode": "raw_ingest",
+                "backend": "inline_events",
+                "source_skill": "ingest-cloudtrail-ocsf",
+                "records_format": "raw_vendor",
+                "query": "",
+            },
         },
     }
 
@@ -576,6 +588,14 @@ def load_harness_profile(path_text: str | None = None) -> HarnessProfile:
         **default["model_policy"]["fallback"],
         **payload.get("model_policy", {}).get("fallback", {}),
     }
+    profile["runtime"] = {
+        **default["runtime"],
+        **payload.get("runtime", {}),
+    }
+    profile["runtime"]["security_data_source"] = {
+        **default["runtime"]["security_data_source"],
+        **payload.get("runtime", {}).get("security_data_source", {}),
+    }
     profile["agent_roster"] = _merge_agent_roster(payload.get("agent_roster"))
     return profile
 
@@ -584,6 +604,28 @@ def _effective_allowed_skills(profile: HarnessProfile) -> list[str]:
     requested = profile.get("allowed_skills") or ALLOWED_SKILLS_READ_ONLY_LIST
     safe_surface = {*ALLOWED_SKILLS_READ_ONLY_LIST, ALLOWED_SKILLS_REMEDIATION}
     return [skill for skill in requested if skill in safe_surface]
+
+
+def _data_source_decision(profile: HarnessProfile) -> dict[str, Any]:
+    source = (profile.get("runtime") or {}).get("security_data_source") or {}
+    mode = source.get("mode") or "raw_ingest"
+    backend = source.get("backend") or "inline_events"
+    source_skill = source.get("source_skill") or (
+        "ingest-cloudtrail-ocsf" if mode == "raw_ingest" else "source-snowflake-query"
+    )
+    return {
+        "schema_version": "langgraph-security-data-source-v1",
+        "mode": mode,
+        "backend": backend,
+        "source_skill": source_skill,
+        "records_format": source.get("records_format") or (
+            "raw_vendor" if mode == "raw_ingest" else "ocsf"
+        ),
+        "query": source.get("query") or "",
+        "raw_ingest_required": mode == "raw_ingest",
+        "security_lake_replay": mode == "security_lake_replay",
+        "decision_source": "harness_profile.runtime.security_data_source",
+    }
 
 
 def _agent_manifest(state: GraphState | None = None) -> list[AgentDefinition]:
@@ -599,7 +641,12 @@ def _pipeline_node_contracts(state: GraphState | None = None) -> list[PipelineNo
         {
             "node": "ingest",
             "agent_id": "evidence-agent",
-            "skills": ["ingest-cloudtrail-ocsf", "source-snowflake-query"],
+            "skills": [
+                "ingest-cloudtrail-ocsf",
+                "source-snowflake-query",
+                "source-clickhouse-query",
+                "source-databricks-query",
+            ],
             "inputs": ["harness_profile", "caller_context", "raw_events"],
             "outputs": ["effective_allowed_skills", "raw_events"],
             "guardrails": ["allowlist_intersection", "no_credentials_in_profile"],
@@ -1054,6 +1101,7 @@ def ingest_node(state: GraphState) -> GraphState:
     state["agent_manifest"] = _agent_manifest(state)
     effective_skills = _effective_allowed_skills(profile)
     state["effective_allowed_skills"] = effective_skills
+    state["data_source_decision"] = _data_source_decision(profile)
     raw_events = state.get("raw_events") or [{
         "source": "cloudtrail",
         "event_name": "CreateAccessKey",
@@ -1061,7 +1109,14 @@ def ingest_node(state: GraphState) -> GraphState:
         "resource_uid": "arn:aws:iam::111122223333:user/build-bot",
     }]
     state["raw_events"] = raw_events
-    _emit_node("ingest", allowlist=",".join(effective_skills), profile=profile["profile_id"], records=len(raw_events))
+    _emit_node(
+        "ingest",
+        allowlist=",".join(effective_skills),
+        profile=profile["profile_id"],
+        records=len(raw_events),
+        data_source_mode=state["data_source_decision"]["mode"],
+        source_skill=state["data_source_decision"]["source_skill"],
+    )
     return state
 
 
@@ -1555,6 +1610,10 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         outputs={"writeback": "audit_eval_pending"},
     )
     state["agent_policy"] = effective_agent_policy(state)
+    state["mcp_call_plan"] = build_mcp_call_plan(
+        state=state,
+        pipeline_contract=pipeline_contract(state),
+    )
     summary_payload = {
         "caller_context": state.get("caller_context"),
         "harness_profile": {
@@ -1564,6 +1623,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "approval_policy": (state.get("harness_profile") or {}).get("approval_policy"),
         },
         "effective_allowed_skills": state.get("effective_allowed_skills"),
+        "data_source_decision": state.get("data_source_decision"),
         "trace": state.get("trace"),
         "findings": state.get("findings"),
         "harness_config": state.get("harness_config"),
@@ -1573,6 +1633,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "agent_runs": state.get("agent_runs"),
         "agent_recommendations": state.get("agent_recommendations"),
         "llm_validation": state.get("llm_validation"),
+        "mcp_call_plan": state.get("mcp_call_plan"),
         "integrity": {
             key: value
             for key, value in (state.get("integrity") or {}).items()
@@ -1603,6 +1664,14 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "api_error_count": len(api_errors),
         "agent_run_count": len(state.get("agent_runs") or []),
         "agent_policy_hash": (state.get("agent_policy") or {}).get("policy_hash"),
+        "mcp_planned_call_count": sum(
+            1 for call in state.get("mcp_call_plan") or []
+            if call.get("status") == "planned"
+        ),
+        "mcp_blocked_call_count": sum(
+            1 for call in state.get("mcp_call_plan") or []
+            if str(call.get("status", "")).startswith("blocked_")
+        ),
         "llm_adapter_accepted": sum(1 for record in llm_validation if record["status"] == "accepted"),
         "llm_adapter_rejected": sum(1 for record in llm_validation if record["status"] == "rejected"),
         "llm_token_budget_status": (state.get("token_budget_usage") or {}).get("status"),
@@ -1634,6 +1703,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "llm_adapter_schema_gate",
             "llm_token_budget_gate",
             "multi_agent_ledger",
+            "mcp_call_plan",
             "conditional_edges",
         ],
         "status": eval_status,
@@ -1750,6 +1820,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         ),
         "profile": final.get("harness_profile"),
         "effective_allowed_skills": final.get("effective_allowed_skills"),
+        "data_source": final.get("data_source_decision"),
         "trace": final.get("trace"),
         "findings_count": len(final.get("findings") or []),
         "confidence_scores": final.get("confidence_scores"),
@@ -1761,6 +1832,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "agent_runs": final.get("agent_runs"),
         "agent_recommendations": final.get("agent_recommendations"),
         "llm_validation": final.get("llm_validation"),
+        "mcp_call_plan": final.get("mcp_call_plan"),
         "llm_evidence_cards": final.get("llm_evidence_cards"),
         "token_budget_usage": final.get("token_budget_usage"),
         "review": final.get("review_decision"),

--- a/examples/agents/schemas/harness_profile.schema.json
+++ b/examples/agents/schemas/harness_profile.schema.json
@@ -286,6 +286,52 @@
         "apply_supported": {
           "type": "boolean",
           "const": false
+        },
+        "security_data_source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "backend",
+            "source_skill"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "raw_ingest",
+                "security_lake_replay"
+              ]
+            },
+            "backend": {
+              "type": "string",
+              "enum": [
+                "inline_events",
+                "snowflake",
+                "clickhouse",
+                "databricks"
+              ]
+            },
+            "source_skill": {
+              "type": "string",
+              "enum": [
+                "ingest-cloudtrail-ocsf",
+                "source-snowflake-query",
+                "source-clickhouse-query",
+                "source-databricks-query"
+              ]
+            },
+            "records_format": {
+              "type": "string",
+              "enum": [
+                "raw_vendor",
+                "ocsf"
+              ]
+            },
+            "query": {
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -735,7 +735,17 @@ class TestLangGraphSocWorkflow:
         assert summary["remediation"]["status"] == "dry_run"
         assert summary["remediation"]["dry_run"] is True
         assert summary["remediation"]["skill"] == "iam-departures-aws"
+        assert summary["data_source"]["mode"] == "raw_ingest"
+        assert summary["data_source"]["source_skill"] == "ingest-cloudtrail-ocsf"
         assert summary["remediation"]["idempotency_key"].startswith("rem-")
+        planned_remediation_call = next(
+            call for call in summary["mcp_call_plan"]
+            if call["skill"] == "iam-departures-aws"
+        )
+        assert planned_remediation_call["status"] == "planned"
+        assert planned_remediation_call["request"]["method"] == "tools/call"
+        assert planned_remediation_call["request"]["params"]["arguments"]["_approval_context"]["ticket_id"] == "SEC-LANGGRAPH-1"
+        assert "--apply" not in planned_remediation_call["request"]["params"]["arguments"]["args"]
         assert summary["idempotency"]["remediation_key"] == summary["remediation"]["idempotency_key"]
         assert summary["integrity"]["approved_payload_hash"]
         assert summary["audit"]["idempotency_key"] == summary["remediation"]["idempotency_key"]
@@ -901,6 +911,9 @@ class TestLangGraphSocWorkflow:
         assert summary["profile"]["profile_id"] == "readonly-soc"
         assert summary["caller_context"]["email"] == "soc-readonly@example.com"
         assert summary["audit"]["profile_id"] == "readonly-soc"
+        assert summary["data_source"]["mode"] == "security_lake_replay"
+        assert summary["data_source"]["backend"] == "snowflake"
+        assert summary["data_source"]["source_skill"] == "source-snowflake-query"
         assert summary["effective_allowed_skills"] == [
             "ingest-cloudtrail-ocsf",
             "source-snowflake-query",
@@ -909,6 +922,23 @@ class TestLangGraphSocWorkflow:
             "discover-control-evidence",
             "convert-ocsf-to-sarif",
         ]
+        ingest_source_calls = [
+            call for call in summary["mcp_call_plan"]
+            if call["node"] == "ingest" and call["skill"].startswith("source-")
+        ]
+        assert [
+            (call["skill"], call["status"]) for call in ingest_source_calls
+        ] == [
+            ("source-snowflake-query", "planned"),
+            ("source-clickhouse-query", "not_required"),
+            ("source-databricks-query", "not_required"),
+        ]
+        normalize_ingest = next(
+            call for call in summary["mcp_call_plan"]
+            if call["node"] == "normalize" and call["skill"] == "ingest-cloudtrail-ocsf"
+        )
+        assert normalize_ingest["status"] == "not_required"
+        assert "already OCSF" in normalize_ingest["reason"]
         assert summary["remediation"]["status"] == "skipped"
 
     def test_profile_llm_metadata_is_bounded(self):
@@ -1197,6 +1227,14 @@ class TestLangGraphContractSchemas:
             )
             assert profile["approval_policy"]["remediation_requires_approval_context"] is True
             assert profile["runtime"]["dry_run_default"] is True
+            data_source = profile["runtime"].get("security_data_source") or {}
+            assert data_source.get("mode") in {"raw_ingest", "security_lake_replay"}
+            if data_source.get("mode") == "raw_ingest":
+                assert data_source.get("source_skill") == "ingest-cloudtrail-ocsf"
+                assert data_source.get("records_format") == "raw_vendor"
+            if data_source.get("mode") == "security_lake_replay":
+                assert data_source.get("source_skill", "").startswith("source-")
+                assert data_source.get("backend") in {"snowflake", "clickhouse", "databricks"}
             if "token_budget" in profile:
                 assert profile["token_budget"]["compression_required"] is True
                 assert profile["token_budget"]["fallback_on_budget_exceeded"] is True
@@ -1351,6 +1389,12 @@ class TestLangGraphHarnessSetup:
                 "gpt-4.1-mini",
                 "--cloud-hint",
                 "aws=AWS_PROFILE=prod-readonly",
+                "--data-source-mode",
+                "security-lake-replay",
+                "--lake-backend",
+                "clickhouse",
+                "--lake-query",
+                "SELECT payload FROM security.events_sink LIMIT 50",
                 "--output-profile",
                 str(profile_path),
                 "--output-env",
@@ -1382,6 +1426,13 @@ class TestLangGraphHarnessSetup:
         assert profile["model_policy"]["models"]["small"] == {
             "provider": "openai",
             "model": "gpt-4.1-mini",
+        }
+        assert profile["runtime"]["security_data_source"] == {
+            "mode": "security_lake_replay",
+            "backend": "clickhouse",
+            "source_skill": "source-clickhouse-query",
+            "records_format": "ocsf",
+            "query": "SELECT payload FROM security.events_sink LIMIT 50",
         }
         roster = {agent["agent_id"]: agent for agent in profile["agent_roster"]}
         assert roster["triage-agent"] == {
@@ -1416,6 +1467,17 @@ class TestLangGraphHarnessSetup:
         assert summary["harness"]["token_budget"]["model_tier"] == "small"
         assert summary["harness"]["model_policy"]["selected_model_tier"] == "small"
         assert summary["harness"]["model_policy"]["selection_source"] == "profile_model_policy"
+        assert summary["data_source"]["mode"] == "security_lake_replay"
+        assert summary["data_source"]["backend"] == "clickhouse"
+        clickhouse_source_call = next(
+            call for call in summary["mcp_call_plan"]
+            if call["node"] == "ingest" and call["skill"] == "source-clickhouse-query"
+        )
+        assert clickhouse_source_call["status"] == "planned"
+        assert clickhouse_source_call["request"]["params"]["arguments"]["args"] == [
+            "--query",
+            "SELECT payload FROM security.events_sink LIMIT 50",
+        ]
         triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
         assert triage_agent["model_tier"] == "small"
         assert triage_agent["skill_scope"] == []
@@ -1449,6 +1511,8 @@ class TestLangGraphHarnessSetup:
         assert "iam-departures-aws" in profile["allowed_skills"]
         assert profile["runtime"]["dry_run_default"] is True
         assert profile["runtime"]["apply_supported"] is False
+        assert profile["runtime"]["security_data_source"]["mode"] == "raw_ingest"
+        assert profile["runtime"]["security_data_source"]["source_skill"] == "ingest-cloudtrail-ocsf"
         assert profile["approval_policy"]["remediation_requires_approval_context"] is True
         assert profile["token_budget"]["model_tier"] == "tiny"
         assert profile["model_policy"]["allowed_model_tiers"] == ["tiny"]


### PR DESCRIPTION
Summary
- Add an offline MCP call planner for the LangGraph SOC harness so graph runs emit exact `tools/call` payloads, caller-scope intersection, HITL attachment, and blocked/not-required call status.
- Add profile-owned `runtime.security_data_source` settings to choose raw ingest vs existing security-lake replay across Snowflake, ClickHouse, and Databricks without storing credentials.
- Extend harness setup, docs, drift checks, generated diagram, and tests for data-source selection and MCP call-plan invariants.

Verification
- `python examples/agents/render_langgraph_pipeline_diagram.py --output docs/diagrams/langgraph-agent-harness.mmd`
- `python examples/agents/check_langgraph_harness_drift.py`
- `uv run --group langgraph pytest examples/agents/tests/test_examples.py -q`
- `uv run ruff check examples/agents`
- `python -m py_compile examples/agents/harness_mcp_bridge.py examples/agents/langgraph_security_graph.py examples/agents/harness_runtime.py examples/agents/configure_langgraph_harness.py`
- `uv run make agent-evals`
- `git diff --check`
- `git grep -n -I -E 'ghp_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]+|SNOWFLAKE_PASSWORD|OPENAI_API_KEY=|ANTHROPIC_API_KEY=|sk-[A-Za-z0-9_-]{20,}' -- examples/agents docs/HARNESS.md || true`

Notes
- This PR plans and validates MCP JSON-RPC calls offline. It does not execute the stdio MCP server, call cloud APIs, call live models, or run remediation.
