### PR TITLE
docs(diagrams): refine README flow visuals

### DIFF
--- a/docs/diagrams/clickhouse-data-lake.mmd
+++ b/docs/diagrams/clickhouse-data-lake.mmd
@@ -21,8 +21,8 @@ flowchart LR
 
     subgraph L1["Normalize and write"]
       direction TB
-      ING["22 ingest-* skills<br/>OCSF 1.8 JSONL"]:::transform
-      SINK["sink-clickhouse-jsonl<br/>append-only insert · dry-run default"]:::transform
+      ING["22 ingest-* skills<br/>OCSF 1.8 JSONL · stable IDs"]:::transform
+      SINK["sink-clickhouse-jsonl<br/>append-only insert · dry-run default · identifier validated"]:::transform
     end
 
     subgraph LAKE["ClickHouse security data lake"]

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">cloud-ai-security-skills architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 22 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 71 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 12 benchmark families covering 143 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, role of each layer, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 22 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 71 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 12 benchmark families covering 143 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, clean flow, contained labels, and wire-format guidance without dense text.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -44,8 +44,8 @@
       <rect x="790" y="0" width="150" height="40" rx="20" fill="#4a2d09" stroke="#fbbf24"/>
       <text x="865" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#fde68a" letter-spacing="1.5">ACT</text>
 
-      <rect x="1050" y="0" width="160" height="40" rx="20" fill="#083b39" stroke="#2dd4bf"/>
-      <text x="1130" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4" letter-spacing="1.5">PERSIST</text>
+      <rect x="1050" y="0" width="172" height="40" rx="20" fill="#083b39" stroke="#2dd4bf"/>
+      <text x="1136" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4" letter-spacing="1.5">PERSIST</text>
     </g>
 
     <!-- SIGNALS panel (taller for vendor-line wrap) -->
@@ -113,35 +113,35 @@
       <text x="994" y="598" font-size="15" fill="#fde68a">or Mermaid for review</text>
     </g>
 
-    <!-- L7 Output (taller, narrower) -->
+    <!-- L7 Output -->
     <g filter="url(#shadow)">
-      <rect x="1252" y="228" width="76" height="392" rx="28" fill="#083b39" stroke="#2dd4bf" stroke-width="1.6"/>
-      <text x="1290" y="270" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4">L7</text>
-      <text x="1290" y="288" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4">Output</text>
-      <text x="1290" y="346" text-anchor="middle" font-size="46" font-weight="900" fill="#ffffff">3</text>
-      <text x="1290" y="380" text-anchor="middle" font-size="11" fill="#99f6e4">sinks</text>
-      <g font-size="13" fill="#ecfeff">
-        <text x="1290" y="430" text-anchor="middle">S3</text>
-        <text x="1290" y="460" text-anchor="middle">Snow</text>
-        <text x="1290" y="480" text-anchor="middle">flake</text>
-        <text x="1290" y="510" text-anchor="middle">Click</text>
-        <text x="1290" y="530" text-anchor="middle">House</text>
+      <rect x="1234" y="228" width="112" height="392" rx="28" fill="#083b39" stroke="#2dd4bf" stroke-width="1.6"/>
+      <text x="1290" y="270" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4">L7 Output</text>
+      <text x="1290" y="334" text-anchor="middle" font-size="46" font-weight="900" fill="#ffffff">3</text>
+      <text x="1290" y="368" text-anchor="middle" font-size="11" fill="#99f6e4">append-only sinks</text>
+      <g font-size="12" font-weight="800" fill="#ecfeff">
+        <rect x="1254" y="404" width="72" height="30" rx="15" fill="#0b4a46" stroke="#2dd4bf"/>
+        <text x="1290" y="424" text-anchor="middle">S3</text>
+        <rect x="1254" y="448" width="72" height="30" rx="15" fill="#0b4a46" stroke="#2dd4bf"/>
+        <text x="1290" y="468" text-anchor="middle">Snowflake</text>
+        <rect x="1254" y="492" width="72" height="30" rx="15" fill="#0b4a46" stroke="#2dd4bf"/>
+        <text x="1290" y="512" text-anchor="middle">ClickHouse</text>
       </g>
       <text x="1290" y="572" text-anchor="middle" font-size="10" fill="#94a3b8">audit +</text>
       <text x="1290" y="586" text-anchor="middle" font-size="10" fill="#94a3b8">ingest-back</text>
       <text x="1290" y="600" text-anchor="middle" font-size="10" fill="#94a3b8">to producer</text>
     </g>
 
