### PR TITLE
test: full-path runner handler tests and lake query-pack contracts

### DIFF
--- a/tests/integration/test_azure_runner_template.py
+++ b/tests/integration/test_azure_runner_template.py
@@ -3,11 +3,48 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import types
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+
+_PASSTHROUGH_CMD = f'{sys.executable} -c "import sys; sys.stdout.write(sys.stdin.read())"'
+_FAILING_CMD = f"{sys.executable} -c \"import sys; sys.stderr.write('boom'); sys.exit(3)\""
+
+
+def _azure_exceptions(monkeypatch) -> tuple[type[Exception], type[Exception]]:
+    """Return the exception classes _put_if_new imports lazily.
+
+    Uses the real azure-core classes when the SDK is installed; otherwise
+    installs a minimal stand-in module so the handler path still runs in
+    SDK-free CI lanes.
+    """
+    try:
+        from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+
+        return ResourceExistsError, ResourceNotFoundError
+    except ImportError:
+        pass
+
+    class _ResourceExistsError(Exception):
+        pass
+
+    class _ResourceNotFoundError(Exception):
+        pass
+
+    exceptions_module = types.ModuleType("azure.core.exceptions")
+    setattr(exceptions_module, "ResourceExistsError", _ResourceExistsError)
+    setattr(exceptions_module, "ResourceNotFoundError", _ResourceNotFoundError)
+    core_module = types.ModuleType("azure.core")
+    setattr(core_module, "exceptions", exceptions_module)
+    azure_module = types.ModuleType("azure")
+    setattr(azure_module, "core", core_module)
+    monkeypatch.setitem(sys.modules, "azure", azure_module)
+    monkeypatch.setitem(sys.modules, "azure.core", core_module)
+    monkeypatch.setitem(sys.modules, "azure.core.exceptions", exceptions_module)
+    return _ResourceExistsError, _ResourceNotFoundError
 
 
 def _load_module(name: str, path: Path):
@@ -169,6 +206,82 @@ class TestAzureBlobEventGridDetectRunner:
             "duplicates": 1,
         }
         assert published == [(lines[0], "finding-1")]
+
+    def test_ingest_event_payloads_accepts_object_and_array(self):
+        single = INGEST._event_payloads(json.dumps({"data": {"url": "https://a/b"}}))
+        assert single == [{"data": {"url": "https://a/b"}}]
+
+        batch = INGEST._event_payloads(json.dumps([{"data": {}}, "not-an-event", {"id": "2"}]))
+        assert batch == [{"data": {}}, {"id": "2"}]
+
+        with pytest.raises(ValueError, match="JSON object or array"):
+            INGEST._event_payloads(json.dumps("just a string"))
+
+    def test_ingest_blob_url_prefers_url_then_blob_url(self):
+        assert (
+            INGEST._blob_url({"data": {"url": " https://a/blob.jsonl "}}) == "https://a/blob.jsonl"
+        )
+        assert (
+            INGEST._blob_url({"data": {"blobUrl": "https://a/alt.jsonl"}}) == "https://a/alt.jsonl"
+        )
+        with pytest.raises(ValueError, match="data.url"):
+            INGEST._blob_url({"data": {}})
+
+    def test_ingest_run_skill_surfaces_skill_stderr(self, monkeypatch):
+        monkeypatch.setenv("INGEST_SKILL_CMD", _FAILING_CMD)
+        with pytest.raises(RuntimeError, match="boom"):
+            INGEST._run_skill("line-1\n")
+
+    def test_ingest_handles_message_batch_and_aggregates_counts(self, monkeypatch):
+        monkeypatch.setattr(INGEST, "_download_blob_text", lambda url: "payload")
+        monkeypatch.setattr(INGEST, "_run_skill", lambda payload: ["line-1", "line-2"])
+        monkeypatch.setattr(INGEST, "_enqueue_detect_lines", lambda lines: len(list(lines)))
+
+        body = json.dumps({"data": {"url": "https://account.blob.core.windows.net/c/b.jsonl"}})
+        result = INGEST.handle_ingest_messages([body, body])
+
+        assert result == {
+            "queue_messages_processed": 2,
+            "blob_events_processed": 2,
+            "blobs_processed": 2,
+            "messages_enqueued": 4,
+        }
+
+    def test_detect_run_skill_passes_lines_through(self, monkeypatch):
+        monkeypatch.setenv("DETECT_SKILL_CMD", _PASSTHROUGH_CMD)
+        assert DETECT._run_skill(["line-1", "line-2"]) == ["line-1", "line-2"]
+
+    def test_detect_put_if_new_dedupes_and_replaces_expired_rows(self, monkeypatch):
+        resource_exists, resource_not_found = _azure_exceptions(monkeypatch)
+        monkeypatch.setenv("DEDUPE_TTL_DAYS", "30")
+
+        class _FakeTable:
+            def __init__(self):
+                self.entities: dict[str, dict] = {}
+
+            def create_entity(self, entity):
+                if entity["RowKey"] in self.entities:
+                    raise resource_exists("conflict")
+                self.entities[entity["RowKey"]] = entity
+
+            def get_entity(self, partition_key, row_key):
+                assert partition_key == "finding"
+                if row_key not in self.entities:
+                    raise resource_not_found("missing")
+                return self.entities[row_key]
+
+            def delete_entity(self, partition_key, row_key):
+                del self.entities[row_key]
+
+        table = _FakeTable()
+        monkeypatch.setattr(DETECT, "_dedupe_table", lambda: table)
+
+        assert DETECT._put_if_new("uid-1", "payload") is True
+        assert DETECT._put_if_new("uid-1", "payload") is False
+
+        # An expired row is replaced instead of counted as a duplicate.
+        table.entities["uid-1"]["expires_at"] = 1
+        assert DETECT._put_if_new("uid-1", "payload") is True
 
     def test_template_contains_azure_components(self):
         template = (ROOT / "runners" / "azure-blob-eventgrid-detect" / "template.bicep").read_text()

