### PR TITLE
chore(audit): fix dependabot lockfile drift class, stale docs, and tooling parity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "pip"
+  # "uv" (not "pip") so Dependabot updates uv.lock together with
+  # pyproject.toml — the pip ecosystem edits only pyproject.toml, which
+  # fails CI's `uv lock --check` gate on every Python bump PR.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 repos:
+  # Keep revs aligned with the versions locked in uv.lock so pre-commit
+  # and `uv run ruff/bandit` agree on findings and formatting.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.10
     hooks:
       - id: ruff
       - id: ruff-format
@@ -12,7 +14,7 @@ repos:
       - id: check-yaml
       - id: check-merge-conflict
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
+    rev: 1.9.4
     hooks:
       - id: bandit
         args:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,11 +49,11 @@ python skills/ingestion/ingest-k8s-audit-ocsf/src/ingest.py audit.jsonl \
 
 | Layer | Shipped | Planned / roadmap |
 |---|---|---|
-| L1 Ingest | 15 shipped ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, MCP | more identity and SaaS sources as demand justifies |
-| L2 Discover | 4 shipped skills (AI BOM, cloud control evidence, control evidence, environment graph) | wider SaaS and infra evidence sources |
-| L3 Detect | 12 shipped detectors tied to MITRE ATT&CK techniques (lateral movement, K8s container escape, K8s privesc + secret read, MCP tool drift, MCP prompt injection, Okta MFA fatigue, Okta credential stuffing, Entra credential addition, Entra role grant, Workspace suspicious login, AWS open security-group) | impossible travel, more AI-agent signals |
-| L4 Evaluate | 7 shipped benchmarks (CIS AWS / GCP / Azure, K8s, Docker / container, GPU cluster, model serving) | native by default, OCSF Compliance Finding (`class_uid=2003`) shipped as opt-in output |
-| L5 Remediate | `iam-departures-aws`, `remediate-aws-sg-revoke`, `remediate-okta-session-kill`, `remediate-container-escape-k8s`, `remediate-k8s-rbac-revoke`, `remediate-mcp-tool-quarantine`, `remediate-entra-credential-revoke`, and `remediate-workspace-session-kill` with HITL, dual audit, dry-run | broader remediation families (see issues #155, #242, #307) |
+| L1 Ingest | 22 shipped ingesters across AWS, GCP, Azure, K8s, Okta, Entra, Workspace, GitHub, Slack, Salesforce, SAP, Workday, MCP, plus 4 source adapters (S3 Select, Snowflake, Databricks, ClickHouse) | more identity and SaaS sources as demand justifies |
+| L2 Discover | 5 shipped skills (AI BOM, cloud control evidence, control evidence, environment graph, IAM-departures reconciler) | wider SaaS and infra evidence sources |
+| L3 Detect | 71 shipped detectors tied to MITRE ATT&CK / OWASP techniques (lateral movement, K8s container escape + privesc + secret read, MCP tool drift + prompt injection, identity attacks across Okta / Entra / Workspace, cloud-config and AI-runtime signals) | impossible travel, more AI-agent signals |
+| L4 Evaluate | 12 shipped benchmarks (CIS AWS / GCP / Azure, K8s, Docker / container, GPU cluster, model serving, CIS AWS Foundations OCSF, NIST AI RMF govern / map / measure / manage) | native by default, OCSF Compliance Finding (`class_uid=2003`) shipped as opt-in output |
+| L5 Remediate | 12 shipped HITL-gated write skills — `iam-departures-{aws,gcp,azure-entra}`, network revokes (`remediate-aws-sg-revoke`, `remediate-gcp-firewall-revoke`, `remediate-azure-nsg-revoke`), session kills (Okta, Workspace), `remediate-container-escape-k8s`, `remediate-k8s-rbac-revoke`, `remediate-mcp-tool-quarantine`, `remediate-entra-credential-revoke` — all with HITL, dual audit, dry-run | broader remediation families (see issues #155, #242, #307) |
 | L6 View | `convert-ocsf-to-sarif`, `convert-ocsf-to-mermaid-attack-flow` | graph overlay, warehouse-ready converters |
 | L7 Output | 3 shipped sinks (`sink-s3-jsonl`, `sink-snowflake-jsonl`, `sink-clickhouse-jsonl`) | BigQuery, Security Lake |
 
@@ -70,7 +70,7 @@ skills/
 └── output/         ← L7 (sink-* skills: append-only persistence)
 ```
 
-The repo ships **54 skills** across these seven layers and the three `source-*` adapters (15 + 4 + 12 + 7 + 8 + 2 + 3, plus 3 `source-*` adapters accounted for under ingestion).
+The repo ships **131 skills** across these seven layers: 22 ingest skills plus 4 `source-*` adapters, 5 discover, 71 detect, 12 evaluate, 12 remediate, 2 view, and 3 output sinks. The authoritative per-skill registry is [`docs/framework-coverage.json`](docs/framework-coverage.json); `scripts/validate_doc_counts.py` gates this paragraph against it in CI.
 
 `skills/detection-engineering/` holds the shared OCSF contract and frozen
 golden fixtures. Executable skills live only under the six layered

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,12 @@ validate:
 	python scripts/validate_framework_coverage.py
 	python scripts/validate_ocsf_metadata.py
 	python scripts/validate_skill_count_consistency.py
+	python scripts/validate_doc_counts.py
 	python scripts/validate_deny_list_parity.py
+	python scripts/validate_captured_provenance.py
+	python scripts/add_skill_trust_frontmatter.py --check
+	python scripts/validate_safe_skill_bar.py
+	python scripts/validate_golden_ocsf.py
 	$(MAKE) docs-check
 
 test:

--- a/presets/README.md
+++ b/presets/README.md
@@ -30,7 +30,7 @@ broader composition model.
 | Preset | Use case | Atoms | Write paths? |
 |---|---|---|---|
 | [`preset-cspm-readonly.json`](preset-cspm-readonly.json) | continuous CSPM scanning + posture review | the three `cspm-*-cis-benchmark` skills, K8s + container + GPU + model-serving evaluation, `convert-ocsf-to-sarif` | none |
-| [`preset-detection-only.json`](preset-detection-only.json) | feed raw logs through ingest + detect, hand findings to a SIEM | the 15 ingest skills, the 29 detect skills, both view skills | none |
+| [`preset-detection-only.json`](preset-detection-only.json) | feed raw logs through ingest + detect, hand findings to a SIEM | a curated 15-ingest / 32-detect subset plus both view skills (the JSON is authoritative) | none |
 | [`preset-incident-response.json`](preset-incident-response.json) | the workflow at [`../examples/workflows/incident-response-okta-mfa-fatigue.md`](../examples/workflows/incident-response-okta-mfa-fatigue.md) | one detector + one discover + one remediate | one HITL-gated session kill |
 | [`preset-ai-runtime.json`](preset-ai-runtime.json) | runtime guardrails for an AI agent platform — detect prompt injection, tool drift, exfiltration | MCP-proxy ingest, the AI-runtime detectors, MCP tool quarantine | one HITL-gated tool quarantine |
 

--- a/runners/README.md
+++ b/runners/README.md
@@ -31,6 +31,9 @@ Read next:
   any-source POST → shipped ingest skill → fan-out to S3 / Snowflake /
   ClickHouse sinks. Default-deny routing, HMAC + bearer auth, single-process
   FastAPI app deployable on App Runner / Cloud Run / Container Apps / Kubernetes.
+- [`mcp-sse`](mcp-sse/): remote MCP SSE transport for the skills server —
+  Dockerfile, Helm chart, and docker-compose packaging so agents can reach the
+  same MCP tool surface over the network instead of stdio.
 
 This is a reference template, not a multi-tenant managed service. Operators still
 own packaging, deployment, sink wiring, IAM review, and environment-specific
@@ -38,10 +41,11 @@ controls.
 
 ## Live Deployment Status
 
-All three runners are shipped and CI-validated.
+All five runners (the three cloud detect pipelines, the webhook receiver, and
+the MCP SSE transport) are shipped and CI-validated.
 
 The repo does not yet claim a captured real-cloud deploy-and-first-event proof
-for all three templates. That remaining work is tracked in
+for all templates. That remaining work is tracked in
 [`#198`](https://github.com/msaad00/cloud-ai-security-skills/issues/198) and
 summarized in [DEPLOYMENT_VERIFICATION.md](DEPLOYMENT_VERIFICATION.md).
 

--- a/scripts/validate_doc_counts.py
+++ b/scripts/validate_doc_counts.py
@@ -72,6 +72,7 @@ def main() -> int:
     skill_index = REPO_ROOT / "docs" / "SKILL_INDEX.md"
     agents = REPO_ROOT / "AGENTS.md"
     mappings = REPO_ROOT / "docs" / "FRAMEWORK_MAPPINGS.md"
+    architecture = REPO_ROOT / "ARCHITECTURE.md"
 
     candidates: list[str | None] = [
         check(readme, r"(\d+)\s+shipped skill bundles", total, "README total"),
@@ -98,6 +99,15 @@ def main() -> int:
             fws.get("mitre-attack-v14", 0),
             "FRAMEWORK_MAPPINGS ATT&CK",
         ),
+        check(architecture, r"repo ships \*\*(\d+) skills\*\*", total, "ARCHITECTURE total"),
+        check(architecture, r"(\d+) ingest skills plus", layers["ingestion"], "ARCHITECTURE ingest"),
+        check(architecture, r"plus (\d+) `source-\*` adapters", layers["sources"], "ARCHITECTURE sources"),
+        check(architecture, r"(\d+) discover", layers["discovery"], "ARCHITECTURE discover"),
+        check(architecture, r"(\d+) detect", layers["detection"], "ARCHITECTURE detect"),
+        check(architecture, r"(\d+) evaluate", layers["evaluation"], "ARCHITECTURE evaluate"),
+        check(architecture, r"(\d+) remediate", layers["remediation"], "ARCHITECTURE remediate"),
+        check(architecture, r"(\d+) view", layers["view"], "ARCHITECTURE view"),
+        check(architecture, r"(\d+) output sinks", layers["output"], "ARCHITECTURE output"),
     ]
     errors: list[str] = [e for e in candidates if e is not None]
     if errors:


### PR DESCRIPTION
## Summary

Findings from an end-to-end repo audit (all tests, mypy, bandit, pip-audit, and the full validator set pass on main — these are the hygiene gaps that remained):

- **Dependabot → uv ecosystem**: the `pip` ecosystem edits only `pyproject.toml`, so every Python bump PR failed CI's `uv lock --check` gate (e.g. #555). The native `uv` ecosystem updates `uv.lock` together with the manifest, fixing this class of failures at the source.
- **Stale root `ARCHITECTURE.md`**: claimed 54 skills with old per-layer counts; refreshed to the real 131 (22+4 ingest, 5 discover, 71 detect, 12 evaluate, 12 remediate, 2 view, 3 output) and added it to `validate_doc_counts.py` so it can't drift silently again.
- **`presets/README.md`**: corrected the `preset-detection-only` description (said 15/29, JSON actually allowlists 15 ingest / 32 detect).
- **`runners/README.md`**: "all three runners" → five (adds `webhook-receiver` context and lists the previously undocumented `mcp-sse` runner).
- **Makefile parity**: `make validate` was missing 5 validators CI runs (`doc_counts`, `captured_provenance`, `trust_frontmatter --check`, `safe_skill_bar`, `golden_ocsf`) — local green could still fail CI.
- **Pre-commit rev drift**: ruff `v0.6.9` → `v0.15.10`, bandit `1.7.10` → `1.9.4`, matching the versions locked in `uv.lock`.

## Test plan

- [x] `make validate` (full validator set incl. new ARCHITECTURE.md count gates)
- [x] `ruff check` clean
- [x] `pytest skills/ tests/` — full suite green
- [x] `validate_doc_counts.py` passes with the new ARCHITECTURE.md checks

Made with [Cursor](https://cursor.com)