### PR TITLE
feat: live OpenAI-compatible BYOM adapter and model-quality eval mode

### DIFF
--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -200,6 +200,27 @@ DEMO_LLM_MODEL=chat-model-fixture-v1 \
 DEMO_LANGCHAIN_ADAPTER_FIXTURE=/path/to/langchain-message.json \
 python examples/agents/langgraph_security_graph.py
 
+# Live BYOM adapter: one OpenAI-compatible client covers OpenAI, Azure
+# OpenAI, Ollama, vLLM, and LiteLLM. Activates only in
+# external_llm_optional mode; stdlib-only; single bounded call, no retries.
+# The API key is never in a profile — name the env var that holds it
+# (default OPENAI_API_KEY; keyless is fine for local Ollama/vLLM).
+# Model output still passes the same closed schema gate; any network or
+# parse failure falls back to deterministic triage.
+DEMO_EXTERNAL_LLM_ALLOWED=yes \
+DEMO_LLM_PROVIDER=openai \
+DEMO_LLM_MODEL=gpt-4.1-mini \
+DEMO_OPENAI_BASE_URL=https://api.openai.com/v1 \
+DEMO_OPENAI_API_KEY_ENV=OPENAI_API_KEY \
+python examples/agents/langgraph_security_graph.py
+
+# Same adapter against a local Ollama endpoint (no key):
+DEMO_EXTERNAL_LLM_ALLOWED=yes \
+DEMO_LLM_PROVIDER=ollama \
+DEMO_LLM_MODEL=llama3.1 \
+DEMO_OPENAI_BASE_URL=http://127.0.0.1:11434/v1 \
+python examples/agents/langgraph_security_graph.py
+
 # Retryable API error path: no write intent is created without approval;
 # approved retries reuse the same remediation idempotency key.
 DEMO_APPROVE=yes \
@@ -221,6 +242,16 @@ python examples/agents/eval_langgraph_harness.py --check
 python examples/agents/eval_langgraph_harness.py --check \
   --output artifacts/langgraph-harness-eval.json \
   --append-jsonl artifacts/langgraph-harness-eval-history.jsonl
+
+# Model-quality mode: score the configured triage adapter (fixture or live
+# OpenAI-compatible endpoint) against the golden priorities/actions. With no
+# adapter configured it scores the deterministic path (agreement 1.0), so the
+# same command works offline in CI and against a live model for BYOM drift.
+DEMO_OPENAI_BASE_URL=http://127.0.0.1:11434/v1 \
+python examples/agents/eval_langgraph_harness.py --model-quality --check \
+  --min-agreement 0.75 \
+  --output artifacts/langgraph-model-quality.json \
+  --append-jsonl artifacts/langgraph-model-quality-history.jsonl
 
 # Diagram artifact: render docs/diagrams/langgraph-agent-harness.mmd
 # from the code-backed pipeline_contract().
@@ -285,9 +316,14 @@ metadata without duplicating graph logic. `HarnessRunConfig` also accepts
 stateful `approval_context`, so CI, SOAR, ticketing, or MCP wrappers do not
 need to rely on process-wide approval env vars.
 Adapter plumbing lives in [`harness_adapters.py`](harness_adapters.py): the
-graph selects deterministic fallback, JSON fixture, or optional LangChain chat
-fixture adapters, then applies one closed schema gate before any recommendation
-enters graph state.
+graph selects deterministic fallback, JSON fixture, optional LangChain chat
+fixture, or the live OpenAI-compatible BYOM adapter, then applies one closed
+schema gate before any recommendation enters graph state. The live adapter
+(`OpenAICompatTriageAdapter`) speaks the `chat/completions` wire format, so a
+single client covers OpenAI, Azure OpenAI, Ollama, vLLM, and LiteLLM; it makes
+one bounded call (clamped timeout, capped output tokens, no retries) and any
+failure degrades to deterministic triage with the reason recorded in node
+telemetry.
 The graph sends compact finding cards to the optional adapter, not raw events
 or full OCSF payloads. Each triage run records estimated raw and compact input
 tokens, output tokens, compression ratio, cache key, model tier, and fallback

