### PR TITLE
Add --preset flag to harness profile generator

### DIFF
--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -7,6 +7,7 @@ Run:
 
     python examples/agents/configure_langgraph_harness.py \
       --role sdk-cspm \
+      --preset presets/preset-cspm-readonly.json \
       --profile-id acme-sdk-cspm \
       --email sdk-agent@example.com \
       --output-profile artifacts/acme-sdk-cspm.json \
@@ -35,6 +36,7 @@ from langgraph_security_graph import (
     DEFAULT_MODEL_POLICY,
     DEFAULT_TOKEN_BUDGET,
 )
+from sdk_agent_common import apply_preset_to_profile, load_preset
 
 HarnessRole = Literal["readonly-soc", "analyst-triage", "dry-run-remediation", "sdk-cspm"]
 LAKE_SOURCE_SKILLS = {
@@ -321,6 +323,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--allowed-skill", action="append", default=[], help="additional known example skill"
     )
     parser.add_argument(
+        "--preset",
+        help="workflow preset JSON path (intersects role allowlist; fail closed on empty)",
+    )
+    parser.add_argument(
         "--data-source-mode",
         choices=["raw-ingest", "security-lake-replay"],
         default="raw-ingest",
@@ -367,6 +373,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         profile = build_profile(args)
+        if args.preset:
+            preset = load_preset(args.preset)
+            if preset is None:
+                raise ValueError("preset path must be non-empty")
+            profile = apply_preset_to_profile(profile, preset)
+            _assert_no_secret_material(profile, path="profile")
     except ValueError as exc:
         sys.stderr.write(f"error: {exc}\n")
         return 2
@@ -389,6 +401,7 @@ def main(argv: list[str] | None = None) -> int:
                 "profile_id": profile["profile_id"],
                 "role": args.role,
                 "allowed_skills": profile["allowed_skills"],
+                "preset_applied": profile.get("preset_applied"),
                 "approval_required": True,
                 "secrets_written": False,
             },

--- a/examples/agents/harness_profiles/README.md
+++ b/examples/agents/harness_profiles/README.md
@@ -38,6 +38,7 @@ eligible for an operator-owned stdio transport.
 | Lake row shape | `--lake-records-format ocsf` or `raw_vendor` | OCSF rows skip raw normalization; raw rows keep source query followed by ingest |
 | Model use | default deterministic mode, or `--external-llm --llm-provider ... --llm-model ...` | records provider/model metadata and bounded routing; model output cannot set facts, approval, or write intent |
 | MCP execution | default `--mcp-execution-mode plan_only`, or `operator_stdio` with `--mcp-max-calls` | shipped default records the plan only; operator stdio mode can execute read-only calls through a separate transport |
+| Workflow preset | `--preset presets/preset-cspm-readonly.json` | intersects the role allowlist at generation time (same semantics as `CLOUD_SECURITY_MCP_PRESET` at SDK runtime) |
 | Approval source | `--approval-source`, `--min-approvers` | documents the HITL authority; the profile still cannot self-approve |
 
 Security-lake replay profile:

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -1999,6 +1999,40 @@ class TestLangGraphHarnessSetup:
         assert profile["agent_roster"][0]["agent_id"] == "triage-agent"
         assert "iam-departures-aws" not in profile["allowed_skills"]
 
+    def test_setup_generator_intersects_workflow_preset(self, tmp_path: Path):
+        profile_path = tmp_path / "acme-sdk-cspm-preset.json"
+        env_path = tmp_path / "acme-sdk-cspm-preset.env"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--role",
+                "sdk-cspm",
+                "--preset",
+                "presets/preset-cspm-readonly.json",
+                "--profile-id",
+                "acme-sdk-cspm-preset",
+                "--email",
+                "sdk-agent@example.com",
+                "--output-profile",
+                str(profile_path),
+                "--output-env",
+                str(env_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+        assert result.returncode == 0, result.stderr
+        setup_summary = json.loads(result.stdout)
+        assert setup_summary["preset_applied"] == "cspm-readonly"
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        assert profile["preset_applied"] == "cspm-readonly"
+        assert "detect-lateral-movement" not in profile["allowed_skills"]
+        assert "cspm-aws-cis-benchmark" in profile["allowed_skills"]
+
     def test_setup_generator_can_mark_readonly_mcp_stdio_execution(self, tmp_path: Path):
         profile_path = tmp_path / "acme-readonly-stdio.json"
         env_path = tmp_path / "acme-readonly-stdio.env"

--- a/presets/README.md
+++ b/presets/README.md
@@ -71,6 +71,18 @@ CLOUD_SECURITY_MCP_PRESET=preset-cspm-readonly.json \
 The effective allowlist is **profile ∩ preset ∩ caller** (empty intersection
 raises at load time).
 
+Generate a harness profile with the preset baked in:
+
+```bash
+python examples/agents/configure_langgraph_harness.py \
+  --role sdk-cspm \
+  --preset preset-cspm-readonly.json \
+  --profile-id acme-sdk-cspm \
+  --email sdk-agent@example.com \
+  --output-profile artifacts/acme-sdk-cspm.json \
+  --output-env artifacts/acme-sdk-cspm.env
+```
+
 The wrapper records `caller_skill_scope_count` and
 `caller_skill_scope_hash` in the audit event so the same preset across
 runs is recognisable in post-hoc analysis.


### PR DESCRIPTION
## Summary
- `configure_langgraph_harness.py --preset` intersects `presets/*.json` with the selected role allowlist when generating harness profiles.
- Reuses `sdk_agent_common.apply_preset_to_profile` — same fail-closed semantics as `CLOUD_SECURITY_MCP_PRESET` at SDK runtime.
- Documents the flag in harness profile README and `presets/README.md`.

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run ruff format --check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py::TestLangGraphHarnessSetup::test_setup_generator_intersects_workflow_preset -q`
- [x] `python examples/agents/check_langgraph_harness_drift.py`


Made with [Cursor](https://cursor.com)