### PR TITLE
docs: fix README quickstart groups and SVG text-overflow bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git clone --branch v0.11.0 https://github.com/msaad00/cloud-ai-security-skills.g
 cd cloud-ai-security-skills
 
 # 2 · Install only the deps the skills you'll run need
-uv sync --group dev --group aws --group k8s        # or --group gcp / --group azure / --group ai-runtime / --group databricks / --group snowflake / --group clickhouse / --group identity / --group saas
+uv sync --group dev --group aws        # or --group gcp / --group azure / --group mcp / --group iam_departures / --group langgraph / --group webhook — see docs/INSTALL.md
 
 # 3 · Run a detection on a captured fixture (no cloud creds needed)
 python skills/ingestion/ingest-cloudtrail-ocsf/src/ingest.py \

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -62,10 +62,10 @@
         <rect x="102" y="470" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
         <text x="166" y="494" text-anchor="middle">Warehouses</text>
       </g>
-      <text x="110" y="540" font-size="13" fill="#94a3b8">AWS · GCP · Azure · K8s</text>
-      <text x="110" y="560" font-size="13" fill="#94a3b8">Okta · Entra · Workspace</text>
-      <text x="110" y="580" font-size="13" fill="#94a3b8">Slack · Workday · Salesforce</text>
-      <text x="110" y="600" font-size="13" fill="#94a3b8">Snowflake · Databricks · MCP</text>
+      <text x="110" y="540" font-size="11" fill="#94a3b8">AWS · GCP · Azure · K8s</text>
+      <text x="110" y="560" font-size="11" fill="#94a3b8">Okta · Entra · Workspace</text>
+      <text x="110" y="580" font-size="11" fill="#94a3b8">Slack · Workday · Salesforce</text>
+      <text x="110" y="600" font-size="11" fill="#94a3b8">Snowflake · Databricks · MCP</text>
     </g>
 
     <!-- L1 Ingest + L2 Discover (boxes widened to 260, descriptions wrapped to 2 short lines) -->

--- a/docs/images/clickhouse-data-lake.svg
+++ b/docs/images/clickhouse-data-lake.svg
@@ -64,7 +64,7 @@
     <text x="64" y="94" class="sub">Operator-owned storage, read-only replay, and audit closure for cloud, identity, Kubernetes, SaaS, and MCP security events.</text>
 
     <g transform="translate(1246,42)">
-      <rect x="0" y="0" width="290" height="70" rx="14" fill="#101827" stroke="#334155"/>
+      <rect x="0" y="0" width="322" height="70" rx="14" fill="#101827" stroke="#334155"/>
       <g transform="translate(22,18)">
         <rect x="0" y="0" width="12" height="34" fill="#facc15"/>
         <rect x="18" y="0" width="12" height="34" fill="#fbbf24"/>
@@ -115,7 +115,7 @@
           <circle cx="27" cy="29" r="17" fill="#2563eb"/>
           <text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#ffffff">AZ</text>
           <text x="55" y="26" class="badge">Azure</text>
-          <text x="55" y="43" class="tiny">activity · NSG</text>
+          <text x="50" y="43" class="tiny" style="font-size:10px">activity · NSG</text>
         </g>
         <g transform="translate(134,74)">
           <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>

--- a/docs/images/coverage-matrix.svg
+++ b/docs/images/coverage-matrix.svg
@@ -22,7 +22,7 @@
 
   <!-- Summary cards: keep the main truth visible before the long table. -->
   <g font-family="Inter, system-ui, sans-serif">
-    <rect x="1010" y="42" width="154" height="70" rx="14" fill="#052e2b" stroke="#22c55e"/>
+    <rect x="1010" y="42" width="166" height="70" rx="14" fill="#052e2b" stroke="#22c55e"/>
     <text x="1030" y="72" fill="#5eead4" font-size="24" font-weight="900">13 / 71</text>
     <text x="1030" y="94" fill="#bbf7d0" font-size="12" font-weight="800">closed-loop detections</text>
 
