### PR TITLE
feat(examples): add LangGraph MCP execution contract

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -120,6 +120,15 @@ normalizer; `records_format=raw_vendor` keeps the source query followed by the
 ingest/normalize skill. Queries stay read-only and credentials remain outside
 the profile.
 
+Profiles also declare `runtime.mcp_execution`. The shipped profiles use
+`mode=plan_only`, `transport=mcp_stdio_jsonrpc`,
+`execute_planned_calls=false`, and `allow_write_calls=false`. The graph still
+builds exact MCP `tools/call` JSON-RPC payloads, but the harness emits a
+separate `mcp_execution` ledger showing those planned calls were skipped by
+policy. Operator-owned integrations can opt a generated profile into
+`mode=operator_stdio` for read-only call execution through their own MCP
+transport; write-capable execution remains disabled in the example schema.
+
 `HARNESS.md` is therefore the readable operator contract; the graph nodes,
 adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are
 the executable harness.
@@ -143,8 +152,10 @@ The drift checker regenerates the diagram from `pipeline_contract()` in memory,
 validates closed schemas and stock profiles, verifies metadata-only preflight
 policy, runs the importable wrapper validation path, checks harness docs/CI
 references, and scans the harness docs/profiles for PAT/API-key/password
-literals. It remains offline: no cloud credentials, model calls, approval
-tokens, cloud APIs, or remediation execution.
+literals. It also verifies that stock profiles declare MCP execution policy and
+do not enable write-capable execution. It remains offline: no cloud
+credentials, model calls, approval tokens, cloud APIs, or remediation
+execution.
 
 The LLM/agent harness records provider/model/mode, model-policy selection, and
 token-budget policy in state and audit output. `model_policy` selects the

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -143,6 +143,18 @@ python examples/agents/run_langgraph_harness.py \
   --profile examples/agents/harness_profiles/dry-run-remediation.json \
   --approval-context /path/to/approval-context.json
 
+# MCP execution is explicit. Shipped profiles emit mcp_call_plan plus
+# mcp_execution=plan_only; generated profiles can mark read-only calls eligible
+# for an operator-owned stdio transport without enabling write execution.
+python examples/agents/configure_langgraph_harness.py \
+  --role readonly-soc \
+  --profile-id acme-readonly-stdio \
+  --email analyst@example.com \
+  --mcp-execution-mode operator_stdio \
+  --mcp-max-calls 3 \
+  --output-profile artifacts/acme-readonly-stdio.json \
+  --output-env artifacts/acme-readonly-stdio.env
+
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
 DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json \
 DEMO_APPROVE=yes \

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -226,6 +226,15 @@ def _check_profiles() -> DriftCheck:
                 failures.append(f"{profile_path.name}: lake replay must use a source-* query skill")
             if data_source.get("backend") not in {"snowflake", "clickhouse", "databricks"}:
                 failures.append(f"{profile_path.name}: lake replay backend must be a shipped warehouse source")
+        mcp_execution = profile["runtime"].get("mcp_execution") or {}
+        if mcp_execution.get("transport") != "mcp_stdio_jsonrpc":
+            failures.append(f"{profile_path.name}: MCP execution transport must be stdio JSON-RPC")
+        if mcp_execution.get("mode") == "plan_only" and mcp_execution.get("execute_planned_calls") is not False:
+            failures.append(f"{profile_path.name}: plan_only must not execute planned MCP calls")
+        if mcp_execution.get("allow_write_calls") is not False:
+            failures.append(f"{profile_path.name}: write-capable MCP execution must stay disabled")
+        if mcp_execution.get("max_calls", 0) < 0:
+            failures.append(f"{profile_path.name}: MCP max_calls must be non-negative")
         if profile["approval_policy"].get("remediation_requires_approval_context") is not True:
             failures.append(f"{profile_path.name}: remediation must require approval context")
         if profile["token_budget"].get("fallback_on_budget_exceeded") is not True:

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -134,10 +134,22 @@ def _security_data_source(args: argparse.Namespace) -> dict[str, str]:
     }
 
 
