### PR TITLE
Audit fix: agent docs false claims, broken links, preset errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Skills are grouped into layered categories — not by cloud. The category answer
 
 ```
 skills/
-├── ingestion/                     # raw source → OCSF 1.8 (15 ingest-* + 4 source-*)
+├── ingestion/                     # raw source → OCSF 1.8 (22 ingest-* + 4 source-*)
 │   ├── ingest-cloudtrail-ocsf/
 │   ├── ingest-vpc-flow-logs-ocsf/
 │   ├── ingest-vpc-flow-logs-gcp-ocsf/

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ You do not pick this repo **instead of** LangGraph or LangChain. You compose the
 |---|---|---|
 | **This repo** | security skills, OCSF wire, HITL gates, allowlists, audit | 131 skill bundles + MCP wrapper |
 | **LangGraph** | multi-step workflow state, branches, checkpoints, HITL routing | [`examples/agents/langgraph_security_graph.py`](examples/agents/langgraph_security_graph.py) + [`harness_profiles/`](examples/agents/harness_profiles/) |
-| **LangChain** | optional LLM message/tool adapter (single-turn glue) | optional adapter in [`harness_adapters.py`](examples/agents/harness_adapters.py) |
+| **LangChain** | MCP stdio wiring or optional LLM message adapter inside LangGraph triage | [`examples/agents/langchain_mcp_security_agent.py`](examples/agents/langchain_mcp_security_agent.py) + [`harness_adapters.py`](examples/agents/harness_adapters.py) |
 
 **LangGraph** fits SOC workflows: ingest → enrich → triage → analyst review → dry-run remediate → audit. Profiles swap allowlists, data sources, and model policy without forking skills.
 
-**LangChain** fits when you want a chat-message adapter in front of the same bounded triage schema gate — not when you need durable graph state.
+**LangChain** fits MCP-first agent loops via [`langchain_mcp_security_agent.py`](examples/agents/langchain_mcp_security_agent.py), or as an optional chat-message adapter behind the LangGraph triage schema gate — not when you need durable graph state alone.
 
 Packaged profiles (read-only SOC, analyst triage, dry-run remediation) and golden eval fixtures ship under [`examples/agents/`](examples/agents/). Details: [`docs/HARNESS.md`](docs/HARNESS.md).
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -135,7 +135,21 @@ Reference examples:
 - [`examples/agents/sdk_agent_common.py`](../examples/agents/sdk_agent_common.py) — shared profile + live `tools/list` discovery
 - [`examples/agents/anthropic_sdk_security_agent.py`](../examples/agents/anthropic_sdk_security_agent.py)
 - [`examples/agents/openai_sdk_security_agent.py`](../examples/agents/openai_sdk_security_agent.py)
-- [`examples/agents/langchain_mcp_security_agent.py`](../examples/agents/langchain_mcp_security_agent.py) — `langchain-mcp-adapters` config block, anti-LCEL guidance
+- [`examples/agents/langchain_mcp_security_agent.py`](../examples/agents/langchain_mcp_security_agent.py) — MCP stdio config block + anti-LCEL guidance (offline runnable; `langchain-mcp-adapters` when installed)
+- [`examples/agents/cursor_mcp_security_agent.py`](../examples/agents/cursor_mcp_security_agent.py) — project `.cursor/mcp.json` block
+- [`examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py) — Windsurf `mcp_config.json` block
+
+Generate a profile with a workflow preset baked in:
+
+```bash
+python examples/agents/configure_langgraph_harness.py \
+  --role sdk-cspm \
+  --preset presets/preset-cspm-readonly.json \
+  --profile-id acme-sdk-cspm \
+  --email sdk-agent@example.com \
+  --output-profile artifacts/acme-sdk-cspm.json \
+  --output-env artifacts/acme-sdk-cspm.env
+```
 
 ```bash
 python examples/agents/langchain_mcp_security_agent.py

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -59,4 +59,4 @@ whitelist explicitly.
 - [`../../mcp-server/README.md`](../../mcp-server/README.md) — server internals, timeout / audit semantics
 - [`../../CLAUDE.md`](../../CLAUDE.md) — agent guardrails required before invoking any skill
 - [`../../docs/HITL_POLICY.md`](../HITL_POLICY.md) — when human approval is required, across all clients
-- [`../../examples/agents/`](../../examples/agents/) — runnable agent-SDK integration examples (Anthropic, OpenAI, LangGraph)
+- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, LangGraph)

--- a/docs/integrations/claude-ai-web.md
+++ b/docs/integrations/claude-ai-web.md
@@ -12,7 +12,7 @@ If you see a guide claiming otherwise, it's out of date or inaccurate.
 |---|---|
 | Interactive chat + local skill calls | [Claude Desktop](claude-desktop.md) — supports stdio MCP |
 | CLI / IDE usage | [Claude Code](../../.mcp.json) — already wired at repo root |
-| Headless agent that uses these skills | Anthropic Agent SDK ([`../../examples/agents/anthropic-sdk-security-agent.py`](../../examples/agents/anthropic-sdk-security-agent.py)) |
+| Headless agent that uses these skills | Anthropic Agent SDK ([`../../examples/agents/anthropic_sdk_security_agent.py`](../../examples/agents/anthropic_sdk_security_agent.py)) |
 | CI pipeline runs a skill | call the skill script directly — MCP not needed |
 
 ## Can I make claude.ai reach my local skills over HTTP?
@@ -29,7 +29,7 @@ Until the repo ships an explicit hosted MCP server with authn + audit (not on
 the current roadmap), **use Claude Desktop or Claude Code** for local skill
 access. For pure-cloud agent use cases, use the Anthropic Agent SDK with the
 repo checked out on the agent host; that path is covered by
-[`../../examples/agents/anthropic-sdk-security-agent.py`](../../examples/agents/anthropic-sdk-security-agent.py).
+[`../../examples/agents/anthropic_sdk_security_agent.py`](../../examples/agents/anthropic_sdk_security_agent.py).
 
 ## Why this restriction exists
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -67,7 +67,7 @@ remediation):
 - If the server errors on first call, check **Settings → MCP → View Logs**.
 - `${workspaceFolder}` only works inside `.cursor/mcp.json`, not the global
   `~/.cursor/mcp.json`.
-- Offline reference: [`../examples/agents/cursor_mcp_security_agent.py`](../examples/agents/cursor_mcp_security_agent.py)
+- Offline reference: [`../../examples/agents/cursor_mcp_security_agent.py`](../../examples/agents/cursor_mcp_security_agent.py)
   emits a portable `.cursor/mcp.json` block from a harness profile.
 
 ## HITL + audit behavior

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -51,7 +51,7 @@ connects.
   not auto-reload.
 - Cascade's agentic mode can chain many tool calls — the wrapper's per-call
   audit record is still one-per-invocation, so the audit trail remains clean.
-- Offline reference: [`../examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py)
+- Offline reference: [`../../examples/agents/windsurf_mcp_security_agent.py`](../../examples/agents/windsurf_mcp_security_agent.py)
   emits an absolute-path `mcp_config.json` block from a harness profile.
 
 ## HITL + audit behavior

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -9,7 +9,7 @@ allowlist regardless of which SDK is driving the loop.
 |---|---|---|
 | [`anthropic_sdk_security_agent.py`](anthropic_sdk_security_agent.py) | Anthropic Python SDK (Managed Agent) | CSPM scan → triage loop with HITL gate on remediation |
 | [`openai_sdk_security_agent.py`](openai_sdk_security_agent.py) | OpenAI Agents SDK | Parallel port of the Anthropic example for portability |
