### PR TITLE
docs(harness): align invocation surface wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Agentic security skills for cloud and AI — 131 shipped skill bundles. OCSF 1.8 on the wire. 143 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, GitHub, Slack, Workday, Salesforce, SAP, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, and persistent cloud runners.](docs/images/hero-banner.svg)
+![Agentic security skills for cloud and AI — 131 shipped skill bundles. OCSF 1.8 on the wire. 143 CIS + NIST AI RMF benchmark checks. Framework coverage across MITRE ATT&CK, MITRE ATLAS, OWASP Top 10, and OWASP LLM Top 10. MCP-audited tool calls. HITL dual-audited remediation. Runs against AWS, GCP, Azure, Kubernetes, Okta, Microsoft Entra, Google Workspace, GitHub, Slack, Workday, Salesforce, SAP, Snowflake, Databricks, ClickHouse, and MCP proxy. Access surfaces: CLI, CI, MCP, webhook, library, and persistent cloud runners.](docs/images/hero-banner.svg)
 
 <p align="center">
   <a href="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml?query=branch%3Amain"><img alt="CI" src="https://github.com/msaad00/cloud-ai-security-skills/actions/workflows/ci.yml/badge.svg?branch=main"></a>
@@ -29,7 +29,7 @@
 ## Why pick this
 
 - **Plug-and-play in 60 seconds** — repo-shipped `.mcp.json` works in Claude Code out of the box; copy-paste configs for Claude Desktop, Cursor, Windsurf, Codex, Cortex, Zed in [`docs/AGENT_QUICKSTART.md`](docs/AGENT_QUICKSTART.md).
-- **Every skill is a single-concern bundle** — `SKILL.md + src/ + tests/` you can run as a stdin/stdout one-liner, an MCP tool, a CI step, a webhook, or a library call. Same bundle, no per-surface drift.
+- **Every skill is a single-concern bundle** — `SKILL.md + src/ + tests/` you can run as a stdin/stdout one-liner, an MCP tool, a CI step, a webhook, a library call, or a persistent runner. Same bundle, no per-surface drift.
 - **Built for agents, not just humans** — OCSF 1.8 on the wire, HMAC-chained audit, HITL gates and allowlist intersection enforced by the wrapper — so an LLM can't bypass the trust contract.
 - **Designed for closed-loop security work** — normalize, detect, evaluate, review, dry-run, remediate, and write audit/evidence rows back into the operator-owned lake.
 