-    <!-- Arrows (recomputed for new x-offsets: signals 262, intake 322-582, analyze 642-902, act 962-1222, output 1252-1328) -->
+    <!-- Arrows (signals 262, intake 322-582, analyze 642-902, act 962-1222, output 1234-1346) -->
     <path d="M262 420H312" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
     <path d="M582 318H632" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
     <path d="M582 530H632" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
     <path d="M902 318H952" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
     <path d="M902 530H952" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-    <path d="M1222 424H1242" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M1222 424H1228" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
 
     <!-- Wire-contract footer -->
-    <rect x="72" y="676" width="1256" height="60" rx="18" fill="#0b1220" stroke="#334155"/>
+    <rect x="72" y="676" width="1274" height="60" rx="18" fill="#0b1220" stroke="#334155"/>
     <text x="102" y="704" font-size="15" fill="#cbd5e1">Wire contract: <tspan font-weight="800" fill="#5eead4">OCSF 1.8</tspan> on Ingest + Detect · <tspan font-weight="800" fill="#fbbf24">native</tspan> on Discover + Remediate · <tspan font-weight="800" fill="#a78bfa">SARIF / Mermaid</tspan> on View · <tspan font-weight="800" fill="#22d3ee">pass-through</tspan> on Output</text>
     <text x="102" y="724" font-size="13" fill="#94a3b8">OCSF 1.8 where interop matters · native where state and audit matter more · rendered output on view · pass-through on sinks.</text>
   </g>

--- a/docs/images/clickhouse-data-lake.svg
+++ b/docs/images/clickhouse-data-lake.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">ClickHouse security data lake closed-loop architecture</title>
-  <desc id="desc">Clean lane diagram showing signals, OCSF normalization, append-only ClickHouse storage, read-only replay, skill outputs, and HITL audit closure.</desc>
+  <desc id="desc">Clean lane diagram showing covered signals, OCSF normalization, append-only ClickHouse writes, governed ClickHouse tables, read-only replay, operator artifacts, HITL review, audit write-back, materialized views, and the customer-owned trust boundary.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -165,7 +165,7 @@
         <rect x="0" y="48" width="190" height="34" rx="9" fill="#0f2a3b" stroke="#38bdf8"/>
         <text x="95" y="70" text-anchor="middle" class="badge">dry-run default</text>
         <rect x="0" y="96" width="190" height="34" rx="9" fill="#0f2a3b" stroke="#38bdf8"/>
-        <text x="95" y="118" text-anchor="middle" class="badge">validated table name</text>
+        <text x="95" y="118" text-anchor="middle" class="badge">identifier validated</text>
       </g>
     </g>
 
@@ -250,7 +250,7 @@
     <g filter="url(#softShadow)">
       <rect x="1052" y="858" width="454" height="72" rx="18" fill="#111827" stroke="#475569"/>
       <text x="1084" y="887" class="cardTitle">Customer-owned boundary</text>
-      <text x="1084" y="906" class="tiny">Endpoint, credentials, TLS, retention, tenancy,</text>
+      <text x="1084" y="906" class="tiny">Cluster, database, roles, TLS, retention, tenancy,</text>
       <text x="1084" y="922" class="tiny">and dashboard access stay under operator control.</text>
     </g>
 


### PR DESCRIPTION
## Summary
- Refine the README architecture layer SVG so the output sink column has readable S3, Snowflake, and ClickHouse labels without split words or cramped text.
- Align the ClickHouse data lake SVG and Mermaid source with the Snowflake terminology for identifier validation and customer-owned boundaries.
- Keep the visual changes scoped to existing README assets and code-native diagram sources.

## Verification
- `git diff --check`
- `rsvg-convert docs/images/architecture-layers.svg -o /tmp/cloud-ai-security-skills-diagrams/architecture-layers-next.png`
- `rsvg-convert docs/images/clickhouse-data-lake.svg -o /tmp/cloud-ai-security-skills-diagrams/clickhouse-data-lake-next.png`
- `rsvg-convert docs/images/snowflake-data-lake.svg -o /tmp/cloud-ai-security-skills-diagrams/snowflake-data-lake-current.png`
- Scoped secret-pattern grep over the touched Mermaid and SVG files

## Notes
- Visual review performed against rendered PNG snapshots.
- No passwords, PATs, or API-key literals were added.