-| [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first wiring via `langchain-mcp-adapters` — do not wrap skill CLIs as LCEL tools |
+| [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first stdio pattern; `langchain-mcp-adapters` config when installed — not LCEL skill wrappers |
 | [`cursor_mcp_security_agent.py`](cursor_mcp_security_agent.py) | Cursor | Project-scoped `.cursor/mcp.json` + harness profile; same MCP audit/HITL contract |
 | [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
@@ -32,6 +32,7 @@ Generate a matching harness profile (same allowlist shape as
 ```bash
 python examples/agents/configure_langgraph_harness.py \
   --role sdk-cspm \
+  --preset presets/preset-cspm-readonly.json \
   --profile-id acme-sdk-cspm \
   --email sdk-agent@example.com \
   --output-profile artifacts/acme-sdk-cspm.json \
@@ -40,7 +41,7 @@ python examples/agents/configure_langgraph_harness.py \
 
 ## Safety posture — every example enforces the same invariants
 
-1. **Read-only skill allowlist.** Every example sets
+1. **Read-only skill allowlist.** MCP SDK and IDE reference examples set
    `CLOUD_SECURITY_MCP_ALLOWED_SKILLS=<comma-separated read-only skills>` on
    the MCP server subprocess. Remediation skills are **not** registered as
    tools. An agent loop cannot call what isn't on the list.
@@ -60,7 +61,7 @@ python examples/agents/configure_langgraph_harness.py \
 
 ## Anti-pattern called out — agent-loop exploitation
 
-Each example includes a `DONT_DO_THIS` section showing a naive loop that
+This README includes a `DONT_DO_THIS` section below showing a naive loop that
 chains `detect → remediate` without a human gate:
 
 ```python

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -379,7 +379,7 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValueError("preset path must be non-empty")
             profile = apply_preset_to_profile(profile, preset)
             _assert_no_secret_material(profile, path="profile")
-    except ValueError as exc:
+    except (ValueError, FileNotFoundError) as exc:
         sys.stderr.write(f"error: {exc}\n")
         return 2
     args.output_profile.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -1,4 +1,4 @@
-"""Smoke tests for the three agent-SDK reference examples.
+"""Smoke tests for the agent MCP and LangGraph reference examples.
 
 Each example must:
   1. Run offline (no network, no real LLM), exit 0
@@ -2054,6 +2054,33 @@ class TestLangGraphHarnessSetup:
         assert profile["preset_applied"] == "cspm-readonly"
         assert "detect-lateral-movement" not in profile["allowed_skills"]
         assert "cspm-aws-cis-benchmark" in profile["allowed_skills"]
+
+    def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.SCRIPT),
+                "--role",
+                "sdk-cspm",
+                "--preset",
+                "presets/does-not-exist.json",
+                "--profile-id",
+                "acme-bad-preset",
+                "--email",
+                "sdk-agent@example.com",
+                "--output-profile",
+                str(tmp_path / "bad.json"),
+                "--output-env",
+                str(tmp_path / "bad.env"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+        assert result.returncode == 2
+        assert "preset not found" in result.stderr
 
     def test_setup_generator_can_mark_readonly_mcp_stdio_execution(self, tmp_path: Path):
         profile_path = tmp_path / "acme-readonly-stdio.json"


### PR DESCRIPTION
## Summary
End-to-end audit fixes for docs/code drift:

- **Broken links:** `docs/integrations/cursor.md` and `windsurf.md` used `../examples/` (resolved under `docs/`) — fixed to `../../examples/agents/`.
- **Broken links:** `claude-ai-web.md` pointed at nonexistent `anthropic-sdk-security-agent.py` — fixed to `anthropic_sdk_security_agent.py`.
- **False claims:** agent README said every example file includes `DONT_DO_THIS` and that every example sets `CLOUD_SECURITY_MCP_ALLOWED_SKILLS` — clarified to README-only anti-pattern and MCP SDK/IDE examples.
- **Stale counts:** `CLAUDE.md` said 15 ingest skills — corrected to 22 + 4 sources (matches CI validators).
- **LangChain positioning:** README/HARNESS/examples table no longer imply `langchain-mcp-adapters` is imported by the offline reference script.
- **Bug:** `configure_langgraph_harness.py --preset` now fails closed on missing preset files (`FileNotFoundError`).
- **Docs gap:** HARNESS + integrations index now list Cursor, Windsurf, and `--preset` profile generation.

## Validation
- [x] `make validate`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`
- [x] `uv run ruff format --check .`


Made with [Cursor](https://cursor.com)