### PR TITLE
docs(mcp): align SSE transport status

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -410,7 +410,7 @@ This section is the heart of the design. Without it, each agent (Claude Code, Co
 2. **Tool spec generation** — each skill becomes one MCP tool. Tool name = `SKILL.md` `name` field. Tool description = the full frontmatter `description` (which already leads with "Use when…" and closes with "Do NOT use…" per the Anthropic pattern).
 3. **Input schema** — current implementation exposes a conservative `input: string` (stdin payload) and `args: string[]` (fixed CLI args passed to the skill entrypoint). This keeps the wrapper thin and avoids inventing a second API surface. Tighter CLI-derived schemas are a follow-up.
 4. **Invocation** — the server shells out to `python3 <skill-path>/src/<entry>.py`, streams the tool's `input` to the skill's stdin, captures stdout, and wraps non-zero exits as MCP tool errors with stderr attached.
-5. **Transport** — stdio (local) ships now. HTTP/SSE stays a follow-up for hosted deployments.
+5. **Transport** — stdio (local) is the default. The opt-in SSE / streamable HTTP listener ships under [`mcp-server/src/transports/sse.py`](../mcp-server/src/transports/sse.py), keeps the same dispatch and audit contract, and is documented in [`MCP_TRANSPORT.md`](MCP_TRANSPORT.md).
 
 ### Why MCP and not a bespoke API
 
@@ -513,7 +513,7 @@ This is the architectural roadmap. Vendor-story PRs (#29–#39) continue in para
 |---|---|---|---|
 | **ARCHITECTURE.md** | This document | **P0** | Locks the design so every subsequent PR lands correctly |
 | **PR #39 reshape** | `git mv` skills into `ingest-*`, `evaluate-*`, `remediate-*`, etc. Add empty `sinks/` `runners/` `mcp-server/` `query/` dirs with READMEs. | **P0** | Without this, later PRs land in the wrong place and we pay for it twice |
-| **PR U — mcp-server** | Auto-discover every skill, expose via MCP stdio + HTTP/SSE, test against Claude Code + Cortex Code CLI | **P0** | The single highest-leverage PR: unlocks every agent for every future skill |
+| **PR U — mcp-server** | Auto-discover every skill, expose via MCP stdio plus opt-in SSE / streamable HTTP, test against Claude Code + Cortex Code CLI | **P0** | The single highest-leverage PR: unlocks every agent for every future skill |
 | **PR T — sink-snowflake-ocsf** | Schema DDL, COPY INTO loader, idempotent MERGE, Cortex query pack, Cortex Analyst semantic model | **P0** | Proves the persistent mode works end-to-end, directly enables Cortex Code CLI users |
 | **PR X — enrich-pii-redact-ocsf** | Field-level redaction with rule config, **gates every sink run in regulated mode** | **P0** | Regulatory prerequisite — no sink runs in a regulated environment without it |
 | **PR V — first runner** | `runner-s3-to-snowflake` with checkpoint state, idempotency tests | P1 | Proves streaming mode works. Unlocks continuous pipeline |

--- a/docs/RUNTIME_ISOLATION.md
+++ b/docs/RUNTIME_ISOLATION.md
@@ -163,7 +163,7 @@ Transport expectations:
 - TLS for external API calls and remote sinks
 - local MCP uses stdio, not an unauthenticated network listener
 - MCP wrappers should emit invocation audit events that identify the tool, caller context presence, approval context presence, exit code, and a hashed argument payload without echoing secrets or raw stdin
-- any future HTTP or SSE transport must add explicit authentication, integrity, and timeout controls
+- any network MCP transport must add explicit authentication, integrity, and timeout controls; the shipped opt-in SSE / streamable HTTP transport uses bearer keys, public-bind refusal, shared audit-chain integrity, and the same per-call timeout path as stdio
 
 Storage expectations:
 - findings, evidence, and inventories should be encrypted at rest in the chosen sink

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-Thin stdio MCP wrapper for `cloud-ai-security-skills`.
+Thin MCP wrapper for `cloud-ai-security-skills`.
 
 This server does not replace the existing skills model. It auto-discovers
 `skills/*/*/SKILL.md`, resolves each supported skill to its existing Python
@@ -92,3 +92,10 @@ python3 mcp-server/src/server.py
 ```
 
 Project-scoped Claude Code config lives in the repo root at [`.mcp.json`](../.mcp.json).
+
+Transports:
+
+- `stdio` is the default local MCP transport.
+- `sse` / streamable HTTP is opt-in for networked clients and requires bearer
+  keys plus the dependency groups documented in
+  [`docs/MCP_TRANSPORT.md`](../docs/MCP_TRANSPORT.md).

--- a/mcp-server/src/transports/sse.py
+++ b/mcp-server/src/transports/sse.py
@@ -64,7 +64,8 @@ try:  # pragma: no cover - exercised only when the extra is missing
 except ModuleNotFoundError as exc:  # pragma: no cover
     raise ModuleNotFoundError(
         "mcp-server SSE transport requires `sse-starlette`, `starlette`, and "
-        "`uvicorn`. Install with `uv sync --group dev --extra mcp-sse` or pin "
+        "`uvicorn`. Install with "
+        "`uv sync --group dev --group mcp-sse --group http-runtime` or pin "
         "those packages in your deployment image."
     ) from exc
 
@@ -324,7 +325,7 @@ def serve() -> int:
     except ModuleNotFoundError as exc:  # pragma: no cover
         raise ModuleNotFoundError(
             "mcp-server SSE transport requires `uvicorn`. Install with "
-            "`uv sync --group dev --extra mcp-sse`."
+            "`uv sync --group dev --group http-runtime`."
         ) from exc
     bind = (os.environ.get(BIND_ENV) or DEFAULT_BIND).strip() or DEFAULT_BIND
     port_raw = (os.environ.get(PORT_ENV) or "").strip()

--- a/mcp-server/tests/test_sse_transport.py
+++ b/mcp-server/tests/test_sse_transport.py
@@ -41,8 +41,8 @@ GOLDEN_DIR = REPO_ROOT / "skills" / "detection-engineering" / "golden"
 # the read-only path is well-trodden.
 
 # Skip the whole suite when sse-starlette / starlette is not installed
-# in the active venv. The repo's `mcp-sse` extra pulls them in; CI
-# pre-installs the dev group + all extras.
+# in the active venv. The repo's `mcp-sse` dependency group pulls them
+# in; CI pre-installs the dev group plus optional transport groups.
 sse_starlette = pytest.importorskip("sse_starlette")
 starlette = pytest.importorskip("starlette")
 from starlette.testclient import TestClient  # noqa: E402


### PR DESCRIPTION
Summary
- Update architecture/runtime docs so SSE / streamable HTTP is described as a shipped opt-in transport, not future work.
- Point the MCP server README at the transport contract while preserving stdio as the default local path.
- Fix SSE transport missing-dependency hints to use the repo's dependency groups instead of stale `--extra` wording.

Verification
- `git diff --check`
- `uv run ruff check mcp-server/src/transports/sse.py mcp-server/tests/test_sse_transport.py --config pyproject.toml`
- `uv run pytest mcp-server/tests/test_sse_transport.py -q -rs`
- `uv run --group mcp-sse --group http-runtime pytest mcp-server/tests/test_sse_transport.py -q`
- `python scripts/validate_doc_counts.py`
- `python scripts/validate_skill_count_consistency.py`
- stale MCP/SSE wording search over mcp-server/docs/tests
- scoped literal-secret scan over changed files
