### PR TITLE
Harden secret-literal scanning across agent harness paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,11 +134,7 @@ jobs:
       - name: OCSF 1.8 golden-fixture validation
         run: python scripts/validate_golden_ocsf.py
       - name: Check for hardcoded secrets
-        run: |
-          ! grep -rn "AKIA[A-Z0-9]\{16\}" skills/*/*/src/ mcp-server/src/ scripts/ --include="*.py" || exit 1
-          ! grep -rn "sk-[a-zA-Z0-9]\{20,\}" skills/*/*/src/ mcp-server/src/ scripts/ --include="*.py" || exit 1
-          ! grep -rn "ghp_[a-zA-Z0-9]\{36\}" skills/*/*/src/ mcp-server/src/ scripts/ --include="*.py" || exit 1
-          echo "No hardcoded secrets found in enforced executable paths"
+        run: python scripts/check_secret_literals.py
       - name: Dependency vulnerability audit
         run: pip-audit "${{ github.workspace }}"
 
@@ -152,7 +148,7 @@ jobs:
         with:
           python-version: "3.11"
           packages: bandit
-      - run: bandit -r skills mcp-server scripts -c pyproject.toml --severity-level medium
+      - run: bandit -r skills mcp-server scripts examples/agents -c pyproject.toml --severity-level medium
 
   # ── Unit tests, grouped into category lanes ───────────────────
   test-compliance:

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ validate:
 	python scripts/add_skill_trust_frontmatter.py --check
 	python scripts/validate_safe_skill_bar.py
 	python scripts/validate_golden_ocsf.py
+	python scripts/check_secret_literals.py
 	$(MAKE) docs-check
 
 test:

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -331,28 +331,44 @@ def _check_docs_wired() -> DriftCheck:
     )
 
 
-def _check_no_harness_secret_literals() -> DriftCheck:
+def _harness_secret_scan_paths() -> list[Path]:
     paths = [
         HARNESS_DOC,
         EXAMPLES_README,
+        REPO_ROOT / "docs" / "AGENT_QUICKSTART.md",
         EXAMPLES / "configure_langgraph_harness.py",
         EXAMPLES / "inspect_langgraph_harness.py",
         EXAMPLES / "run_langgraph_harness.py",
         EXAMPLES / "execute_langgraph_mcp_plan.py",
+        EXAMPLES / "sdk_agent_common.py",
+        EXAMPLES / "anthropic_sdk_security_agent.py",
+        EXAMPLES / "openai_sdk_security_agent.py",
+        EXAMPLES / "langchain_mcp_security_agent.py",
+        EXAMPLES / "cursor_mcp_security_agent.py",
+        EXAMPLES / "harness_adapters.py",
+        EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),
+        *sorted((REPO_ROOT / "presets").glob("*.json")),
     ]
+    return [path for path in paths if path.is_file()]
+
+
+def _check_no_harness_secret_literals() -> DriftCheck:
     findings: list[str] = []
-    for path in paths:
+    for path in _harness_secret_scan_paths():
         text = path.read_text(encoding="utf-8")
-        for pattern in SECRET_PATTERNS:
-            for match in pattern.finditer(text):
-                findings.append(
-                    f"{path.relative_to(REPO_ROOT)}:{match.start()}: {match.group(0)[:32]}"
-                )
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if "re.compile(" in line or "SECRET_PATTERNS" in line:
+                continue
+            for pattern in SECRET_PATTERNS:
+                for match in pattern.finditer(line):
+                    findings.append(
+                        f"{path.relative_to(REPO_ROOT)}:{line_no}: {match.group(0)[:32]}"
+                    )
     return DriftCheck(
         "harness_docs_have_no_secret_literals",
         not findings,
-        "no PAT/API-key/password literals in harness docs or profiles"
+        "no PAT/API-key/password literals in harness docs, profiles, or presets"
         if not findings
         else findings,
     )

--- a/examples/agents/harness_adapters.py
+++ b/examples/agents/harness_adapters.py
@@ -280,7 +280,7 @@ class OpenAICompatTriageAdapter:
         if not self.evidence_cards:
             return []
         try:
-            with urllib.request.urlopen(  # noqa: S310 - see _request
+            with urllib.request.urlopen(  # noqa: S310  # nosec B310 - operator-configured HTTPS/local endpoint; see _request
                 self._request(), timeout=self.timeout_seconds
             ) as response:
                 response_payload = json.loads(response.read().decode("utf-8"))

--- a/scripts/check_secret_literals.py
+++ b/scripts/check_secret_literals.py
@@ -102,9 +102,7 @@ def main() -> int:
         for finding in all_findings:
             print(finding, file=sys.stderr)
         return 1
-    print(
-        f"Secret literal check passed: {len(_iter_paths())} enforced path(s), no literals."
-    )
+    print(f"Secret literal check passed: {len(_iter_paths())} enforced path(s), no literals.")
     return 0
 
 

--- a/scripts/check_secret_literals.py
+++ b/scripts/check_secret_literals.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Fail closed on hardcoded secret literals in enforced repo paths.
+
+Scans skill sources, MCP server, scripts, agent harness entrypoints, shipped
+presets, and harness profiles. Test trees and golden fixtures are excluded —
+they intentionally carry synthetic token shapes for detector regression tests.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SECRET_PATTERNS = [
+    re.compile(r"AKIA[A-Z0-9]{16}"),
+    re.compile(r"sk-[a-zA-Z0-9]{20,}"),
+    re.compile(r"ghp_[a-zA-Z0-9]{36,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(
+        r"(?i)\b(?:openai_api_key|anthropic_api_key|github_token|"
+        r"aws_secret_access_key|snowflake_password|secret_access_key)\b"
+        r"\s*[:=]\s*[\"'][^\"']{4,}[\"']"
+    ),
+    re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----"),
+]
+
+SKIP_LINE_MARKERS = (
+    "re.compile(",
+    "SECRET_PATTERNS",
+    "SECRET_VALUE_RE",
+    "SECRET_FIELD_RE",
+    "synthetic_pat",
+    "redacted-test-value",
+    "must not contain password",
+    "no PAT/API-key/password literals",
+)
+
+PYTHON_GLOBS = [
+    "skills/*/src/*.py",
+    "skills/*/*/src/*.py",
+    "mcp-server/src/*.py",
+    "mcp-server/src/**/*.py",
+    "scripts/*.py",
+    "examples/agents/*.py",
+]
+
+TEXT_GLOBS = [
+    "examples/agents/harness_profiles/*.json",
+    "presets/*.json",
+    "docs/AGENT_QUICKSTART.md",
+]
+
+
+def _iter_paths() -> list[Path]:
+    seen: set[Path] = set()
+    paths: list[Path] = []
+    for pattern in [*PYTHON_GLOBS, *TEXT_GLOBS]:
+        for path in REPO_ROOT.glob(pattern):
+            resolved = path.resolve()
+            if resolved in seen or not path.is_file():
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if "/tests/" in rel or rel.startswith("tests/"):
+                continue
+            if "/golden/" in rel or "/tests/golden/" in rel:
+                continue
+            seen.add(resolved)
+            paths.append(path)
+    return sorted(paths)
+
+
+def _scan_file(path: Path) -> list[str]:
+    findings: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if any(marker in line for marker in SKIP_LINE_MARKERS):
+            continue
+        for pattern in SECRET_PATTERNS:
+            match = pattern.search(line)
+            if match is None:
+                continue
+            snippet = match.group(0)
+            if len(snippet) > 40:
+                snippet = snippet[:37] + "..."
+            try:
+                display = path.relative_to(REPO_ROOT)
+            except ValueError:
+                display = path
+            findings.append(f"{display}:{line_no}: {snippet}")
+    return findings
+
+
+def main() -> int:
+    all_findings: list[str] = []
+    for path in _iter_paths():
+        all_findings.extend(_scan_file(path))
+    if all_findings:
+        print("Hardcoded secret literals found:", file=sys.stderr)
+        for finding in all_findings:
+            print(finding, file=sys.stderr)
+        return 1
+    print(
+        f"Secret literal check passed: {len(_iter_paths())} enforced path(s), no literals."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -768,3 +768,26 @@ class TestCountDriftScan:
         assert pat.search('out["L7 Output<br/>3 sinks · S3"]') is not None
         # Should NOT match prose (no <br/> prefix)
         assert pat.search("The repo ships 49 skills today.") is None
+
+
+class TestSecretLiteralChecker:
+    def test_repo_passes_secret_literal_gate(self):
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / "check_secret_literals.py")],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=ROOT,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+
+    def test_detects_synthetic_secret_in_temp_file(self, tmp_path: Path):
+        checker = _load_module(
+            "cloud_security_check_secret_literals_test",
+            SCRIPTS / "check_secret_literals.py",
+        )
+        bad = tmp_path / "leak.py"
+        bad.write_text('API_KEY = "sk-abcdefghijklmnopqrstuvwxyz123456"\n', encoding="utf-8")
+        assert checker._scan_file(bad)


### PR DESCRIPTION
## Summary
- Adds `scripts/check_secret_literals.py` — scans 197 enforced paths (skill `src/`, MCP server, scripts, `examples/agents/*.py`, harness profiles, presets, `AGENT_QUICKSTART.md`).
- Replaces ad-hoc CI `grep` with the centralized checker; wires into `make validate`.
- Extends harness drift doctor to scan SDK agent modules, presets, and quickstart docs.
- Extends `bandit` CI to `examples/agents/`.

Excludes test trees and golden fixtures (synthetic token shapes for detector regression).

## Audit result (local)
- No `.env`, `.pem`, or `.key` files tracked in git
- `safe_mcp_env()` strips API keys from MCP subprocess env (tested)
- Harness profiles/docs reject password/PAT literals at generation time
- No telemetry/phone-home in MCP server beyond local audit

## Test plan
- [x] `python scripts/check_secret_literals.py`
- [x] `python examples/agents/check_langgraph_harness_drift.py`
- [x] `pytest tests/integration/test_skill_validation_scripts.py::TestSecretLiteralChecker -q`


Made with [Cursor](https://cursor.com)