### PR TITLE
docs(readme): polish architecture visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@
 
 ---
 
+## Start here
+
+| Need | First read | Proof artifact |
+|---|---|---|
+| Run a local pipeline | [`docs/QUICKSTART.md`](docs/QUICKSTART.md) | `findings.sarif` from fixture data |
+| Pick a skill | [`docs/SKILL_INDEX.md`](docs/SKILL_INDEX.md) | skill bundle with `SKILL.md`, `src/`, `tests/` |
+| Wire an agent | [`docs/AGENT_QUICKSTART.md`](docs/AGENT_QUICKSTART.md) | MCP tool calls through `.mcp.json` |
+| Govern an agentic SOC workflow | [`docs/HARNESS.md`](docs/HARNESS.md) | LangGraph profile, audit ledger, eval report |
+| Build a warehouse lake | [`docs/CLICKHOUSE_DATA_LAKE.md`](docs/CLICKHOUSE_DATA_LAKE.md) or [`docs/SNOWFLAKE_DATA_LAKE.md`](docs/SNOWFLAKE_DATA_LAKE.md) | append-only lake tables plus replay query adapter |
+
 ## Why pick this
 
 - **Plug-and-play in 60 seconds** — repo-shipped `.mcp.json` works in Claude Code out of the box; copy-paste configs for Claude Desktop, Cursor, Windsurf, Codex, Cortex, Zed in [`docs/AGENT_QUICKSTART.md`](docs/AGENT_QUICKSTART.md).
 - **Every skill is a single-concern bundle** — `SKILL.md + src/ + tests/` you can run as a stdin/stdout one-liner, an MCP tool, a CI step, a webhook, or a library call. Same bundle, no per-surface drift.
 - **Built for agents, not just humans** — OCSF 1.8 on the wire, HMAC-chained audit, HITL gates and allowlist intersection enforced by the wrapper — so an LLM can't bypass the trust contract.
+- **Designed for closed-loop security work** — normalize, detect, evaluate, review, dry-run, remediate, and write audit/evidence rows back into the operator-owned lake.
 
 ---
 
