### PR TITLE
Add Cursor MCP-first security agent example

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -60,6 +60,12 @@ portable across clones:
 
 Enable: **Cursor Settings → MCP → cloud-ai-security-skills → on**.
 
+Runnable offline example (harness profile + live `tools/list`):
+
+[`../examples/agents/cursor_mcp_security_agent.py`](../examples/agents/cursor_mcp_security_agent.py)
+
+Project config details: [`integrations/cursor.md`](integrations/cursor.md).
+
 ---
 
 ## Windsurf
@@ -115,6 +121,16 @@ Multi-step graph (ingest → detect → triage → remediate) with HITL approval
 nodes:
 
 [`../examples/agents/langgraph_security_graph.py`](../examples/agents/langgraph_security_graph.py)
+
+Native interrupt/resume at the analyst gate:
+
+[`../examples/agents/langgraph_hitl_interrupt_resume.py`](../examples/agents/langgraph_hitl_interrupt_resume.py)
+
+---
+
+## LangChain MCP (not LCEL wrappers)
+
+[`../examples/agents/langchain_mcp_security_agent.py`](../examples/agents/langchain_mcp_security_agent.py)
 
 ---
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -67,6 +67,8 @@ remediation):
 - If the server errors on first call, check **Settings → MCP → View Logs**.
 - `${workspaceFolder}` only works inside `.cursor/mcp.json`, not the global
   `~/.cursor/mcp.json`.
+- Offline reference: [`../examples/agents/cursor_mcp_security_agent.py`](../examples/agents/cursor_mcp_security_agent.py)
+  emits a portable `.cursor/mcp.json` block from a harness profile.
 
 ## HITL + audit behavior
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -10,6 +10,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`anthropic_sdk_security_agent.py`](anthropic_sdk_security_agent.py) | Anthropic Python SDK (Managed Agent) | CSPM scan → triage loop with HITL gate on remediation |
 | [`openai_sdk_security_agent.py`](openai_sdk_security_agent.py) | OpenAI Agents SDK | Parallel port of the Anthropic example for portability |
 | [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first wiring via `langchain-mcp-adapters` — do not wrap skill CLIs as LCEL tools |
+| [`cursor_mcp_security_agent.py`](cursor_mcp_security_agent.py) | Cursor | Project-scoped `.cursor/mcp.json` + harness profile; same MCP audit/HITL contract |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/cursor_mcp_security_agent.py
+++ b/examples/agents/cursor_mcp_security_agent.py
@@ -1,0 +1,72 @@
+"""Cursor — MCP-first security agent example.
+
+Cursor loads skills through project-scoped ``.cursor/mcp.json`` (stdio MCP).
+This reference shows the same harness-profile + live ``tools/list`` path as
+the Anthropic, OpenAI, and LangChain SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/cursor_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+
+def build_cursor_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block for ``.cursor/mcp.json`` — portable with ``${workspaceFolder}``."""
+    allowlist = read_allowlist(profile)
+    return {
+        "mcpServers": {
+            "cloud-ai-security-skills": {
+                "command": mcp_stdio_command()[0],
+                "args": ["${workspaceFolder}/mcp-server/src/server.py"],
+                "env": {
+                    **safe_mcp_env(allowed_skills=allowlist),
+                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
+                },
+            }
+        }
+    }
+
+
+def cursor_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "cursor_mcp_json",
+        "config_path": ".cursor/mcp.json",
+        "docs": "docs/integrations/cursor.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_cursor_tools",
+        "mcp_config": build_cursor_mcp_config(profile),
+        "remediation_chain": "separate_composer_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="cursor-mcp-demo-1")
+    triage["cursor_binding"] = cursor_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -28,6 +28,7 @@ SCRIPTS = [
     EXAMPLES / "anthropic_sdk_security_agent.py",
     EXAMPLES / "openai_sdk_security_agent.py",
     EXAMPLES / "langchain_mcp_security_agent.py",
+    EXAMPLES / "cursor_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -263,6 +264,24 @@ class TestHitlGateReachable:
         assert binding["integration"] == "mcp_stdio_jsonrpc"
         assert binding["anti_pattern"] == "do_not_wrap_skill_clis_as_langchain_tools"
         assert "cloud-ai-security-skills" in binding["mcp_servers"]
+        assert payload["mcp_tools_discovered"]
+
+    def test_cursor_mcp_binding_documents_project_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "cursor_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["cursor_binding"]
+        assert binding["integration"] == "cursor_mcp_json"
+        assert binding["config_path"] == ".cursor/mcp.json"
+        assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
         assert payload["mcp_tools_discovered"]
 
     def test_langgraph_reaches_remediation_with_approval(self):


### PR DESCRIPTION
## Summary
- Adds `cursor_mcp_security_agent.py` — same harness-profile + live `tools/list` path as Anthropic/OpenAI/LangChain SDK examples, emitting a portable `.cursor/mcp.json` block with `${workspaceFolder}`.
- Updates `docs/AGENT_QUICKSTART.md`, `docs/integrations/cursor.md`, and `examples/agents/README.md`.
- Adds smoke + binding tests in `test_examples.py`.

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`


Made with [Cursor](https://cursor.com)