### PR TITLE
LangChain MCP-first agent example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.11"
-          packages: pytest ruff
+          packages: pytest ruff pyyaml
       - run: ruff check examples/agents --config pyproject.toml
       - name: Run dependency-light agent examples
         run: pytest examples/agents/tests/test_examples.py -q

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -116,6 +116,39 @@ CLOUD_SECURITY_HARNESS_PROFILE=examples/agents/harness_profiles/dry-run-remediat
 The demo pauses before ``review``, injects operator ``approval_context`` via
 ``update_state``, then resumes into dry-run remediation planning.
 
+## Agent + AI pluggability — MCP first, not LCEL wrappers
+
+Frameworks (LangChain, LangGraph, OpenAI Agents SDK, Anthropic Agent SDK, Cursor,
+Codex) should bind the **repo MCP server** as their tool surface. Skills stay
+behind one audited contract: allowlists, HITL gates, dry-run defaults, and
+HMAC audit chains do not fork per framework.
+
+| Do | Don't |
+|---|---|
+| Spawn `mcp-server/src/server.py` over stdio JSON-RPC | Wrap `python skills/.../detect.py` as `@tool` / LCEL chains |
+| Load a harness profile for allowlists + caller context | Hard-code skill names in agent source |
+| Keep remediation on a **separate** loop after human approval | Register `remediate-*` beside `detect-*` in one tool set |
+| Pick model adapters inside the harness triage node only | Let the model invent CVSS/MITRE/approval facts |
+
+Reference examples:
+
+- [`examples/agents/sdk_agent_common.py`](../examples/agents/sdk_agent_common.py) — shared profile + live `tools/list` discovery
+- [`examples/agents/anthropic_sdk_security_agent.py`](../examples/agents/anthropic_sdk_security_agent.py)
+- [`examples/agents/openai_sdk_security_agent.py`](../examples/agents/openai_sdk_security_agent.py)
+- [`examples/agents/langchain_mcp_security_agent.py`](../examples/agents/langchain_mcp_security_agent.py) — `langchain-mcp-adapters` config block, anti-LCEL guidance
+
+```bash
+python examples/agents/langchain_mcp_security_agent.py
+
+CLOUD_SECURITY_HARNESS_PROFILE=examples/agents/harness_profiles/sdk-cspm-agent.json \\
+  DEMO_APPROVE=yes python examples/agents/langchain_mcp_security_agent.py
+```
+
+Bounded LLM triage inside the LangGraph harness uses pluggable adapters
+(`harness_adapters.py`): deterministic offline, JSON fixture, OpenAI-compatible
+HTTP, or LangChain chat-message fixtures — all validated before they touch
+workflow state.
+
 Execute or re-evaluate the emitted MCP plan as a separate artifact:
 
 ```bash

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -9,6 +9,7 @@ allowlist regardless of which SDK is driving the loop.
 |---|---|---|
 | [`anthropic_sdk_security_agent.py`](anthropic_sdk_security_agent.py) | Anthropic Python SDK (Managed Agent) | CSPM scan → triage loop with HITL gate on remediation |
 | [`openai_sdk_security_agent.py`](openai_sdk_security_agent.py) | OpenAI Agents SDK | Parallel port of the Anthropic example for portability |
+| [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first wiring via `langchain-mcp-adapters` — do not wrap skill CLIs as LCEL tools |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/langchain_mcp_security_agent.py
+++ b/examples/agents/langchain_mcp_security_agent.py
@@ -1,0 +1,86 @@
+"""LangChain agents — MCP interoperability pattern (not LCEL skill wrappers).
+
+Supported integration path for LangChain, LangGraph, and other agent frameworks:
+
+  1. Spawn the repo MCP server as a stdio JSON-RPC subprocess.
+  2. Bind MCP ``tools/list`` results to your agent (``langchain-mcp-adapters``,
+     OpenAI Agents SDK ``McpServer``, Anthropic MCP config, etc.).
+  3. Never re-wrap skill CLIs as ``@tool`` decorators or LCEL chains — that
+     forks the audit contract, HITL gates, and allowlist enforcement.
+
+This reference runs offline: it loads a harness profile, discovers tools via
+live MCP, and stops at the HITL gate unless ``DEMO_APPROVE=yes``.
+
+Real LangChain wiring (when ``langchain-mcp-adapters`` is installed):
+
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    client = MultiServerMCPClient(build_langchain_mcp_servers(profile))
+    tools = await client.get_tools()
+    agent = create_react_agent(model, tools)  # framework-specific
+
+Run:
+
+    python examples/agents/langchain_mcp_security_agent.py
+
+    DEMO_APPROVE=yes python examples/agents/langchain_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+
+def build_langchain_mcp_servers(profile: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Config block for ``MultiServerMCPClient`` / LangGraph tool nodes."""
+    allowlist = read_allowlist(profile)
+    command = mcp_stdio_command()
+    return {
+        "cloud-ai-security-skills": {
+            "transport": "stdio",
+            "command": command[0],
+            "args": command[1:],
+            "env": safe_mcp_env(allowed_skills=allowlist),
+        }
+    }
+
+
+def langchain_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    """Operator-facing metadata — no live LangChain import required."""
+    return {
+        "integration": "mcp_stdio_jsonrpc",
+        "anti_pattern": "do_not_wrap_skill_clis_as_langchain_tools",
+        "recommended_packages": ["langchain-mcp-adapters", "langgraph"],
+        "mcp_servers": build_langchain_mcp_servers(profile),
+        "remediation_chain": "separate_agent_loop_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="langchain-mcp-demo-1")
+    triage["langchain_binding"] = langchain_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -27,6 +27,7 @@ DIAGRAMS = REPO_ROOT / "docs" / "diagrams"
 SCRIPTS = [
     EXAMPLES / "anthropic_sdk_security_agent.py",
     EXAMPLES / "openai_sdk_security_agent.py",
+    EXAMPLES / "langchain_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -121,8 +122,9 @@ class TestExampleSmoke:
             [sys.executable, str(script)],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
             check=False,
+            cwd=REPO_ROOT,
             env=env,
         )
         assert result.returncode == 0, f"script failed: {result.stderr}"
@@ -138,8 +140,9 @@ class TestExampleSmoke:
             [sys.executable, str(script)],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
             check=False,
+            cwd=REPO_ROOT,
             env=env,
         )
         audit_lines = [
@@ -212,8 +215,9 @@ class TestHitlGateReachable:
             [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
             check=False,
+            cwd=REPO_ROOT,
             env=env,
         )
         # The real subprocess in stage 3 shells into the reconciler handler
@@ -236,11 +240,30 @@ class TestHitlGateReachable:
             text=True,
             timeout=60,
             check=False,
+            cwd=REPO_ROOT,
             env=env,
         )
         assert "remediation_dry_run" in result.stdout or "reconciler" in (
             result.stdout + result.stderr
         )
+
+    def test_langchain_mcp_binding_documents_stdio_transport(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "langchain_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["langchain_binding"]
+        assert binding["integration"] == "mcp_stdio_jsonrpc"
+        assert binding["anti_pattern"] == "do_not_wrap_skill_clis_as_langchain_tools"
+        assert "cloud-ai-security-skills" in binding["mcp_servers"]
+        assert payload["mcp_tools_discovered"]
 
     def test_langgraph_reaches_remediation_with_approval(self):
         env = {


### PR DESCRIPTION
## Summary
- Add `examples/agents/langchain_mcp_security_agent.py` showing the supported LangChain integration path: stdio MCP server + `langchain-mcp-adapters` config, not LCEL skill wrappers.
- Document agent/AI pluggability in `docs/HARNESS.md` (MCP first, separate remediation loop, harness profile customization).
- Smoke tests cover offline run + binding metadata.

**Stacks on #577** — merge #577 first, then rebase this onto `main` if needed.

## Test plan
- [x] `pytest examples/agents/tests/test_examples.py -k langchain`
- [x] `python examples/agents/langchain_mcp_security_agent.py`


Made with [Cursor](https://cursor.com)