--- a/examples/agents/eval_langgraph_harness.py
+++ b/examples/agents/eval_langgraph_harness.py
@@ -32,7 +32,14 @@ ENV_KEYS = [
     "DEMO_LLM_PROVIDER",
     "DEMO_LLM_MODEL",
     "DEMO_LLM_ADAPTER_FIXTURE",
+    "DEMO_OPENAI_BASE_URL",
+    "DEMO_OPENAI_API_KEY_ENV",
+    "DEMO_OPENAI_TIMEOUT_SECONDS",
 ]
+# Model-quality mode keeps the operator's adapter env (fixture or live
+# OpenAI-compatible endpoint) so the run measures that adapter; it still
+# strips approval context so no case can auto-approve.
+MODEL_QUALITY_STRIPPED_ENV_KEYS = ["DEMO_APPROVE", "DEMO_APPROVER", "DEMO_TICKET"]
 
 
 def _stable_hash(payload: Any) -> str:
@@ -518,6 +525,114 @@ def run_dataset(dataset_path: Path) -> dict[str, Any]:
     }
 
 
+def _first_validation(summary: dict[str, Any]) -> dict[str, Any]:
+    records = summary.get("llm_validation") or []
+    if not records:
+        return {}
+    return records[0]
+
+
+def _operator_adapter_configured() -> bool:
+    return any(
+        os.environ.get(key)
+        for key in (
+            "DEMO_LLM_ADAPTER_FIXTURE",
+            "DEMO_LANGCHAIN_ADAPTER_FIXTURE",
+            "DEMO_OPENAI_BASE_URL",
+        )
+    )
+
+
+def run_model_quality_case(case: dict[str, Any], *, operator_adapter: bool) -> dict[str, Any]:
+    """Replay one golden case and score adapter agreement with the golden triage.
+
+    Unlike ``run_case`` this keeps the operator's DEMO_LLM_* / DEMO_OPENAI_*
+    env so the fixture or live OpenAI-compatible adapter under test actually
+    runs. When no operator adapter is configured, case-declared fixtures
+    apply, matching the regression behavior. Approval env is always stripped.
+    """
+    saved_env = {key: os.environ.get(key) for key in MODEL_QUALITY_STRIPPED_ENV_KEYS}
+    for key in saved_env:
+        os.environ.pop(key, None)
+    fixture_path = None if operator_adapter else _write_adapter_fixture(case)
+    case_env = {
+        key: str(value)
+        for key, value in (case.get("env") or {}).items()
+        if key not in MODEL_QUALITY_STRIPPED_ENV_KEYS and not (operator_adapter and key in ENV_KEYS)
+    }
+    saved_env.update({key: os.environ.get(key) for key in case_env})
+    if fixture_path:
+        saved_env.setdefault("DEMO_LLM_ADAPTER_FIXTURE", os.environ.get("DEMO_LLM_ADAPTER_FIXTURE"))
+    try:
+        os.environ.update(case_env)
+        if fixture_path:
+            os.environ["DEMO_LLM_ADAPTER_FIXTURE"] = str(fixture_path)
+        profile = load_harness_profile(str(_resolve(case["profile"])))
+        initial = {
+            "harness_profile": profile,
+            "caller_context": profile["caller_context"],
+            "raw_events": case.get("raw_events") or [{"source": "demo"}],
+        }
+        summary = summarize(run_graph(initial))
+    finally:
+        if fixture_path:
+            fixture_path.unlink(missing_ok=True)
+        _restore_env(saved_env)
+
+    expected = case["expected"]
+    recommendation = _first_recommendation(summary)
+    validation = _first_validation(summary)
+    priority_agrees = recommendation.get("priority") == expected["recommendation_priority"]
+    action_agrees = recommendation.get("recommended_action") == expected["recommendation_action"]
+    return {
+        "case_id": case["case_id"],
+        "adapter": validation.get("adapter", "deterministic_fallback"),
+        "adapter_status": validation.get("status", "fallback"),
+        "adapter_reason": validation.get("reason"),
+        "generated_by": recommendation.get("generated_by"),
+        "expected_priority": expected["recommendation_priority"],
+        "actual_priority": recommendation.get("priority"),
+        "expected_action": expected["recommendation_action"],
+        "actual_action": recommendation.get("recommended_action"),
+        "priority_agrees": priority_agrees,
+        "action_agrees": action_agrees,
+        "agreement": priority_agrees and action_agrees,
+    }
+
+
+def run_model_quality(dataset_path: Path) -> dict[str, Any]:
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    operator_adapter = _operator_adapter_configured()
+    results = [
+        run_model_quality_case(case, operator_adapter=operator_adapter) for case in dataset["cases"]
+    ]
+    total = len(results)
+    agreements = sum(1 for result in results if result["agreement"])
+    status_counts = {"accepted": 0, "rejected": 0, "fallback": 0}
+    for result in results:
+        status = result["adapter_status"]
+        if status in status_counts:
+            status_counts[status] += 1
+    return {
+        "event": "langgraph_model_quality_eval",
+        "dataset_version": dataset["dataset_version"],
+        "dataset_hash": _stable_hash(dataset)[:16],
+        "adapter_env": {
+            "fixture": bool(os.environ.get("DEMO_LLM_ADAPTER_FIXTURE")),
+            "langchain_fixture": bool(os.environ.get("DEMO_LANGCHAIN_ADAPTER_FIXTURE")),
+            "live_openai_compat": bool(os.environ.get("DEMO_OPENAI_BASE_URL")),
+        },
+        "cases_total": total,
+        "adapter_accepted": status_counts["accepted"],
+        "adapter_rejected": status_counts["rejected"],
+        "adapter_fallback": status_counts["fallback"],
+        "agreement": agreements,
+        "agreement_rate": agreements / total if total else 0.0,
+        "model_policy": "llm_may_rank_summarize_draft_only",
+        "results": results,
+    }
+
+
 def _encoded_report(report: dict[str, Any]) -> str:
     return json.dumps(report, indent=2, sort_keys=True) + "\n"
 