+def _mcp_execution(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "mode": args.mcp_execution_mode,
+        "transport": "mcp_stdio_jsonrpc",
+        "execute_planned_calls": args.mcp_execution_mode == "operator_stdio",
+        "allow_write_calls": False,
+        "max_calls": args.mcp_max_calls,
+    }
+
+
 def build_profile(args: argparse.Namespace) -> dict[str, Any]:
     role: HarnessRole = args.role
     if not PROFILE_ID_RE.match(args.profile_id):
         raise ValueError("profile_id must match ^[a-z0-9][a-z0-9-]{1,63}$")
+    if args.mcp_max_calls < 0:
+        raise ValueError("--mcp-max-calls must be 0 or greater")
     allowed_skills = _profile_allowed_skills(role, args.allowed_skill)
     llm_mode = "external_llm_optional" if args.external_llm else "deterministic_offline"
     session_id = args.session_id or f"{args.profile_id}-session"
@@ -201,6 +213,7 @@ def build_profile(args: argparse.Namespace) -> dict[str, Any]:
             "dry_run_default": True,
             "apply_supported": False,
             "security_data_source": _security_data_source(args),
+            "mcp_execution": _mcp_execution(args),
         },
     }
     _assert_no_secret_material(profile, path="profile")
@@ -258,6 +271,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Shape returned by the lake replay query",
     )
     parser.add_argument("--lake-query", help="Read-only SELECT/WITH/SHOW/DESCRIBE query for lake replay")
+    parser.add_argument(
+        "--mcp-execution-mode",
+        choices=["plan_only", "operator_stdio"],
+        default="plan_only",
+        help="Plan MCP calls only, or mark planned read-only calls eligible for an operator-owned stdio transport",
+    )
+    parser.add_argument(
+        "--mcp-max-calls",
+        type=int,
+        default=0,
+        help="Maximum planned MCP calls an operator-owned transport may execute; 0 means no harness cap",
+    )
     parser.add_argument("--external-llm", action="store_true")
     parser.add_argument("--llm-provider", default="deterministic-local")
     parser.add_argument("--llm-model", default="policy-bounded-triage-v1")