@@ -58,7 +58,7 @@ python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py \
 #     For Claude Desktop, Cursor, Windsurf, Codex, Cortex, Zed: see docs/integrations/.
 ```
 
-Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent runners**. Same `SKILL.md + src/ + tests/`, no per-surface drift.
+Six surfaces, one bundle: **CLI · CI · MCP · webhook receiver · library · persistent runners**. Same `SKILL.md + src/ + tests/`, no per-surface drift.
 
 ## What this repo gives you
 
@@ -81,13 +81,20 @@ Five surfaces, one bundle: **CLI · CI · MCP · webhook receiver · persistent 
 
 **Which vendor signals normalize to OCSF today?** [`docs/INGEST_COVERAGE.md`](docs/INGEST_COVERAGE.md) — the canonical vendor × source × OCSF class matrix, **22 mappings shipped** (AWS · GCP · Azure · Entra · K8s · Okta · Workspace · MCP · **GitHub · Slack · Workday · Salesforce · SAP**) plus the 3 documented roadmap rows (native ClickHouse audit, AWS web-app exfil pipeline, Workspace beyond-login).
 
-**Why use these skills (vs ad-hoc Python your agent writes at runtime, vs LLM-written skills you commit, vs your team writing 90 from scratch)?** [`docs/WHY.md`](docs/WHY.md) — three different alternatives, three different answers. This repo is built for LLMs and agents to invoke (MCP, Agent SDK, library, CLI, webhook, runners — every surface). What you can't prompt-generate: the trust contract (HITL gates, three-layer sandbox, HMAC-chained audit, allowlist intersection, OCSF wire lock), the calibration values (real-corpus thresholds), the cross-cutting maintenance (OCSF version bumps, MITRE catalog updates, vendor schema drift). Cost framing: ~12 engineer-weeks of harness + ~240 hours of detector content to reach v0.10.0 parity, then the maintenance tax per release.
+**Why use these skills instead of ad-hoc agent code?** [`docs/WHY.md`](docs/WHY.md) compares runtime Python, committed LLM-written skills, and building the catalog from scratch. The short version:
+
+| Need | What this repo already gives you |
+|---|---|
+| Agent-callable execution | MCP, CLI, CI, webhook, library, and runners over the same skill bundle, with Agent SDK and LangGraph examples on top |
+| Trust contract | HITL gates, three-layer sandbox, HMAC-chained audit, allowlist intersection, OCSF wire lock |
+| Maintained security content | real-corpus thresholds, OCSF version bumps, MITRE catalog updates, vendor schema drift handling |
+| Cost baseline | ~12 engineer-weeks of harness plus ~240 hours of detector content to reach v0.10.0 parity, before ongoing maintenance |
 
 **Independent security grades.** [`docs/SECURITY_GRADES.md`](docs/SECURITY_GRADES.md) — auto-generated, regenerated weekly by `scripts/regen_security_grades.py`: Bandit (code findings), pip-audit (CVEs), agent-bom (skill trust + provenance), 13 in-repo trust-contract validators. Composite grade visible at the top of the doc.
 
 ## Architecture
 
-External signals enter through two intake layers, pass through two analyze layers, exit through two act layers, and persist through one output layer. MCP, CLI, CI, webhook, and runners all invoke the same skill bundle — the surface is transport, not behavior.
+External signals enter through two intake layers, pass through two analyze layers, exit through two act layers, and persist through one output layer. MCP, CLI, CI, webhook, library calls, and runners all invoke the same skill bundle — the surface is transport, not behavior.
 
 ![Clean architecture layers diagram — signals feed intake, analyze, act, and persist stages across the seven shipped skill layers.](docs/images/architecture-layers.svg)
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -14,9 +14,9 @@ Read next:
 
 Visuals: [`diagrams/agent-topology.mmd`](diagrams/agent-topology.mmd) renders the full surface set; [`diagrams/mcp-trust-boundary.mmd`](diagrams/mcp-trust-boundary.mmd) traces the wrapper lifecycle; [`diagrams/pipeline-blast-radius.mmd`](diagrams/pipeline-blast-radius.mmd) colour-codes each layer by capability.
 
-## Five surfaces, one bundle
+## Six surfaces, one bundle
 
-The same `SKILL.md + src/ + tests/` runs unchanged behind all five
+The same `SKILL.md + src/ + tests/` runs unchanged behind all six
 surfaces. None of them forks the skill model:
 
 | Surface | Where | Use when |
@@ -30,7 +30,7 @@ surfaces. None of them forks the skill model:
 
 ## Optional agentic SOC harness
 
-LangGraph / LangChain / SOAR sit above the five skill surfaces. They may own
+LangGraph / LangChain / SOAR sit above the six skill surfaces. They may own
 workflow state, model choice, routing, retries, checkpointing, escalation, and
 analyst-note drafting, but they do not own security facts or write authority.
 

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -116,9 +116,9 @@ Then comes the **maintenance tax**:
 - **Every vendor schema change** (Snowflake adds a column, Okta retires
   an event type, Entra renames a field) is a contract change. We see
   it once across the OSS commons; a fork sees it per-team.
-- **The five-surface harness** (CLI + CI + MCP + webhook + cloud-runner)
+- **The six-surface harness** (CLI + CI + MCP + webhook + library + cloud-runner)
   has to evolve together. Slip one surface and the contract drifts.
-  Same `SKILL.md` runs all five here; a fork that picks two has to
+  Same `SKILL.md` runs all six here; a fork that picks two has to
   port back when it needs the third.
 
 The OSS commons is the real argument against a fork: shared maintenance


### PR DESCRIPTION
Summary
- Align README and harness docs on the six shipped invocation surfaces: CLI, CI, MCP, webhook, library, and persistent runners.
- Replace a dense README value paragraph with a compact table for agent execution, trust contract, maintained content, and cost baseline.
- Keep LangGraph, LangChain, and Agent SDK positioned as orchestration/examples above the deterministic skill bundle.

Verification
- `git diff --check`
- `python scripts/validate_skill_count_consistency.py`
- `python examples/agents/check_langgraph_harness_drift.py`
- `rg -n "(?i)(password\\s*=|passwd\\s*=|pwd\\s*=|api[_-]?key\\s*=|secret\\s*=|token\\s*=|bearer\\s+[A-Za-z0-9._-]{12,}|ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16})" README.md docs/HARNESS.md docs/WHY.md || true`
