### PR TITLE
docs(roadmap): align closed vendor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Six surfaces, one bundle: **CLI · CI · MCP · webhook receiver · library · p
 
 **Find a skill:** [`docs/SKILL_INDEX.md`](docs/SKILL_INDEX.md) groups every shipped skill by **environment** (AWS · GCP · Azure/Entra · K8s · Identity · AI/MCP · Web · Cross-env) and by **purpose** (ingest / discover / detect / evaluate / remediate / view / output / source), and points at the framework-mapping docs for control-catalog pivots.
 
-**Which vendor signals normalize to OCSF today?** [`docs/INGEST_COVERAGE.md`](docs/INGEST_COVERAGE.md) — the canonical vendor × source × OCSF class matrix, **22 mappings shipped** (AWS · GCP · Azure · Entra · K8s · Okta · Workspace · MCP · **GitHub · Slack · Workday · Salesforce · SAP**) plus the 3 documented roadmap rows (native ClickHouse audit, AWS web-app exfil pipeline, Workspace beyond-login).
+**Which vendor signals normalize to OCSF today?** [`docs/INGEST_COVERAGE.md`](docs/INGEST_COVERAGE.md) — the canonical vendor × source × OCSF class matrix, **22 ingest skills shipped** (AWS · GCP · Azure · Entra · K8s · Okta · Workspace · MCP · **GitHub · Slack · Workday · Salesforce · SAP**) plus explicit not-yet-shipped rows for native ClickHouse audit, AWS web-app exfil pipeline, and Workspace Drive / Mobile depth.
 
 **Why use these skills instead of ad-hoc agent code?** [`docs/WHY.md`](docs/WHY.md) compares runtime Python, committed LLM-written skills, and building the catalog from scratch. The short version:
 

--- a/docs/INGEST_COVERAGE.md
+++ b/docs/INGEST_COVERAGE.md
@@ -5,7 +5,8 @@ through this repo's ingest layer — and what's not yet covered.
 
 This page is the single source of truth for **"which signal can I send and
 get OCSF out the other side?"** The rows below are the canonical answer at
-HEAD; the roadmap rows below are tracked in their linked issues.
+HEAD; the not-yet-shipped rows below distinguish active tracking issues from
+explicit follow-on gaps.
 
 ## Currently shipped — 22 ingest skills
 
@@ -56,13 +57,13 @@ A dedicated native `ingest-clickhouse-query-log-ocsf` is on the roadmap (see
 below) — for now `detect-clickhouse-bulk-export` reads `system.query_log`
 records already shaped as OCSF API Activity 6003 by an upstream pipeline.
 
-## Roadmap — not yet shipped, tracked
+## Roadmap and explicit gaps — not yet shipped
 
-| Vendor | Source | Target OCSF class | Tracking |
+| Vendor | Source | Target OCSF class | Tracking / disposition |
 |---|---|---|---|
 | ClickHouse | `system.query_log` native ingest | API Activity 6003 | [`#436`](https://github.com/msaad00/cloud-ai-security-skills/issues/436) — `ingest-clickhouse-query-log-ocsf` |
 | AWS | Lambda + API Gateway access logs | HTTP Activity 4002 | [`#253`](https://github.com/msaad00/cloud-ai-security-skills/issues/253) — first detection-side use case is the web-app exfil arc |
-| Google Workspace | Drive / Mobile feeds (beyond login, token, and admin role activity) | API Activity 6003 + User Access 3005 | [`#32`](https://github.com/msaad00/cloud-ai-security-skills/issues/32) — follow-on vendor depth |
+| Google Workspace | Drive / Mobile feeds (beyond login, token, and admin role activity) | API Activity 6003 + User Access 3005 | Explicit follow-on gap; [`#32`](https://github.com/msaad00/cloud-ai-security-skills/issues/32) delivered the login / token / admin baseline |
 
 ## What "shipped" means here
 
@@ -73,15 +74,15 @@ A row in the shipped table guarantees:
 3. The skill is exercised by at least one downstream detector or test in CI.
 4. The OCSF wire shape is locked by snapshot test.
 
-A row in the roadmap table guarantees:
+A row in the roadmap / explicit-gaps table guarantees:
 
-1. There's a tracking issue (linked).
+1. If a tracking issue is linked, it owns the next shipped slice; otherwise the row is a deliberately documented gap, not an active claim.
 2. The intended OCSF class is documented up-front.
 3. Nothing is half-built or stubbed in the repo today.
 
 ## Adding a new vendor mapping
 
-1. Open or claim the tracking issue.
+1. Open or claim the tracking issue, unless the row is only being documented as an explicit future gap.
 2. Add the SKILL.md + `src/ingest.py` + golden fixture under `skills/ingestion/ingest-<vendor>-<source>-ocsf/`.
 3. Run `scripts/coverage_summary.py --write` and `scripts/generate_framework_coverage_doc.py` to refresh the auto-generated docs.
 4. Move the row in this file from the roadmap table to the shipped table in the same PR.

--- a/skills/detection/detect-admin-role-grant-workspace/SKILL.md
+++ b/skills/detection/detect-admin-role-grant-workspace/SKILL.md
@@ -83,6 +83,6 @@ export WORKSPACE_AUTHORIZED_ADMIN_ROLE_GRANTERS="breakglass-admin@example.com"
 cat workspace-admin.ocsf.jsonl | python src/detect.py > workspace-admin-role-findings.ocsf.jsonl
 ```
 
-## Roadmap
+## Delivery note
 
-Part of Google Workspace vendor story issue #32.
+Delivered as part of Google Workspace vendor story issue #32.

--- a/skills/detection/detect-suspicious-oauth-grant-workspace/SKILL.md
+++ b/skills/detection/detect-suspicious-oauth-grant-workspace/SKILL.md
@@ -78,6 +78,6 @@ export WORKSPACE_PREAPPROVED_OAUTH_CLIENT_IDS="trusted-client-1,trusted-client-2
 cat workspace-admin.ocsf.jsonl | python src/detect.py > workspace-oauth-findings.ocsf.jsonl
 ```
 
-## Roadmap
+## Delivery note
 
-Part of Google Workspace vendor story issue #32.
+Delivered as part of Google Workspace vendor story issue #32.

--- a/skills/ingestion/ingest-workspace-admin-ocsf/SKILL.md
+++ b/skills/ingestion/ingest-workspace-admin-ocsf/SKILL.md
@@ -103,6 +103,6 @@ python src/ingest.py workspace-admin-reports.json --output-format native > works
 - Preserves native identifiers for audit correlation.
 - Keeps unsupported event names visible in stderr so coverage gaps are measurable.
 
-## Roadmap
+## Delivery note
 
-Part of Google Workspace vendor story issue #32.
+Delivered as part of Google Workspace vendor story issue #32.


### PR DESCRIPTION
Summary
- Clarifies README ingest coverage as 22 shipped ingest skills plus explicit not-yet-shipped rows.
- Updates INGEST_COVERAGE roadmap language so closed Workspace issue #32 is not presented as an active follow-on tracker.
- Converts Workspace skill roadmap notes into delivery notes for the shipped #32 work.

Verification
- python scripts/validate_skill_count_consistency.py
- python scripts/validate_doc_counts.py
- python scripts/validate_skill_contract.py
- git diff --check
- focused secret-pattern scan on touched files

Notes
- Docs-only change. No generated assets or runtime behavior changed.
- Existing untracked duplicate files with ` 2` suffix were left unstaged.