@@ -547,6 +662,21 @@ def main() -> int:
         "--check", action="store_true", help="exit nonzero when pass rate is below threshold"
     )
     parser.add_argument(
+        "--model-quality",
+        action="store_true",
+        help=(
+            "score the configured triage adapter (fixture or live "
+            "OpenAI-compatible endpoint) against the golden priorities and "
+            "actions instead of running the harness regression checks"
+        ),
+    )
+    parser.add_argument(
+        "--min-agreement",
+        type=float,
+        default=1.0,
+        help="minimum agreement rate for --model-quality --check",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="write the JSON eval report to this path",
@@ -558,14 +688,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    report = run_dataset(args.dataset)
+    if args.model_quality:
+        report = run_model_quality(args.dataset)
+        gate = report["agreement_rate"] >= args.min_agreement
+    else:
+        report = run_dataset(args.dataset)
+        gate = report["pass_rate"] >= args.min_pass_rate
     encoded = _encoded_report(report)
     print(encoded, end="")
     if args.output:
         _write_json(args.output, encoded)
     if args.append_jsonl:
         _append_history(args.append_jsonl, report)
-    if args.check and report["pass_rate"] < args.min_pass_rate:
+    if args.check and not gate:
         return 1
     return 0
 

--- a/examples/agents/harness_adapters.py
+++ b/examples/agents/harness_adapters.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any, Literal, Mapping, Protocol
 
@@ -181,10 +184,157 @@ class LangChainChatFixtureAdapter:
         return []
 
 
+_DEFAULT_LIVE_TIMEOUT_SECONDS = 30
+_MAX_LIVE_TIMEOUT_SECONDS = 120
+_MAX_LIVE_OUTPUT_TOKENS = 1024
+_JSON_FENCE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+_LIVE_SYSTEM_PROMPT = (
+    "You are a bounded SOC triage assistant. You may rank, summarize, and "
+    "draft only. You never approve actions, never set CVSS/MITRE/EPSS/KEV "
+    "facts, never set tenant scope or write intent, and never mutate audit "
+    "state. For each evidence card, reply with STRICT JSON only: an array of "
+    'objects with exactly these keys: "finding_uid" (copy it verbatim), '
+    '"priority" (one of critical|high|medium|low), "recommended_action" '
+    '(one of request_approval|investigate|close), and "rationale" (one or '
+    "two sentences). No prose outside the JSON."
+)
+
+
+def _parse_adapter_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        recommendations = payload.get("recommendations", [])
+        return [item for item in recommendations if isinstance(item, dict)]
+    return []
+
+
+class OpenAICompatTriageAdapter:
+    """Live BYOM adapter for any OpenAI-compatible chat-completions endpoint.
+
+    One adapter covers OpenAI, Azure OpenAI, Ollama, vLLM, LiteLLM, and any
+    other server that speaks `POST {base_url}/chat/completions`. It holds no
+    authority: outputs are untrusted candidates and every recommendation
+    still passes ``validate_adapter_recommendation`` before use. Failures
+    (network, HTTP, bad JSON) degrade to the deterministic fallback by
+    returning no candidates; the reason is kept on ``last_error`` for the
+    caller's telemetry. Single attempt, bounded timeout, no retries.
+    """
+
+    adapter_id = "openai_compat_adapter"
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        evidence_cards: list[dict[str, Any]],
+        api_key: str | None = None,
+        timeout_seconds: int = _DEFAULT_LIVE_TIMEOUT_SECONDS,
+        max_output_tokens: int = _MAX_LIVE_OUTPUT_TOKENS,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.evidence_cards = evidence_cards
+        self.api_key = api_key
+        self.timeout_seconds = max(1, min(int(timeout_seconds), _MAX_LIVE_TIMEOUT_SECONDS))
+        self.max_output_tokens = max(64, min(int(max_output_tokens), _MAX_LIVE_OUTPUT_TOKENS))
+        self.last_error: str | None = None
+
+    def _request(self) -> urllib.request.Request:
+        body = {
+            "model": self.model,
+            "temperature": 0,
+            "max_tokens": self.max_output_tokens,
+            "messages": [
+                {"role": "system", "content": _LIVE_SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": json.dumps({"evidence_cards": self.evidence_cards}, sort_keys=True),
+                },
+            ],
+        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return urllib.request.Request(  # noqa: S310 - operator-configured HTTPS/local endpoint
+            f"{self.base_url}/chat/completions",
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+
+    def _extract_content(self, response_payload: Mapping[str, Any]) -> str:
+        choices = response_payload.get("choices")
+        if not isinstance(choices, list) or not choices:
+            raise ValueError("response has no choices")
+        message = choices[0].get("message") if isinstance(choices[0], dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("response has no message content")
+        return content
+
+    def recommendations(self) -> list[dict[str, Any]]:
+        self.last_error = None
+        if not self.evidence_cards:
+            return []
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - see _request
+                self._request(), timeout=self.timeout_seconds
+            ) as response:
+                response_payload = json.loads(response.read().decode("utf-8"))
+            content = self._extract_content(response_payload).strip()
+            fenced = _JSON_FENCE.search(content)
+            if fenced:
+                content = fenced.group(1).strip()
+            return _parse_adapter_payload(json.loads(content))
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            ValueError,
+            json.JSONDecodeError,
+            OSError,
+        ) as exc:
+            # Degrade to the deterministic fallback instead of failing the
+            # graph; the schema gate reports fallback per finding.
+            self.last_error = f"{type(exc).__name__}: {exc}"
+            return []
+
+
+def _live_adapter_from_env(
+    *,
+    harness_config: Mapping[str, Any],
+    environ: Mapping[str, str],
+    evidence_cards: list[dict[str, Any]] | None,
+) -> OpenAICompatTriageAdapter | None:
+    base_url = (environ.get("DEMO_OPENAI_BASE_URL") or "").strip()
+    if not base_url:
+        return None
+    if harness_config.get("mode") != "external_llm_optional":
+        # Profiles stay authoritative: a live endpoint never activates in
+        # deterministic_offline mode.
+        return None
+    # Workload-identity-first: the key itself is never in the profile; the
+    # operator names the env var that holds it (keyless is fine for local
+    # Ollama / vLLM endpoints).
+    key_env = environ.get("DEMO_OPENAI_API_KEY_ENV", "OPENAI_API_KEY")
+    timeout_raw = (environ.get("DEMO_OPENAI_TIMEOUT_SECONDS") or "").strip()
+    timeout_seconds = int(timeout_raw) if timeout_raw.isdigit() else _DEFAULT_LIVE_TIMEOUT_SECONDS
+    return OpenAICompatTriageAdapter(
+        base_url=base_url,
+        model=str(harness_config.get("model") or "policy-bounded-triage-v1"),
+        evidence_cards=list(evidence_cards or []),
+        api_key=environ.get(key_env) or None,
+        timeout_seconds=timeout_seconds,
+    )
+
+
 def select_triage_adapter(
     *,
     harness_config: Mapping[str, Any],
     environ: Mapping[str, str] = os.environ,
+    evidence_cards: list[dict[str, Any]] | None = None,
 ) -> TriageAdapter:
     """Select the optional adapter without granting it extra authority."""
     langchain_fixture = environ.get("DEMO_LANGCHAIN_ADAPTER_FIXTURE")
@@ -195,8 +345,13 @@ def select_triage_adapter(
     if fixture_path:
         return FixtureTriageAdapter(Path(fixture_path))
 
-    if harness_config.get("provider") == "langchain":
-        return DeterministicFallbackAdapter()
+    live_adapter = _live_adapter_from_env(
+        harness_config=harness_config,
+        environ=environ,
+        evidence_cards=evidence_cards,
+    )
+    if live_adapter is not None:
+        return live_adapter
 
     return DeterministicFallbackAdapter()
 

--- a/examples/agents/langgraph_security_graph.py
+++ b/examples/agents/langgraph_security_graph.py
@@ -1356,7 +1356,11 @@ def llm_triage_node(state: GraphState) -> GraphState:
         harness_config=harness_config,
         evidence_cards=evidence_cards,
     )
-    adapter = select_triage_adapter(harness_config=harness_config, environ=os.environ)
+    adapter = select_triage_adapter(
+        harness_config=harness_config,
+        environ=os.environ,
+        evidence_cards=evidence_cards,
+    )
     adapter_recommendations = {}
     if initial_budget_usage["status"] != "fallback":
         adapter_recommendations = {
@@ -1425,6 +1429,8 @@ def llm_triage_node(state: GraphState) -> GraphState:
         mode=harness_config["mode"],
         provider=harness_config["provider"],
         model=harness_config["model"],
+        adapter=adapter.adapter_id,
+        adapter_error=getattr(adapter, "last_error", None),
         recommendations=len(recommendations),
         accepted=sum(1 for record in validation_records if record["status"] == "accepted"),
         rejected=sum(1 for record in validation_records if record["status"] == "rejected"),

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -2085,6 +2085,318 @@ class TestLangGraphHarnessDriftCheck:
         assert "harness_docs_have_no_secret_literals" in check_names
 
 
+class TestOpenAICompatAdapter:
+    """Live BYOM adapter: bounded request shape, tolerant parsing, safe failure."""
+
+    @staticmethod
+    def _adapters():
+        sys.path.insert(0, str(EXAMPLES))
+        try:
+            import harness_adapters
+        finally:
+            sys.path.pop(0)
+        return harness_adapters
+
+    @staticmethod
+    def _cards():
+        return [{"finding_uid": "det-1", "title": "access key created", "severity": "high"}]
+
+    def _response(self, content: str) -> bytes:
+        return json.dumps({"choices": [{"message": {"content": content}}]}).encode("utf-8")
+
+    def _fake_urlopen(self, monkeypatch, adapters, body: bytes, capture: dict):
+        import contextlib
+        import io
+
+        @contextlib.contextmanager
+        def fake_urlopen(request, timeout=None):
+            capture["url"] = request.full_url
+            capture["headers"] = dict(request.header_items())
+            capture["body"] = json.loads(request.data.decode("utf-8"))
+            capture["timeout"] = timeout
+            yield io.BytesIO(body)
+
+        monkeypatch.setattr(adapters.urllib.request, "urlopen", fake_urlopen)
+
+    def test_sends_bounded_openai_request(self, monkeypatch):
+        adapters = self._adapters()
+        capture: dict = {}
+        content = json.dumps(
+            [
+                {
+                    "finding_uid": "det-1",
+                    "priority": "high",
+                    "recommended_action": "investigate",
+                    "rationale": "new key on a build principal",
+                }
+            ]
+        )
+        self._fake_urlopen(monkeypatch, adapters, self._response(content), capture)
+
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="https://llm.example/v1/",
+            model="gpt-4.1-mini",
+            evidence_cards=self._cards(),
+            api_key="test-key",
+            timeout_seconds=999,
+        )
+        recommendations = adapter.recommendations()
+
+        assert capture["url"] == "https://llm.example/v1/chat/completions"
+        assert capture["headers"].get("Authorization") == "Bearer test-key"
+        assert capture["body"]["model"] == "gpt-4.1-mini"
+        assert capture["body"]["temperature"] == 0
+        assert capture["timeout"] == 120  # clamped to the bounded maximum
+        system_prompt = capture["body"]["messages"][0]["content"]
+        assert "rank, summarize, and draft only" in system_prompt
+        assert "never approve" in system_prompt
+        assert recommendations == [
+            {
+                "finding_uid": "det-1",
+                "priority": "high",
+                "recommended_action": "investigate",
+                "rationale": "new key on a build principal",
+            }
+        ]
+        assert adapter.last_error is None
+
+    def test_parses_fenced_json_and_recommendations_object(self, monkeypatch):
+        adapters = self._adapters()
+        payload = {
+            "recommendations": [
+                {
+                    "finding_uid": "det-1",
+                    "priority": "medium",
+                    "recommended_action": "close",
+                    "rationale": "benign automation",
+                }
+            ]
+        }
+        content = "```json\n" + json.dumps(payload) + "\n```"
+        self._fake_urlopen(monkeypatch, adapters, self._response(content), {})
+
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="https://llm.example/v1",
+            model="m",
+            evidence_cards=self._cards(),
+        )
+        assert adapter.recommendations() == payload["recommendations"]
+
+    def test_keyless_endpoint_sends_no_auth_header(self, monkeypatch):
+        adapters = self._adapters()
+        capture: dict = {}
+        self._fake_urlopen(monkeypatch, adapters, self._response("[]"), capture)
+
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="http://127.0.0.1:11434/v1",
+            model="llama3",
+            evidence_cards=self._cards(),
+        )
+        adapter.recommendations()
+        assert "Authorization" not in capture["headers"]
+
+    def test_network_failure_degrades_to_no_candidates(self, monkeypatch):
+        adapters = self._adapters()
+
+        def fail_urlopen(request, timeout=None):
+            raise adapters.urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(adapters.urllib.request, "urlopen", fail_urlopen)
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="https://llm.example/v1",
+            model="m",
+            evidence_cards=self._cards(),
+        )
+        assert adapter.recommendations() == []
+        assert "URLError" in (adapter.last_error or "")
+
+    def test_non_json_content_degrades_to_no_candidates(self, monkeypatch):
+        adapters = self._adapters()
+        self._fake_urlopen(monkeypatch, adapters, self._response("I think this looks fine."), {})
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="https://llm.example/v1",
+            model="m",
+            evidence_cards=self._cards(),
+        )
+        assert adapter.recommendations() == []
+        assert adapter.last_error is not None
+
+    def test_empty_evidence_skips_the_network_entirely(self, monkeypatch):
+        adapters = self._adapters()
+
+        def explode(request, timeout=None):  # pragma: no cover - must not run
+            raise AssertionError("no network call expected without evidence")
+
+        monkeypatch.setattr(adapters.urllib.request, "urlopen", explode)
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="https://llm.example/v1",
+            model="m",
+            evidence_cards=[],
+        )
+        assert adapter.recommendations() == []
+
+    def test_selection_requires_external_mode_and_base_url(self, monkeypatch):
+        adapters = self._adapters()
+
+        offline = adapters.select_triage_adapter(
+            harness_config={"mode": "deterministic_offline", "model": "m"},
+            environ={"DEMO_OPENAI_BASE_URL": "https://llm.example/v1"},
+            evidence_cards=self._cards(),
+        )
+        assert offline.adapter_id == "deterministic_fallback"
+
+        no_url = adapters.select_triage_adapter(
+            harness_config={"mode": "external_llm_optional", "model": "m"},
+            environ={},
+            evidence_cards=self._cards(),
+        )
+        assert no_url.adapter_id == "deterministic_fallback"
+
+        live = adapters.select_triage_adapter(
+            harness_config={"mode": "external_llm_optional", "model": "gpt-4.1-mini"},
+            environ={
+                "DEMO_OPENAI_BASE_URL": "https://llm.example/v1",
+                "DEMO_OPENAI_API_KEY_ENV": "MY_KEY",
+                "MY_KEY": "secret",
+                "DEMO_OPENAI_TIMEOUT_SECONDS": "5",
+            },
+            evidence_cards=self._cards(),
+        )
+        assert live.adapter_id == "openai_compat_adapter"
+        assert live.model == "gpt-4.1-mini"
+        assert live.api_key == "secret"
+        assert live.timeout_seconds == 5
+
+    def test_fixture_adapter_still_beats_live_endpoint(self, tmp_path, monkeypatch):
+        adapters = self._adapters()
+        fixture = tmp_path / "fixture.json"
+        fixture.write_text("[]", encoding="utf-8")
+        selected = adapters.select_triage_adapter(
+            harness_config={"mode": "external_llm_optional", "model": "m"},
+            environ={
+                "DEMO_LLM_ADAPTER_FIXTURE": str(fixture),
+                "DEMO_OPENAI_BASE_URL": "https://llm.example/v1",
+            },
+            evidence_cards=self._cards(),
+        )
+        assert selected.adapter_id == "fixture_llm_adapter"
+
+    def test_live_output_still_passes_the_schema_gate(self, monkeypatch):
+        """A live adapter that emits forbidden keys is rejected downstream."""
+        adapters = self._adapters()
+        content = json.dumps(
+            [
+                {
+                    "finding_uid": "det-1",
+                    "priority": "high",
+                    "recommended_action": "request_approval",
+                    "rationale": "looks bad",
+                    "approval": {"approved": True},
+                }
+            ]
+        )
+        self._fake_urlopen(monkeypatch, adapters, self._response(content), {})
+        adapter = adapters.OpenAICompatTriageAdapter(
+            base_url="https://llm.example/v1",
+            model="m",
+            evidence_cards=self._cards(),
+        )
+        candidate = adapter.recommendations()[0]
+        fallback = {"finding_uid": "det-1", "output_hash": "abc"}
+        accepted, validation = adapters.validate_adapter_recommendation(
+            candidate=candidate,
+            fallback=fallback,
+            finding_uid="det-1",
+            harness_config={"provider": "openai", "model": "m"},
+            adapter_id=adapter.adapter_id,
+        )
+        assert validation["status"] == "rejected"
+        assert validation["reason"].startswith("forbidden_output:approval")
+        assert accepted == fallback
+
+
+class TestModelQualityEval:
+    """Model-quality mode scores adapter agreement against the golden dataset."""
+
+    SCRIPT = EXAMPLES / "eval_langgraph_harness.py"
+
+    def _run(self, tmp_path, env=None, extra_args=()):
+        report_path = tmp_path / "model-quality.json"
+        run_env = {key: value for key, value in os.environ.items() if not key.startswith("DEMO_")}
+        run_env.update(env or {})
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--model-quality",
+                "--check",
+                "--output",
+                str(report_path),
+                *extra_args,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            env=run_env,
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8")) if report_path.exists() else {}
+        return result, report
+
+    def test_default_run_agrees_with_golden_dataset(self, tmp_path):
+        result, report = self._run(tmp_path)
+        assert result.returncode == 0, result.stderr
+        assert report["event"] == "langgraph_model_quality_eval"
+        assert report["cases_total"] == 8
+        assert report["agreement_rate"] == 1.0
+        assert report["adapter_accepted"] >= 1
+        assert report["adapter_env"] == {
+            "fixture": False,
+            "langchain_fixture": False,
+            "live_openai_compat": False,
+        }
+
+    def test_low_quality_adapter_fails_the_gate(self, tmp_path):
+        import hashlib
+
+        # Same uid derivation the harness uses for the golden CreateAccessKey
+        # event, so the schema gate accepts this low-quality recommendation.
+        golden_event = {
+            "source": "cloudtrail",
+            "event_name": "CreateAccessKey",
+            "actor_uid": "AIDAEXAMPLE",
+            "resource_uid": "arn:aws:iam::111122223333:user/build-bot",
+        }
+        encoded = json.dumps(golden_event, sort_keys=True, separators=(",", ":")).encode()
+        finding_uid = f"det-evt-{hashlib.sha256(encoded).hexdigest()[:12]}"
+
+        fixture = tmp_path / "bad-adapter.json"
+        # Valid schema, wrong triage: the gate accepts it, agreement drops.
+        fixture.write_text(
+            json.dumps(
+                [
+                    {
+                        "finding_uid": finding_uid,
+                        "priority": "low",
+                        "recommended_action": "close",
+                        "rationale": "nothing to see here",
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        result, report = self._run(
+            tmp_path,
+            env={
+                "DEMO_LLM_ADAPTER_FIXTURE": str(fixture),
+                "DEMO_EXTERNAL_LLM_ALLOWED": "yes",
+            },
+        )
+        assert result.returncode == 1
+        assert report["adapter_env"]["fixture"] is True
+        assert report["agreement_rate"] < 1.0
+
+
 class TestLangGraphHarnessEvals:
     """Regression coverage for profile/triage eval tracking."""
 


### PR DESCRIPTION
## Summary
Phase 3 of the audit plan — makes BYOM real instead of metadata-only.

**Live BYOM adapter.** `OpenAICompatTriageAdapter` in `examples/agents/harness_adapters.py` is a stdlib-only client for any `chat/completions` endpoint, so one adapter covers OpenAI, Azure OpenAI, Ollama, vLLM, and LiteLLM. Trust posture is unchanged by design:
- Activates only when `DEMO_OPENAI_BASE_URL` is set **and** the profile resolves to `external_llm_optional`; fixture adapters keep precedence so the eval gate stays hermetic.
- Bounded by construction: single call, timeout clamped to ≤120 s, capped output tokens, no retries, and no network call at all when there are no evidence cards.
- Workload-identity-first: the profile never holds a key — `DEMO_OPENAI_API_KEY_ENV` names the env var that does (keyless allowed for local Ollama/vLLM).
- Every output still passes the existing `validate_adapter_recommendation` closed schema gate; network/parse failures degrade to deterministic triage with the reason recorded on `last_error` and in `llm_triage` node telemetry.

**Model-quality eval mode.** `eval_langgraph_harness.py --model-quality` replays the golden triage dataset through the configured adapter (fixture or live endpoint) and reports accepted/rejected/fallback counts plus priority+action agreement against the golden expectations, gated by `--min-agreement`. With no adapter configured it scores the deterministic path (agreement 1.0), so the same command works offline in CI and against a live model for BYOM quality drift. Reuses the existing `--output` / `--append-jsonl` artifact plumbing.

**Docs.** `examples/agents/README.md` gains live-adapter run recipes (OpenAI and local Ollama) and the model-quality eval workflow.

## Test plan
- [x] 11 new tests in `examples/agents/tests/test_examples.py` (79 passed, 3 skipped total): request shape/auth/timeout clamping, fenced-JSON + `recommendations`-object parsing, keyless mode, failure degradation, selection precedence, schema-gate rejection of live forbidden outputs, and both model-quality gate outcomes
- [x] `eval_langgraph_harness.py --check` and `--model-quality --check` both pass
- [x] `check_langgraph_harness_drift.py`, `ruff check`, `ruff format --check`, mypy clean

Made with [Cursor](https://cursor.com)