### PR TITLE
docs(counts): extend drift coverage

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -1,6 +1,6 @@
 # Agent Quickstart
 
-Give any agent these 117 skills in under 60 seconds. Pick your client,
+Give any agent these 131 skills in under 60 seconds. Pick your client,
 paste the snippet, restart. Replace `/abs/path/to/cloud-ai-security-skills`
 with the absolute path to your local clone.
 

--- a/docs/CLICKHOUSE_DATA_LAKE.md
+++ b/docs/CLICKHOUSE_DATA_LAKE.md
@@ -21,7 +21,7 @@ visible because the shipped tables are append-only `MergeTree` tables.
    any cloud / SaaS / IdP / K8s / MCP signal
                          │
                          ▼
-                ingest-*  (17 skills)        ──── L1 normalize to OCSF 1.8
+                ingest-*  (22 skills)        ──── L1 normalize to OCSF 1.8
                          │
                          ▼
                 sink-clickhouse-jsonl --apply ──── L7 append-only insert
@@ -41,7 +41,7 @@ visible because the shipped tables are append-only `MergeTree` tables.
                 source-clickhouse-query        ──── read-only SQL gate
                          │
                          ▼
-                detect-*  (64 skills)          ──── L3 deterministic rules
+                detect-*  (71 skills)          ──── L3 deterministic rules
                 view-*    (2 skills)           ──── L6 SARIF / Mermaid
                 discover-control-evidence      ──── L2 posture / compliance
                          │

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -36,7 +36,7 @@ on a stdlib-only Python 3.11+. Cloud-specific skills (anything that talks to
 AWS / GCP / Azure / K8s / Snowflake / Databricks / ClickHouse) need their
 group installed first: `uv sync --group dev --group <cloud>`.
 
-> No top-level CLI is shipped today (the repo is structured as 117
+> No top-level CLI is shipped today (the repo is structured as 131
 > independent skill bundles, not a single binary). A `uvx`-installable entry
 > point that wraps the most common pipelines is tracked as a P1 follow-up.
 

--- a/docs/SNOWFLAKE_DATA_LAKE.md
+++ b/docs/SNOWFLAKE_DATA_LAKE.md
@@ -21,7 +21,7 @@ make replay windows duplicate-aware, while the shipped tables stay append-only.
    any cloud / SaaS / IdP / K8s / MCP signal
                          │
                          ▼
-                ingest-*  (17 skills)         ──── L1 normalize to OCSF 1.8
+                ingest-*  (22 skills)         ──── L1 normalize to OCSF 1.8
                          │
                          ▼
                 sink-snowflake-jsonl --apply  ──── L7 append-only insert

--- a/scripts/validate_skill_count_consistency.py
+++ b/scripts/validate_skill_count_consistency.py
@@ -50,6 +50,27 @@ CLAIMS: list[Claim] = [
     # descriptions are now checked directly because these visuals are source SVG.
     # docs/ARCHITECTURE.md claims
     (REPO_ROOT / "docs" / "ARCHITECTURE.md", r"(\d+) shipped detectors", "detection"),
+    (REPO_ROOT / "docs" / "AGENT_QUICKSTART.md", r"Give any agent these (\d+) skills", "total"),
+    (
+        REPO_ROOT / "docs" / "QUICKSTART.md",
+        r"repo is structured as (\d+)[\s>]+independent\s+skill bundles",
+        "total",
+    ),
+    (
+        REPO_ROOT / "docs" / "CLICKHOUSE_DATA_LAKE.md",
+        r"ingest-\*\s+\((\d+) skills\)",
+        "ingest_only",
+    ),
+    (
+        REPO_ROOT / "docs" / "CLICKHOUSE_DATA_LAKE.md",
+        r"detect-\*\s+\((\d+) skills\)",
+        "detection",
+    ),
+    (
+        REPO_ROOT / "docs" / "SNOWFLAKE_DATA_LAKE.md",
+        r"ingest-\*\s+\((\d+) skills\)",
+        "ingest_only",
+    ),
     # Core SVG / alt-text surfaces that drifted during the ATT&CK + CIS expansion.
     (
         REPO_ROOT / "docs" / "images" / "runtime-surfaces.svg",


### PR DESCRIPTION
Summary
- Updates stale public skill counts in AGENT_QUICKSTART, QUICKSTART, ClickHouse lake, and Snowflake lake docs.
- Corrects lake TL;DR ingest and detection counts to match the current 131-skill registry.
- Extends scripts/validate_skill_count_consistency.py so these docs are count-gated in CI.

Verification
- python scripts/validate_skill_count_consistency.py
- python scripts/validate_doc_counts.py
- git diff --check
- targeted stale-count and secret-pattern scan on touched files

Notes
- Docs/validator-only change. Runtime behavior and generated assets unchanged.
- Existing untracked duplicate files with ` 2` suffix were left unstaged.