@@ -30,7 +30,7 @@
     <text x="1202" y="72" fill="#fbbf24" font-size="19" font-weight="900">HITL gated</text>
     <text x="1202" y="94" fill="#fed7aa" font-size="12" font-weight="800">dry-run before writes</text>
 
-    <rect x="1364" y="42" width="188" height="70" rx="14" fill="#2a0b1e" stroke="#ef4444"/>
+    <rect x="1364" y="42" width="208" height="70" rx="14" fill="#2a0b1e" stroke="#ef4444"/>
     <text x="1384" y="72" fill="#f87171" font-size="19" font-weight="900">Red = detect-first</text>
     <text x="1384" y="94" fill="#fecaca" font-size="12" font-weight="800">no autonomous action implied</text>
   </g>
@@ -480,7 +480,7 @@
     <text x="430"  y="1914" fill="#cbd5e1" font-size="14">OWASP LLM05 · OWASP MCP Top 10</text>
     <rect x="760"  y="1898" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1898" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1914" fill="#fee2e2" font-size="13">detection-only — MCP tool schema references a host outside MCP_PLUGIN_ALLOWED_HOSTS (#255)</text>
+    <text x="1020" y="1914" fill="#fee2e2" font-size="13">detection-only — MCP tool schema references a non-allowlisted host (#255)</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="1934" fill="#f1f5f9" font-size="14">detect-mcp-adversarial-input-corpus</text>
@@ -501,14 +501,14 @@
     <text x="430"  y="1974" fill="#cbd5e1" font-size="14">OWASP LLM10 · ATLAS AML.T0034</text>
     <rect x="760"  y="1958" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1958" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1974" fill="#fee2e2" font-size="13">detection-only — MCP tool responses repeatedly breach output ceilings in the same session (#255)</text>
+    <text x="1020" y="1974" fill="#fee2e2" font-size="13">detection-only — MCP tool responses repeatedly breach output ceilings (#255)</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="1994" fill="#f1f5f9" font-size="14">detect-azure-private-endpoint-to-external-sub</text>
     <text x="430"  y="1994" fill="#cbd5e1" font-size="14">T1071.001 / T1567 (TA0010)</text>
     <rect x="760"  y="1978" width="40" height="22" rx="4" fill="#16a34a" stroke="#22c55e"/>
     <rect x="880"  y="1978" width="40" height="22" rx="4" fill="#7f1d1d" stroke="#ef4444"/>
-    <text x="1020" y="1994" fill="#fee2e2" font-size="13">detection-only — Azure private endpoint pinned to a subscription outside the authorized set (#253)</text>
+    <text x="1020" y="1994" fill="#fee2e2" font-size="13">detection-only — Azure private endpoint pinned to an unauthorized subscription (#253)</text>
   </g>
   <g font-family="Inter, system-ui, sans-serif">
     <text x="48"   y="2014" fill="#f1f5f9" font-size="14">detect-aws-cloudtrail-event-selector-tampering</text>

--- a/docs/images/iam-departures-aws.svg
+++ b/docs/images/iam-departures-aws.svg
@@ -78,7 +78,7 @@
 
   <g font-family="Segoe UI, ui-sans-serif, Arial, sans-serif">
     <g transform="translate(46,38)">
-      <rect x="0" y="0" width="214" height="32" rx="16" fill="#221306" stroke="#f59e0b"/>
+      <rect x="0" y="0" width="240" height="32" rx="16" fill="#221306" stroke="#f59e0b"/>
       <use href="#aws" x="12" y="7" width="18" height="18"/>
       <text x="38" y="21" fill="#fbbf24" font-size="12" font-weight="800" letter-spacing="1.4">AWS FLAGSHIP WORKFLOW</text>
     </g>
@@ -164,7 +164,7 @@
     <g filter="url(#shadow)">
       <rect x="530" y="240" width="126" height="64" rx="12" fill="url(#panel)" stroke="#ec4899" stroke-width="1.4"/>
       <use href="#sfn" x="544" y="252" width="22" height="22"/>
-      <text x="574" y="267" fill="#fbcfe8" font-size="13" font-weight="800">Step Function</text>
+      <text x="574" y="267" fill="#fbcfe8" font-size="12" font-weight="800">Step Function</text>
       <text x="544" y="290" fill="#94a3b8" font-size="10">map · one user per item</text>
     </g>
 

--- a/docs/images/snowflake-data-lake.svg
+++ b/docs/images/snowflake-data-lake.svg
@@ -59,7 +59,7 @@
     <text x="64" y="94" class="sub">The same closed loop as ClickHouse, drawn for governed warehouse-native replay and audit write-back.</text>
 
     <g transform="translate(1238,38)">
-      <rect x="0" y="0" width="298" height="78" rx="16" fill="#101827" stroke="#334155"/>
+      <rect x="0" y="0" width="334" height="78" rx="16" fill="#101827" stroke="#334155"/>
       <g transform="translate(48,39)">
         <line x1="-24" y1="0" x2="24" y2="0" stroke="#bfdbfe" stroke-width="4" stroke-linecap="round"/>
         <line x1="0" y1="-24" x2="0" y2="24" stroke="#bfdbfe" stroke-width="4" stroke-linecap="round"/>
@@ -116,7 +116,7 @@
           <circle cx="25" cy="25" r="16" fill="#111827" stroke="#94a3b8"/>
           <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#f8fafc">ID</text>
           <text x="50" y="22" class="badge">Identity</text>
-          <text x="50" y="39" class="tiny">Entra, Okta</text>
+          <text x="47" y="39" class="tiny">Entra, Okta</text>
         </g>
 
         <g transform="translate(0,132)">
@@ -219,7 +219,7 @@
       <text x="460" y="684" class="body">detect-* rules</text>
       <text x="460" y="708" class="body">Snowflake detections</text>
       <text x="460" y="732" class="body">view-* renderers</text>
-      <text x="460" y="762" class="tiny" fill="#c4b5fd">UID windows prevent duplicate findings</text>
+      <text x="460" y="762" class="tiny" fill="#c4b5fd">UID windows stop duplicate findings</text>
     </g>
 
     <g filter="url(#softShadow)">


### PR DESCRIPTION
## Summary
- **README quickstart bug:** step 2 told users to run `uv sync --group k8s` and offered `ai-runtime / databricks / snowflake / clickhouse / identity / saas` — none of these groups exist in `pyproject.toml`, so the command fails with `Group 'k8s' is not defined`. The line now lists the real groups (`aws / gcp / azure / mcp / iam_departures / langgraph / webhook`) and points at `docs/INSTALL.md`.
- **SVG visual bugs:** fixed 12 text-overflow defects across five hand-authored SVGs in `docs/images/` where labels overflowed their container box or ran off the canvas edge:
  - `architecture-layers.svg` — vendor list lines overflowed the Signals panel
  - `clickhouse-data-lake.svg` — ClickHouse-pack card too narrow; Azure badge caption overflow
  - `snowflake-data-lake.svg` — Snowflake-pack card too narrow; Identity badge and replay-note overflow
  - `coverage-matrix.svg` — two summary cards too narrow; three `detection-only` note strings ran past the 1600 px canvas edge
  - `iam-departures-aws.svg` — flagship pill too narrow for its letter-spaced label; Step Function label overflow

## Verification
- Browser-based bounding-box audit of all 8 `docs/images/*.svg`: **0 overflow issues** after the fix (was 12 across 5 files).
- All 9 `docs/diagrams/*.mmd` and all 5 embedded mermaid blocks in docs parse and render clean under mermaid 11.
- README quickstart pipeline re-run end to end (`ingest → detect → SARIF`, 1 finding); every local README link target exists; `v0.11.0` tag verified.
- `scripts/validate_doc_counts.py` and `scripts/validate_skill_count_consistency.py` pass.

Made with [Cursor](https://cursor.com)