### PR TITLE
Add Windsurf MCP-first security agent example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           python-version: "3.11"
           packages: pytest ruff pyyaml
       - run: ruff check examples/agents --config pyproject.toml
+      - run: ruff format --check examples/agents --config pyproject.toml
       - name: Run dependency-light agent examples
         run: pytest examples/agents/tests/test_examples.py -q
       - name: Run LangGraph harness eval gate

--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -86,6 +86,12 @@ Windsurf does not expand `~`):
 
 Reload: **Settings → Cascade → MCP → Refresh**.
 
+Runnable offline example (harness profile + live `tools/list`):
+
+[`../examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py)
+
+Project config details: [`integrations/windsurf.md`](integrations/windsurf.md).
+
 ---
 
 ## Codex · Cortex · Zed

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -51,6 +51,8 @@ connects.
   not auto-reload.
 - Cascade's agentic mode can chain many tool calls — the wrapper's per-call
   audit record is still one-per-invocation, so the audit trail remains clean.
+- Offline reference: [`../examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py)
+  emits an absolute-path `mcp_config.json` block from a harness profile.
 
 ## HITL + audit behavior
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -11,6 +11,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`openai_sdk_security_agent.py`](openai_sdk_security_agent.py) | OpenAI Agents SDK | Parallel port of the Anthropic example for portability |
 | [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first wiring via `langchain-mcp-adapters` — do not wrap skill CLIs as LCEL tools |
 | [`cursor_mcp_security_agent.py`](cursor_mcp_security_agent.py) | Cursor | Project-scoped `.cursor/mcp.json` + harness profile; same MCP audit/HITL contract |
+| [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -345,6 +345,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "openai_sdk_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",
         EXAMPLES / "cursor_mcp_security_agent.py",
+        EXAMPLES / "windsurf_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -29,6 +29,7 @@ SCRIPTS = [
     EXAMPLES / "openai_sdk_security_agent.py",
     EXAMPLES / "langchain_mcp_security_agent.py",
     EXAMPLES / "cursor_mcp_security_agent.py",
+    EXAMPLES / "windsurf_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -282,6 +283,27 @@ class TestHitlGateReachable:
         assert binding["integration"] == "cursor_mcp_json"
         assert binding["config_path"] == ".cursor/mcp.json"
         assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
+        assert payload["mcp_tools_discovered"]
+
+    def test_windsurf_mcp_binding_documents_absolute_path_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "windsurf_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["windsurf_binding"]
+        assert binding["integration"] == "windsurf_mcp_config_json"
+        assert binding["config_path"] == "~/.codeium/windsurf/mcp_config.json"
+        assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
+        assert binding["mcp_config"]["mcpServers"]["cloud-ai-security-skills"]["args"][0].endswith(
+            "mcp-server/src/server.py"
+        )
         assert payload["mcp_tools_discovered"]
 
     def test_langgraph_reaches_remediation_with_approval(self):

--- a/examples/agents/windsurf_mcp_security_agent.py
+++ b/examples/agents/windsurf_mcp_security_agent.py
@@ -1,0 +1,76 @@
+"""Windsurf — MCP-first security agent example.
+
+Windsurf (Codeium Cascade) loads skills through ``~/.codeium/windsurf/mcp_config.json``
+(stdio MCP, absolute paths). This reference shows the same harness-profile +
+live ``tools/list`` path as the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/windsurf_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    REPO_ROOT,
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+
+
+def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block for ``~/.codeium/windsurf/mcp_config.json`` (absolute path required)."""
+    allowlist = read_allowlist(profile)
+    return {
+        "mcpServers": {
+            "cloud-ai-security-skills": {
+                "command": mcp_stdio_command()[0],
+                "args": [str(MCP_SERVER_PATH)],
+                "env": {
+                    **safe_mcp_env(allowed_skills=allowlist),
+                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
+                },
+            }
+        }
+    }
+
+
+def windsurf_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "windsurf_mcp_config_json",
+        "config_path": "~/.codeium/windsurf/mcp_config.json",
+        "docs": "docs/integrations/windsurf.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_cascade_tools",
+        "mcp_config": build_windsurf_mcp_config(profile),
+        "path_note": "Windsurf does not expand ~ — replace with an absolute clone path before paste",
+        "remediation_chain": "separate_cascade_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="windsurf-mcp-demo-1")
+    triage["windsurf_binding"] = windsurf_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `windsurf_mcp_security_agent.py` — harness profile + live `tools/list`, emitting a Windsurf `mcp_config.json` block with absolute MCP server path.
- Updates `docs/AGENT_QUICKSTART.md`, `docs/integrations/windsurf.md`, and agent README.
- Adds `ruff format --check examples/agents` to the `agent-examples` CI job to catch format drift before merge.

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run ruff format --check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`


Made with [Cursor](https://cursor.com)