### PR TITLE
docs: simplify architecture and data-lake SVGs

### DIFF
--- a/docs/images/agentic-soc-orchestrator.svg
+++ b/docs/images/agentic-soc-orchestrator.svg
@@ -1,175 +1,73 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="820" viewBox="0 0 1600 820" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" viewBox="0 0 1200 320" role="img" aria-labelledby="title desc">
   <title id="title">Optional agentic SOC orchestrator</title>
-  <desc id="desc">LangGraph owns multi-step workflow state and HITL routing. LangChain is optional LLM adapter glue. cloud-ai-security-skills owns deterministic skills, schemas, trust rails, and audit.</desc>
+  <desc id="desc">LangGraph owns workflow state. cloud-ai-security-skills owns deterministic skills and trust rails. LangChain is optional LLM adapter glue.</desc>
+
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#06101f"/>
-      <stop offset="0.55" stop-color="#0d172a"/>
-      <stop offset="1" stop-color="#111827"/>
+      <stop offset="0%" stop-color="#060b17"/>
+      <stop offset="100%" stop-color="#0d172a"/>
     </linearGradient>
-    <pattern id="grid" width="44" height="44" patternUnits="userSpaceOnUse">
-      <path d="M44 0H0V44" fill="none" stroke="#20314f" stroke-opacity="0.22" stroke-width="1"/>
-    </pattern>
-    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%">
-      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.30"/>
-    </filter>
-    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#60a5fa"/>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#60a5fa"/>
     </marker>