--- a/examples/agents/harness_mcp_bridge.py
+++ b/examples/agents/harness_mcp_bridge.py
@@ -9,6 +9,7 @@ the graph would send, while staying offline for tests and docs.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any, Mapping
 
 CALLER_CONTEXT_KEYS = frozenset({
@@ -46,6 +47,8 @@ SOURCE_SKILLS = {
     "source-clickhouse-query",
     "source-databricks-query",
 }
+EXECUTION_MODES = {"plan_only", "operator_stdio"}
+MCP_EXECUTION_SCHEMA_VERSION = "langgraph-mcp-execution-v1"
 
 
 def _stable_json(value: Any) -> str:
@@ -274,3 +277,153 @@ def build_mcp_call_plan(
                 "request": request,
             })
     return plan
+
+
+def _execution_config(profile: Mapping[str, Any] | None) -> dict[str, Any]:
+    runtime = (profile or {}).get("runtime") or {}
+    configured = runtime.get("mcp_execution") or {}
+    mode = configured.get("mode") or "plan_only"
+    if mode not in EXECUTION_MODES:
+        mode = "plan_only"
+    return {
+        "mode": mode,
+        "transport": configured.get("transport") or "mcp_stdio_jsonrpc",
+        "execute_planned_calls": bool(configured.get("execute_planned_calls", False)),
+        "allow_write_calls": bool(configured.get("allow_write_calls", False)),
+        "max_calls": int(configured.get("max_calls", 0)),
+    }
+
+
+def _jsonrpc_error_classification(error: Mapping[str, Any]) -> str:
+    code = int(error.get("code") or 0)
+    message = str(error.get("message") or "").lower()
+    retryable_markers = ("timeout", "rate limit", "temporarily unavailable", "try again", "503", "429")
+    if code in {-32000, -32001, -32002} or any(marker in message for marker in retryable_markers):
+        return "retryable"
+    return "terminal"
+
+
+def execute_mcp_call_plan(
+    *,
+    call_plan: list[dict[str, Any]],
+    profile: Mapping[str, Any] | None,
+    transport: Callable[[dict[str, Any]], Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Evaluate or execute a planned MCP call set under operator-owned policy.
+
+    The default shipped profile is `plan_only`, so this function produces an
+    execution ledger without opening an MCP subprocess. Downstream harnesses can
+    pass a transport callable that owns stdio/session lifecycle and returns a
+    JSON-RPC response. Write-capable calls are never executed unless the
+    operator config explicitly opts into that capability.
+    """
+    config = _execution_config(profile)
+    results: list[dict[str, Any]] = []
+    executed_count = 0
+    planned_calls = [call for call in call_plan if call.get("status") == "planned"]
+    for call in call_plan:
+        request = call.get("request")
+        base = {
+            "node": call.get("node"),
+            "skill": call.get("skill"),
+            "request_id": (request or {}).get("id") if isinstance(request, dict) else None,
+            "write_capable": bool(call.get("write_capable")),
+        }
+        if call.get("status") != "planned":
+            results.append({
+                **base,
+                "status": "not_executed",
+                "reason": f"call plan status is {call.get('status')}",
+            })
+            continue
+        if config["mode"] == "plan_only":
+            results.append({
+                **base,
+                "status": "skipped_plan_only",
+                "reason": "profile runtime.mcp_execution.mode is plan_only",
+            })
+            continue
+        if not config["execute_planned_calls"]:
+            results.append({
+                **base,
+                "status": "blocked_execution_disabled",
+                "reason": "execute_planned_calls is false",
+            })
+            continue
+        if config["max_calls"] and executed_count >= config["max_calls"]:
+            results.append({
+                **base,
+                "status": "blocked_max_calls",
+                "reason": "max_calls reached",
+            })
+            continue
+        if call.get("write_capable") and not config["allow_write_calls"]:
+            results.append({
+                **base,
+                "status": "blocked_write_execution",
+                "reason": "write-capable MCP execution is disabled",
+            })
+            continue
+        if transport is None:
+            results.append({
+                **base,
+                "status": "blocked_no_transport",
+                "reason": "no operator-owned MCP transport supplied",
+            })
+            continue
+        if not isinstance(request, dict) or request.get("method") != "tools/call":
+            results.append({
+                **base,
+                "status": "blocked_invalid_request",
+                "reason": "planned request is not a tools/call JSON-RPC object",
+            })
+            continue
+
+        try:
+            response = dict(transport(request))
+        except Exception as exc:  # pragma: no cover - covered by direct unit path
+            results.append({
+                **base,
+                "status": "transport_error",
+                "reason": exc.__class__.__name__,
+                "classification": "retryable",
+            })
+            continue
+        executed_count += 1
+        error = response.get("error")
+        if isinstance(error, dict):
+            results.append({
+                **base,
+                "status": "api_error",
+                "reason": str(error.get("message") or "jsonrpc_error"),
+                "classification": _jsonrpc_error_classification(error),
+                "response_id": response.get("id"),
+            })
+        else:
+            results.append({
+                **base,
+                "status": "executed",
+                "reason": "operator transport returned JSON-RPC result",
+                "response_id": response.get("id"),
+            })
+
+    status_counts: dict[str, int] = {}
+    for result in results:
+        status = str(result.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+    return {
+        "schema_version": MCP_EXECUTION_SCHEMA_VERSION,
+        "mode": config["mode"],
+        "transport": config["transport"],
+        "execute_planned_calls": config["execute_planned_calls"],
+        "allow_write_calls": config["allow_write_calls"],
+        "max_calls": config["max_calls"],
+        "planned_call_count": len(planned_calls),
+        "executed_call_count": status_counts.get("executed", 0) + status_counts.get("api_error", 0),
+        "write_executed_count": sum(
+            1 for result in results
+            if result.get("write_capable") and result.get("status") in {"executed", "api_error"}
+        ),
+        "status_counts": status_counts,
+        "results": results,
+    }

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -53,11 +53,18 @@ Profiles control:
   fixed and re-applies no-write/HITL guardrails.
 - `approval_policy`: documentation of the HITL source; profiles never grant
   approval by themselves.
+- `runtime.security_data_source`: whether the run ingests raw events or
+  replays an existing Snowflake/ClickHouse/Databricks security lake.
+- `runtime.mcp_execution`: whether planned MCP calls are only recorded
+  (`plan_only`, the shipped default) or eligible for an operator-owned stdio
+  transport. Example profiles keep `allow_write_calls=false`.
 
 At runtime the harness emits `agent_policy`, which intersects the roster skill
 scope with `allowed_skills`. Approval alone is not enough to reach dry-run
 remediation; the remediation skill must also be present in the effective
-allowlist.
+allowlist. It also emits `mcp_call_plan` and `mcp_execution` separately, so
+operators can distinguish intended MCP calls from calls actually executed by a
+live transport.
 
 Included profiles:
 

--- a/examples/agents/harness_profiles/analyst-triage.json
+++ b/examples/agents/harness_profiles/analyst-triage.json
@@ -90,6 +90,13 @@
       "source_skill": "ingest-cloudtrail-ocsf",
       "records_format": "raw_vendor",
       "query": ""
+    },
+    "mcp_execution": {
+      "mode": "plan_only",
+      "transport": "mcp_stdio_jsonrpc",
+      "execute_planned_calls": false,
+      "allow_write_calls": false,
+      "max_calls": 0
     }
   }
 }

--- a/examples/agents/harness_profiles/dry-run-remediation.json
+++ b/examples/agents/harness_profiles/dry-run-remediation.json
@@ -100,6 +100,13 @@
       "source_skill": "ingest-cloudtrail-ocsf",
       "records_format": "raw_vendor",
       "query": ""
+    },
+    "mcp_execution": {
+      "mode": "plan_only",
+      "transport": "mcp_stdio_jsonrpc",
+      "execute_planned_calls": false,
+      "allow_write_calls": false,
+      "max_calls": 0
     }
   }
 }

--- a/examples/agents/harness_profiles/readonly-soc.json
+++ b/examples/agents/harness_profiles/readonly-soc.json
@@ -89,6 +89,13 @@
       "source_skill": "source-snowflake-query",
       "records_format": "ocsf",
       "query": "SELECT payload FROM security.events_sink WHERE class_uid = 6003 LIMIT 100"
+    },
+    "mcp_execution": {
+      "mode": "plan_only",
+      "transport": "mcp_stdio_jsonrpc",
+      "execute_planned_calls": false,
+      "allow_write_calls": false,
+      "max_calls": 0
     }
   }
 }

--- a/examples/agents/harness_runtime.py
+++ b/examples/agents/harness_runtime.py
@@ -188,6 +188,24 @@ def validate_harness_summary(summary: Mapping[str, Any]) -> tuple[str, ...]:
     if audit.get("mcp_planned_call_count") != len(planned_mcp_calls):
         errors.append("audit MCP planned call count must match call plan")
 
+    mcp_execution = summary.get("mcp_execution") or {}
+    if mcp_execution.get("schema_version") != "langgraph-mcp-execution-v1":
+        errors.append("summary must include MCP execution report")
+    if mcp_execution.get("planned_call_count") != len(planned_mcp_calls):
+        errors.append("MCP execution planned count must match call plan")
+    if mcp_execution.get("write_executed_count", 0) > 0:
+        errors.append("example harness must not execute write-capable MCP calls")
+    if mcp_execution.get("mode") == "plan_only":
+        if mcp_execution.get("executed_call_count") != 0:
+            errors.append("plan_only MCP execution must not execute calls")
+        status_counts = mcp_execution.get("status_counts") or {}
+        if status_counts.get("skipped_plan_only", 0) != len(planned_mcp_calls):
+            errors.append("plan_only MCP execution must skip every planned call")
+    if audit.get("mcp_executed_call_count") != mcp_execution.get("executed_call_count"):
+        errors.append("audit MCP executed count must match execution report")
+    if audit.get("mcp_write_executed_count") != mcp_execution.get("write_executed_count"):
+        errors.append("audit MCP write executed count must match execution report")
+
     contract = summary.get("pipeline_contract") or {}
     triage_nodes = [
         node

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -42,7 +42,7 @@ from harness_adapters import (
     select_triage_adapter,
     validate_adapter_recommendation,
 )
-from harness_mcp_bridge import build_mcp_call_plan
+from harness_mcp_bridge import build_mcp_call_plan, execute_mcp_call_plan
 
 ALLOWED_SKILLS_READ_ONLY_LIST = [
     "ingest-cloudtrail-ocsf",
@@ -303,6 +303,7 @@ class GraphState(TypedDict, total=False):
     token_budget_usage: dict[str, Any]
     data_source_decision: dict[str, Any]
     mcp_call_plan: list[dict[str, Any]]
+    mcp_execution: dict[str, Any]
     audit_record: dict[str, Any]
     eval_record: EvalRecord
     trace: list[WorkflowStage]
@@ -509,6 +510,13 @@ def _default_harness_profile() -> HarnessProfile:
                 "records_format": "raw_vendor",
                 "query": "",
             },
+            "mcp_execution": {
+                "mode": "plan_only",
+                "transport": "mcp_stdio_jsonrpc",
+                "execute_planned_calls": False,
+                "allow_write_calls": False,
+                "max_calls": 0,
+            },
         },
     }
 
@@ -595,6 +603,10 @@ def load_harness_profile(path_text: str | None = None) -> HarnessProfile:
     profile["runtime"]["security_data_source"] = {
         **default["runtime"]["security_data_source"],
         **payload.get("runtime", {}).get("security_data_source", {}),
+    }
+    profile["runtime"]["mcp_execution"] = {
+        **default["runtime"]["mcp_execution"],
+        **payload.get("runtime", {}).get("mcp_execution", {}),
     }
     profile["agent_roster"] = _merge_agent_roster(payload.get("agent_roster"))
     return profile
@@ -1614,6 +1626,10 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         state=state,
         pipeline_contract=pipeline_contract(state),
     )
+    state["mcp_execution"] = execute_mcp_call_plan(
+        call_plan=state["mcp_call_plan"],
+        profile=state.get("harness_profile"),
+    )
     summary_payload = {
         "caller_context": state.get("caller_context"),
         "harness_profile": {
@@ -1634,6 +1650,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
         "agent_recommendations": state.get("agent_recommendations"),
         "llm_validation": state.get("llm_validation"),
         "mcp_call_plan": state.get("mcp_call_plan"),
+        "mcp_execution": state.get("mcp_execution"),
         "integrity": {
             key: value
             for key, value in (state.get("integrity") or {}).items()
@@ -1672,6 +1689,8 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             1 for call in state.get("mcp_call_plan") or []
             if str(call.get("status", "")).startswith("blocked_")
         ),
+        "mcp_executed_call_count": (state.get("mcp_execution") or {}).get("executed_call_count", 0),
+        "mcp_write_executed_count": (state.get("mcp_execution") or {}).get("write_executed_count", 0),
         "llm_adapter_accepted": sum(1 for record in llm_validation if record["status"] == "accepted"),
         "llm_adapter_rejected": sum(1 for record in llm_validation if record["status"] == "rejected"),
         "llm_token_budget_status": (state.get("token_budget_usage") or {}).get("status"),
@@ -1704,6 +1723,7 @@ def audit_eval_writeback_node(state: GraphState) -> GraphState:
             "llm_token_budget_gate",
             "multi_agent_ledger",
             "mcp_call_plan",
+            "mcp_execution_policy",
             "conditional_edges",
         ],
         "status": eval_status,
@@ -1833,6 +1853,7 @@ def summarize(final: GraphState) -> dict[str, Any]:
         "agent_recommendations": final.get("agent_recommendations"),
         "llm_validation": final.get("llm_validation"),
         "mcp_call_plan": final.get("mcp_call_plan"),
+        "mcp_execution": final.get("mcp_execution"),
         "llm_evidence_cards": final.get("llm_evidence_cards"),
         "token_budget_usage": final.get("token_budget_usage"),
         "review": final.get("review_decision"),

--- a/examples/agents/schemas/harness_profile.schema.json
+++ b/examples/agents/schemas/harness_profile.schema.json
@@ -332,6 +332,40 @@
               "type": "string"
             }
           }
+        },
+        "mcp_execution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "transport",
+            "execute_planned_calls",
+            "allow_write_calls"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "plan_only",
+                "operator_stdio"
+              ]
+            },
+            "transport": {
+              "type": "string",
+              "const": "mcp_stdio_jsonrpc"
+            },
+            "execute_planned_calls": {
+              "type": "boolean"
+            },
+            "allow_write_calls": {
+              "type": "boolean",
+              "const": false
+            },
+            "max_calls": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
         }
       }
     }

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -746,6 +746,12 @@ class TestLangGraphSocWorkflow:
         assert planned_remediation_call["request"]["method"] == "tools/call"
         assert planned_remediation_call["request"]["params"]["arguments"]["_approval_context"]["ticket_id"] == "SEC-LANGGRAPH-1"
         assert "--apply" not in planned_remediation_call["request"]["params"]["arguments"]["args"]
+        assert summary["mcp_execution"]["schema_version"] == "langgraph-mcp-execution-v1"
+        assert summary["mcp_execution"]["mode"] == "plan_only"
+        assert summary["mcp_execution"]["planned_call_count"] == summary["audit"]["mcp_planned_call_count"]
+        assert summary["mcp_execution"]["executed_call_count"] == 0
+        assert summary["mcp_execution"]["write_executed_count"] == 0
+        assert summary["mcp_execution"]["status_counts"]["skipped_plan_only"] == summary["audit"]["mcp_planned_call_count"]
         assert summary["idempotency"]["remediation_key"] == summary["remediation"]["idempotency_key"]
         assert summary["integrity"]["approved_payload_hash"]
         assert summary["audit"]["idempotency_key"] == summary["remediation"]["idempotency_key"]
@@ -792,6 +798,64 @@ class TestLangGraphSocWorkflow:
         assert "write_intent" in triage_agent["forbidden_outputs"]
         assert summary["llm_validation"][0]["status"] == "fallback"
         assert summary["llm_validation"][0]["reason"] == "no_adapter_output"
+
+    def test_mcp_execution_bridge_executes_readonly_and_blocks_writes(self):
+        sys.path.insert(0, str(EXAMPLES))
+        try:
+            from harness_mcp_bridge import execute_mcp_call_plan
+        finally:
+            sys.path.pop(0)
+
+        call_plan = [
+            {
+                "node": "ingest",
+                "skill": "source-snowflake-query",
+                "status": "planned",
+                "write_capable": False,
+                "request": {
+                    "jsonrpc": "2.0",
+                    "id": "wf:ingest:source-snowflake-query",
+                    "method": "tools/call",
+                    "params": {"name": "source-snowflake-query", "arguments": {}},
+                },
+            },
+            {
+                "node": "remediate",
+                "skill": "iam-departures-aws",
+                "status": "planned",
+                "write_capable": True,
+                "request": {
+                    "jsonrpc": "2.0",
+                    "id": "wf:remediate:iam-departures-aws",
+                    "method": "tools/call",
+                    "params": {"name": "iam-departures-aws", "arguments": {}},
+                },
+            },
+        ]
+        profile = {
+            "runtime": {
+                "mcp_execution": {
+                    "mode": "operator_stdio",
+                    "transport": "mcp_stdio_jsonrpc",
+                    "execute_planned_calls": True,
+                    "allow_write_calls": False,
+                    "max_calls": 10,
+                }
+            }
+        }
+
+        def fake_transport(request: dict) -> dict:
+            return {"jsonrpc": "2.0", "id": request["id"], "result": {"ok": True}}
+
+        report = execute_mcp_call_plan(
+            call_plan=call_plan,
+            profile=profile,
+            transport=fake_transport,
+        )
+        assert report["executed_call_count"] == 1
+        assert report["write_executed_count"] == 0
+        assert report["status_counts"] == {"executed": 1, "blocked_write_execution": 1}
+        assert report["results"][1]["skill"] == "iam-departures-aws"
 
     def test_token_budget_overage_uses_deterministic_fallback(self):
         summary, _ = self._run(extra_env={
@@ -1235,6 +1299,11 @@ class TestLangGraphContractSchemas:
             if data_source.get("mode") == "security_lake_replay":
                 assert data_source.get("source_skill", "").startswith("source-")
                 assert data_source.get("backend") in {"snowflake", "clickhouse", "databricks"}
+            mcp_execution = profile["runtime"].get("mcp_execution") or {}
+            assert mcp_execution["transport"] == "mcp_stdio_jsonrpc"
+            assert mcp_execution["allow_write_calls"] is False
+            if mcp_execution["mode"] == "plan_only":
+                assert mcp_execution["execute_planned_calls"] is False
             if "token_budget" in profile:
                 assert profile["token_budget"]["compression_required"] is True
                 assert profile["token_budget"]["fallback_on_budget_exceeded"] is True
@@ -1434,6 +1503,13 @@ class TestLangGraphHarnessSetup:
             "records_format": "ocsf",
             "query": "SELECT payload FROM security.events_sink LIMIT 50",
         }
+        assert profile["runtime"]["mcp_execution"] == {
+            "mode": "plan_only",
+            "transport": "mcp_stdio_jsonrpc",
+            "execute_planned_calls": False,
+            "allow_write_calls": False,
+            "max_calls": 0,
+        }
         roster = {agent["agent_id"]: agent for agent in profile["agent_roster"]}
         assert roster["triage-agent"] == {
             "agent_id": "triage-agent",
@@ -1478,10 +1554,51 @@ class TestLangGraphHarnessSetup:
             "--query",
             "SELECT payload FROM security.events_sink LIMIT 50",
         ]
+        assert summary["mcp_execution"]["mode"] == "plan_only"
+        assert summary["mcp_execution"]["executed_call_count"] == 0
         triage_agent = next(agent for agent in summary["agents"] if agent["agent_id"] == "triage-agent")
         assert triage_agent["model_tier"] == "small"
         assert triage_agent["skill_scope"] == []
         assert summary["review"]["status"] == "blocked"
+
+    def test_setup_generator_can_mark_readonly_mcp_stdio_execution(self, tmp_path: Path):
+        profile_path = tmp_path / "acme-readonly-stdio.json"
+        env_path = tmp_path / "acme-readonly-stdio.env"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--role",
+                "readonly-soc",
+                "--profile-id",
+                "acme-readonly-stdio",
+                "--email",
+                "analyst@example.com",
+                "--mcp-execution-mode",
+                "operator_stdio",
+                "--mcp-max-calls",
+                "2",
+                "--output-profile",
+                str(profile_path),
+                "--output-env",
+                str(env_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        assert profile["runtime"]["mcp_execution"] == {
+            "mode": "operator_stdio",
+            "transport": "mcp_stdio_jsonrpc",
+            "execute_planned_calls": True,
+            "allow_write_calls": False,
+            "max_calls": 2,
+        }
+        schema = json.loads(self.PROFILE_SCHEMA.read_text(encoding="utf-8"))
+        assert _schema_errors(schema, profile) == []
 
     def test_setup_generator_dry_run_profile_still_requires_approval(self, tmp_path: Path):
         profile_path = tmp_path / "acme-remediation-dryrun.json"


### PR DESCRIPTION
Summary
- Add mcp_execution policy/reporting beside mcp_call_plan so profiles distinguish planned MCP calls from calls actually executed.
- Keep shipped profiles plan_only with write-capable execution disabled, and add generator/schema/drift validation for the execution policy.
- Document the safe default and operator-owned stdio mode for read-only execution.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- python examples/agents/check_langgraph_harness_drift.py
- uv run ruff check examples/agents
- uv run make agent-evals
- python -m py_compile examples/agents/harness_mcp_bridge.py examples/agents/langgraph_security_graph.py examples/agents/harness_runtime.py examples/agents/configure_langgraph_harness.py examples/agents/check_langgraph_harness_drift.py
- git diff --check
- scoped harness secret grep over examples/agents and docs/HARNESS.md

Notes
- The example harness still does not start a live MCP server, call cloud APIs, call live models, or execute remediation by default. Operator-owned transports can be injected for read-only execution paths; write execution remains disabled in the example schema.