### PR TITLE
feat(examples): add LangGraph MCP plan executor

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -101,6 +101,18 @@ python examples/agents/run_langgraph_harness.py \
   --replay-checkpoint artifacts/langgraph-checkpoint.json
 ```
 
+Execute or re-evaluate the emitted MCP plan as a separate artifact:
+
+```bash
+python examples/agents/run_langgraph_harness.py \
+  --profile examples/agents/harness_profiles/readonly-soc.json \
+  --output artifacts/harness-summary.json
+
+python examples/agents/execute_langgraph_mcp_plan.py \
+  --summary artifacts/harness-summary.json \
+  --output artifacts/harness-mcp-execution.json
+```
+
 The runner calls the same importable wrapper used by CI or SOAR integrations,
 keeps validation on by default, and accepts `--langgraph-runtime` when the
 optional LangGraph dependency is installed. `--approve` only supplies demo
@@ -127,7 +139,11 @@ builds exact MCP `tools/call` JSON-RPC payloads, but the harness emits a
 separate `mcp_execution` ledger showing those planned calls were skipped by
 policy. Operator-owned integrations can opt a generated profile into
 `mode=operator_stdio` for read-only call execution through their own MCP
-transport; write-capable execution remains disabled in the example schema.
+transport. The standalone `execute_langgraph_mcp_plan.py` utility consumes an
+existing harness summary and emits a second execution report, so live transport
+attempts do not mutate the graph's state hash. It uses a credential-scrubbed
+subprocess environment for the bundled stdio helper; write-capable execution
+remains disabled in the example schema.
 
 `HARNESS.md` is therefore the readable operator contract; the graph nodes,
 adapter gates, runtime wrapper, schemas, checkpoint replay, and eval runner are

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -155,6 +155,14 @@ python examples/agents/configure_langgraph_harness.py \
   --output-profile artifacts/acme-readonly-stdio.json \
   --output-env artifacts/acme-readonly-stdio.env
 
+python examples/agents/run_langgraph_harness.py \
+  --profile artifacts/acme-readonly-stdio.json \
+  --output artifacts/acme-readonly-stdio-summary.json
+
+python examples/agents/execute_langgraph_mcp_plan.py \
+  --summary artifacts/acme-readonly-stdio-summary.json \
+  --output artifacts/acme-readonly-stdio-mcp-execution.json
+
 # Approved path: remediation reaches dry-run only and writes audit/eval output.
 DEMO_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediation.json \
 DEMO_APPROVE=yes \

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -44,6 +44,7 @@ EXPECTED_SCHEMAS = [
 REQUIRED_DOC_TOKENS = [
     "inspect_langgraph_harness.py",
     "run_langgraph_harness.py",
+    "execute_langgraph_mcp_plan.py",
     "eval_langgraph_harness.py --check",
     "render_langgraph_pipeline_diagram.py",
     "check_langgraph_harness_drift.py",
@@ -328,6 +329,7 @@ def _check_no_harness_secret_literals() -> DriftCheck:
         EXAMPLES / "configure_langgraph_harness.py",
         EXAMPLES / "inspect_langgraph_harness.py",
         EXAMPLES / "run_langgraph_harness.py",
+        EXAMPLES / "execute_langgraph_mcp_plan.py",
         *sorted(PROFILES.glob("*.json")),
     ]
     findings: list[str] = []

--- a/examples/agents/execute_langgraph_mcp_plan.py
+++ b/examples/agents/execute_langgraph_mcp_plan.py
@@ -1,0 +1,116 @@
+"""Execute or re-evaluate a LangGraph harness MCP call plan.
+
+This command consumes a JSON summary produced by `run_langgraph_harness.py` or
+`langgraph_security_graph.py`. By default it stays offline and reports what
+the profile policy would do. It only starts a local MCP stdio server when the
+summary profile has `runtime.mcp_execution.mode=operator_stdio` and the
+operator passes `--allow-operator-stdio`.
+
+Run:
+
+    python examples/agents/run_langgraph_harness.py \
+      --profile examples/agents/harness_profiles/readonly-soc.json \
+      --output artifacts/harness-summary.json
+
+    python examples/agents/execute_langgraph_mcp_plan.py \
+      --summary artifacts/harness-summary.json \
+      --output artifacts/harness-mcp-execution.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from harness_mcp_bridge import execute_mcp_call_plan
+from harness_mcp_transport import McpStdioTransport, safe_mcp_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path | None) -> dict[str, Any]:
+    text = sys.stdin.read() if path is None else path.read_text(encoding="utf-8")
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise ValueError("harness summary must be a JSON object")
+    return payload
+
+
+def _mcp_command(args: argparse.Namespace) -> list[str]:
+    if args.mcp_server_arg:
+        return [args.mcp_server_command, *args.mcp_server_arg]
+    return [args.mcp_server_command, str(REPO_ROOT / "mcp-server" / "src" / "server.py")]
+
+
+def _execution_report(summary: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    profile = summary.get("profile") or {}
+    call_plan = summary.get("mcp_call_plan") or []
+    if not isinstance(call_plan, list):
+        raise ValueError("summary.mcp_call_plan must be an array")
+    runtime = (profile.get("runtime") or {}).get("mcp_execution") or {}
+    allowed_skills = summary.get("effective_allowed_skills") or []
+    if (
+        args.allow_operator_stdio
+        and runtime.get("mode") == "operator_stdio"
+        and runtime.get("execute_planned_calls") is True
+    ):
+        command = _mcp_command(args)
+        with McpStdioTransport(
+            command,
+            env=safe_mcp_env(allowed_skills=allowed_skills),
+            timeout_seconds=args.timeout_seconds,
+        ) as transport:
+            return execute_mcp_call_plan(
+                call_plan=call_plan,
+                profile=profile,
+                transport=transport,
+            )
+    return execute_mcp_call_plan(call_plan=call_plan, profile=profile)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summary", type=Path, help="Harness summary JSON path; defaults to stdin")
+    parser.add_argument("--output", type=Path, help="Optional JSON report output path")
+    parser.add_argument(
+        "--allow-operator-stdio",
+        action="store_true",
+        help="Permit local stdio MCP execution when the summary profile also opts into operator_stdio",
+    )
+    parser.add_argument(
+        "--mcp-server-command",
+        default=sys.executable,
+        help="Command used for the local MCP stdio server",
+    )
+    parser.add_argument(
+        "--mcp-server-arg",
+        action="append",
+        default=[],
+        help="Argument for --mcp-server-command; repeat for multiple args",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=30)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = _load_json(args.summary)
+        report = _execution_report(summary, args)
+    except Exception as exc:
+        sys.stderr.write(f"langgraph MCP plan execution failed: {exc}\n")
+        return 1
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/harness_mcp_transport.py
+++ b/examples/agents/harness_mcp_transport.py
@@ -1,0 +1,161 @@
+"""Operator-owned stdio transport for harness MCP execution reports.
+
+This helper speaks the repo MCP server's content-length-framed JSON-RPC
+transport. It is intentionally separate from the graph: the graph produces an
+audited plan, and an operator can evaluate that plan with this transport in a
+second step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from typing import Any, BinaryIO
+
+SAFE_ENV_NAMES = {
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "NO_COLOR",
+    "PATH",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "SYSTEMROOT",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "TZ",
+    "USER",
+    "VIRTUAL_ENV",
+    "WINDIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+}
+
+MCP_POLICY_ENV_NAMES = {
+    "CLOUD_SECURITY_MCP_ALLOWED_SKILLS",
+    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS",
+    "CLOUD_SECURITY_MCP_TIMEOUT_SECONDS",
+}
+
+
+def safe_mcp_env(*, allowed_skills: Sequence[str] = ()) -> dict[str, str]:
+    """Return a subprocess env that excludes credentials and arbitrary tokens."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in SAFE_ENV_NAMES or key in MCP_POLICY_ENV_NAMES
+    }
+    if allowed_skills:
+        env["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"] = ",".join(sorted(set(allowed_skills)))
+        env["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] = "true"
+    return env
+
+
+def _write_message(stream: BinaryIO, message: Mapping[str, Any]) -> None:
+    payload = json.dumps(message, sort_keys=True).encode("utf-8")
+    stream.write(f"Content-Length: {len(payload)}\r\n\r\n".encode("utf-8"))
+    stream.write(payload)
+    stream.flush()
+
+
+def _readline(stream: BinaryIO, *, deadline: float) -> bytes:
+    timeout = max(0.0, deadline - time.monotonic())
+    ready, _, _ = select.select([stream], [], [], timeout)
+    if not ready:
+        raise TimeoutError("timed out waiting for MCP response header")
+    return stream.readline()
+
+
+def _read_exact(stream: BinaryIO, length: int, *, deadline: float) -> bytes:
+    chunks: list[bytes] = []
+    remaining = length
+    while remaining > 0:
+        timeout = max(0.0, deadline - time.monotonic())
+        ready, _, _ = select.select([stream], [], [], timeout)
+        if not ready:
+            raise TimeoutError("timed out waiting for MCP response body")
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise RuntimeError("MCP server closed stdout before response body completed")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _read_message(stream: BinaryIO, *, deadline: float) -> dict[str, Any]:
+    headers: dict[str, str] = {}
+    while True:
+        line = _readline(stream, deadline=deadline)
+        if not line:
+            raise RuntimeError("MCP server closed stdout before returning a response")
+        if line in (b"\r\n", b"\n"):
+            break
+        key, value = line.decode("utf-8").split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    length = int(headers.get("content-length", "0"))
+    if length <= 0:
+        raise RuntimeError("MCP response missing content-length")
+    payload = _read_exact(stream, length, deadline=deadline)
+    decoded = json.loads(payload.decode("utf-8"))
+    if not isinstance(decoded, dict):
+        raise RuntimeError("MCP response payload must be a JSON object")
+    return decoded
+
+
+class McpStdioTransport:
+    """Long-lived stdio JSON-RPC transport for planned MCP calls."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float = 30,
+    ) -> None:
+        if not command:
+            raise ValueError("MCP stdio command must not be empty")
+        self.command = list(command)
+        self.env = dict(env or safe_mcp_env())
+        self.timeout_seconds = timeout_seconds
+        self._process: subprocess.Popen[bytes] | None = None
+
+    def __enter__(self) -> "McpStdioTransport":
+        self._process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+            bufsize=0,
+        )
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        process = self._process
+        if process is None:
+            return
+        if process.stdin is not None:
+            process.stdin.close()
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
+
+    def __call__(self, request: dict[str, Any]) -> Mapping[str, Any]:
+        process = self._process
+        if process is None or process.stdin is None or process.stdout is None:
+            raise RuntimeError("MCP stdio transport is not started")
+        started = time.monotonic()
+        _write_message(process.stdin, request)
+        if process.poll() is not None:
+            raise RuntimeError(f"MCP server exited with code {process.returncode}")
+        return _read_message(process.stdout, deadline=started + self.timeout_seconds)

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -511,6 +511,148 @@ class TestLangGraphHarnessRunner:
         assert "--raw-events must be a JSON object" in result.stderr
 
 
+class TestLangGraphMcpPlanExecutor:
+    """Coverage for executing MCP call plans as a separate harness artifact."""
+
+    SCRIPT = EXAMPLES / "execute_langgraph_mcp_plan.py"
+
+    @staticmethod
+    def _summary(mode: str = "plan_only") -> dict:
+        return {
+            "profile": {
+                "runtime": {
+                    "mcp_execution": {
+                        "mode": mode,
+                        "transport": "mcp_stdio_jsonrpc",
+                        "execute_planned_calls": mode == "operator_stdio",
+                        "allow_write_calls": False,
+                        "max_calls": 5,
+                    }
+                }
+            },
+            "effective_allowed_skills": ["source-snowflake-query"],
+            "mcp_call_plan": [
+                {
+                    "node": "ingest",
+                    "skill": "source-snowflake-query",
+                    "status": "planned",
+                    "write_capable": False,
+                    "request": {
+                        "jsonrpc": "2.0",
+                        "id": "wf:ingest:source-snowflake-query",
+                        "method": "tools/call",
+                        "params": {
+                            "name": "source-snowflake-query",
+                            "arguments": {
+                                "args": ["--query", "SELECT payload FROM security.events_sink LIMIT 1"],
+                                "input": "",
+                                "_caller_context": {
+                                    "allowed_skills": ["source-snowflake-query"],
+                                },
+                            },
+                        },
+                    },
+                }
+            ],
+        }
+
+    def test_executor_replays_plan_only_summary_without_transport(self, tmp_path: Path):
+        summary_path = tmp_path / "summary.json"
+        summary_path.write_text(json.dumps(self._summary(), sort_keys=True), encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT), "--summary", str(summary_path)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["mode"] == "plan_only"
+        assert report["executed_call_count"] == 0
+        assert report["status_counts"] == {"skipped_plan_only": 1}
+
+    def test_executor_runs_operator_stdio_with_local_fake_server(self, tmp_path: Path):
+        summary_path = tmp_path / "summary.json"
+        summary_path.write_text(json.dumps(self._summary("operator_stdio"), sort_keys=True), encoding="utf-8")
+        fake_server = tmp_path / "fake_mcp_server.py"
+        fake_server.write_text(
+            """
+import json
+import sys
+
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\\r\\n", b"\\n"):
+            break
+        key, value = line.decode("utf-8").split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    payload = sys.stdin.buffer.read(int(headers["content-length"]))
+    return json.loads(payload.decode("utf-8"))
+
+
+def write_message(message):
+    payload = json.dumps(message).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(payload)}\\r\\n\\r\\n".encode("utf-8"))
+    sys.stdout.buffer.write(payload)
+    sys.stdout.buffer.flush()
+
+
+while True:
+    request = read_message()
+    if request is None:
+        break
+    write_message({
+        "jsonrpc": "2.0",
+        "id": request.get("id"),
+        "result": {"ok": True, "tool": request.get("params", {}).get("name")},
+    })
+""",
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--summary",
+                str(summary_path),
+                "--allow-operator-stdio",
+                "--mcp-server-command",
+                sys.executable,
+                "--mcp-server-arg",
+                str(fake_server),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["mode"] == "operator_stdio"
+        assert report["executed_call_count"] == 1
+        assert report["write_executed_count"] == 0
+        assert report["status_counts"] == {"executed": 1}
+
+    def test_safe_mcp_env_does_not_forward_api_keys(self, monkeypatch: pytest.MonkeyPatch):
+        sys.path.insert(0, str(EXAMPLES))
+        try:
+            from harness_mcp_transport import safe_mcp_env
+        finally:
+            sys.path.pop(0)
+        monkeypatch.setenv("OPENAI_API_KEY", "redacted-test-value")
+        monkeypatch.setenv("CLOUD_SECURITY_MCP_TIMEOUT_SECONDS", "5")
+        env = safe_mcp_env(allowed_skills=["source-snowflake-query"])
+        assert "OPENAI_API_KEY" not in env
+        assert env["CLOUD_SECURITY_MCP_TIMEOUT_SECONDS"] == "5"
+        assert env["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"] == "source-snowflake-query"
+
+
 class TestLangGraphSocWorkflow:
     """Regression coverage for the expanded SOC workflow graph."""
 


### PR DESCRIPTION
Summary
- Add a standalone executor for LangGraph harness mcp_call_plan artifacts so execution/replay is separate from the graph state hash.
- Add a credential-scrubbed stdio JSON-RPC transport helper for operator-owned read-only MCP execution.
- Document the executor path and extend drift/tests to cover plan-only and fake stdio execution.

Verification
- uv run --group langgraph pytest examples/agents/tests/test_examples.py -q
- python examples/agents/check_langgraph_harness_drift.py
- uv run ruff check examples/agents
- python -m py_compile examples/agents/harness_mcp_transport.py examples/agents/execute_langgraph_mcp_plan.py examples/agents/harness_mcp_bridge.py examples/agents/check_langgraph_harness_drift.py
- uv run make agent-evals
- git diff --check
- scoped harness secret grep over examples/agents and docs/HARNESS.md

Notes
- Default execution remains plan-only. The new CLI starts stdio transport only with --allow-operator-stdio and a profile summary that opts into operator_stdio.
- The stdio helper builds a scrubbed environment and does not forward API keys, cloud credentials, passwords, or PATs.