--- a/tests/integration/test_clickhouse_lake_pack.py
+++ b/tests/integration/test_clickhouse_lake_pack.py
@@ -1,0 +1,117 @@
+"""Contract tests for the ClickHouse data-lake pack.
+
+The detection query packs (lateral-movement, privilege-escalation-k8s) already
+have pytest coverage; these tests give the ClickHouse lake DDL the same
+treatment: golden column locks, append-only/retention markers, and a guarantee
+that every replay query template stays inside the read-only SQL subset that
+`source-clickhouse-query` enforces at runtime.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PACK = ROOT / "packs" / "clickhouse"
+
+GOLDEN_COLUMNS = json.loads((PACK / "golden" / "expected_columns.json").read_text())
+
+SINK_TABLES = {
+    "security.findings_sink": "ddl/02_findings_sink.sql",
+    "security.events_sink": "ddl/03_events_sink.sql",
+    "security.evidence_sink": "ddl/04_evidence_sink.sql",
+    "security.audit_sink": "ddl/05_audit_sink.sql",
+}
+ROLLUP_VIEWS = {
+    "security.findings_by_rule_hourly": "materialized-views/01_findings_by_rule_hourly.sql",
+    "security.events_by_class_daily": "materialized-views/02_events_by_class_daily.sql",
+    "security.remediations_by_outcome_daily": "materialized-views/03_remediations_by_outcome_daily.sql",
+}
+QUERY_TEMPLATES = sorted((PACK / "queries").glob("*.sql"))
+
+
+def _load_read_only_sql():
+    path = ROOT / "skills" / "_shared" / "read_only_sql.py"
+    spec = importlib.util.spec_from_file_location("read_only_sql_clickhouse_pack_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+READ_ONLY_SQL = _load_read_only_sql()
+
+
+def _strip_comment_lines(sql: str) -> str:
+    return "\n".join(line for line in sql.splitlines() if not line.lstrip().startswith("--"))
+
+
+class TestClickHouseLakeDdl:
+    def test_golden_covers_every_sink_and_rollup(self):
+        assert set(GOLDEN_COLUMNS) == set(SINK_TABLES) | set(ROLLUP_VIEWS)
+
+    @pytest.mark.parametrize("table,ddl_file", sorted(SINK_TABLES.items()))
+    def test_sink_ddl_declares_golden_columns(self, table, ddl_file):
+        sql = (PACK / ddl_file).read_text()
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in sql
+        for column in GOLDEN_COLUMNS[table]:
+            assert column in sql, f"{ddl_file} is missing golden column {column!r}"
+
+    @pytest.mark.parametrize("table,ddl_file", sorted(SINK_TABLES.items()))
+    def test_sink_ddl_keeps_lake_contract_markers(self, table, ddl_file):
+        sql = (PACK / ddl_file).read_text()
+        assert "ENGINE = MergeTree" in sql, f"{ddl_file} must stay on MergeTree"
+        assert "PARTITION BY" in sql, f"{ddl_file} must keep monthly partitioning"
+        if table == "security.audit_sink":
+            # Legal-hold chain: audit rows are deleted only after a hold
+            # release, so TTL is intentionally absent.
+            assert "TTL ingested_at" not in sql
+        else:
+            assert "TTL ingested_at" in sql, f"{ddl_file} must keep TTL-managed retention"
+
+    @pytest.mark.parametrize("view,view_file", sorted(ROLLUP_VIEWS.items()))
+    def test_rollup_views_declare_golden_columns(self, view, view_file):
+        sql = (PACK / view_file).read_text()
+        assert view in sql
+        assert "MATERIALIZED VIEW" in sql
+        for column in GOLDEN_COLUMNS[view]:
+            assert column in sql, f"{view_file} is missing golden column {column!r}"
+
+    def test_row_policies_cover_tenant_scoped_sinks(self):
+        sql = (PACK / "ddl" / "06_row_policies.sql").read_text()
+        # audit_sink is intentionally excluded: the audit trail is
+        # operator-owned and not tenant-partitioned.
+        for short_name in ("findings_sink", "events_sink", "evidence_sink"):
+            assert short_name in sql, f"row policies must mention {short_name}"
+
+
+class TestClickHouseReplayQueries:
+    def test_query_templates_shipped(self):
+        names = {path.name for path in QUERY_TEMPLATES}
+        assert names == {
+            "audit_trail_last_hour.sql",
+            "backfill_detection_window.sql",
+            "replay_findings_last_day.sql",
+            "top_rules_by_finding_volume.sql",
+        }
+
+    @pytest.mark.parametrize("query_file", QUERY_TEMPLATES, ids=lambda p: p.name)
+    def test_query_passes_source_adapter_read_only_gate(self, query_file):
+        raw = query_file.read_text()
+        stripped = _strip_comment_lines(raw)
+        # Same normalization source-clickhouse-query applies at runtime.
+        normalized = READ_ONLY_SQL.normalize_read_only_query(stripped)
+        assert normalized.upper().startswith(("SELECT", "WITH"))
+
+    @pytest.mark.parametrize("query_file", QUERY_TEMPLATES, ids=lambda p: p.name)
+    def test_query_reads_only_pack_tables(self, query_file):
+        stripped = _strip_comment_lines(query_file.read_text())
+        assert "security." in stripped
+        referenced = {table for table in GOLDEN_COLUMNS if table in stripped}
+        assert referenced, f"{query_file.name} must read from a pack-managed table"

--- a/tests/integration/test_gcp_runner_template.py
+++ b/tests/integration/test_gcp_runner_template.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import base64
 import importlib.util
+import json
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
+
+_PASSTHROUGH_CMD = f'{sys.executable} -c "import sys; sys.stdout.write(sys.stdin.read())"'
+_FAILING_CMD = f"{sys.executable} -c \"import sys; sys.stderr.write('boom'); sys.exit(3)\""
 
 
 def _load_module(name: str, path: Path):
@@ -118,3 +124,94 @@ class TestGcpGcsPubsubDetectRunner:
         monkeypatch.setenv("DEDUPE_TTL_DAYS", "10")
         base = datetime(2026, 4, 17, tzinfo=UTC)
         assert DETECT._expires_at(now=base) == datetime(2026, 4, 27, tzinfo=UTC)
+
+    def test_decode_pubsub_event_without_data_returns_empty(self):
+        assert DETECT._decode_pubsub_event({}) == []
+        assert DETECT._decode_pubsub_event({"data": ""}) == []
+
+    def test_ingest_run_skill_surfaces_skill_stderr(self, monkeypatch):
+        monkeypatch.setenv("INGEST_SKILL_CMD", _FAILING_CMD)
+        with pytest.raises(RuntimeError, match="boom"):
+            INGEST._run_skill("line-1\n")
+
+    def test_ingest_gcs_event_end_to_end(self, monkeypatch):
+        monkeypatch.setenv("INGEST_SKILL_CMD", _PASSTHROUGH_CMD)
+        monkeypatch.setenv("DETECT_TOPIC", "projects/test/topics/detect")
+
+        monkeypatch.setattr(
+            INGEST, "_read_object", lambda bucket, name: f"{bucket}/{name}:line-1\nline-2\n"
+        )
+        published: list[tuple[str, bytes]] = []
+
+        class _FakePublisher:
+            def publish(self, topic, payload):
+                published.append((topic, payload))
+
+        monkeypatch.setattr(INGEST, "_publisher_client", lambda: _FakePublisher())
+
+        result = INGEST.handle_gcs_event({"bucket": "raw-bucket", "name": "audit/day1.jsonl"}, None)
+
+        assert result == {"objects_processed": 1, "messages_enqueued": 2}
+        assert published == [
+            ("projects/test/topics/detect", b"raw-bucket/audit/day1.jsonl:line-1"),
+            ("projects/test/topics/detect", b"line-2"),
+        ]
+
+    def test_detect_pubsub_event_end_to_end_dedupes(self, monkeypatch):
+        monkeypatch.setenv("DETECT_SKILL_CMD", _PASSTHROUGH_CMD)
+        monkeypatch.setenv("FINDINGS_TOPIC", "projects/test/topics/findings")
+
+        dedupe_results = iter([True, False])
+        monkeypatch.setattr(DETECT, "_put_if_new", lambda uid, payload: next(dedupe_results))
+        monkeypatch.setattr(DETECT, "_publisher_client", lambda: object())
+        published: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            DETECT,
+            "_publish_findings",
+            lambda publisher, topic, records: published.extend(records),
+        )
+
+        finding_new = json.dumps({"finding_info": {"uid": "finding-new"}})
+        finding_dup = json.dumps({"event_uid": "event-dup"})
+        payload = f"{finding_new}\n{finding_dup}\n".encode("utf-8")
+        event = {"data": base64.b64encode(payload).decode("ascii")}
+
+        result = DETECT.handle_pubsub_event(event, None)
+
+        assert result == {"messages_processed": 2, "published": 1, "duplicates": 1}
+        assert published == [(finding_new, "finding-new")]
+
+    def test_detect_put_if_new_returns_false_on_conflict(self, monkeypatch):
+        monkeypatch.setenv("DEDUPE_COLLECTION", "dedupe")
+        monkeypatch.setenv("DEDUPE_TTL_DAYS", "30")
+
+        class _FakeDocument:
+            def __init__(self, existing: set[str], uid: str):
+                self.existing = existing
+                self.uid = uid
+
+            def create(self, item):
+                if self.uid in self.existing:
+                    raise DETECT.Conflict("already exists")
+                self.existing.add(self.uid)
+
+        class _FakeCollection:
+            def __init__(self, existing: set[str]):
+                self.existing = existing
+
+            def document(self, uid):
+                return _FakeDocument(self.existing, uid)
+
+        class _FakeFirestore:
+            def __init__(self):
+                self.existing: set[str] = set()
+
+            def collection(self, name):
+                assert name == "dedupe"
+                return _FakeCollection(self.existing)
+
+        client = _FakeFirestore()
+        monkeypatch.setattr(DETECT, "_firestore_client", lambda: client)
+
+        assert DETECT._put_if_new("uid-1", "payload") is True
+        assert DETECT._put_if_new("uid-1", "payload") is False

--- a/tests/integration/test_runner_template.py
+++ b/tests/integration/test_runner_template.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
+
+# stdin -> stdout passthrough, used as a stand-in skill so handler tests
+# exercise the real subprocess path without needing a cloud fixture.
+_PASSTHROUGH_CMD = f'{sys.executable} -c "import sys; sys.stdout.write(sys.stdin.read())"'
+_FAILING_CMD = f"{sys.executable} -c \"import sys; sys.stderr.write('boom'); sys.exit(3)\""
 
 
 def _load_module(name: str, path: Path):
@@ -104,3 +112,105 @@ class TestAwsS3SqsDetectRunner:
 
         assert [len(batch) for batch in seen_batches] == [10, 2]
         assert seen_batches[0][0]["Subject"] == "skill-finding:uid-0"
+
+    def test_detect_publish_findings_raises_on_partial_failure(self, monkeypatch):
+        class _FakeClient:
+            def publish_batch(self, **kwargs):
+                return {"Failed": [{"Id": "0-0"}]}
+
+        monkeypatch.setattr(DETECT, "_sns_client", lambda: _FakeClient())
+        monkeypatch.setattr(DETECT, "_sns_topic", lambda: "arn:aws:sns:us-east-1:123:topic")
+
+        with pytest.raises(RuntimeError, match="publish_batch failed"):
+            DETECT._publish_findings([("line-0", "uid-0")])
+
+    def test_ingest_run_skill_passes_payload_through(self, monkeypatch):
+        monkeypatch.setenv("INGEST_SKILL_CMD", _PASSTHROUGH_CMD)
+        assert INGEST._run_skill("line-1\n\nline-2\n") == ["line-1", "line-2"]
+
+    def test_ingest_run_skill_surfaces_skill_stderr(self, monkeypatch):
+        monkeypatch.setenv("INGEST_SKILL_CMD", _FAILING_CMD)
+        with pytest.raises(RuntimeError, match="boom"):
+            INGEST._run_skill("line-1\n")
+
+    def test_detect_run_skill_joins_lines_for_stdin(self, monkeypatch):
+        monkeypatch.setenv("DETECT_SKILL_CMD", _PASSTHROUGH_CMD)
+        assert DETECT._run_skill(["line-1", "line-2"]) == ["line-1", "line-2"]
+
+    def test_detect_extract_uid_rejects_record_without_identity(self):
+        with pytest.raises(ValueError, match="finding_info.uid"):
+            DETECT._extract_uid({"metadata": {"uid": ""}})
+
+    def test_ingest_lambda_handler_end_to_end(self, monkeypatch):
+        monkeypatch.setenv("INGEST_SKILL_CMD", _PASSTHROUGH_CMD)
+        monkeypatch.setenv("DETECT_QUEUE_URL", "https://sqs.test/queue")
+
+        class _FakeBody:
+            def read(self):
+                return b"line-1\nline-2\n"
+
+        class _FakeS3:
+            def get_object(self, Bucket, Key):
+                assert (Bucket, Key) == ("raw-bucket", "audit/day1.jsonl")
+                return {"Body": _FakeBody()}
+
+        sent: list[tuple[str, str]] = []
+
+        class _FakeSqs:
+            def send_message(self, QueueUrl, MessageBody):
+                sent.append((QueueUrl, MessageBody))
+
+        monkeypatch.setattr(INGEST, "_s3_client", lambda: _FakeS3())
+        monkeypatch.setattr(INGEST, "_sqs_client", lambda: _FakeSqs())
+
+        event = {
+            "Records": [
+                {"s3": {"bucket": {"name": "raw-bucket"}, "object": {"key": "audit/day1.jsonl"}}}
+            ]
+        }
+        result = INGEST.lambda_handler(event, None)
+
+        assert result == {"objects_processed": 1, "messages_enqueued": 2}
+        assert sent == [
+            ("https://sqs.test/queue", "line-1"),
+            ("https://sqs.test/queue", "line-2"),
+        ]
+
+    def test_detect_lambda_handler_dedupes_and_publishes(self, monkeypatch):
+        monkeypatch.setenv("DETECT_SKILL_CMD", _PASSTHROUGH_CMD)
+
+        dedupe_results = iter([True, False])
+        monkeypatch.setattr(DETECT, "_put_if_new", lambda uid, payload: next(dedupe_results))
+        published: list[tuple[str, str]] = []
+        monkeypatch.setattr(DETECT, "_publish_findings", lambda records: published.extend(records))
+
+        finding_new = json.dumps({"finding_info": {"uid": "finding-new"}})
+        finding_dup = json.dumps({"event_uid": "event-dup"})
+        event = {"Records": [{"body": finding_new}, {"body": finding_dup}]}
+
+        result = DETECT.lambda_handler(event, None)
+
+        assert result == {"messages_processed": 2, "published": 1, "duplicates": 1}
+        assert published == [(finding_new, "finding-new")]
+
+    def test_detect_put_if_new_true_then_false_for_same_uid(self, monkeypatch):
+        monkeypatch.setenv("DEDUPE_TTL_DAYS", "30")
+
+        class _FakeTable:
+            def __init__(self):
+                self.items: dict[str, dict] = {}
+
+            def put_item(self, Item, ConditionExpression):
+                assert ConditionExpression == "attribute_not_exists(pk)"
+                if Item["pk"] in self.items:
+                    raise DETECT.ClientError(
+                        {"Error": {"Code": "ConditionalCheckFailedException"}}, "PutItem"
+                    )
+                self.items[Item["pk"]] = Item
+
+        table = _FakeTable()
+        monkeypatch.setattr(DETECT, "_dedupe_table", lambda: table)
+
+        assert DETECT._put_if_new("uid-1", "payload") is True
+        assert DETECT._put_if_new("uid-1", "payload") is False
+        assert set(table.items) == {"uid-1"}

--- a/tests/integration/test_snowflake_lake_pack.py
+++ b/tests/integration/test_snowflake_lake_pack.py
@@ -1,0 +1,113 @@
+"""Contract tests for the Snowflake data-lake pack.
+
+Mirrors the ClickHouse lake-pack tests: golden column locks on the DDL and
+dynamic-table rollups, retention/governance markers, and read-only enforcement
+for the replay query templates that `source-snowflake-query` executes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PACK = ROOT / "packs" / "snowflake"
+
+GOLDEN_COLUMNS = json.loads((PACK / "golden" / "expected_columns.json").read_text())
+
+SINK_TABLES = {
+    "security_db.ops.findings_sink": "ddl/02_findings_sink.sql",
+    "security_db.ops.events_sink": "ddl/03_events_sink.sql",
+    "security_db.ops.evidence_sink": "ddl/04_evidence_sink.sql",
+    "security_db.ops.audit_sink": "ddl/05_audit_sink.sql",
+}
+ROLLUP_TABLES = {
+    "security_db.ops.findings_by_rule_hourly": "dynamic-tables/01_findings_by_rule_hourly.sql",
+    "security_db.ops.events_by_class_daily": "dynamic-tables/02_events_by_class_daily.sql",
+    "security_db.ops.remediations_by_outcome_daily": "dynamic-tables/03_remediations_by_outcome_daily.sql",
+}
+QUERY_TEMPLATES = sorted((PACK / "queries").glob("*.sql"))
+
+
+def _load_read_only_sql():
+    path = ROOT / "skills" / "_shared" / "read_only_sql.py"
+    spec = importlib.util.spec_from_file_location("read_only_sql_snowflake_pack_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+READ_ONLY_SQL = _load_read_only_sql()
+
+
+def _strip_comment_lines(sql: str) -> str:
+    return "\n".join(line for line in sql.splitlines() if not line.lstrip().startswith("--"))
+
+
+class TestSnowflakeLakeDdl:
+    def test_golden_covers_every_sink_and_rollup(self):
+        assert set(GOLDEN_COLUMNS) == set(SINK_TABLES) | set(ROLLUP_TABLES)
+
+    @pytest.mark.parametrize("table,ddl_file", sorted(SINK_TABLES.items()))
+    def test_sink_ddl_declares_golden_columns(self, table, ddl_file):
+        sql = (PACK / ddl_file).read_text()
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in sql
+        for column in GOLDEN_COLUMNS[table]:
+            assert column in sql, f"{ddl_file} is missing golden column {column!r}"
+
+    @pytest.mark.parametrize("table,ddl_file", sorted(SINK_TABLES.items()))
+    def test_sink_ddl_keeps_lake_contract_markers(self, table, ddl_file):
+        sql = (PACK / ddl_file).read_text()
+        assert "CLUSTER BY" in sql, f"{ddl_file} must keep its clustering key"
+        assert "DATA_RETENTION_TIME_IN_DAYS" in sql, f"{ddl_file} must keep Time Travel retention"
+
+    @pytest.mark.parametrize("table,table_file", sorted(ROLLUP_TABLES.items()))
+    def test_rollup_dynamic_tables_declare_golden_columns(self, table, table_file):
+        sql = (PACK / table_file).read_text()
+        assert table in sql
+        assert "DYNAMIC TABLE" in sql
+        for column in GOLDEN_COLUMNS[table]:
+            assert column in sql, f"{table_file} is missing golden column {column!r}"
+
+    def test_row_access_policies_cover_tenant_scoped_sinks(self):
+        sql = (PACK / "ddl" / "06_row_policies.sql").read_text()
+        # audit_sink is intentionally excluded: the audit trail is
+        # operator-owned and not tenant-partitioned.
+        for short_name in ("findings_sink", "events_sink", "evidence_sink"):
+            assert short_name in sql, f"row access policies must mention {short_name}"
+
+    def test_iceberg_variant_stays_optional(self):
+        sql = (PACK / "ddl" / "07_iceberg_open_format.sql").read_text()
+        assert "ICEBERG" in sql.upper()
+
+
+class TestSnowflakeReplayQueries:
+    def test_query_templates_shipped(self):
+        names = {path.name for path in QUERY_TEMPLATES}
+        assert names == {
+            "audit_trail_last_hour.sql",
+            "backfill_detection_window.sql",
+            "replay_findings_last_day.sql",
+            "top_rules_by_finding_volume.sql",
+        }
+
+    @pytest.mark.parametrize("query_file", QUERY_TEMPLATES, ids=lambda p: p.name)
+    def test_query_passes_source_adapter_read_only_gate(self, query_file):
+        raw = query_file.read_text()
+        stripped = _strip_comment_lines(raw)
+        # Same normalization source-snowflake-query applies at runtime.
+        normalized = READ_ONLY_SQL.normalize_read_only_query(stripped)
+        assert normalized.upper().startswith(("SELECT", "WITH"))
+
+    @pytest.mark.parametrize("query_file", QUERY_TEMPLATES, ids=lambda p: p.name)
+    def test_query_reads_only_pack_tables(self, query_file):
+        stripped = _strip_comment_lines(query_file.read_text())
+        assert "security_db.ops." in stripped
+        referenced = {table for table in GOLDEN_COLUMNS if table in stripped}
+        assert referenced, f"{query_file.name} must read from a pack-managed table"


### PR DESCRIPTION
## Summary
Phase 2 of the audit plan — closes the two test-coverage gaps called out in the repo audit.

**Runner handlers.** The aws/gcp/azure runner templates had helper-level tests only (env validation, TTL parsing, batching); the actual handler entry points were untested. This adds full-path tests using fake cloud clients plus a real subprocess stand-in skill:
- AWS: `lambda_handler` ingest (S3 → skill → SQS) and detect (SQS → skill → dedupe → SNS) end to end, DynamoDB conditional-put dedupe, SNS `publish_batch` partial-failure error path, `_run_skill` success + stderr surfacing.
- GCP: `handle_gcs_event` and `handle_pubsub_event` end to end, Firestore `Conflict` dedupe, empty payload decode.
- Azure: Event Grid payload/blob-url parsing edge cases, multi-message batch aggregation, Table Storage dedupe including the expired-row-replacement branch — runs with or without the azure SDK installed.

**Lake query packs.** `packs/clickhouse/` and `packs/snowflake/` were sqlfluff-linted but had no pytest contract (the two detection query packs did). New contract tests lock:
- `golden/expected_columns.json` against sink DDL and rollup views/dynamic tables,
- retention/engine markers (MergeTree + TTL, CLUSTER BY + Time Travel; `audit_sink` intentionally TTL-free for legal hold),
- tenant row policies on the findings/events/evidence sinks,
- every replay query template passing the same read-only SQL gate (`skills/_shared/read_only_sql.py`) that `source-clickhouse-query` / `source-snowflake-query` enforce at runtime.

## Test plan
- [x] `pytest tests/integration/` — 120 passed locally (35 new tests)
- [x] `ruff check` + `ruff format --check` clean
- [x] mypy: no new errors (one pre-existing note on main unchanged)

Made with [Cursor](https://cursor.com)