### PR TITLE
Add Codex MCP-first security agent example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,15 @@ jobs:
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
           "${HOME}/.local/bin/bicep" --version
       - name: Install shellcheck
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends shellcheck
+        run: |
+          set -euo pipefail
+          for list in /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*; do
+            if [ -e "$list" ]; then
+              sudo mv "$list" "${list}.disabled"
+            fi
+          done
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends shellcheck
       - name: cfn-lint — CloudFormation
         run: |
           cfn-lint skills/remediation/iam-departures-aws/infra/cloudformation.yaml

--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -106,6 +106,10 @@ Runnable offline Cortex example (harness profile + live `tools/list`):
 
 [`../examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py)
 
+Runnable offline Codex example (harness profile + live `tools/list`):
+
+[`../examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py)
+
 ---
 
 ## Anthropic Agent SDK

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -139,6 +139,7 @@ Reference examples:
 - [`examples/agents/cursor_mcp_security_agent.py`](../examples/agents/cursor_mcp_security_agent.py) — project `.cursor/mcp.json` block
 - [`examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py) — Windsurf `mcp_config.json` block
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
+- [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/SKILL_CONTRACT.md
+++ b/docs/SKILL_CONTRACT.md
@@ -150,12 +150,8 @@ Rules:
 - `approver_roles`, when present, should name the roles allowed to approve write-capable actions
 - `min_approvers`, when present, must be an integer greater than or equal to 1
 - `mcp_timeout_seconds`, when present, must be an integer between 1 and 900 and names the per-call subprocess timeout the MCP wrapper should apply to this skill. It is opt-in; skills that do not declare it inherit the global default (60 seconds) or whatever the operator sets via the `CLOUD_SECURITY_MCP_TIMEOUT_SECONDS` env var. The env var wins over the per-skill value so on-call can widen or tighten the window without editing `SKILL.md`
-<<<<<<< HEAD
 - write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy; the repo MCP wrapper uses them to require `_approval_context` and enforce approver count
 - `approver_roles` is policy metadata, not proof that every local CLI path validates role membership itself; a `SKILL.md` body should only claim in-code role enforcement when the shipped handler or wrapper actually performs that check
-=======
-- write-capable skills should declare `approver_roles` and `min_approvers` when enterprise wrappers need machine-readable approval policy; the repo MCP wrapper uses them to require `_approval_context` and enforce approver count
->>>>>>> origin/main
 - write-capable skills should preserve caller, approver, and request or session identifiers in their audit trail when the runtime provides them
 
 ## Required language

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -59,4 +59,4 @@ whitelist explicitly.
 - [`../../mcp-server/README.md`](../../mcp-server/README.md) — server internals, timeout / audit semantics
 - [`../../CLAUDE.md`](../../CLAUDE.md) — agent guardrails required before invoking any skill
 - [`../../docs/HITL_POLICY.md`](../HITL_POLICY.md) — when human approval is required, across all clients
-- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, LangGraph)
+- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, Codex, LangGraph)

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -51,6 +51,8 @@ model cannot call what isn't in its tool registry.
 - If `python3` is behind a pyenv shim, prefer the absolute interpreter path
   (e.g. `/Users/you/.pyenv/versions/3.11.9/bin/python3`) to avoid PATH
   surprises when Codex spawns the subprocess.
+- Offline reference: [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py)
+  emits a `~/.codex/config.toml` fragment from a harness profile.
 
 ## HITL + audit behavior
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -13,6 +13,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cursor_mcp_security_agent.py`](cursor_mcp_security_agent.py) | Cursor | Project-scoped `.cursor/mcp.json` + harness profile; same MCP audit/HITL contract |
 | [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
+| [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -347,6 +347,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "cursor_mcp_security_agent.py",
         EXAMPLES / "windsurf_mcp_security_agent.py",
         EXAMPLES / "cortex_mcp_security_agent.py",
+        EXAMPLES / "codex_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/codex_mcp_security_agent.py
+++ b/examples/agents/codex_mcp_security_agent.py
@@ -1,0 +1,81 @@
+"""Codex — MCP-first security agent example.
+
+Codex CLI and IDE extensions load skills through ``~/.codex/config.toml`` (stdio
+MCP, absolute paths). This reference shows the same harness-profile + live
+``tools/list`` path as the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/codex_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    REPO_ROOT,
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
+    """Fragment for ``~/.codex/config.toml`` — absolute path required."""
+    allowlist = read_allowlist(profile)
+    env = {
+        **safe_mcp_env(allowed_skills=allowlist),
+        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
+    }
+    env_pairs = ", ".join(f"{key} = {_toml_string(value)}" for key, value in sorted(env.items()))
+    command = mcp_stdio_command()[0]
+    return (
+        "[mcp_servers.cloud-ai-security-skills]\n"
+        f"command = {_toml_string(command)}\n"
+        f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
+        f"env = {{ {env_pairs} }}\n"
+    )
+
+
+def codex_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "codex_config_toml",
+        "config_path": "~/.codex/config.toml",
+        "docs": "docs/integrations/codex.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_codex_tools",
+        "mcp_toml": build_codex_mcp_toml(profile),
+        "path_note": "Replace the args path with your clone location before paste",
+        "remediation_chain": "separate_codex_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="codex-mcp-demo-1")
+    triage["codex_binding"] = codex_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -31,6 +31,7 @@ SCRIPTS = [
     EXAMPLES / "cursor_mcp_security_agent.py",
     EXAMPLES / "windsurf_mcp_security_agent.py",
     EXAMPLES / "cortex_mcp_security_agent.py",
+    EXAMPLES / "codex_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -326,6 +327,25 @@ class TestHitlGateReachable:
             "${workspaceFolder}"
             in binding["mcp_config"]["mcpServers"]["cloud-ai-security-skills"]["args"][0]
         )
+        assert payload["mcp_tools_discovered"]
+
+    def test_codex_mcp_binding_documents_toml_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "codex_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["codex_binding"]
+        assert binding["integration"] == "codex_config_toml"
+        assert binding["config_path"] == "~/.codex/config.toml"
+        assert "[mcp_servers.cloud-ai-security-skills]" in binding["mcp_toml"]
+        assert "mcp-server/src/server.py" in binding["mcp_toml"]
         assert payload["mcp_tools_discovered"]
 
     def test_langgraph_reaches_remediation_with_approval(self):


### PR DESCRIPTION
## Summary
- Adds `codex_mcp_security_agent.py` for OpenAI Codex CLI (`~/.codex/config.toml`, absolute MCP path).
- Updates agent README, `AGENT_QUICKSTART`, `HARNESS.md`, and `integrations/codex.md`.
- Smoke + binding tests.

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run ruff format --check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`


Made with [Cursor](https://cursor.com)