### PR TITLE
Add Cortex MCP-first security agent example

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -102,6 +102,10 @@ Same shape as the Claude Desktop block above, in each client's MCP config:
 - Cortex: [`integrations/cortex.md`](integrations/cortex.md)
 - Zed: [`integrations/zed.md`](integrations/zed.md)
 
+Runnable offline Cortex example (harness profile + live `tools/list`):
+
+[`../examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py)
+
 ---
 
 ## Anthropic Agent SDK

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -138,6 +138,7 @@ Reference examples:
 - [`examples/agents/langchain_mcp_security_agent.py`](../examples/agents/langchain_mcp_security_agent.py) — MCP stdio config block + anti-LCEL guidance (offline runnable; `langchain-mcp-adapters` when installed)
 - [`examples/agents/cursor_mcp_security_agent.py`](../examples/agents/cursor_mcp_security_agent.py) — project `.cursor/mcp.json` block
 - [`examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py) — Windsurf `mcp_config.json` block
+- [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -59,4 +59,4 @@ whitelist explicitly.
 - [`../../mcp-server/README.md`](../../mcp-server/README.md) — server internals, timeout / audit semantics
 - [`../../CLAUDE.md`](../../CLAUDE.md) — agent guardrails required before invoking any skill
 - [`../../docs/HITL_POLICY.md`](../HITL_POLICY.md) — when human approval is required, across all clients
-- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, LangGraph)
+- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, LangGraph)

--- a/docs/integrations/cortex.md
+++ b/docs/integrations/cortex.md
@@ -77,6 +77,8 @@ DynamoDB / IAM.
   after editing `.cortex/mcp.json`.
 - If running Cortex Code inside Snowpark Container Services, mount the repo
   as a read-only volume; the wrapper will auto-discover SKILLs at startup.
+- Offline reference: [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py)
+  emits a portable `.cortex/mcp.json` block from a harness profile.
 
 ## HITL + audit behavior
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -12,6 +12,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first stdio pattern; `langchain-mcp-adapters` config when installed — not LCEL skill wrappers |
 | [`cursor_mcp_security_agent.py`](cursor_mcp_security_agent.py) | Cursor | Project-scoped `.cursor/mcp.json` + harness profile; same MCP audit/HITL contract |
 | [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |
+| [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -346,6 +346,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "langchain_mcp_security_agent.py",
         EXAMPLES / "cursor_mcp_security_agent.py",
         EXAMPLES / "windsurf_mcp_security_agent.py",
+        EXAMPLES / "cortex_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/cortex_mcp_security_agent.py
+++ b/examples/agents/cortex_mcp_security_agent.py
@@ -1,0 +1,72 @@
+"""Cortex Code CLI — MCP-first security agent example.
+
+Cortex loads skills through project-scoped ``.cortex/mcp.json`` (stdio MCP).
+This reference shows the same harness-profile + live ``tools/list`` path as
+the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/cortex_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+
+def build_cortex_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block for ``.cortex/mcp.json`` — portable with ``${workspaceFolder}``."""
+    allowlist = read_allowlist(profile)
+    return {
+        "mcpServers": {
+            "cloud-ai-security-skills": {
+                "command": mcp_stdio_command()[0],
+                "args": ["${workspaceFolder}/mcp-server/src/server.py"],
+                "env": {
+                    **safe_mcp_env(allowed_skills=allowlist),
+                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
+                },
+            }
+        }
+    }
+
+
+def cortex_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "cortex_mcp_json",
+        "config_path": ".cortex/mcp.json",
+        "docs": "docs/integrations/cortex.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_cortex_tools",
+        "mcp_config": build_cortex_mcp_config(profile),
+        "remediation_chain": "separate_cortex_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="cortex-mcp-demo-1")
+    triage["cortex_binding"] = cortex_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -30,6 +30,7 @@ SCRIPTS = [
     EXAMPLES / "langchain_mcp_security_agent.py",
     EXAMPLES / "cursor_mcp_security_agent.py",
     EXAMPLES / "windsurf_mcp_security_agent.py",
+    EXAMPLES / "cortex_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -303,6 +304,27 @@ class TestHitlGateReachable:
         assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
         assert binding["mcp_config"]["mcpServers"]["cloud-ai-security-skills"]["args"][0].endswith(
             "mcp-server/src/server.py"
+        )
+        assert payload["mcp_tools_discovered"]
+
+    def test_cortex_mcp_binding_documents_project_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "cortex_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["cortex_binding"]
+        assert binding["integration"] == "cortex_mcp_json"
+        assert binding["config_path"] == ".cortex/mcp.json"
+        assert (
+            "${workspaceFolder}"
+            in binding["mcp_config"]["mcpServers"]["cloud-ai-security-skills"]["args"][0]
         )
         assert payload["mcp_tools_discovered"]
 


### PR DESCRIPTION
## Summary
- Adds `cortex_mcp_security_agent.py` for Snowflake Cortex Code CLI (`.cortex/mcp.json` + `${workspaceFolder}`).
- Updates agent README, `AGENT_QUICKSTART`, `HARNESS.md`, and `integrations/cortex.md`.
- Smoke + binding tests.

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run ruff format --check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`


Made with [Cursor](https://cursor.com)