-    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#34d399"/>
-    </marker>
-    <marker id="arrowAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#f59e0b"/>
-    </marker>
-    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#fb7185"/>
-    </marker>
-    <style>
-      .font{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
-      .h1{font-size:34px;font-weight:850;fill:#f8fafc}
-      .sub{font-size:15px;fill:#cbd5e1}
-      .eyebrow{font-size:11px;font-weight:850;letter-spacing:.08em;text-transform:uppercase}
-      .cardTitle{font-size:16px;font-weight:850;fill:#f8fafc}
-      .body{font-size:12px;fill:#cbd5e1}
-      .tiny{font-size:11px;fill:#94a3b8}
-      .badge{font-size:12px;font-weight:850;fill:#f8fafc}
-    </style>
   </defs>
 
-  <rect width="1600" height="820" fill="url(#bg)"/>
-  <rect width="1600" height="820" fill="url(#grid)"/>
+  <rect width="1200" height="320" fill="url(#bg)"/>
 
-  <g class="font">
-    <text x="64" y="64" class="h1">Agentic SOC Orchestrator</text>
-    <text x="64" y="94" class="sub">LangGraph owns workflow state and branches. LangChain is optional model glue. Skills own facts, policy, confidence, audit, and write gates.</text>
+  <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
+    <text x="48" y="48" font-size="26" font-weight="800" fill="#f8fafc">Agentic SOC orchestrator</text>
+    <text x="48" y="74" font-size="13" fill="#94a3b8">Compose LangGraph + skills — not either/or</text>
 
-    <rect x="64" y="130" width="1472" height="144" rx="22" fill="#0b1830" stroke="#2563eb"/>
-    <text x="94" y="166" class="eyebrow" fill="#93c5fd">Optional workflow and agent layer</text>
-    <g filter="url(#softShadow)">
-      <rect x="94" y="192" width="196" height="54" rx="14" fill="#111827" stroke="#475569"/>
-      <text x="124" y="215" class="cardTitle">SOC operator</text>
-      <text x="124" y="235" class="tiny">role, tenant, allowlist</text>
+    <!-- ownership row -->
+    <g transform="translate(48,100)">
+      <rect x="0" y="0" width="340" height="72" rx="14" fill="#0f2a3b" stroke="#22d3ee"/>
+      <text x="24" y="30" font-size="14" font-weight="800" fill="#67e8f9">LangGraph</text>
+      <text x="24" y="52" font-size="11" fill="#94a3b8">workflow state · branches · checkpoints · HITL routing</text>
 
-      <rect x="334" y="192" width="238" height="54" rx="14" fill="#0f2a3b" stroke="#22d3ee"/>
-      <text x="364" y="215" class="cardTitle">LangGraph DAG</text>
-      <text x="364" y="235" class="tiny">nodes, edges, conditions</text>
+      <rect x="360" y="0" width="400" height="72" rx="14" fill="#112244" stroke="#60a5fa" stroke-width="2"/>
+      <text x="384" y="30" font-size="14" font-weight="800" fill="#dbeafe">cloud-ai-security-skills</text>
+      <text x="384" y="52" font-size="11" fill="#94a3b8">131 skills · OCSF wire · MCP · dry-run · audit · allowlists</text>
 
-      <rect x="616" y="192" width="254" height="54" rx="14" fill="#172033" stroke="#475569"/>
-      <text x="646" y="215" class="cardTitle">Model router</text>
-      <text x="646" y="235" class="tiny">small task model, local, customer LLM</text>
-
-      <rect x="914" y="192" width="260" height="54" rx="14" fill="#172033" stroke="#475569"/>
-      <text x="944" y="215" class="cardTitle">Tool boundary</text>
-      <text x="944" y="235" class="tiny">MCP, CLI, CI, runner, library</text>
-
-      <rect x="1218" y="192" width="288" height="54" rx="14" fill="#172033" stroke="#475569"/>
-      <text x="1248" y="215" class="cardTitle">Harness profile</text>
-      <text x="1248" y="235" class="tiny">budget, data source, approvals</text>
-    </g>
-    <path d="M290 219H326" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
-    <path d="M572 219H608" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
-    <path d="M870 219H906" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
-    <path d="M1174 219H1210" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
-
-    <rect x="64" y="306" width="1472" height="282" rx="22" fill="#052e2b" stroke="#0f766e"/>
-    <text x="94" y="342" class="eyebrow" fill="#5eead4">End-to-end pipeline over deterministic repo skills</text>
-
-    <g filter="url(#softShadow)">
-      <rect x="94" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
-      <text x="118" y="402" class="cardTitle">Source</text>
-      <text x="118" y="426" class="body">raw ingest</text>
-      <text x="118" y="446" class="tiny">or lake replay</text>
-
-      <rect x="286" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
-      <text x="310" y="402" class="cardTitle">Normalize</text>
-      <text x="310" y="426" class="body">OCSF/native</text>
-      <text x="310" y="446" class="tiny">stable IDs, hashes</text>
-
-      <rect x="478" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
-      <text x="502" y="402" class="cardTitle">Enrich</text>
-      <text x="502" y="426" class="body">OSV, NVD</text>
-      <text x="502" y="446" class="tiny">EPSS, KEV</text>
-
-      <rect x="670" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
-      <text x="694" y="402" class="cardTitle">Correlate</text>
-      <text x="694" y="426" class="body">identity, tools</text>
-      <text x="694" y="446" class="tiny">lineage windows</text>
-
-      <rect x="862" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
-      <text x="886" y="402" class="cardTitle">Confidence</text>
-      <text x="886" y="426" class="body">reason codes</text>
-      <text x="886" y="446" class="tiny">no model facts</text>
-
-      <rect x="1054" y="374" width="150" height="88" rx="14" fill="#0f172a" stroke="#34d399"/>
-      <text x="1078" y="402" class="cardTitle">Map</text>
-      <text x="1078" y="426" class="body">MITRE, CVSS</text>
-      <text x="1078" y="446" class="tiny">EPSS, KEV, controls</text>
-
-      <rect x="1246" y="374" width="150" height="88" rx="14" fill="#0b1830" stroke="#60a5fa"/>
-      <text x="1270" y="402" class="cardTitle">LLM triage</text>
-      <text x="1270" y="426" class="body">rank, summarize</text>
-      <text x="1270" y="446" class="tiny">schema gated</text>
+      <rect x="780" y="0" width="324" height="72" rx="14" fill="#172033" stroke="#475569"/>
+      <text x="804" y="30" font-size="14" font-weight="800" fill="#e2e8f0">LangChain (optional)</text>
+      <text x="804" y="52" font-size="11" fill="#94a3b8">LLM message adapter · bounded triage schema gate</text>
     </g>
 
-    <path d="M244 418H278" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
-    <path d="M436 418H470" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
-    <path d="M628 418H662" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
-    <path d="M820 418H854" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
-    <path d="M1012 418H1046" stroke="#34d399" stroke-width="3" marker-end="url(#arrowGreen)" fill="none"/>
-    <path d="M1204 418H1238" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrowBlue)" fill="none"/>
+    <!-- pipeline row -->
+    <g transform="translate(48,196)">
+      <rect x="0" y="0" width="1104" height="88" rx="14" fill="#052e2b" stroke="#0f766e"/>
+      <text x="24" y="28" font-size="10" font-weight="700" fill="#5eead4" letter-spacing="1.2">EXAMPLE PIPELINE</text>
 
-    <g filter="url(#softShadow)">
-      <rect x="286" y="498" width="166" height="56" rx="14" fill="#3b2403" stroke="#f59e0b"/>
-      <text x="316" y="521" class="cardTitle">Review</text>
-      <text x="316" y="541" class="tiny" fill="#fef3c7">HITL approval required</text>
+      <g font-size="11" font-weight="700" fill="#e2e8f0">
+        <rect x="24" y="40" width="88" height="32" rx="10" fill="#0f172a" stroke="#34d399"/>
+        <text x="68" y="61" text-anchor="middle">ingest</text>
+        <path d="M120 56H140" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
 
-      <rect x="500" y="498" width="178" height="56" rx="14" fill="#4c0519" stroke="#fb7185"/>
-      <text x="530" y="521" class="cardTitle">Dry-run action</text>
-      <text x="530" y="541" class="tiny" fill="#fecdd3">idempotency key reused</text>
+        <rect x="148" y="40" width="88" height="32" rx="10" fill="#0f172a" stroke="#34d399"/>
+        <text x="192" y="61" text-anchor="middle">enrich</text>
+        <path d="M244 56H264" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
 
-      <rect x="726" y="498" width="178" height="56" rx="14" fill="#3b2403" stroke="#f59e0b"/>
-      <text x="756" y="521" class="cardTitle">Retry branch</text>
-      <text x="756" y="541" class="tiny" fill="#fef3c7">bounded retry only</text>
+        <rect x="272" y="40" width="88" height="32" rx="10" fill="#0f172a" stroke="#34d399"/>
+        <text x="316" y="61" text-anchor="middle">triage</text>
+        <path d="M368 56H388" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
 
-      <rect x="952" y="498" width="178" height="56" rx="14" fill="#3b2403" stroke="#f59e0b"/>
-      <text x="982" y="521" class="cardTitle">Escalate</text>
-      <text x="982" y="541" class="tiny" fill="#fef3c7">terminal errors to human</text>
+        <rect x="396" y="40" width="110" height="32" rx="10" fill="#0f172a" stroke="#fbbf24"/>
+        <text x="451" y="61" text-anchor="middle">analyst review</text>
+        <path d="M514 56H534" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
 
-      <rect x="1178" y="498" width="218" height="56" rx="14" fill="#111827" stroke="#94a3b8"/>
-      <text x="1208" y="521" class="cardTitle">Audit and eval</text>
-      <text x="1208" y="541" class="tiny">state hash, pass rate, writeback</text>
+        <rect x="542" y="40" width="130" height="32" rx="10" fill="#0f172a" stroke="#fbbf24"/>
+        <text x="607" y="61" text-anchor="middle">dry-run remediate</text>
+        <path d="M680 56H700" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
+
+        <rect x="708" y="40" width="88" height="32" rx="10" fill="#0f172a" stroke="#2dd4bf"/>
+        <text x="752" y="61" text-anchor="middle">audit</text>
+        <path d="M804 56H824" stroke="#60a5fa" stroke-width="2" marker-end="url(#arrow)"/>
+
+        <rect x="832" y="40" width="120" height="32" rx="10" fill="#0f172a" stroke="#2dd4bf"/>
+        <text x="892" y="61" text-anchor="middle">verify closure</text>
+      </g>
+
+      <text x="980" y="61" font-size="10" fill="#64748b">harness_profiles/</text>
     </g>
-    <path d="M1321 462V484C1321 492 1313 498 1303 498H452" stroke="#60a5fa" stroke-width="2.8" marker-end="url(#arrowBlue)" fill="none"/>
-    <path d="M452 526H492" stroke="#fb7185" stroke-width="3" marker-end="url(#arrowRose)" fill="none"/>
-    <path d="M678 526H718" stroke="#f59e0b" stroke-width="3" marker-end="url(#arrowAmber)" fill="none"/>
-    <path d="M589 554V572H1041V556" stroke="#f59e0b" stroke-width="2.6" marker-end="url(#arrowAmber)" fill="none" stroke-dasharray="7 7"/>
-    <path d="M815 498V480H1287V496" stroke="#f59e0b" stroke-width="2.6" marker-end="url(#arrowAmber)" fill="none"/>
-    <path d="M1130 526H1170" stroke="#f59e0b" stroke-width="3" marker-end="url(#arrowAmber)" fill="none" stroke-dasharray="7 7"/>
-
-    <rect x="64" y="626" width="1472" height="126" rx="22" fill="#2a1207" stroke="#d97706"/>
-    <text x="94" y="662" class="eyebrow" fill="#fed7aa">Trust rails the workflow cannot bypass</text>
-    <g>
-      <rect x="94" y="684" width="174" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="181" y="706" text-anchor="middle" class="badge">sandbox + RLIMIT</text>
-      <rect x="298" y="684" width="198" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="397" y="706" text-anchor="middle" class="badge">allowlist intersection</text>
-      <rect x="526" y="684" width="180" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="616" y="706" text-anchor="middle" class="badge">token budgets</text>
-      <rect x="736" y="684" width="188" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="830" y="706" text-anchor="middle" class="badge">integrity hashes</text>
-      <rect x="954" y="684" width="176" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="1042" y="706" text-anchor="middle" class="badge">dry-run first</text>
-      <rect x="1160" y="684" width="170" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="1245" y="706" text-anchor="middle" class="badge">HMAC audit</text>
-      <rect x="1360" y="684" width="146" height="34" rx="17" fill="#111827" stroke="#475569"/>
-      <text x="1433" y="706" text-anchor="middle" class="badge">HITL gates</text>
-    </g>
-
-    <path d="M453 246V294C453 302 460 306 474 306H1321V366" stroke="#60a5fa" stroke-width="2.5" marker-end="url(#arrowBlue)" fill="none" stroke-dasharray="8 7"/>
-    <path d="M743 246V286C743 298 753 306 770 306H1321" stroke="#60a5fa" stroke-width="2.5" fill="none" stroke-dasharray="8 7"/>
-    <path d="M1287 554V618" stroke="#34d399" stroke-width="2.5" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="8 7"/>
-
-    <text x="94" y="786" class="tiny" fill="#94a3b8">Invariant: LLM output can rank, summarize, and draft. Repo skills own facts, schemas, confidence, mappings, idempotency, approval state, API-error routing, audit records, and replayable evidence.</text>
   </g>
 </svg>

--- a/docs/images/architecture-layers.svg
+++ b/docs/images/architecture-layers.svg
@@ -1,148 +1,88 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="780" viewBox="0 0 1400 780" role="img" aria-labelledby="layers-title layers-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-labelledby="layers-title layers-desc">
   <title id="layers-title">Cloud AI Security Skills — architecture layers</title>
-  <desc id="layers-desc">Seven skill layers presented as a clean architecture board. Signals enter on the left and feed two intake layers: L1 Ingest with 22 ingesters plus 4 source adapters, and L2 Discover with 5 inventory, graph, AI BOM, and evidence skills. Intake feeds two analyze layers: L3 Detect with 71 deterministic MITRE-tagged findings emitting OCSF Detection Finding 2004, and L4 Evaluate with 12 benchmark families covering 143 checks. Analyze feeds two act layers: L5 Remediate with 12 HITL dual-audited write paths, and L6 View with 2 OCSF-to-render converters. L7 Output persists to three append-only sinks: S3, Snowflake, and ClickHouse. The diagram emphasizes counts, clean flow, contained labels, and wire-format guidance without dense text.</desc>
+  <desc id="layers-desc">Seven skill layers in a left-to-right flow. L1 Ingest with 22 ingesters plus 4 source adapters. L2 Discover with 5 inventory skills. L3 Detect with 71 deterministic findings. L4 Evaluate with 12 benchmark families. L5 Remediate with 12 HITL write paths. L6 View with 2 OCSF-to-render converters. L7 Output with 3 append-only sinks.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#07101f"/>
-      <stop offset="100%" stop-color="#0f1b31"/>
+      <stop offset="0%" stop-color="#060b17"/>
+      <stop offset="100%" stop-color="#0a1325"/>
     </linearGradient>
-    <radialGradient id="glow" cx="20%" cy="10%" r="80%">
-      <stop offset="0%" stop-color="#2563eb" stop-opacity="0.16"/>
-      <stop offset="60%" stop-color="#2563eb" stop-opacity="0"/>
-      <stop offset="100%" stop-color="#2563eb" stop-opacity="0"/>
-    </radialGradient>
-    <pattern id="grid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#1d2942" stroke-opacity="0.35" stroke-width="1"/>
-    </pattern>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#020617" flood-opacity="0.45"/>
-    </filter>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0 0L10 5L0 10z" fill="#7dd3fc"/>
     </marker>
   </defs>
 
-  <rect width="1400" height="780" fill="url(#bg)"/>
-  <rect width="1400" height="780" fill="url(#grid)"/>
-  <rect width="1400" height="780" fill="url(#glow)"/>
+  <rect width="1200" height="360" fill="url(#bg)"/>
 
-  <g font-family="Inter, Arial, sans-serif">
-    <text x="72" y="76" font-size="38" font-weight="800" fill="#f8fafc">Architecture: seven skill layers, one readable flow</text>
-    <text x="72" y="112" font-size="18" fill="#cbd5e1">Signals enter on the left. The repo normalizes, analyzes, acts, then persists through producer-owned sinks.</text>
+  <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
+    <text x="48" y="52" font-size="28" font-weight="800" fill="#f8fafc">Seven skill layers, one flow</text>
+    <text x="48" y="80" font-size="14" fill="#94a3b8">Same bundles on CLI · CI · MCP · runners · library</text>
 
-    <g transform="translate(72,156)">
-      <rect x="0" y="0" width="160" height="40" rx="20" fill="#0f172a" stroke="#475569"/>
-      <text x="80" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#cbd5e1" letter-spacing="1.5">SIGNALS</text>
-
-      <rect x="240" y="0" width="160" height="40" rx="20" fill="#102345" stroke="#60a5fa"/>
-      <text x="320" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#bfdbfe" letter-spacing="1.5">INTAKE</text>
-
-      <rect x="510" y="0" width="170" height="40" rx="20" fill="#0a3b35" stroke="#34d399"/>
-      <text x="595" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#bbf7d0" letter-spacing="1.5">ANALYZE</text>
-
-      <rect x="790" y="0" width="150" height="40" rx="20" fill="#4a2d09" stroke="#fbbf24"/>
-      <text x="865" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#fde68a" letter-spacing="1.5">ACT</text>
-
-      <rect x="1050" y="0" width="172" height="40" rx="20" fill="#083b39" stroke="#2dd4bf"/>
-      <text x="1136" y="26" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4" letter-spacing="1.5">PERSIST</text>
+    <!-- phase pills -->
+    <g transform="translate(48,100)">
+      <rect x="0" y="0" width="88" height="26" rx="13" fill="#0f172a" stroke="#475569"/>
+      <text x="44" y="18" text-anchor="middle" font-size="10" font-weight="700" fill="#cbd5e1" letter-spacing="1.2">SIGNALS</text>
+      <rect x="168" y="0" width="88" height="26" rx="13" fill="#102345" stroke="#60a5fa"/>
+      <text x="212" y="18" text-anchor="middle" font-size="10" font-weight="700" fill="#bfdbfe" letter-spacing="1.2">INTAKE</text>
+      <rect x="336" y="0" width="88" height="26" rx="13" fill="#0a3b35" stroke="#34d399"/>
+      <text x="380" y="18" text-anchor="middle" font-size="10" font-weight="700" fill="#bbf7d0" letter-spacing="1.2">ANALYZE</text>
+      <rect x="504" y="0" width="72" height="26" rx="13" fill="#4a2d09" stroke="#fbbf24"/>
+      <text x="540" y="18" text-anchor="middle" font-size="10" font-weight="700" fill="#fde68a" letter-spacing="1.2">ACT</text>
+      <rect x="656" y="0" width="88" height="26" rx="13" fill="#083b39" stroke="#2dd4bf"/>
+      <text x="700" y="18" text-anchor="middle" font-size="10" font-weight="700" fill="#99f6e4" letter-spacing="1.2">PERSIST</text>
     </g>
 
-    <!-- SIGNALS panel (taller for vendor-line wrap) -->
-    <g filter="url(#shadow)">
-      <rect x="72" y="228" width="190" height="406" rx="28" fill="#0f172a" stroke="#334155" stroke-width="1.5"/>
-      <text x="110" y="278" font-size="30" font-weight="800" fill="#f8fafc">Signals</text>
-      <g font-size="16" fill="#dbeafe">
-        <rect x="102" y="314" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
-        <text x="166" y="338" text-anchor="middle">Cloud APIs</text>
-        <rect x="102" y="366" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
-        <text x="166" y="390" text-anchor="middle">Raw logs</text>
-        <rect x="102" y="418" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
-        <text x="166" y="442" text-anchor="middle">Identity</text>
-        <rect x="102" y="470" width="128" height="38" rx="19" fill="#111c30" stroke="#334155"/>
-        <text x="166" y="494" text-anchor="middle">Warehouses</text>
-      </g>
-      <text x="110" y="540" font-size="11" fill="#94a3b8">AWS · GCP · Azure · K8s</text>
-      <text x="110" y="560" font-size="11" fill="#94a3b8">Okta · Entra · Workspace</text>
-      <text x="110" y="580" font-size="11" fill="#94a3b8">Slack · Workday · Salesforce</text>
-      <text x="110" y="600" font-size="11" fill="#94a3b8">Snowflake · Databricks · MCP</text>
+    <!-- layer cards -->
+    <g transform="translate(48,148)">
+      <rect x="0" y="0" width="100" height="120" rx="16" fill="#0f172a" stroke="#334155"/>
+      <text x="50" y="36" text-anchor="middle" font-size="11" font-weight="700" fill="#94a3b8">Sources</text>
+      <text x="50" y="72" text-anchor="middle" font-size="22" font-weight="800" fill="#f8fafc">logs</text>
+      <text x="50" y="96" text-anchor="middle" font-size="10" fill="#64748b">APIs · IdP · SaaS</text>
+
+      <path d="M108 60H128" stroke="#7dd3fc" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="136" y="0" width="118" height="56" rx="14" fill="#112244" stroke="#60a5fa"/>
+      <text x="195" y="24" text-anchor="middle" font-size="12" font-weight="800" fill="#dbeafe">L1 Ingest</text>
+      <text x="195" y="44" text-anchor="middle" font-size="20" font-weight="900" fill="#fff">22+4</text>
+
+      <rect x="136" y="64" width="118" height="56" rx="14" fill="#112244" stroke="#60a5fa"/>
+      <text x="195" y="88" text-anchor="middle" font-size="12" font-weight="800" fill="#dbeafe">L2 Discover</text>
+      <text x="195" y="108" text-anchor="middle" font-size="20" font-weight="900" fill="#fff">5</text>
+
+      <path d="M262 60H282" stroke="#7dd3fc" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="290" y="0" width="118" height="56" rx="14" fill="#0a3b35" stroke="#34d399"/>
+      <text x="349" y="24" text-anchor="middle" font-size="12" font-weight="800" fill="#d1fae5">L3 Detect</text>
+      <text x="349" y="44" text-anchor="middle" font-size="20" font-weight="900" fill="#fff">71</text>
+
+      <rect x="290" y="64" width="118" height="56" rx="14" fill="#0a3b35" stroke="#34d399"/>
+      <text x="349" y="88" text-anchor="middle" font-size="12" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
+      <text x="349" y="108" text-anchor="middle" font-size="20" font-weight="900" fill="#fff">12</text>
+
+      <path d="M416 60H436" stroke="#7dd3fc" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="444" y="0" width="118" height="56" rx="14" fill="#4a2d09" stroke="#fbbf24"/>
+      <text x="503" y="24" text-anchor="middle" font-size="12" font-weight="800" fill="#fde68a">L5 Remediate</text>
+      <text x="503" y="44" text-anchor="middle" font-size="20" font-weight="900" fill="#fff">12</text>
+
+      <rect x="444" y="64" width="118" height="56" rx="14" fill="#4a2d09" stroke="#fbbf24"/>
+      <text x="503" y="88" text-anchor="middle" font-size="12" font-weight="800" fill="#fde68a">L6 View</text>
+      <text x="503" y="108" text-anchor="middle" font-size="20" font-weight="900" fill="#fff">2</text>
+
+      <path d="M570 60H590" stroke="#7dd3fc" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="598" y="0" width="118" height="120" rx="16" fill="#083b39" stroke="#2dd4bf"/>
+      <text x="657" y="28" text-anchor="middle" font-size="12" font-weight="800" fill="#99f6e4">L7 Output</text>
+      <text x="657" y="58" text-anchor="middle" font-size="28" font-weight="900" fill="#fff">3</text>
+      <text x="657" y="82" text-anchor="middle" font-size="10" fill="#94a3b8">S3 · Snowflake</text>
+      <text x="657" y="98" text-anchor="middle" font-size="10" fill="#94a3b8">ClickHouse</text>
     </g>
 
-    <!-- L1 Ingest + L2 Discover (boxes widened to 260, descriptions wrapped to 2 short lines) -->
-    <g filter="url(#shadow)">
-      <rect x="322" y="228" width="260" height="180" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
-      <text x="354" y="270" font-size="18" font-weight="800" fill="#dbeafe">L1 Ingest</text>
-      <text x="354" y="332" font-size="56" font-weight="900" fill="#ffffff">22 + 4</text>
-      <text x="354" y="364" font-size="15" fill="#bfdbfe">normalize source data to</text>
-      <text x="354" y="386" font-size="15" fill="#bfdbfe">OCSF 1.8 or native JSONL</text>
-
-      <rect x="322" y="440" width="260" height="180" rx="28" fill="#112244" stroke="#60a5fa" stroke-width="1.6"/>
-      <text x="354" y="482" font-size="18" font-weight="800" fill="#dbeafe">L2 Discover</text>
-      <text x="354" y="544" font-size="56" font-weight="900" fill="#ffffff">5</text>
-      <text x="354" y="576" font-size="15" fill="#bfdbfe">inventory · graph · AI BOM</text>
-      <text x="354" y="598" font-size="15" fill="#bfdbfe">CycloneDX · evidence</text>
-    </g>
-
-    <!-- L3 Detect + L4 Evaluate -->
-    <g filter="url(#shadow)">
-      <rect x="642" y="228" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
-      <text x="674" y="270" font-size="18" font-weight="800" fill="#d1fae5">L3 Detect</text>
-      <text x="674" y="332" font-size="56" font-weight="900" fill="#ffffff">71</text>
-      <text x="674" y="364" font-size="15" fill="#a7f3d0">deterministic MITRE-tagged</text>
-      <text x="674" y="386" font-size="15" fill="#a7f3d0">OCSF Detection Finding 2004</text>
-
-      <rect x="642" y="440" width="260" height="180" rx="28" fill="#0a3b35" stroke="#34d399" stroke-width="1.6"/>
-      <text x="674" y="482" font-size="18" font-weight="800" fill="#d1fae5">L4 Evaluate</text>
-      <text x="674" y="544" font-size="56" font-weight="900" fill="#ffffff">12</text>
-      <text x="674" y="576" font-size="15" fill="#a7f3d0">143 benchmark checks across</text>
-      <text x="674" y="598" font-size="15" fill="#a7f3d0">CIS · K8s · container · AI</text>
-    </g>
-
-    <!-- L5 Remediate + L6 View -->
-    <g filter="url(#shadow)">
-      <rect x="962" y="228" width="260" height="180" rx="28" fill="#4a2d09" stroke="#fbbf24" stroke-width="1.6"/>
-      <text x="994" y="270" font-size="18" font-weight="800" fill="#fde68a">L5 Remediate</text>
-      <text x="994" y="332" font-size="56" font-weight="900" fill="#ffffff">12</text>
-      <text x="994" y="364" font-size="15" fill="#fde68a">HITL · dry-run-first</text>
-      <text x="994" y="386" font-size="15" fill="#fde68a">dual-audited write paths</text>
-
-      <rect x="962" y="440" width="260" height="180" rx="28" fill="#4a2d09" stroke="#fbbf24" stroke-width="1.6"/>
-      <text x="994" y="482" font-size="18" font-weight="800" fill="#fde68a">L6 View</text>
-      <text x="994" y="544" font-size="56" font-weight="900" fill="#ffffff">2</text>
-      <text x="994" y="576" font-size="15" fill="#fde68a">render OCSF to SARIF</text>
-      <text x="994" y="598" font-size="15" fill="#fde68a">or Mermaid for review</text>
-    </g>
-
-    <!-- L7 Output -->
-    <g filter="url(#shadow)">
-      <rect x="1234" y="228" width="112" height="392" rx="28" fill="#083b39" stroke="#2dd4bf" stroke-width="1.6"/>
-      <text x="1290" y="270" text-anchor="middle" font-size="14" font-weight="800" fill="#99f6e4">L7 Output</text>
-      <text x="1290" y="334" text-anchor="middle" font-size="46" font-weight="900" fill="#ffffff">3</text>
-      <text x="1290" y="368" text-anchor="middle" font-size="11" fill="#99f6e4">append-only sinks</text>
-      <g font-size="12" font-weight="800" fill="#ecfeff">
-        <rect x="1254" y="404" width="72" height="30" rx="15" fill="#0b4a46" stroke="#2dd4bf"/>
-        <text x="1290" y="424" text-anchor="middle">S3</text>
-        <rect x="1254" y="448" width="72" height="30" rx="15" fill="#0b4a46" stroke="#2dd4bf"/>
-        <text x="1290" y="468" text-anchor="middle">Snowflake</text>
-        <rect x="1254" y="492" width="72" height="30" rx="15" fill="#0b4a46" stroke="#2dd4bf"/>
-        <text x="1290" y="512" text-anchor="middle">ClickHouse</text>
-      </g>
-      <text x="1290" y="572" text-anchor="middle" font-size="10" fill="#94a3b8">audit +</text>
-      <text x="1290" y="586" text-anchor="middle" font-size="10" fill="#94a3b8">ingest-back</text>
-      <text x="1290" y="600" text-anchor="middle" font-size="10" fill="#94a3b8">to producer</text>
-    </g>
-
-    <!-- Arrows (signals 262, intake 322-582, analyze 642-902, act 962-1222, output 1234-1346) -->
-    <path d="M262 420H312" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-    <path d="M582 318H632" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-    <path d="M582 530H632" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-    <path d="M902 318H952" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-    <path d="M902 530H952" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-    <path d="M1222 424H1228" stroke="#7dd3fc" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
-
-    <!-- Wire-contract footer -->
-    <rect x="72" y="676" width="1274" height="60" rx="18" fill="#0b1220" stroke="#334155"/>
-    <text x="102" y="704" font-size="15" fill="#cbd5e1">Wire contract: <tspan font-weight="800" fill="#5eead4">OCSF 1.8</tspan> on Ingest + Detect · <tspan font-weight="800" fill="#fbbf24">native</tspan> on Discover + Remediate · <tspan font-weight="800" fill="#a78bfa">SARIF / Mermaid</tspan> on View · <tspan font-weight="800" fill="#22d3ee">pass-through</tspan> on Output</text>
-    <text x="102" y="724" font-size="13" fill="#94a3b8">OCSF 1.8 where interop matters · native where state and audit matter more · rendered output on view · pass-through on sinks.</text>
+    <rect x="48" y="296" width="1104" height="44" rx="12" fill="#0b1220" stroke="#334155"/>
+    <text x="68" y="324" font-size="12" fill="#cbd5e1">
+      Wire: <tspan font-weight="700" fill="#5eead4">OCSF 1.8</tspan> ingest+detect ·
+      <tspan font-weight="700" fill="#fbbf24">native</tspan> discover+remediate ·
+      <tspan font-weight="700" fill="#a78bfa">SARIF/Mermaid</tspan> view · pass-through sinks
+    </text>
   </g>
 </svg>

--- a/docs/images/clickhouse-data-lake.svg
+++ b/docs/images/clickhouse-data-lake.svg
@@ -1,292 +1,76 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
-  <title id="title">ClickHouse security data lake closed-loop architecture</title>
-  <desc id="desc">Clean lane diagram showing covered signals, OCSF normalization, append-only ClickHouse writes, governed ClickHouse tables, read-only replay, operator artifacts, HITL review, audit write-back, materialized views, and the customer-owned trust boundary.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="340" viewBox="0 0 1200 340" role="img" aria-labelledby="title desc">
+  <title id="title">ClickHouse security data lake</title>
+  <desc id="desc">Closed-loop flow: source signals, OCSF ingest, append-only ClickHouse lake, detect and evaluate, HITL remediate, audit write-back.</desc>
 
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#07111f"/>
-      <stop offset="0.52" stop-color="#0d172a"/>
-      <stop offset="1" stop-color="#121827"/>
+      <stop offset="0%" stop-color="#060b17"/>
+      <stop offset="100%" stop-color="#121827"/>
     </linearGradient>
-    <linearGradient id="lakeFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#6a4407"/>
-      <stop offset="1" stop-color="#2d1d05"/>
-    </linearGradient>
-    <linearGradient id="goldStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#facc15"/>
-      <stop offset="0.45" stop-color="#f59e0b"/>
-      <stop offset="1" stop-color="#fef08a"/>
-    </linearGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M48 0H0V48" fill="none" stroke="#20314f" stroke-opacity="0.24" stroke-width="1"/>
-    </pattern>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%">
-      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.28"/>
-    </filter>
-    <marker id="arrowCyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#22d3ee"/>
+    <symbol id="clickhouse" viewBox="0 0 24 24">
+      <path fill="#FFCC00" d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z"/>
+    </symbol>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#22d3ee"/>
     </marker>
-    <marker id="arrowGold" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#facc15"/>
+    <marker id="arrowBack" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#34d399"/>
     </marker>
-    <marker id="arrowViolet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#a78bfa"/>
-    </marker>
-    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#34d399"/>
-    </marker>
-    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#fb7185"/>
-    </marker>
-    <style>
-      .font { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; }
-      .h1 { font-size: 34px; font-weight: 850; fill: #f8fafc; }
-      .sub { font-size: 15px; fill: #cbd5e1; }
-      .eyebrow { font-size: 11px; font-weight: 850; letter-spacing: 0.08em; text-transform: uppercase; }
-      .cardTitle { font-size: 17px; font-weight: 850; fill: #f8fafc; }
-      .cardSub { font-size: 13px; fill: #cbd5e1; }
-      .body { font-size: 12px; fill: #cbd5e1; }
-      .tiny { font-size: 11px; fill: #94a3b8; }
-      .badge { font-size: 12px; font-weight: 850; fill: #f8fafc; }
-      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
-    </style>
   </defs>
 
-  <rect width="1600" height="980" fill="url(#bg)"/>
-  <rect width="1600" height="980" fill="url(#grid)"/>
+  <rect width="1200" height="340" fill="url(#bg)"/>
 
-  <g class="font">
-    <!-- Header -->
-    <text x="64" y="64" class="h1">ClickHouse Security Data Lake</text>
-    <text x="64" y="94" class="sub">Operator-owned storage, read-only replay, and audit closure for cloud, identity, Kubernetes, SaaS, and MCP security events.</text>
+  <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
+    <text x="48" y="48" font-size="26" font-weight="800" fill="#f8fafc">ClickHouse security data lake</text>
+    <text x="48" y="74" font-size="13" fill="#94a3b8">High-volume append-only lake · materialized views · read-only replay</text>
 
-    <g transform="translate(1246,42)">
-      <rect x="0" y="0" width="322" height="70" rx="14" fill="#101827" stroke="#334155"/>
-      <g transform="translate(22,18)">
-        <rect x="0" y="0" width="12" height="34" fill="#facc15"/>
-        <rect x="18" y="0" width="12" height="34" fill="#fbbf24"/>
-        <rect x="36" y="0" width="12" height="27" fill="#fde047"/>
-        <rect x="54" y="0" width="12" height="18" fill="#fef08a"/>
-      </g>
-      <text x="108" y="29" class="cardTitle">ClickHouse pack</text>
-      <text x="108" y="51" class="tiny">DDL · rollups · row policies · replay SQL</text>
+    <g transform="translate(48,108)">
+      <rect x="0" y="0" width="130" height="88" rx="14" fill="#0f172a" stroke="#334155"/>
+      <text x="65" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#e2e8f0">Sources</text>
+      <text x="65" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">VPC flow · audit</text>
+      <text x="65" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">MCP proxy · SaaS</text>
+
+      <path d="M138 44H168" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="176" y="0" width="150" height="88" rx="14" fill="#112244" stroke="#60a5fa"/>
+      <text x="251" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#dbeafe">Ingest</text>
+      <text x="251" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">22 ingest skills</text>
+      <text x="251" y="70" text-anchor="middle" font-size="10" fill="#5eead4">→ OCSF 1.8</text>
+
+      <path d="M334 44H364" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="372" y="0" width="170" height="88" rx="14" fill="#2d1d05" stroke="#facc15" stroke-width="2"/>
+      <use href="#clickhouse" x="388" y="12" width="32" height="32"/>
+      <text x="468" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#fef08a">ClickHouse lake</text>
+      <text x="468" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">MergeTree JSONL</text>
+      <text x="468" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">materialized views</text>
+
+      <path d="M550 44H580" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="588" y="0" width="150" height="88" rx="14" fill="#0a3b35" stroke="#34d399"/>
+      <text x="663" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#d1fae5">Detect</text>
+      <text x="663" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">71 skills · MITRE</text>
+      <text x="663" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">source-* adapters</text>
+
+      <path d="M746 44H776" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="784" y="0" width="150" height="88" rx="14" fill="#4a2d09" stroke="#fbbf24"/>
+      <text x="859" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#fde68a">Remediate</text>
+      <text x="859" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">HITL · dry-run</text>
+      <text x="859" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">dual audit</text>
+
+      <path d="M942 44H972" stroke="#22d3ee" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="980" y="0" width="124" height="88" rx="14" fill="#083b39" stroke="#2dd4bf"/>
+      <text x="1042" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#99f6e4">Audit</text>
+      <text x="1042" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">write-back</text>
+      <text x="1042" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">closed loop</text>
     </g>
 
-    <!-- Lane labels -->
-    <g transform="translate(64,138)">
-      <rect x="0" y="0" width="146" height="30" rx="15" fill="#083344" stroke="#155e75"/>
-      <text x="73" y="20" text-anchor="middle" class="eyebrow" fill="#67e8f9">Write lane</text>
-    </g>
-    <g transform="translate(64,574)">
-      <rect x="0" y="0" width="150" height="30" rx="15" fill="#2e1065" stroke="#6d28d9"/>
-      <text x="75" y="20" text-anchor="middle" class="eyebrow" fill="#c4b5fd">Replay lane</text>
-    </g>
-    <g transform="translate(64,820)">
-      <rect x="0" y="0" width="174" height="30" rx="15" fill="#4c0519" stroke="#9f1239"/>
-      <text x="87" y="20" text-anchor="middle" class="eyebrow" fill="#fda4af">Governance lane</text>
-    </g>
+    <path d="M1028 204 C1028 248 468 248 468 204" stroke="#34d399" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#arrowBack)"/>
+    <text x="748" y="268" text-anchor="middle" font-size="11" fill="#6ee7b7">sink-clickhouse-jsonl append-only · replay converges on outage recovery</text>
 
-    <!-- Signals -->
-    <g filter="url(#softShadow)">
-      <rect x="64" y="190" width="312" height="318" rx="18" fill="#101827" stroke="#334155"/>
-      <text x="92" y="230" class="cardTitle">Covered signals</text>
-      <text x="92" y="253" class="cardSub">Existing OCSF ingest sources</text>
-
-      <g transform="translate(92,284)">
-        <g>
-          <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="27" cy="29" r="17" fill="#ff9900"/>
-          <text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#111827">AWS</text>
-          <text x="55" y="26" class="badge">AWS</text>
-          <text x="55" y="43" class="tiny">trail · flow</text>
-        </g>
-        <g transform="translate(134,0)">
-          <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="27" cy="29" r="17" fill="#4285f4"/>
-          <text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#ffffff">GCP</text>
-          <text x="55" y="26" class="badge">GCP</text>
-          <text x="55" y="43" class="tiny">audit · SCC</text>
-        </g>
-        <g transform="translate(0,74)">
-          <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="27" cy="29" r="17" fill="#2563eb"/>
-          <text x="27" y="34" text-anchor="middle" font-size="10" font-weight="900" fill="#ffffff">AZ</text>
-          <text x="55" y="26" class="badge">Azure</text>
-          <text x="50" y="43" class="tiny" style="font-size:10px">activity · NSG</text>
-        </g>
-        <g transform="translate(134,74)">
-          <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="27" cy="29" r="17" fill="#111827" stroke="#94a3b8"/>
-          <text x="27" y="34" text-anchor="middle" font-size="9" font-weight="900" fill="#f8fafc">ID</text>
-          <text x="55" y="26" class="badge">Identity</text>
-          <text x="55" y="43" class="tiny">Entra · Okta</text>
-        </g>
-        <g transform="translate(0,148)">
-          <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="27" cy="29" r="17" fill="#326ce5"/>
-          <text x="27" y="34" text-anchor="middle" font-size="9" font-weight="900" fill="#ffffff">K8s</text>
-          <text x="55" y="26" class="badge">Runtime</text>
-          <text x="55" y="43" class="tiny">K8s · MCP</text>
-        </g>
-        <g transform="translate(134,148)">
-          <rect x="0" y="0" width="118" height="58" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="27" cy="29" r="17" fill="#334155"/>
-          <text x="27" y="34" text-anchor="middle" font-size="9" font-weight="900" fill="#ffffff">SaaS</text>
-          <text x="55" y="26" class="badge">SaaS</text>
-          <text x="55" y="43" class="tiny">GH · Slack</text>
-        </g>
-      </g>
-    </g>
-
-    <!-- Normalize -->
-    <g filter="url(#softShadow)">
-      <rect x="438" y="222" width="238" height="254" rx="18" fill="#083344" stroke="#22d3ee"/>
-      <text x="468" y="262" class="cardTitle">Normalize</text>
-      <text x="468" y="286" class="cardSub">22 OCSF ingest skills</text>
-      <rect x="468" y="316" width="178" height="50" rx="12" fill="#0e7490" stroke="#67e8f9"/>
-      <text x="557" y="337" text-anchor="middle" class="badge">OCSF 1.8 JSONL</text>
-      <text x="557" y="356" text-anchor="middle" class="tiny" fill="#cffafe">stdout pipe contract</text>
-      <text x="468" y="400" class="body">Stable IDs:</text>
-      <text x="468" y="422" class="mono" font-size="12" fill="#e0f2fe">event_uid</text>
-      <text x="568" y="422" class="mono" font-size="12" fill="#e0f2fe">finding_uid</text>
-    </g>
-
-    <!-- Sink -->
-    <g filter="url(#softShadow)">
-      <rect x="738" y="222" width="250" height="254" rx="18" fill="#111827" stroke="#38bdf8"/>
-      <text x="768" y="262" class="cardTitle">Write</text>
-      <text x="768" y="286" class="cardSub">sink-clickhouse-jsonl</text>
-      <g transform="translate(768,320)">
-        <rect x="0" y="0" width="190" height="34" rx="9" fill="#0f2a3b" stroke="#38bdf8"/>
-        <text x="95" y="22" text-anchor="middle" class="badge">append-only insert</text>
-        <rect x="0" y="48" width="190" height="34" rx="9" fill="#0f2a3b" stroke="#38bdf8"/>
-        <text x="95" y="70" text-anchor="middle" class="badge">dry-run default</text>
-        <rect x="0" y="96" width="190" height="34" rx="9" fill="#0f2a3b" stroke="#38bdf8"/>
-        <text x="95" y="118" text-anchor="middle" class="badge">identifier validated</text>
-      </g>
-    </g>
-
-    <!-- Lake -->
-    <g filter="url(#shadow)">
-      <rect x="1052" y="166" width="454" height="390" rx="22" fill="url(#lakeFill)" stroke="url(#goldStroke)" stroke-width="2"/>
-      <g transform="translate(1084,204)">
-        <rect x="0" y="0" width="14" height="38" fill="#facc15"/>
-        <rect x="21" y="0" width="14" height="38" fill="#fbbf24"/>
-        <rect x="42" y="0" width="14" height="30" fill="#fde047"/>
-        <rect x="63" y="0" width="14" height="20" fill="#fef08a"/>
-      </g>
-      <text x="1184" y="225" font-size="24" font-weight="850" fill="#fef9c3">ClickHouse lake</text>
-      <text x="1184" y="250" class="body" fill="#fde68a">pre-provisioned schema; skills hold no DDL rights</text>
-
-      <g transform="translate(1086,290)">
-        <rect x="0" y="0" width="178" height="70" rx="13" fill="#70480a" stroke="#facc15"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#fef3c7">events_sink</text>
-        <text x="20" y="50" class="tiny" fill="#fde68a">90-day hot tier</text>
-      </g>
-      <g transform="translate(1284,290)">
-        <rect x="0" y="0" width="178" height="70" rx="13" fill="#70480a" stroke="#facc15"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#fef3c7">findings_sink</text>
-        <text x="20" y="50" class="tiny" fill="#fde68a">365-day history</text>
-      </g>
-      <g transform="translate(1086,380)">
-        <rect x="0" y="0" width="178" height="70" rx="13" fill="#70480a" stroke="#facc15"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#fef3c7">evidence_sink</text>
-        <text x="20" y="50" class="tiny" fill="#fde68a">7-year hold</text>
-      </g>
-      <g transform="translate(1284,380)">
-        <rect x="0" y="0" width="178" height="70" rx="13" fill="#70480a" stroke="#facc15"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#fef3c7">audit_sink</text>
-        <text x="20" y="50" class="tiny" fill="#fde68a">legal-hold chain</text>
-      </g>
-      <rect x="1086" y="476" width="376" height="52" rx="13" fill="#854d0e" stroke="#fde047" stroke-dasharray="6 5"/>
-      <text x="1274" y="498" text-anchor="middle" font-size="13" font-weight="850" fill="#fef9c3">rollup materialized views</text>
-      <text x="1274" y="518" text-anchor="middle" class="tiny" fill="#fde68a">rule volume · class volume · remediation outcomes</text>
-    </g>
-
-    <!-- Replay source -->
-    <g filter="url(#softShadow)">
-      <rect x="738" y="622" width="250" height="162" rx="18" fill="#1e1b4b" stroke="#a78bfa"/>
-      <text x="768" y="662" class="cardTitle">Read</text>
-      <text x="768" y="686" class="cardSub">source-clickhouse-query</text>
-      <rect x="768" y="716" width="190" height="38" rx="10" fill="#312e81" stroke="#a78bfa"/>
-      <text x="863" y="740" text-anchor="middle" class="badge">read-only SQL gate</text>
-      <text x="768" y="770" class="tiny" fill="#c4b5fd">SELECT · WITH · SHOW · DESCRIBE</text>
-    </g>
-
-    <!-- Skill replay -->
-    <g filter="url(#softShadow)">
-      <rect x="438" y="622" width="238" height="162" rx="18" fill="#2e1065" stroke="#a78bfa"/>
-      <text x="468" y="662" class="cardTitle">Replay rows</text>
-      <text x="468" y="688" class="body">detect-* rules</text>
-      <text x="468" y="712" class="body">view-* renderers</text>
-      <text x="468" y="736" class="body">control evidence</text>
-      <text x="468" y="764" class="tiny" fill="#c4b5fd">UID-aware windows for de-dupe</text>
-    </g>
-
-    <!-- Outputs -->
-    <g filter="url(#softShadow)">
-      <rect x="64" y="622" width="312" height="162" rx="18" fill="#052e2b" stroke="#34d399"/>
-      <text x="92" y="662" class="cardTitle">Operator artifacts</text>
-      <text x="92" y="690" class="body">new findings</text>
-      <text x="92" y="714" class="body">SARIF handoff</text>
-      <text x="92" y="738" class="body">Mermaid attack-flow</text>
-      <text x="92" y="762" class="body">dashboard query pack</text>
-    </g>
-
-    <!-- Governance -->
-    <g filter="url(#softShadow)">
-      <rect x="438" y="858" width="238" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/>
-      <text x="468" y="887" class="cardTitle">HITL response</text>
-      <text x="468" y="910" class="tiny" fill="#fecdd3">dry-run first · approved window</text>
-    </g>
-    <g filter="url(#softShadow)">
-      <rect x="738" y="858" width="250" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/>
-      <text x="768" y="887" class="cardTitle">Audit write-back</text>
-      <text x="768" y="910" class="tiny" fill="#fecdd3">remediation and MCP records</text>
-    </g>
-    <g filter="url(#softShadow)">
-      <rect x="1052" y="858" width="454" height="72" rx="18" fill="#111827" stroke="#475569"/>
-      <text x="1084" y="887" class="cardTitle">Customer-owned boundary</text>
-      <text x="1084" y="906" class="tiny">Cluster, database, roles, TLS, retention, tenancy,</text>
-      <text x="1084" y="922" class="tiny">and dashboard access stay under operator control.</text>
-    </g>
-
-    <!-- Arrows: write lane -->
-    <path d="M376 349H438" stroke="#22d3ee" stroke-width="3.2" marker-end="url(#arrowCyan)" fill="none"/>
-    <path d="M676 349H738" stroke="#22d3ee" stroke-width="3.2" marker-end="url(#arrowCyan)" fill="none"/>
-    <path d="M988 349H1052" stroke="#22d3ee" stroke-width="3.2" marker-end="url(#arrowCyan)" fill="none"/>
-    <text x="1002" y="333" class="tiny" fill="#a5f3fc">insert</text>
-
-    <!-- Arrows: replay lane -->
-    <path d="M1052 703H988" stroke="#facc15" stroke-width="3.2" marker-end="url(#arrowGold)" fill="none"/>
-    <text x="1000" y="686" class="tiny" fill="#fde68a">query</text>
-    <path d="M738 703H676" stroke="#a78bfa" stroke-width="3.2" marker-end="url(#arrowViolet)" fill="none"/>
-    <path d="M438 703H376" stroke="#34d399" stroke-width="3.2" marker-end="url(#arrowGreen)" fill="none"/>
-
-    <!-- Return loop from outputs to lake, routed below cards -->
-    <path d="M220 784V812C220 834 250 846 290 846H1320C1350 846 1366 828 1366 802V556" stroke="#34d399" stroke-width="2.6" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="9 8"/>
-    <text x="650" y="834" class="tiny" fill="#a7f3d0">artifact rows can re-land through sink-clickhouse-jsonl</text>
-
-    <!-- Governance loop -->
-    <path d="M676 894H738" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/>
-    <path d="M988 894H1052" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/>
-    <path d="M863 858V818C863 804 878 796 904 796H1372C1392 796 1402 784 1402 760V556" stroke="#fb7185" stroke-width="2.6" marker-end="url(#arrowRose)" fill="none" stroke-dasharray="9 8"/>
-    <text x="1008" y="778" class="tiny" fill="#fda4af">audit_sink captures decisions and tool activity</text>
-
-    <!-- Footer -->
-    <g transform="translate(64,952)">
-      <circle cx="6" cy="-4" r="5" fill="#22d3ee"/>
-      <text x="20" y="0" class="tiny" fill="#a5f3fc">write</text>
-      <circle cx="88" cy="-4" r="5" fill="#facc15"/>
-      <text x="102" y="0" class="tiny" fill="#fde68a">read</text>
-      <circle cx="166" cy="-4" r="5" fill="#34d399"/>
-      <text x="180" y="0" class="tiny" fill="#a7f3d0">artifact</text>
-      <circle cx="270" cy="-4" r="5" fill="#fb7185"/>
-      <text x="284" y="0" class="tiny" fill="#fda4af">audit</text>
-      <text x="384" y="0" class="tiny">Append-only tables preserve history; stable UIDs support duplicate-aware replay queries.</text>
-    </g>
+    <rect x="48" y="288" width="1104" height="36" rx="10" fill="#0b1220" stroke="#334155"/>
+    <text x="68" y="312" font-size="11" fill="#94a3b8">Customer-owned trust boundary · no hosted runner required · packs in docs/CLICKHOUSE_DATA_LAKE.md</text>
   </g>
 </svg>

--- a/docs/images/snowflake-data-lake.svg
+++ b/docs/images/snowflake-data-lake.svg
@@ -1,281 +1,77 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
-  <title id="title">Snowflake security data lake closed-loop architecture</title>
-  <desc id="desc">Readable lane diagram showing covered signals, OCSF normalization, append-only Snowflake writes, governed Snowflake tables, read-only replay, operator artifacts, HITL review, audit write-back, row access policies, dynamic tables, managed Iceberg, and the customer-owned trust boundary.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="340" viewBox="0 0 1200 340" role="img" aria-labelledby="title desc">
+  <title id="title">Snowflake security data lake</title>
+  <desc id="desc">Closed-loop flow: source signals, OCSF ingest, append-only Snowflake lake, detect and evaluate, HITL remediate, audit write-back.</desc>
+
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#06101f"/>
-      <stop offset="0.52" stop-color="#0a1528"/>
-      <stop offset="1" stop-color="#0f172a"/>
+      <stop offset="0%" stop-color="#060b17"/>
+      <stop offset="100%" stop-color="#0a1528"/>
     </linearGradient>
-    <linearGradient id="lakeFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0d3a70"/>
-      <stop offset="1" stop-color="#081f3e"/>
-    </linearGradient>
-    <linearGradient id="lakeStroke" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#93c5fd"/>
-      <stop offset="0.52" stop-color="#29b5e8"/>
-      <stop offset="1" stop-color="#dbeafe"/>
-    </linearGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M48 0H0V48" fill="none" stroke="#20314f" stroke-opacity="0.24" stroke-width="1"/>
-    </pattern>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-    <filter id="softShadow" x="-14%" y="-14%" width="128%" height="128%">
-      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#020617" flood-opacity="0.28"/>
-    </filter>
-    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#60a5fa"/>
+    <symbol id="snowflake" viewBox="0 0 24 24">
+      <path fill="#29B5E8" d="M24 3.459c0 .646-.418 1.18-1.141 1.18-.723 0-1.142-.534-1.142-1.18 0-.647.419-1.18 1.142-1.18.723 0 1.141.533 1.141 1.18zm-.228 0c0-.533-.38-.951-.913-.951s-.913.38-.913.95c0 .533.38.952.913.952.57 0 .913-.419.913-.951zm-1.37-.533h.495c.266 0 .456.152.456.38 0 .153-.076.229-.19.305l.19.266v.038h-.266l-.19-.266h-.229v.266h-.266zm.495.228h-.229v.267h.229c.114 0 .152-.038.152-.114.038-.077-.038-.153-.152-.153zM7.602 12.4c.038-.151.076-.304.076-.456 0-.114-.038-.228-.038-.342-.114-.343-.304-.647-.646-.838l-4.87-2.777c-.685-.38-1.56-.152-1.94.533-.381.685-.153 1.56.532 1.94l2.701 1.56-2.701 1.56c-.685.38-.913 1.256-.533 1.94.38.685 1.256.914 1.94.533l4.832-2.777c.343-.267.571-.533.647-.876zm1.332 2.626c-.266-.038-.57.038-.837.19l-4.832 2.777c-.685.38-.913 1.256-.532 1.94.38.686 1.255.914 1.94.533l2.701-1.56v3.12c0 .8.647 1.408 1.446 1.408.799 0 1.407-.647 1.407-1.408v-5.592c0-.761-.57-1.37-1.293-1.408zm4.946-6.088c.266.038.57-.038.837-.19l4.832-2.777c.685-.38.913-1.256.532-1.94-.38-.686-1.255-.914-1.94-.533l-2.701 1.56V1.975c0-.799-.647-1.408-1.446-1.408-.799 0-1.446.609-1.446 1.408V7.53c0 .76.609 1.37 1.332 1.407zM3.265 5.97l4.832 2.777c.266.152.533.19.837.19.723-.038 1.331-.684 1.331-1.407V1.975c0-.799-.646-1.408-1.407-1.408-.799 0-1.446.647-1.446 1.408v3.12l-2.701-1.56c-.685-.38-1.56-.152-1.94.533-.419.646-.19 1.521.494 1.902zm9.093 6.011a.412.412 0 00-.114-.266l-.57-.571a.346.346 0 00-.267-.114.412.412 0 00-.266.114l-.571.57a.411.411 0 00-.114.267c0 .076.038.19.114.267l.57.57a.345.345 0 00.267.114c.076 0 .19-.038.266-.114l.571-.57a.412.412 0 00.114-.267zm1.598.533L11.94 14.53c-.039.038-.153.114-.229.114h-.608a.411.411 0 01-.267-.114L8.82 12.514a.408.408 0 01-.076-.229v-.608c0-.076.038-.19.114-.267l2.016-2.016a.41.41 0 01.267-.114h.608a.41.41 0 01.267.114l2.016 2.016a.347.347 0 01.114.267v.608c-.076.077-.114.19-.19.229zm5.593 5.44l-4.832-2.777c-.266-.152-.57-.19-.837-.152-.723.038-1.332.684-1.332 1.408v5.554c0 .8.647 1.408 1.408 1.408.799 0 1.446-.647 1.446-1.408v-3.12l2.7 1.56c.686.38 1.561.152 1.941-.533.419-.646.19-1.521-.494-1.94zm2.549-7.533l-2.701 1.56 2.7 1.56c.686.38.914 1.256.533 1.94-.38.685-1.255.913-1.94.533l-4.832-2.778a1.644 1.644 0 01-.647-.798c-.037-.153-.076-.305-.076-.457 0-.114.039-.228.039-.342.114-.343.342-.647.646-.837l4.832-2.778c.685-.38 1.56-.152 1.94.533.457.609.19 1.484-.494 1.864"/>
+    </symbol>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#60a5fa"/>
     </marker>
-    <marker id="arrowViolet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#a78bfa"/>
+    <marker id="arrowBack" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L10 5L0 10z" fill="#34d399"/>
     </marker>
-    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#34d399"/>
-    </marker>
-    <marker id="arrowRose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0 0L10 5L0 10Z" fill="#fb7185"/>
-    </marker>
-    <style>
-      .font{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
-      .h1{font-size:34px;font-weight:850;fill:#f8fafc}
-      .sub{font-size:15px;fill:#cbd5e1}
-      .eyebrow{font-size:11px;font-weight:850;letter-spacing:.08em;text-transform:uppercase}
-      .cardTitle{font-size:17px;font-weight:850;fill:#f8fafc}
-      .cardSub{font-size:13px;fill:#cbd5e1}
-      .body{font-size:12px;fill:#cbd5e1}
-      .tiny{font-size:11px;fill:#94a3b8}
-      .badge{font-size:12px;font-weight:850;fill:#f8fafc}
-      .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono",monospace}
-    </style>
   </defs>
 
-  <rect width="1600" height="980" fill="url(#bg)"/>
-  <rect width="1600" height="980" fill="url(#grid)"/>
+  <rect width="1200" height="340" fill="url(#bg)"/>
 
-  <g class="font">
-    <text x="64" y="64" class="h1">Snowflake Security Data Lake</text>
-    <text x="64" y="94" class="sub">The same closed loop as ClickHouse, drawn for governed warehouse-native replay and audit write-back.</text>
+  <g font-family="Inter, Segoe UI, ui-sans-serif, Arial, sans-serif">
+    <text x="48" y="48" font-size="26" font-weight="800" fill="#f8fafc">Snowflake security data lake</text>
+    <text x="48" y="74" font-size="13" fill="#94a3b8">Governed warehouse-native replay · append-only writes · audit write-back</text>
 
-    <g transform="translate(1238,38)">
-      <rect x="0" y="0" width="334" height="78" rx="16" fill="#101827" stroke="#334155"/>
-      <g transform="translate(48,39)">
-        <line x1="-24" y1="0" x2="24" y2="0" stroke="#bfdbfe" stroke-width="4" stroke-linecap="round"/>
-        <line x1="0" y1="-24" x2="0" y2="24" stroke="#bfdbfe" stroke-width="4" stroke-linecap="round"/>
-        <line x1="-17" y1="-17" x2="17" y2="17" stroke="#60a5fa" stroke-width="4" stroke-linecap="round"/>
-        <line x1="17" y1="-17" x2="-17" y2="17" stroke="#60a5fa" stroke-width="4" stroke-linecap="round"/>
-        <circle cx="0" cy="0" r="6" fill="#102a4c" stroke="#dbeafe" stroke-width="2"/>
-      </g>
-      <text x="104" y="33" class="cardTitle">Snowflake pack</text>
-      <text x="104" y="55" class="tiny">DDL, dynamic tables, row policies, Iceberg</text>
+    <g transform="translate(48,108)">
+      <rect x="0" y="0" width="130" height="88" rx="14" fill="#0f172a" stroke="#334155"/>
+      <text x="65" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#e2e8f0">Sources</text>
+      <text x="65" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">CloudTrail · Okta</text>
+      <text x="65" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">K8s · SaaS logs</text>
+
+      <path d="M138 44H168" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="176" y="0" width="150" height="88" rx="14" fill="#112244" stroke="#60a5fa"/>
+      <text x="251" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#dbeafe">Ingest</text>
+      <text x="251" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">22 ingest skills</text>
+      <text x="251" y="70" text-anchor="middle" font-size="10" fill="#5eead4">→ OCSF 1.8</text>
+
+      <path d="M334 44H364" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="372" y="0" width="170" height="88" rx="14" fill="#0d3a70" stroke="#29b5e8" stroke-width="2"/>
+      <use href="#snowflake" x="388" y="12" width="32" height="32"/>
+      <text x="468" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#e0f2fe">Snowflake lake</text>
+      <text x="468" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">append-only JSONL</text>
+      <text x="468" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">RAP · dynamic tables</text>
+
+      <path d="M550 44H580" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="588" y="0" width="150" height="88" rx="14" fill="#0a3b35" stroke="#34d399"/>
+      <text x="663" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#d1fae5">Detect</text>
+      <text x="663" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">71 skills · MITRE</text>
+      <text x="663" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">read-only replay</text>
+
+      <path d="M746 44H776" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="784" y="0" width="150" height="88" rx="14" fill="#4a2d09" stroke="#fbbf24"/>
+      <text x="859" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#fde68a">Remediate</text>
+      <text x="859" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">HITL · dry-run</text>
+      <text x="859" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">dual audit</text>
+
+      <path d="M942 44H972" stroke="#60a5fa" stroke-width="3" marker-end="url(#arrow)"/>
+
+      <rect x="980" y="0" width="124" height="88" rx="14" fill="#083b39" stroke="#2dd4bf"/>
+      <text x="1042" y="32" text-anchor="middle" font-size="12" font-weight="700" fill="#99f6e4">Audit</text>
+      <text x="1042" y="54" text-anchor="middle" font-size="10" fill="#94a3b8">write-back</text>
+      <text x="1042" y="70" text-anchor="middle" font-size="10" fill="#94a3b8">closed loop</text>
     </g>
 
-    <g transform="translate(64,138)">
-      <rect x="0" y="0" width="146" height="30" rx="15" fill="#0c2a4d" stroke="#2563eb"/>
-      <text x="73" y="20" text-anchor="middle" class="eyebrow" fill="#bfdbfe">Write lane</text>
-    </g>
-    <g transform="translate(64,562)">
-      <rect x="0" y="0" width="180" height="30" rx="15" fill="#1e1b4b" stroke="#6d28d9"/>
-      <text x="90" y="20" text-anchor="middle" class="eyebrow" fill="#c4b5fd">Replay lane</text>
-    </g>
-    <g transform="translate(64,812)">
-      <rect x="0" y="0" width="192" height="30" rx="15" fill="#4c0519" stroke="#9f1239"/>
-      <text x="96" y="20" text-anchor="middle" class="eyebrow" fill="#fda4af">Governance lane</text>
-    </g>
+    <!-- audit write-back arc -->
+    <path d="M1028 204 C1028 248 468 248 468 204" stroke="#34d399" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#arrowBack)"/>
+    <text x="748" y="268" text-anchor="middle" font-size="11" fill="#6ee7b7">ingest-back verifies closure on next reconciler run</text>
 
-    <g filter="url(#softShadow)">
-      <rect x="64" y="192" width="296" height="294" rx="18" fill="#101827" stroke="#334155"/>
-      <text x="92" y="232" class="cardTitle">Covered signals</text>
-      <text x="92" y="255" class="cardSub">Existing ingest and source coverage</text>
-      <g transform="translate(92,288)">
-        <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
-        <circle cx="25" cy="25" r="16" fill="#ff9900"/>
-        <text x="25" y="30" text-anchor="middle" font-size="10" font-weight="900" fill="#111827">AWS</text>
-        <text x="50" y="22" class="badge">AWS</text>
-        <text x="50" y="39" class="tiny">trail, flow</text>
-
-        <g transform="translate(122,0)">
-          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="25" cy="25" r="16" fill="#4285f4"/>
-          <text x="25" y="30" text-anchor="middle" font-size="10" font-weight="900" fill="#fff">GCP</text>
-          <text x="50" y="22" class="badge">GCP</text>
-          <text x="50" y="39" class="tiny">audit, SCC</text>
-        </g>
-
-        <g transform="translate(0,66)">
-          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="25" cy="25" r="16" fill="#2563eb"/>
-          <text x="25" y="30" text-anchor="middle" font-size="10" font-weight="900" fill="#fff">AZ</text>
-          <text x="50" y="22" class="badge">Azure</text>
-          <text x="50" y="39" class="tiny">activity</text>
-        </g>
-
-        <g transform="translate(122,66)">
-          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="25" cy="25" r="16" fill="#111827" stroke="#94a3b8"/>
-          <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#f8fafc">ID</text>
-          <text x="50" y="22" class="badge">Identity</text>
-          <text x="47" y="39" class="tiny">Entra, Okta</text>
-        </g>
-
-        <g transform="translate(0,132)">
-          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="25" cy="25" r="16" fill="#326ce5"/>
-          <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#fff">K8s</text>
-          <text x="50" y="22" class="badge">Runtime</text>
-          <text x="50" y="39" class="tiny">K8s, MCP</text>
-        </g>
-
-        <g transform="translate(122,132)">
-          <rect x="0" y="0" width="106" height="50" rx="12" fill="#172033" stroke="#475569"/>
-          <circle cx="25" cy="25" r="16" fill="#29b5e8"/>
-          <text x="25" y="30" text-anchor="middle" font-size="9" font-weight="900" fill="#082f49">SF</text>
-          <text x="50" y="22" class="badge">SaaS</text>
-          <text x="50" y="39" class="tiny">GH, Slack</text>
-        </g>
-      </g>
-    </g>
-
-    <g filter="url(#softShadow)">
-      <rect x="430" y="230" width="230" height="214" rx="18" fill="#0c2a4d" stroke="#60a5fa"/>
-      <text x="460" y="270" class="cardTitle">Normalize</text>
-      <text x="460" y="294" class="cardSub">22 ingest skills</text>
-      <rect x="460" y="324" width="170" height="50" rx="12" fill="#1d4ed8" stroke="#93c5fd"/>
-      <text x="545" y="345" text-anchor="middle" class="badge">OCSF 1.8 JSONL</text>
-      <text x="545" y="364" text-anchor="middle" class="tiny" fill="#dbeafe">stdout pipe contract</text>
-      <text x="460" y="406" class="body">Stable IDs: event_uid,</text>
-      <text x="460" y="426" class="body">finding_uid, tenant hints</text>
-    </g>
-
-    <g filter="url(#softShadow)">
-      <rect x="724" y="230" width="242" height="238" rx="18" fill="#111827" stroke="#60a5fa"/>
-      <text x="754" y="270" class="cardTitle">Write</text>
-      <text x="754" y="294" class="cardSub">sink-snowflake-jsonl</text>
-      <rect x="754" y="324" width="182" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/>
-      <text x="845" y="346" text-anchor="middle" class="badge">append-only insert</text>
-      <rect x="754" y="372" width="182" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/>
-      <text x="845" y="394" text-anchor="middle" class="badge">dry-run default</text>
-      <rect x="754" y="420" width="182" height="34" rx="9" fill="#102a4c" stroke="#60a5fa"/>
-      <text x="845" y="442" text-anchor="middle" class="badge">identifier validated</text>
-    </g>
-
-    <g filter="url(#shadow)">
-      <rect x="1034" y="162" width="502" height="414" rx="24" fill="url(#lakeFill)" stroke="url(#lakeStroke)" stroke-width="2"/>
-      <g transform="translate(1102,222)">
-        <line x1="-31" y1="0" x2="31" y2="0" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round"/>
-        <line x1="0" y1="-31" x2="0" y2="31" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round"/>
-        <line x1="-22" y1="-22" x2="22" y2="22" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
-        <line x1="22" y1="-22" x2="-22" y2="22" stroke="#60a5fa" stroke-width="5" stroke-linecap="round"/>
-        <circle cx="0" cy="0" r="8" fill="#0b2445" stroke="#dbeafe" stroke-width="3"/>
-      </g>
-      <text x="1162" y="222" font-size="24" font-weight="850" fill="#e0f2fe">Snowflake lake</text>
-      <text x="1162" y="248" class="body" fill="#dbeafe">security_db.ops, provisioned by packs/snowflake</text>
-
-      <g transform="translate(1074,288)">
-        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">events_sink</text>
-        <text x="20" y="50" class="tiny" fill="#bfdbfe">90-day hot tier</text>
-      </g>
-      <g transform="translate(1300,288)">
-        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">findings_sink</text>
-        <text x="20" y="50" class="tiny" fill="#bfdbfe">365-day history</text>
-      </g>
-      <g transform="translate(1074,378)">
-        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">evidence_sink</text>
-        <text x="20" y="50" class="tiny" fill="#bfdbfe">7-year hold</text>
-      </g>
-      <g transform="translate(1300,378)">
-        <rect x="0" y="0" width="184" height="70" rx="13" fill="#123d73" stroke="#93c5fd"/>
-        <text x="20" y="28" font-size="14" font-weight="850" fill="#e0f2fe">audit_sink</text>
-        <text x="20" y="50" class="tiny" fill="#bfdbfe">legal-hold chain</text>
-      </g>
-      <g transform="translate(1074,476)">
-        <rect x="0" y="0" width="186" height="54" rx="13" fill="#0b2445" stroke="#93c5fd" stroke-dasharray="6 5"/>
-        <text x="93" y="23" text-anchor="middle" font-size="13" font-weight="850" fill="#e0f2fe">dynamic tables</text>
-        <text x="93" y="43" text-anchor="middle" class="tiny" fill="#bfdbfe">rule and event rollups</text>
-      </g>
-      <g transform="translate(1298,476)">
-        <rect x="0" y="0" width="186" height="54" rx="13" fill="#0b2445" stroke="#93c5fd" stroke-dasharray="6 5"/>
-        <text x="93" y="23" text-anchor="middle" font-size="13" font-weight="850" fill="#e0f2fe">managed Iceberg</text>
-        <text x="93" y="43" text-anchor="middle" class="tiny" fill="#bfdbfe">Horizon Catalog path</text>
-      </g>
-    </g>
-
-    <g filter="url(#softShadow)">
-      <rect x="724" y="616" width="242" height="170" rx="18" fill="#1e1b4b" stroke="#a78bfa"/>
-      <text x="754" y="656" class="cardTitle">Read gate</text>
-      <text x="754" y="680" class="cardSub">source-snowflake-query</text>
-      <rect x="754" y="710" width="182" height="38" rx="10" fill="#312e81" stroke="#a78bfa"/>
-      <text x="845" y="734" text-anchor="middle" class="badge">read-only SQL</text>
-      <text x="754" y="766" class="tiny" fill="#c4b5fd">SELECT, WITH, SHOW, DESCRIBE</text>
-    </g>
-
-    <g filter="url(#softShadow)">
-      <rect x="430" y="616" width="230" height="170" rx="18" fill="#2e1065" stroke="#a78bfa"/>
-      <text x="460" y="656" class="cardTitle">Replay rows</text>
-      <text x="460" y="684" class="body">detect-* rules</text>
-      <text x="460" y="708" class="body">Snowflake detections</text>
-      <text x="460" y="732" class="body">view-* renderers</text>
-      <text x="460" y="762" class="tiny" fill="#c4b5fd">UID windows stop duplicate findings</text>
-    </g>
-
-    <g filter="url(#softShadow)">
-      <rect x="64" y="616" width="296" height="170" rx="18" fill="#052e2b" stroke="#34d399"/>
-      <text x="92" y="656" class="cardTitle">Operator artifacts</text>
-      <text x="92" y="684" class="body">new findings</text>
-      <text x="92" y="708" class="body">SARIF handoff</text>
-      <text x="92" y="732" class="body">Mermaid attack-flow</text>
-      <text x="92" y="756" class="body">dashboard query pack</text>
-    </g>
-
-    <g filter="url(#softShadow)">
-      <rect x="430" y="854" width="230" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/>
-      <text x="460" y="883" class="cardTitle">HITL response</text>
-      <text x="460" y="906" class="tiny" fill="#fecdd3">approved window, dry-run first</text>
-    </g>
-    <g filter="url(#softShadow)">
-      <rect x="724" y="854" width="242" height="72" rx="18" fill="#4c0519" stroke="#fb7185"/>
-      <text x="754" y="883" class="cardTitle">Audit write-back</text>
-      <text x="754" y="906" class="tiny" fill="#fecdd3">remediation and MCP records</text>
-    </g>
-    <g filter="url(#softShadow)">
-      <rect x="1034" y="854" width="502" height="72" rx="18" fill="#111827" stroke="#475569"/>
-      <text x="1066" y="883" class="cardTitle">Customer-owned boundary</text>
-      <text x="1066" y="904" class="tiny">Account, warehouse, grants, row policy, retention, credentials,</text>
-      <text x="1066" y="920" class="tiny">dashboard access, and network controls stay under operator control.</text>
-    </g>
-
-    <path d="M360 337H430" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/>
-    <path d="M660 337H724" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/>
-    <path d="M966 349H1034" stroke="#60a5fa" stroke-width="3.2" marker-end="url(#arrowBlue)" fill="none"/>
-    <text x="990" y="318" class="tiny" fill="#bfdbfe">insert</text>
-
-    <path d="M1034 700H966" stroke="#a78bfa" stroke-width="3.2" marker-end="url(#arrowViolet)" fill="none"/>
-    <text x="986" y="682" class="tiny" fill="#c4b5fd">query</text>
-    <path d="M724 700H660" stroke="#a78bfa" stroke-width="3.2" marker-end="url(#arrowViolet)" fill="none"/>
-    <path d="M430 700H360" stroke="#34d399" stroke-width="3.2" marker-end="url(#arrowGreen)" fill="none"/>
-
-    <path d="M210 786V812C210 834 240 842 288 842H1286C1318 842 1334 824 1334 792V576" stroke="#34d399" stroke-width="2.6" marker-end="url(#arrowGreen)" fill="none" stroke-dasharray="9 8"/>
-    <text x="590" y="833" class="tiny" fill="#a7f3d0">artifact rows can re-land through sink-snowflake-jsonl</text>
-
-    <path d="M660 890H724" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/>
-    <path d="M966 890H1034" stroke="#fb7185" stroke-width="3.2" marker-end="url(#arrowRose)" fill="none"/>
-    <path d="M845 854V818C845 802 864 794 894 794H1430C1458 794 1472 778 1472 746V576" stroke="#fb7185" stroke-width="2.6" marker-end="url(#arrowRose)" fill="none" stroke-dasharray="9 8"/>
-    <text x="1010" y="779" class="tiny" fill="#fda4af">audit_sink captures decisions, tool calls, and approvals</text>
-
-    <g transform="translate(64,952)">
-      <circle cx="0" cy="0" r="5" fill="#60a5fa"/>
-      <text x="18" y="4" class="tiny">write</text>
-      <circle cx="88" cy="0" r="5" fill="#a78bfa"/>
-      <text x="106" y="4" class="tiny">read</text>
-      <circle cx="168" cy="0" r="5" fill="#34d399"/>
-      <text x="186" y="4" class="tiny">artifact</text>
-      <circle cx="268" cy="0" r="5" fill="#fb7185"/>
-      <text x="286" y="4" class="tiny">audit</text>
-    </g>
-    <text x="560" y="956" class="tiny" fill="#94a3b8">Append-only tables preserve history; stable IDs support duplicate-aware replay queries.</text>
+    <rect x="48" y="288" width="1104" height="36" rx="10" fill="#0b1220" stroke="#334155"/>
+    <text x="68" y="312" font-size="11" fill="#94a3b8">Customer-owned trust boundary · no hosted runner required · packs in docs/SNOWFLAKE_DATA_LAKE.md</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Replaces four dense diagrams (780–980px tall) with compact 320–360px layouts aligned to the minimal hero style.
- **architecture-layers.svg**: single-row layer flow with counts only — no vendor wall of text.
- **snowflake-data-lake.svg** / **clickhouse-data-lake.svg**: left-to-right closed loop with real Simple Icons on the lake card.
- **agentic-soc-orchestrator.svg**: three ownership boxes (LangGraph · skills · LangChain) + one pipeline strip.

## Test plan
- [x] `make validate`
- [ ] Visual check on GitHub README render


Made with [Cursor](https://cursor.com)