@@ -94,6 +105,8 @@ More visuals (Mermaid sources under [`docs/diagrams/`](docs/diagrams/), GitHub r
 
 Deeper reads: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · [`docs/HARNESS.md`](docs/HARNESS.md) · [`docs/SKILL_CONTRACT.md`](docs/SKILL_CONTRACT.md) · [`docs/SKILL_COMPOSITION.md`](docs/SKILL_COMPOSITION.md)
 
+The design invariant is deliberately simple: deterministic skills own evidence, schemas, mappings, confidence, policy, write intent, and audit. Optional orchestrators own workflow state, node ordering, model selection, retries, escalation, and checkpoints.
+
 ## Agentic SOC orchestration
 
 The repo is strongest when the skills stay deterministic and LangGraph /
@@ -122,6 +135,11 @@ The optional LLM adapter path is schema-gated: model output can rank and draft
 triage rationale, but attempts to set approvals, CVSS/MITRE/EPSS/KEV facts,
 tenant scope, idempotency keys, or write intent are rejected and fall back to
 deterministic triage.
+Token use is governed by the same harness profile: small-model routing for
+bounded tasks, prompt compaction before triage, per-node budgets, and eval
+write-back for pass-rate and cost drift. Integrity hashes, idempotency keys,
+and retryable-vs-terminal API error routing stay in deterministic state, not in
+model output.
 
 ![Optional agentic SOC orchestrator: LangGraph or LangChain controls the workflow DAG and LLM/model choice, while cloud-ai-security-skills owns deterministic ingest, normalize, enrich, correlate, map, review, audit, eval artifacts, sandbox/RLIMIT, allowlist, dry-run, HITL, and HMAC audit rails.](docs/images/agentic-soc-orchestrator.svg)
 
@@ -131,6 +149,14 @@ deterministic triage.
 | Workflow state and branching | LangGraph / LangChain / SOAR | nodes, edges, retries, escalation, checkpointing |
 | LLM output | Orchestrator | rank, summarize, explain, and draft; never authoritative for policy or audit |
 | Write approval | HITL gate + remediation skill | dry-run first, bounded blast radius, audited operator context |
+
+| Agentic concern | Where it is enforced |
+|---|---|
+| Data source choice | harness profile: raw ingest, security lake replay, or fixture |
+| Token and model budget | model router + profile limits, with compaction before LLM triage |
+| Integrity and idempotency | normalized state hashes and remediation idempotency keys |
+| API failures | deterministic retryable vs terminal routing before writeback |
+| No hallucinated facts | schema-gated LLM adapter; mappings and scores come from code |
 
 ## ClickHouse-powered security data lake (hero use case)
 

--- a/docs/diagrams/agentic-soc-orchestrator.mmd
+++ b/docs/diagrams/agentic-soc-orchestrator.mmd
@@ -1,5 +1,6 @@
 %% Optional agentic SOC orchestrator over cloud-ai-security-skills.
-%% LangGraph/LangChain own workflow state; repo skills own facts and gates.
+%% LangGraph/LangChain own workflow state and model choice; repo skills own
+%% facts, scores, policy, integrity, idempotency, audit, and write gates.
 
 flowchart LR
     classDef orch fill:#0b1830,stroke:#60a5fa,color:#dbeafe
@@ -7,22 +8,34 @@ flowchart LR
     classDef guard fill:#2a1207,stroke:#d97706,color:#fed7aa
     classDef audit fill:#4c0519,stroke:#fb7185,color:#fff1f2
 
-    AGENT["SOC agent"]:::orch
+    AGENT["SOC operator<br/>role · tenant · allowlist"]:::orch
     GRAPH["LangGraph / LangChain DAG<br/>nodes · edges · conditions"]:::orch
-    LLM["LLM options<br/>OpenAI · local · customer model"]:::orch
-    TOOL["Tool boundary<br/>MCP · CLI · CI · runner · library"]:::orch
+    LLM["model router<br/>small task model · local · customer LLM"]:::orch
+    TOOL["tool boundary<br/>MCP · CLI · CI · runner · library"]:::orch
+    PROFILE["harness profile<br/>budget · data source · approvals"]:::orch
 
-    ING["ingest"]:::skill
-    NORM["normalize"]:::skill
+    SRC["source choice<br/>raw ingest or lake replay"]:::skill
+    NORM["normalize<br/>stable IDs · integrity hash"]:::skill
     ENRICH["enrich<br/>OSV · NVD · EPSS · KEV"]:::skill
     CORR["correlate<br/>identity · tools · lineage"]:::skill
-    MAP["map<br/>MITRE · CVSS · controls · confidence"]:::skill
-    REVIEW["analyst review<br/>HITL gate"]:::audit
-    WRITE["dry-run remediation<br/>audit/evidence writeback"]:::audit
+    CONF["confidence<br/>reason codes · no model facts"]:::skill
+    MAP["map<br/>MITRE · CVSS · controls"]:::skill
+    TRIAGE["LLM triage<br/>rank · summarize · draft only"]:::orch
+    REVIEW["analyst review<br/>HITL gate"]:::guard
+    REM["dry-run remediation<br/>idempotency key reused"]:::audit
+    RETRY["retry branch<br/>retryable API errors"]:::guard
+    ESC["escalate<br/>terminal errors to human"]:::guard
+    WRITE["audit and eval writeback<br/>state hash · pass rate"]:::audit
 
-    RAILS["non-bypassable rails<br/>sandbox · RLIMIT · allowlist intersection · HMAC audit · dry-run first"]:::guard
+    RAILS["non-bypassable rails<br/>sandbox · RLIMIT · allowlist intersection · token budgets · integrity hashes · dry-run first · HMAC audit"]:::guard
 
-    AGENT --> GRAPH --> LLM --> TOOL
-    TOOL --> ING --> NORM --> ENRICH --> CORR --> MAP --> REVIEW --> WRITE
+    AGENT --> GRAPH --> LLM --> TOOL --> PROFILE
+    PROFILE --> SRC --> NORM --> ENRICH --> CORR --> CONF --> MAP --> TRIAGE --> REVIEW
+    REVIEW -- approved --> REM
+    REVIEW -- blocked --> WRITE
+    REM -- retryable API error --> RETRY --> WRITE
+    REM -- terminal API error --> ESC --> WRITE
+    REM -- dry-run OK --> WRITE
     RAILS -. enforced around every tool call .-> TOOL
-    RAILS -. blocks unsafe writes .-> REVIEW
+    RAILS -. bounds model authority .-> TRIAGE
+    RAILS -. blocks unsafe writes .-> REM

--- a/docs/diagrams/snowflake-data-lake.mmd
+++ b/docs/diagrams/snowflake-data-lake.mmd
@@ -13,8 +13,8 @@ flowchart LR
     classDef policy fill:#111827,stroke:#475569,color:#cbd5e1
 
     SIG["Covered signals<br/>cloud · identity · SaaS · Kubernetes · MCP"]:::signal
-    ING["Normalize<br/>22 ingest skills<br/>OCSF 1.8 JSONL"]:::write
-    SINK["Write<br/>sink-snowflake-jsonl<br/>append-only · dry-run default"]:::write
+    ING["Normalize<br/>22 ingest skills<br/>OCSF 1.8 JSONL · stable IDs"]:::write
+    SINK["Write<br/>sink-snowflake-jsonl<br/>append-only · dry-run default · identifier validated"]:::write
 
     subgraph SNOW["Snowflake account — security_db.ops"]
       direction TB
@@ -29,7 +29,7 @@ flowchart LR
     ART["Operator artifacts<br/>findings · SARIF · attack-flow · dashboards"]:::output
     HITL["HITL response<br/>approved window"]:::audit
     AUDIT["Audit write-back<br/>remediation and MCP records"]:::audit
-    BOUNDARY["Customer-owned boundary<br/>account · warehouse · grants · retention · row policy"]:::policy
+    BOUNDARY["Customer-owned boundary<br/>account · warehouse · grants · retention · row policy · credentials"]:::policy
 
     SIG --> ING --> SINK --> TABLES
     TABLES --> RLS --> DT

--- a/docs/images/agentic-soc-orchestrator.svg
+++ b/docs/images/agentic-soc-orchestrator.svg
@@ -1,27 +1,175 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="820" viewBox="0 0 1600 820" role="img" aria-labelledby="title desc">
   <title id="title">Optional agentic SOC orchestrator over cloud-ai-security-skills</title>
-  <desc id="desc">Architecture diagram showing LangGraph or LangChain as an optional orchestration layer over deterministic cloud-ai-security-skills APIs, MCP tools, security gates, audit records, and evaluation artifacts.</desc>
+  <desc id="desc">Architecture diagram showing LangGraph or LangChain as an optional orchestration layer over deterministic cloud-ai-security-skills APIs and MCP tools. The workflow covers data source selection, ingest or lake replay, normalize, enrich, correlate, confidence, MITRE CVSS EPSS KEV mapping, bounded LLM triage, analyst review, dry-run remediation, retry or escalation, audit, and eval write-back with non-bypassable trust rails.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#06101f"/><stop offset="0.55" stop-color="#0d172a"/><stop offset="1" stop-color="#111827"/></linearGradient>
-    <pattern id="grid" width="44" height="44" patternUnits="userSpaceOnUse"><path d="M44 0H0V44" fill="none" stroke="#20314f" stroke-opacity="0.22" stroke-width="1"/></pattern>
-    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%"><feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.30"/></filter>
-    <marker id="arrowCyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#22d3ee"/></marker>
-    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#34d399"/></marker>
-    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#fb7185"/></marker>
-    <style>.font{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}.h1{font-size:34px;font-weight:850;fill:#f8fafc}.sub{font-size:15px;fill:#cbd5e1}.eyebrow{font-size:11px;font-weight:850;letter-spacing:.08em;text-transform:uppercase}.cardTitle{font-size:17px;font-weight:850;fill:#f8fafc}.body{font-size:12px;fill:#cbd5e1}.tiny{font-size:11px;fill:#94a3b8}.badge{font-size:12px;font-weight:850;fill:#f8fafc}</style>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#06101f"/>
+      <stop offset="0.55" stop-color="#0d172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="44" height="44" patternUnits="userSpaceOnUse">
+      <path d="M44 0H0V44" fill="none" stroke="#20314f" stroke-opacity="0.22" stroke-width="1"/>
+    </pattern>
+    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.30"/>
+    </filter>
+    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#60a5fa"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#34d399"/>
+    </marker>
+    <marker id="arrowAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#f59e0b"/>
+    </marker>
+    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#fb7185"/>
+    </marker>
+    <style>
+      .font{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
+      .h1{font-size:34px;font-weight:850;fill:#f8fafc}
+      .sub{font-size:15px;fill:#cbd5e1}
+      .eyebrow{font-size:11px;font-weight:850;letter-spacing:.08em;text-transform:uppercase}
+      .cardTitle{font-size:16px;font-weight:850;fill:#f8fafc}
+      .body{font-size:12px;fill:#cbd5e1}
+      .tiny{font-size:11px;fill:#94a3b8}
+      .badge{font-size:12px;font-weight:850;fill:#f8fafc}
+    </style>
   </defs>
-  <rect width="1600" height="760" fill="url(#bg)"/><rect width="1600" height="760" fill="url(#grid)"/>
+
+  <rect width="1600" height="820" fill="url(#bg)"/>
+  <rect width="1600" height="820" fill="url(#grid)"/>
+
   <g class="font">
-    <text x="64" y="64" class="h1">Agentic SOC Orchestrator</text><text x="64" y="94" class="sub">LangGraph or LangChain can run the playbook; deterministic skills own the evidence, policy checks, scoring, audit, and write gates.</text>
-    <rect x="64" y="132" width="1472" height="148" rx="22" fill="#0b1830" stroke="#2563eb"/><text x="94" y="168" class="eyebrow" fill="#93c5fd">Optional orchestration layer</text>
-    <g filter="url(#softShadow)"><rect x="94" y="194" width="196" height="56" rx="14" fill="#111827" stroke="#475569"/><text x="124" y="228" class="cardTitle">SOC agent</text><rect x="334" y="194" width="246" height="56" rx="14" fill="#0f2a3b" stroke="#22d3ee"/><text x="364" y="220" class="cardTitle">LangGraph DAG</text><text x="364" y="240" class="tiny">nodes · edges · conditions</text><rect x="624" y="194" width="230" height="56" rx="14" fill="#172033" stroke="#475569"/><text x="654" y="220" class="cardTitle">LLM options</text><text x="654" y="240" class="tiny">OpenAI · local · customer model</text><rect x="898" y="194" width="260" height="56" rx="14" fill="#172033" stroke="#475569"/><text x="928" y="220" class="cardTitle">Tool boundary</text><text x="928" y="240" class="tiny">MCP · CLI · CI · runner · library</text><rect x="1202" y="194" width="290" height="56" rx="14" fill="#172033" stroke="#475569"/><text x="1232" y="220" class="cardTitle">Policy context</text><text x="1232" y="240" class="tiny">caller allowlist · tenant · budget</text></g>
-    <path d="M290 222H326" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrowCyan)" fill="none"/><path d="M580 222H616" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrowCyan)" fill="none"/><path d="M854 222H890" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrowCyan)" fill="none"/><path d="M1158 222H1194" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrowCyan)" fill="none"/>
-    <rect x="64" y="318" width="1472" height="230" rx="22" fill="#052e2b" stroke="#0f766e"/><text x="94" y="354" class="eyebrow" fill="#5eead4">Deterministic skill pipeline</text>
-    <g filter="url(#softShadow)"><rect x="94" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="118" y="416" class="cardTitle">Ingest</text><text x="118" y="440" class="body">raw logs</text><text x="118" y="460" class="tiny">OCSF/native in</text><rect x="288" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="312" y="416" class="cardTitle">Normalize</text><text x="312" y="440" class="body">stable IDs</text><text x="312" y="460" class="tiny">schema contract</text><rect x="482" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="506" y="416" class="cardTitle">Enrich</text><text x="506" y="440" class="body">OSV · NVD</text><text x="506" y="460" class="tiny">EPSS · KEV</text><rect x="676" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="700" y="416" class="cardTitle">Correlate</text><text x="700" y="440" class="body">identity · tools</text><text x="700" y="460" class="tiny">lineage windows</text><rect x="870" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="894" y="416" class="cardTitle">Map</text><text x="894" y="440" class="body">MITRE · CVSS</text><text x="894" y="460" class="tiny">controls · confidence</text><rect x="1064" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="1088" y="416" class="cardTitle">Review</text><text x="1088" y="440" class="body">HITL gate</text><text x="1088" y="460" class="tiny">reason codes</text><rect x="1258" y="386" width="154" height="90" rx="14" fill="#0f172a" stroke="#34d399"/><text x="1282" y="416" class="cardTitle">Write back</text><text x="1282" y="440" class="body">audit · evidence</text><text x="1282" y="460" class="tiny">eval artifacts</text></g>
-    <path d="M248 431H280" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/><path d="M442 431H474" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/><path d="M636 431H668" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/><path d="M830 431H862" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/><path d="M1024 431H1056" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/><path d="M1218 431H1250" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
-    <rect x="64" y="586" width="1472" height="106" rx="22" fill="#2a1207" stroke="#d97706"/><text x="94" y="622" class="eyebrow" fill="#fed7aa">Trust rails that the orchestrator cannot bypass</text>
-    <rect x="94" y="642" width="190" height="32" rx="16" fill="#111827" stroke="#475569"/><text x="189" y="663" text-anchor="middle" class="badge">sandbox + RLIMIT</text><rect x="320" y="642" width="200" height="32" rx="16" fill="#111827" stroke="#475569"/><text x="420" y="663" text-anchor="middle" class="badge">allowlist intersection</text><rect x="556" y="642" width="190" height="32" rx="16" fill="#111827" stroke="#475569"/><text x="651" y="663" text-anchor="middle" class="badge">dry-run first</text><rect x="782" y="642" width="190" height="32" rx="16" fill="#111827" stroke="#475569"/><text x="877" y="663" text-anchor="middle" class="badge">HMAC audit chain</text><rect x="1008" y="642" width="190" height="32" rx="16" fill="#111827" stroke="#475569"/><text x="1103" y="663" text-anchor="middle" class="badge">analyst approval</text><rect x="1234" y="642" width="258" height="32" rx="16" fill="#111827" stroke="#475569"/><text x="1363" y="663" text-anchor="middle" class="badge">evaluation outputs</text>
-    <path d="M457 250V300C457 310 463 318 475 318H1335C1350 318 1358 330 1358 346V378" stroke="#22d3ee" stroke-width="2.5" marker-end="url(#arrowCyan)" fill="none" stroke-dasharray="8 7"/><path d="M1335 476V574" stroke="#34d399" stroke-width="2.5" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="8 7"/><path d="M1141 476V574" stroke="#fb7185" stroke-width="2.5" marker-end="url(#arrowRose)" fill="none" stroke-dasharray="8 7"/>
-    <text x="94" y="724" class="tiny" fill="#94a3b8">Invariant: LLM output can rank, summarize, and draft; repo skills own facts, schemas, policy verdicts, confidence, remediation gates, audit records, and replayable evidence.</text>
+    <text x="64" y="64" class="h1">Agentic SOC Orchestrator</text>
+    <text x="64" y="94" class="sub">LangGraph or LangChain owns workflow state and model choice; cloud-ai-security-skills owns facts, policy, confidence, audit, and write gates.</text>
+
+    <rect x="64" y="130" width="1472" height="144" rx="22" fill="#0b1830" stroke="#2563eb"/>
+    <text x="94" y="166" class="eyebrow" fill="#93c5fd">Optional workflow and agent layer</text>
+    <g filter="url(#softShadow)">
+      <rect x="94" y="192" width="196" height="54" rx="14" fill="#111827" stroke="#475569"/>
+      <text x="124" y="215" class="cardTitle">SOC operator</text>
+      <text x="124" y="235" class="tiny">role, tenant, allowlist</text>
+
+      <rect x="334" y="192" width="238" height="54" rx="14" fill="#0f2a3b" stroke="#22d3ee"/>
+      <text x="364" y="215" class="cardTitle">LangGraph DAG</text>
+      <text x="364" y="235" class="tiny">nodes, edges, conditions</text>
+
+      <rect x="616" y="192" width="254" height="54" rx="14" fill="#172033" stroke="#475569"/>
+      <text x="646" y="215" class="cardTitle">Model router</text>
+      <text x="646" y="235" class="tiny">small task model, local, customer LLM</text>
+
+      <rect x="914" y="192" width="260" height="54" rx="14" fill="#172033" stroke="#475569"/>
+      <text x="944" y="215" class="cardTitle">Tool boundary</text>
+      <text x="944" y="235" class="tiny">MCP, CLI, CI, runner, library</text>
+
+      <rect x="1218" y="192" width="288" height="54" rx="14" fill="#172033" stroke="#475569"/>
+      <text x="1248" y="215" class="cardTitle">Harness profile</text>
+      <text x="1248" y="235" class="tiny">budget, data source, approvals</text>
+    </g>
+    <path d="M290 219H326" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
+    <path d="M572 219H608" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
+    <path d="M870 219H906" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
+    <path d="M1174 219H1210" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
+
+    <rect x="64" y="306" width="1472" height="282" rx="22" fill="#052e2b" stroke="#0f766e"/>
+    <text x="94" y="342" class="eyebrow" fill="#5eead4">End-to-end pipeline over deterministic repo skills</text>
+
+    <g filter="url(#softShadow)">
+      <rect x="94" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
+      <text x="118" y="402" class="cardTitle">Source</text>
+      <text x="118" y="426" class="body">raw ingest</text>
+      <text x="118" y="446" class="tiny">or lake replay</text>
+
+      <rect x="286" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
+      <text x="310" y="402" class="cardTitle">Normalize</text>
+      <text x="310" y="426" class="body">OCSF/native</text>
+      <text x="310" y="446" class="tiny">stable IDs, hashes</text>
+
+      <rect x="478" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
+      <text x="502" y="402" class="cardTitle">Enrich</text>
+      <text x="502" y="426" class="body">OSV, NVD</text>
+      <text x="502" y="446" class="tiny">EPSS, KEV</text>
+
+      <rect x="670" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
+      <text x="694" y="402" class="cardTitle">Correlate</text>
+      <text x="694" y="426" class="body">identity, tools</text>
+      <text x="694" y="446" class="tiny">lineage windows</text>
+
+      <rect x="862" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
+      <text x="886" y="402" class="cardTitle">Confidence</text>
+      <text x="886" y="426" class="body">reason codes</text>
+      <text x="886" y="446" class="tiny">no model facts</text>
+
+      <rect x="1054" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
+      <text x="1078" y="402" class="cardTitle">Map</text>
+      <text x="1078" y="426" class="body">MITRE, CVSS</text>
+      <text x="1078" y="446" class="tiny">EPSS, KEV, controls</text>
+
+      <rect x="1246" y="374" width="150" height="88" rx="14" fill="#0b1830" stroke="#60a5fa"/>
+      <text x="1270" y="402" class="cardTitle">LLM triage</text>
+      <text x="1270" y="426" class="body">rank, summarize</text>
+      <text x="1270" y="446" class="tiny">schema gated</text>
+    </g>
+
+    <path d="M244 418H278" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
+    <path d="M436 418H470" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
+    <path d="M628 418H662" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
+    <path d="M820 418H854" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
+    <path d="M1012 418H1046" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
+    <path d="M1204 418H1238" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
+
+    <g filter="url(#softShadow)">
+      <rect x="286" y="498" width="166" height="56" rx="14" fill="#3b2403" stroke="#f59e0b"/>
+      <text x="316" y="521" class="cardTitle">Review</text>
+      <text x="316" y="541" class="tiny" fill="#fef3c7">HITL approval required</text>
+
+      <rect x="500" y="498" width="178" height="56" rx="14" fill="#4c0519" stroke="#fb7185"/>
+      <text x="530" y="521" class="cardTitle">Dry-run action</text>
+      <text x="530" y="541" class="tiny" fill="#fecdd3">idempotency key reused</text>
+
+      <rect x="726" y="498" width="178" height="56" rx="14" fill="#3b2403" stroke="#f59e0b"/>
+      <text x="756" y="521" class="cardTitle">Retry branch</text>
+      <text x="756" y="541" class="tiny" fill="#fef3c7">bounded retry only</text>
+
+      <rect x="952" y="498" width="178" height="56" rx="14" fill="#3b2403" stroke="#f59e0b"/>
+      <text x="982" y="521" class="cardTitle">Escalate</text>
+      <text x="982" y="541" class="tiny" fill="#fef3c7">terminal errors to human</text>
+
+      <rect x="1178" y="498" width="218" height="56" rx="14" fill="#111827" stroke="#94a3b8"/>
+      <text x="1208" y="521" class="cardTitle">Audit and eval</text>
+      <text x="1208" y="541" class="tiny">state hash, pass rate, writeback</text>
+    </g>
+    <path d="M1321 462V484C1321 492 1313 498 1303 498H452" stroke="#60a5fa" stroke-width="2.8" marker-end="url(#arrowBlue)" fill="none"/>
+    <path d="M452 526H492" stroke="#fb7185" stroke-width="3" marker-end="url(#arrowRose)" fill="none"/>
+    <path d="M678 526H718" stroke="#f59e0b" stroke-width="3" marker-end="url(#arrowAmber)" fill="none"/>
+    <path d="M589 554V572H1041V556" stroke="#f59e0b" stroke-width="2.6" marker-end="url(#arrowAmber)" fill="none" stroke-dasharray="7 7"/>
+    <path d="M815 498V480H1287V496" stroke="#f59e0b" stroke-width="2.6" marker-end="url(#arrowAmber)" fill="none"/>
+    <path d="M1130 526H1170" stroke="#f59e0b" stroke-width="3" marker-end="url(#arrowAmber)" fill="none" stroke-dasharray="7 7"/>
+
+    <rect x="64" y="626" width="1472" height="126" rx="22" fill="#2a1207" stroke="#d97706"/>
+    <text x="94" y="662" class="eyebrow" fill="#fed7aa">Trust rails the workflow cannot bypass</text>
+    <g>
+      <rect x="94" y="684" width="174" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="181" y="706" text-anchor="middle" class="badge">sandbox + RLIMIT</text>
+      <rect x="298" y="684" width="198" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="397" y="706" text-anchor="middle" class="badge">allowlist intersection</text>
+      <rect x="526" y="684" width="180" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="616" y="706" text-anchor="middle" class="badge">token budgets</text>
+      <rect x="736" y="684" width="188" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="830" y="706" text-anchor="middle" class="badge">integrity hashes</text>
+      <rect x="954" y="684" width="176" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="1042" y="706" text-anchor="middle" class="badge">dry-run first</text>
+      <rect x="1160" y="684" width="170" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="1245" y="706" text-anchor="middle" class="badge">HMAC audit</text>
+      <rect x="1360" y="684" width="146" height="34" rx="17" fill="#111827" stroke="#475569"/>
+      <text x="1433" y="706" text-anchor="middle" class="badge">HITL gates</text>
+    </g>
+
+    <path d="M453 246V294C453 302 460 306 474 306H1321V366" stroke="#60a5fa" stroke-width="2.5" marker-end="url(#arrowBlue)" fill="none" stroke-dasharray="8 7"/>
+    <path d="M743 246V286C743 298 753 306 770 306H1321" stroke="#60a5fa" stroke-width="2.5" fill="none" stroke-dasharray="8 7"/>
+    <path d="M1287 554V618" stroke="#34d399" stroke-width="2.5" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="8 7"/>
+
+    <text x="94" y="786" class="tiny" fill="#94a3b8">Invariant: LLM output can rank, summarize, and draft. Repo skills own facts, schemas, confidence, mappings, idempotency, approval state, API-error routing, audit records, and replayable evidence.</text>
   </g>
 </svg>

--- a/docs/images/snowflake-data-lake.svg
+++ b/docs/images/snowflake-data-lake.svg
@@ -1,42 +1,281 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">Snowflake security data lake closed-loop architecture</title>
-  <desc id="desc">Clean lane diagram showing signals, OCSF normalization, append-only Snowflake storage, read-only replay, skill outputs, HITL approval, audit write-back, row access policies, dynamic tables, and optional managed Iceberg.</desc>
+  <desc id="desc">Readable lane diagram showing covered signals, OCSF normalization, append-only Snowflake writes, governed Snowflake tables, read-only replay, operator artifacts, HITL review, audit write-back, row access policies, dynamic tables, managed Iceberg, and the customer-owned trust boundary.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#06101f"/><stop offset="0.52" stop-color="#0a1528"/><stop offset="1" stop-color="#101827"/></linearGradient>
-    <linearGradient id="snowFill" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#123d73"/><stop offset="1" stop-color="#081f3e"/></linearGradient>
-    <linearGradient id="snowStroke" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#93c5fd"/><stop offset="0.5" stop-color="#29b5e8"/><stop offset="1" stop-color="#dbeafe"/></linearGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse"><path d="M48 0H0V48" fill="none" stroke="#20314f" stroke-opacity="0.24" stroke-width="1"/></pattern>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#020617" flood-opacity="0.42"/></filter>
-    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%"><feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.28"/></filter>
-    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#60a5fa"/></marker>
-    <marker id="arrowViolet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#a78bfa"/></marker>
-    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#34d399"/></marker>
-    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#fb7185"/></marker>
-    <style>.font{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}.h1{font-size:34px;font-weight:850;fill:#f8fafc}.sub{font-size:15px;fill:#cbd5e1}.eyebrow{font-size:11px;font-weight:850;letter-spacing:.08em;text-transform:uppercase}.cardTitle{font-size:17px;font-weight:850;fill:#f8fafc}.cardSub{font-size:13px;fill:#cbd5e1}.body{font-size:12px;fill:#cbd5e1}.tiny{font-size:11px;fill:#94a3b8}.badge{font-size:12px;font-weight:850;fill:#f8fafc}.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono",monospace}</style>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#06101f"/>
+      <stop offset="0.52" stop-color="#0a1528"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+    <linearGradient id="lakeFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d3a70"/>
+      <stop offset="1" stop-color="#081f3e"/>
+    </linearGradient>
+    <linearGradient id="lakeStroke" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#93c5fd"/>
+      <stop offset="0.52" stop-color="#29b5e8"/>
+      <stop offset="1" stop-color="#dbeafe"/>
+    </linearGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" fill="none" stroke="#20314f" stroke-opacity="0.24" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#020617" flood-opacity="0.42"/>
+    </filter>
+    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.28"/>
+    </filter>
+    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#60a5fa"/>
+    </marker>
+    <marker id="arrowViolet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#a78bfa"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#34d399"/>
+    </marker>
+    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#fb7185"/>
+    </marker>
+    <style>
+      .font{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
+      .h1{font-size:34px;font-weight:850;fill:#f8fafc}
+      .sub{font-size:15px;fill:#cbd5e1}
+      .eyebrow{font-size:11px;font-weight:850;letter-spacing:.08em;text-transform:uppercase}
+      .cardTitle{font-size:17px;font-weight:850;fill:#f8fafc}
+      .cardSub{font-size:13px;fill:#cbd5e1}
+      .body{font-size:12px;fill:#cbd5e1}
+      .tiny{font-size:11px;fill:#94a3b8}
+      .badge{font-size:12px;font-weight:850;fill:#f8fafc}
+      .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono",monospace}
+    </style>
   </defs>
-  <rect width="1600" height="980" fill="url(#bg)"/><rect width="1600" height="980" fill="url(#grid)"/>
+
+  <rect width="1600" height="980" fill="url(#bg)"/>
+  <rect width="1600" height="980" fill="url(#grid)"/>
+
   <g class="font">
     <text x="64" y="64" class="h1">Snowflake Security Data Lake</text>
-    <text x="64" y="94" class="sub">Warehouse-native storage, governed replay, and audit closure for cloud, identity, SaaS, Kubernetes, and MCP security events.</text>
-    <g transform="translate(1246,42)"><rect x="0" y="0" width="290" height="70" rx="14" fill="#101827" stroke="#334155"/><g transform="translate(43,35)"><line x1="-22" y1="0" x2="22" y2="0" stroke="#93c5fd" stroke-width="3" stroke-linecap="round"/><line x1="0" y1="-22" x2="0" y2="22" stroke="#93c5fd" stroke-width="3" stroke-linecap="round"/><line x1="-16" y1="-16" x2="16" y2="16" stroke="#60a5fa" stroke-width="3" stroke-linecap="round"/><line x1="16" y1="-16" x2="-16" y2="16" stroke="#60a5fa" stroke-width="3" stroke-linecap="round"/><circle cx="0" cy="0" r="5" fill="#102a4c" stroke="#dbeafe" stroke-width="2"/></g><text x="108" y="29" class="cardTitle">Snowflake pack</text><text x="108" y="51" class="tiny">DDL · dynamic tables · row policies · Iceberg</text></g>
-    <g transform="translate(64,138)"><rect x="0" y="0" width="146" height="30" rx="15" fill="#0c2a4d" stroke="#2563eb"/><text x="73" y="20" text-anchor="middle" class="eyebrow" fill="#bfdbfe">Write lane</text></g>
-    <g transform="translate(64,574)"><rect x="0" y="0" width="150" height="30" rx="15" fill="#1e1b4b" stroke="#6d28d9"/><text x="75" y="20" text-anchor="middle" class="eyebrow" fill="#c4b5fd">Replay lane</text></g>
-    <g transform="translate(64,820)"><rect x="0" y="0" width="174" height="30" rx="15" fill="#4c0519" stroke="#9f1239"/><text x="87" y="20" text-anchor="middle" class="eyebrow" fill="#fda4af">Governance lane</text></g>
-    <g filter="url(#softShadow)"><rect x="64" y="190" width="312" height="318" rx="18" fill="#101827" stroke="#334155"/><text x="92" y="230" class="cardTitle">Covered signals</text><text x="92" y="253" class="cardSub">Existing ingest and source coverage</text>
-      <g transform="translate(92,284)"><g><rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/><circle cx="27" cy="29" r="17" fill="#ff9900"/><text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#111827">AWS</text><text x="55" y="26" class="badge">AWS</text><text x="55" y="43" class="tiny">trail · flow</text></g><g transform="translate(134,0)"><rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/><circle cx="27" cy="29" r="17" fill="#4285f4"/><text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#fff">GCP</text><text x="55" y="26" class="badge">GCP</text><text x="55" y="43" class="tiny">audit · SCC</text></g><g transform="translate(0,74)"><rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/><circle cx="27" cy="29" r="17" fill="#2563eb"/><text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#fff">AZ</text><text x="55" y="26" class="badge">Azure</text><text x="55" y="43" class="tiny">activity · NSG</text></g><g transform="translate(134,74)"><rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/><circle cx="27" cy="29" r="17" fill="#111827" stroke="#94a3b8"/><text x="27" y="34" text-anchor="middle" font-size="9" font-weight="900" fill="#f8fafc">ID</text><text x="55" y="26" class="badge">Identity</text><text x="55" y="43" class="tiny">Entra · Okta</text></g><g transform="translate(0,148)"><rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/><circle cx="27" cy="29" r="17" fill="#326ce5"/><text x="27" y="34" text-anchor="middle" font-size="9" font-weight="900" fill="#fff">K8s</text><text x="55" y="26" class="badge">Runtime</text><text x="55" y="43" class="tiny">K8s · MCP</text></g><g transform="translate(134,148)"><rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/><circle cx="27" cy="29" r="17" fill="#29b5e8"/><text x="27" y="34" text-anchor="middle" font-size="9" font-weight="900" fill="#082f49">SF</text><text x="55" y="26" class="badge">SaaS</text><text x="55" y="43" class="tiny">Snowflake · GH</text></g></g>
+    <text x="64" y="94" class="sub">The same closed loop as ClickHouse, drawn for governed warehouse-native replay and audit write-back.</text>
+
+    <g transform="translate(1238,38)">
+      <rect x="0" y="0" width="298" height="78" rx="16" fill="#101827" stroke="#334155"/>
+      <g transform="translate(48,39)">
+        <line x1="-24" y1="0" x2="24" y2="0" stroke="#bfdbfe" stroke-width="4" stroke-linecap="round"/>
+        <line x1="0" y1="-24" x2="0" y2="24" stroke="#bfdbfe" stroke-width="4" stroke-linecap="round"/>
+        <line x1="-17" y1="-17" x2="17" y2="17" stroke="#60a5fa" stroke-width="4" stroke-linecap="round"/>
+        <line x1="17" y1="-17" x2="-17" y2="17" stroke="#60a5fa" stroke-width="4" stroke-linecap="round"/>
+        <circle cx="0" cy="0" r="6" fill="#102a4c" stroke="#dbeafe" stroke-width="2"/>
+      </g>
+      <text x="104" y="33" class="cardTitle">Snowflake pack</text>
+      <text x="104" y="55" class="tiny">DDL, dynamic tables, row policies, Iceberg</text>
     </g>
-    <g filter="url(#softShadow)"><rect x="438" y="222" width="238" height="254" rx="18" fill="#0c2a4d" stroke="#60a5fa"/><text x="468" y="262" class="cardTitle">Normalize</text><text x="468" y="286" class="cardSub">22 ingest skills</text><rect x="468" y="316" width="178" height="50" rx="12" fill="#1d4ed8" stroke="#93c5fd"/><text x="557" y="337" text-anchor="middle" class="badge">OCSF 1.8 JSONL</text><text x="557" y="356" text-anchor="middle" class="tiny" fill="#dbeafe">stdout pipe contract</text><text x="468" y="400" class="body">Stable IDs:</text><text x="468" y="422" class="mono" font-size="12" fill="#dbeafe">event_uid</text><text x="568" y="422" class="mono" font-size="12" fill="#dbeafe">finding_uid</text></g>
-    <g filter="url(#softShadow)"><rect x="738" y="222" width="250" height="254" rx="18" fill="#111827" stroke="#60a5fa"/><text x="768" y="262" class="cardTitle">Write</text><text x="768" y="286" class="cardSub">sink-snowflake-jsonl</text><g transform="translate(768,320)"><rect x="0" y="0" width="190" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/><text x="95" y="22" text-anchor="middle" class="badge">append-only insert</text><rect x="0" y="48" width="190" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/><text x="95" y="70" text-anchor="middle" class="badge">dry-run default</text><rect x="0" y="96" width="190" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/><text x="95" y="118" text-anchor="middle" class="badge">identifier validated</text></g></g>
-    <g filter="url(#shadow)"><rect x="1052" y="166" width="454" height="390" rx="22" fill="url(#snowFill)" stroke="url(#snowStroke)" stroke-width="2"/><g transform="translate(1124,222)"><line x1="-31" y1="0" x2="31" y2="0" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round"/><line x1="0" y1="-31" x2="0" y2="31" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round"/><line x1="-22" y1="-22" x2="22" y2="22" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/><line x1="22" y1="-22" x2="-22" y2="22" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/><circle cx="0" cy="0" r="8" fill="#0b2445" stroke="#dbeafe" stroke-width="3"/></g><text x="1184" y="225" font-size="24" font-weight="850" fill="#e0f2fe">Snowflake lake</text><text x="1184" y="250" class="body" fill="#dbeafe">pre-provisioned schema; row access policy applied</text>
-      <g transform="translate(1086,290)"><rect x="0" y="0" width="178" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/><text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">events_sink</text><text x="20" y="50" class="tiny" fill="#bfdbfe">90-day hot tier</text></g><g transform="translate(1284,290)"><rect x="0" y="0" width="178" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/><text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">findings_sink</text><text x="20" y="50" class="tiny" fill="#bfdbfe">365-day history</text></g><g transform="translate(1086,380)"><rect x="0" y="0" width="178" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/><text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">evidence_sink</text><text x="20" y="50" class="tiny" fill="#bfdbfe">7-year hold</text></g><g transform="translate(1284,380)"><rect x="0" y="0" width="178" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/><text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">audit_sink</text><text x="20" y="50" class="tiny" fill="#bfdbfe">legal-hold chain</text></g><rect x="1086" y="476" width="180" height="52" rx="13" fill="#0b2445" stroke="#93c5fd" stroke-dasharray="6 5"/><text x="1176" y="498" text-anchor="middle" font-size="13" font-weight="850" fill="#e0f2fe">dynamic tables</text><text x="1176" y="518" text-anchor="middle" class="tiny" fill="#bfdbfe">volume rollups</text><rect x="1284" y="476" width="178" height="52" rx="13" fill="#0b2445" stroke="#93c5fd" stroke-dasharray="6 5"/><text x="1373" y="498" text-anchor="middle" font-size="13" font-weight="850" fill="#e0f2fe">managed Iceberg</text><text x="1373" y="518" text-anchor="middle" class="tiny" fill="#bfdbfe">open-format option</text></g>
-    <g filter="url(#softShadow)"><rect x="738" y="622" width="250" height="162" rx="18" fill="#1e1b4b" stroke="#a78bfa"/><text x="768" y="662" class="cardTitle">Read</text><text x="768" y="686" class="cardSub">source-snowflake-query</text><rect x="768" y="716" width="190" height="38" rx="10" fill="#312e81" stroke="#a78bfa"/><text x="863" y="740" text-anchor="middle" class="badge">read-only SQL gate</text><text x="768" y="770" class="tiny" fill="#c4b5fd">SELECT · WITH · SHOW · DESCRIBE</text></g>
-    <g filter="url(#softShadow)"><rect x="438" y="622" width="238" height="162" rx="18" fill="#2e1065" stroke="#a78bfa"/><text x="468" y="662" class="cardTitle">Replay rows</text><text x="468" y="688" class="body">detect-* rules</text><text x="468" y="712" class="body">Snowflake-native detections</text><text x="468" y="736" class="body">control evidence</text><text x="468" y="764" class="tiny" fill="#c4b5fd">UID-aware windows for de-dupe</text></g>
-    <g filter="url(#softShadow)"><rect x="64" y="622" width="312" height="162" rx="18" fill="#052e2b" stroke="#34d399"/><text x="92" y="662" class="cardTitle">Operator artifacts</text><text x="92" y="690" class="body">new findings</text><text x="92" y="714" class="body">SARIF handoff</text><text x="92" y="738" class="body">Mermaid attack-flow</text><text x="92" y="762" class="body">dashboard query pack</text></g>
-    <g filter="url(#softShadow)"><rect x="438" y="858" width="238" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/><text x="468" y="887" class="cardTitle">HITL response</text><text x="468" y="910" class="tiny" fill="#fecdd3">dry-run first · approved window</text></g><g filter="url(#softShadow)"><rect x="738" y="858" width="250" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/><text x="768" y="887" class="cardTitle">Audit write-back</text><text x="768" y="910" class="tiny" fill="#fecdd3">remediation and MCP records</text></g><g filter="url(#softShadow)"><rect x="1052" y="858" width="454" height="72" rx="18" fill="#111827" stroke="#475569"/><text x="1084" y="887" class="cardTitle">Customer-owned boundary</text><text x="1084" y="906" class="tiny">Account, warehouse, grants, retention, row policy,</text><text x="1084" y="922" class="tiny">credentials, and dashboard access stay under operator control.</text></g>
-    <path d="M376 349H438" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/><path d="M676 349H738" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/><path d="M988 349H1052" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/><text x="1002" y="333" class="tiny" fill="#bfdbfe">insert</text>
-    <path d="M1052 703H988" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/><text x="1000" y="686" class="tiny" fill="#bfdbfe">query</text><path d="M738 703H676" stroke="#a78bfa" stroke-width="3.2" marker-end="url(#arrowViolet)" fill="none"/><path d="M438 703H376" stroke="#34d399" stroke-width="3.2" marker-end="url(#arrowGreen)" fill="none"/>
-    <path d="M220 784V812C220 834 250 846 290 846H1320C1350 846 1366 828 1366 802V556" stroke="#34d399" stroke-width="2.6" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="9 8"/><text x="650" y="834" class="tiny" fill="#a7f3d0">artifact rows can re-land through sink-snowflake-jsonl</text>
-    <path d="M676 894H738" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/><path d="M988 894H1052" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/><path d="M863 858V818C863 804 878 796 904 796H1402V556" stroke="#fb7185" stroke-width="2.6" marker-end="url(#arrowRose)" fill="none" stroke-dasharray="9 8"/><text x="1008" y="778" class="tiny" fill="#fda4af">audit_sink captures decisions and tool activity</text>
-    <g transform="translate(64,952)"><circle cx="0" cy="0" r="5" fill="#60a5fa"/><text x="18" y="4" class="tiny">write</text><circle cx="88" cy="0" r="5" fill="#a78bfa"/><text x="106" y="4" class="tiny">read</text><circle cx="168" cy="0" r="5" fill="#34d399"/><text x="186" y="4" class="tiny">artifact</text><circle cx="268" cy="0" r="5" fill="#fb7185"/><text x="286" y="4" class="tiny">audit</text></g><text x="560" y="956" class="tiny" fill="#94a3b8">Append-only tables preserve history; stable UIDs support duplicate-aware replay queries.</text>
+
+    <g transform="translate(64,138)">
+      <rect x="0" y="0" width="146" height="30" rx="15" fill="#0c2a4d" stroke="#2563eb"/>
+      <text x="73" y="20" text-anchor="middle" class="eyebrow" fill="#bfdbfe">Write lane</text>
+    </g>
+    <g transform="translate(64,562)">
+      <rect x="0" y="0" width="180" height="30" rx="15" fill="#1e1b4b" stroke="#6d28d9"/>
+      <text x="90" y="20" text-anchor="middle" class="eyebrow" fill="#c4b5fd">Replay lane</text>
+    </g>
+    <g transform="translate(64,812)">
+      <rect x="0" y="0" width="192" height="30" rx="15" fill="#4c0519" stroke="#9f1239"/>
+      <text x="96" y="20" text-anchor="middle" class="eyebrow" fill="#fda4af">Governance lane</text>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="64" y="192" width="296" height="294" rx="18" fill="#101827" stroke="#334155"/>
+      <text x="92" y="232" class="cardTitle">Covered signals</text>
+      <text x="92" y="255" class="cardSub">Existing ingest and source coverage</text>
+      <g transform="translate(92,288)">
+        <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
+        <circle cx="25" cy="25" r="16" fill="#ff9900"/>
+        <text x="25" y="30" text-anchor="middle" font-size="10" font-weight="900" fill="#111827">AWS</text>
+        <text x="50" y="22" class="badge">AWS</text>
+        <text x="50" y="39" class="tiny">trail, flow</text>
+
+        <g transform="translate(122,0)">
+          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
+          <circle cx="25" cy="25" r="16" fill="#4285f4"/>
+          <text x="25" y="30" text-anchor="middle" font-size="10" font-weight="900" fill="#fff">GCP</text>
+          <text x="50" y="22" class="badge">GCP</text>
+          <text x="50" y="39" class="tiny">audit, SCC</text>
+        </g>
+
+        <g transform="translate(0,66)">
+          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
+          <circle cx="25" cy="25" r="16" fill="#2563eb"/>
+          <text x="25" y="30" text-anchor="middle" font-size="10" font-weight="900" fill="#fff">AZ</text>
+          <text x="50" y="22" class="badge">Azure</text>
+          <text x="50" y="39" class="tiny">activity</text>
+        </g>
+
+        <g transform="translate(122,66)">
+          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
+          <circle cx="25" cy="25" r="16" fill="#111827" stroke="#94a3b8"/>
+          <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#f8fafc">ID</text>
+          <text x="50" y="22" class="badge">Identity</text>
+          <text x="50" y="39" class="tiny">Entra, Okta</text>
+        </g>
+
+        <g transform="translate(0,132)">
+          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
+          <circle cx="25" cy="25" r="16" fill="#326ce5"/>
+          <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#fff">K8s</text>
+          <text x="50" y="22" class="badge">Runtime</text>
+          <text x="50" y="39" class="tiny">K8s, MCP</text>
+        </g>
+
+        <g transform="translate(122,132)">
+          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
+          <circle cx="25" cy="25" r="16" fill="#29b5e8"/>
+          <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#082f49">SF</text>
+          <text x="50" y="22" class="badge">SaaS</text>
+          <text x="50" y="39" class="tiny">GH, Slack</text>
+        </g>
+      </g>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="430" y="230" width="230" height="214" rx="18" fill="#0c2a4d" stroke="#60a5fa"/>
+      <text x="460" y="270" class="cardTitle">Normalize</text>
+      <text x="460" y="294" class="cardSub">22 ingest skills</text>
+      <rect x="460" y="324" width="170" height="50" rx="12" fill="#1d4ed8" stroke="#93c5fd"/>
+      <text x="545" y="345" text-anchor="middle" class="badge">OCSF 1.8 JSONL</text>
+      <text x="545" y="364" text-anchor="middle" class="tiny" fill="#dbeafe">stdout pipe contract</text>
+      <text x="460" y="406" class="body">Stable IDs: event_uid,</text>
+      <text x="460" y="426" class="body">finding_uid, tenant hints</text>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="724" y="230" width="242" height="238" rx="18" fill="#111827" stroke="#60a5fa"/>
+      <text x="754" y="270" class="cardTitle">Write</text>
+      <text x="754" y="294" class="cardSub">sink-snowflake-jsonl</text>
+      <rect x="754" y="324" width="182" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/>
+      <text x="845" y="346" text-anchor="middle" class="badge">append-only insert</text>
+      <rect x="754" y="372" width="182" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/>
+      <text x="845" y="394" text-anchor="middle" class="badge">dry-run default</text>
+      <rect x="754" y="420" width="182" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/>
+      <text x="845" y="442" text-anchor="middle" class="badge">identifier validated</text>
+    </g>
+
+    <g filter="url(#shadow)">
+      <rect x="1034" y="162" width="502" height="414" rx="24" fill="url(#lakeFill)" stroke="url(#lakeStroke)" stroke-width="2"/>
+      <g transform="translate(1102,222)">
+        <line x1="-31" y1="0" x2="31" y2="0" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round"/>
+        <line x1="0" y1="-31" x2="0" y2="31" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round"/>
+        <line x1="-22" y1="-22" x2="22" y2="22" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
+        <line x1="22" y1="-22" x2="-22" y2="22" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
+        <circle cx="0" cy="0" r="8" fill="#0b2445" stroke="#dbeafe" stroke-width="3"/>
+      </g>
+      <text x="1162" y="222" font-size="24" font-weight="850" fill="#e0f2fe">Snowflake lake</text>
+      <text x="1162" y="248" class="body" fill="#dbeafe">security_db.ops, provisioned by packs/snowflake</text>
+
+      <g transform="translate(1074,288)">
+        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
+        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">events_sink</text>
+        <text x="20" y="50" class="tiny" fill="#bfdbfe">90-day hot tier</text>
+      </g>
+      <g transform="translate(1300,288)">
+        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
+        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">findings_sink</text>
+        <text x="20" y="50" class="tiny" fill="#bfdbfe">365-day history</text>
+      </g>
+      <g transform="translate(1074,378)">
+        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
+        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">evidence_sink</text>
+        <text x="20" y="50" class="tiny" fill="#bfdbfe">7-year hold</text>
+      </g>
+      <g transform="translate(1300,378)">
+        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
+        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">audit_sink</text>
+        <text x="20" y="50" class="tiny" fill="#bfdbfe">legal-hold chain</text>
+      </g>
+      <g transform="translate(1074,476)">
+        <rect x="0" y="0" width="186" height="54" rx="13" fill="#0b2445" stroke="#93c5fd" stroke-dasharray="6 5"/>
+        <text x="93" y="23" text-anchor="middle" font-size="13" font-weight="850" fill="#e0f2fe">dynamic tables</text>
+        <text x="93" y="43" text-anchor="middle" class="tiny" fill="#bfdbfe">rule and event rollups</text>
+      </g>
+      <g transform="translate(1298,476)">
+        <rect x="0" y="0" width="186" height="54" rx="13" fill="#0b2445" stroke="#93c5fd" stroke-dasharray="6 5"/>
+        <text x="93" y="23" text-anchor="middle" font-size="13" font-weight="850" fill="#e0f2fe">managed Iceberg</text>
+        <text x="93" y="43" text-anchor="middle" class="tiny" fill="#bfdbfe">Horizon Catalog path</text>
+      </g>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="724" y="616" width="242" height="170" rx="18" fill="#1e1b4b" stroke="#a78bfa"/>
+      <text x="754" y="656" class="cardTitle">Read gate</text>
+      <text x="754" y="680" class="cardSub">source-snowflake-query</text>
+      <rect x="754" y="710" width="182" height="38" rx="10" fill="#312e81" stroke="#a78bfa"/>
+      <text x="845" y="734" text-anchor="middle" class="badge">read-only SQL</text>
+      <text x="754" y="766" class="tiny" fill="#c4b5fd">SELECT, WITH, SHOW, DESCRIBE</text>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="430" y="616" width="230" height="170" rx="18" fill="#2e1065" stroke="#a78bfa"/>
+      <text x="460" y="656" class="cardTitle">Replay rows</text>
+      <text x="460" y="684" class="body">detect-* rules</text>
+      <text x="460" y="708" class="body">Snowflake detections</text>
+      <text x="460" y="732" class="body">view-* renderers</text>
+      <text x="460" y="762" class="tiny" fill="#c4b5fd">UID windows prevent duplicate findings</text>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="64" y="616" width="296" height="170" rx="18" fill="#052e2b" stroke="#34d399"/>
+      <text x="92" y="656" class="cardTitle">Operator artifacts</text>
+      <text x="92" y="684" class="body">new findings</text>
+      <text x="92" y="708" class="body">SARIF handoff</text>
+      <text x="92" y="732" class="body">Mermaid attack-flow</text>
+      <text x="92" y="756" class="body">dashboard query pack</text>
+    </g>
+
+    <g filter="url(#softShadow)">
+      <rect x="430" y="854" width="230" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/>
+      <text x="460" y="883" class="cardTitle">HITL response</text>
+      <text x="460" y="906" class="tiny" fill="#fecdd3">approved window, dry-run first</text>
+    </g>
+    <g filter="url(#softShadow)">
+      <rect x="724" y="854" width="242" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/>
+      <text x="754" y="883" class="cardTitle">Audit write-back</text>
+      <text x="754" y="906" class="tiny" fill="#fecdd3">remediation and MCP records</text>
+    </g>
+    <g filter="url(#softShadow)">
+      <rect x="1034" y="854" width="502" height="72" rx="18" fill="#111827" stroke="#475569"/>
+      <text x="1066" y="883" class="cardTitle">Customer-owned boundary</text>
+      <text x="1066" y="904" class="tiny">Account, warehouse, grants, row policy, retention, credentials,</text>
+      <text x="1066" y="920" class="tiny">dashboard access, and network controls stay under operator control.</text>
+    </g>
+
+    <path d="M360 337H430" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/>
+    <path d="M660 337H724" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/>
+    <path d="M966 349H1034" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/>
+    <text x="990" y="318" class="tiny" fill="#bfdbfe">insert</text>
+
+    <path d="M1034 700H966" stroke="#a78bfa" stroke-width="3.2" marker-end="url(#arrowViolet)" fill="none"/>
+    <text x="986" y="682" class="tiny" fill="#c4b5fd">query</text>
+    <path d="M724 700H660" stroke="#a78bfa" stroke-width="3.2" marker-end="url(#arrowViolet)" fill="none"/>
+    <path d="M430 700H360" stroke="#34d399" stroke-width="3.2" marker-end="url(#arrowGreen)" fill="none"/>
+
+    <path d="M210 786V812C210 834 240 842 288 842H1286C1318 842 1334 824 1334 792V576" stroke="#34d399" stroke-width="2.6" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="9 8"/>
+    <text x="590" y="833" class="tiny" fill="#a7f3d0">artifact rows can re-land through sink-snowflake-jsonl</text>
+
+    <path d="M660 890H724" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/>
+    <path d="M966 890H1034" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/>
+    <path d="M845 854V818C845 802 864 794 894 794H1430C1458 794 1472 778 1472 746V576" stroke="#fb7185" stroke-width="2.6" marker-end="url(#arrowRose)" fill="none" stroke-dasharray="9 8"/>
+    <text x="1010" y="779" class="tiny" fill="#fda4af">audit_sink captures decisions, tool calls, and approvals</text>
+
+    <g transform="translate(64,952)">
+      <circle cx="0" cy="0" r="5" fill="#60a5fa"/>
+      <text x="18" y="4" class="tiny">write</text>
+      <circle cx="88" cy="0" r="5" fill="#a78bfa"/>
+      <text x="106" y="4" class="tiny">read</text>
+      <circle cx="168" cy="0" r="5" fill="#34d399"/>
+      <text x="186" y="4" class="tiny">artifact</text>
+      <circle cx="268" cy="0" r="5" fill="#fb7185"/>
+      <text x="286" y="4" class="tiny">audit</text>
+    </g>
+    <text x="560" y="956" class="tiny" fill="#94a3b8">Append-only tables preserve history; stable IDs support duplicate-aware replay queries.</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Add a README start-here map and clearer core-vs-orchestrator framing for deterministic skills, LangGraph/LangChain workflow state, token budgets, integrity, idempotency, and API-error routing.
- Redraw the Snowflake data lake hero SVG to match the ClickHouse readability bar with lane labels, contained text, clean arrows, Snowflake branding, governed tables, replay, artifacts, HITL, audit, and customer-owned boundary.
- Redraw the agentic SOC orchestrator SVG and Mermaid source to show the workflow DAG, model router, harness profile, deterministic pipeline, review/remediation branches, and non-bypassable trust rails.

## Verification
- `python examples/agents/check_langgraph_harness_drift.py`
- `git diff --check`
- `rsvg-convert docs/images/snowflake-data-lake.svg -o /tmp/cloud-ai-security-skills-diagrams/snowflake-data-lake.png`
- `rsvg-convert docs/images/agentic-soc-orchestrator.svg -o /tmp/cloud-ai-security-skills-diagrams/agentic-soc-orchestrator.png`
- `rsvg-convert docs/images/architecture-layers.svg -o /tmp/cloud-ai-security-skills-diagrams/architecture-layers.png`
- Scoped secret-pattern grep over touched README, Mermaid, and SVG files

## Notes
- Visual review performed against rendered PNG snapshots for Snowflake, agentic SOC, and architecture layers.
- No passwords, PATs, or API-key literals were added.
