### PR TITLE
Add Zed MCP-first security agent example

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -110,6 +110,10 @@ Runnable offline Codex example (harness profile + live `tools/list`):
 
 [`../examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py)
 
+Runnable offline Zed example (harness profile + live `tools/list`):
+
+[`../examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py)
+
 ---
 
 ## Anthropic Agent SDK

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -140,6 +140,7 @@ Reference examples:
 - [`examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py) — Windsurf `mcp_config.json` block
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
+- [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -59,4 +59,4 @@ whitelist explicitly.
 - [`../../mcp-server/README.md`](../../mcp-server/README.md) — server internals, timeout / audit semantics
 - [`../../CLAUDE.md`](../../CLAUDE.md) — agent guardrails required before invoking any skill
 - [`../../docs/HITL_POLICY.md`](../HITL_POLICY.md) — when human approval is required, across all clients
-- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, Codex, LangGraph)
+- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, Codex, Zed, LangGraph)

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -59,6 +59,8 @@ the SARIF converter, and detector skills available but nothing destructive):
 - If the assistant can't see the tools, run `:language: zed -> Tasks: Show
   Context Server Logs` to inspect stderr from the wrapper.
 - Zed's `path` field does not expand `~` — use absolute paths.
+- Offline reference: [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py)
+  emits a `context_servers` block from a harness profile.
 
 ## HITL + audit behavior
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -14,6 +14,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
+| [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -348,6 +348,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "windsurf_mcp_security_agent.py",
         EXAMPLES / "cortex_mcp_security_agent.py",
         EXAMPLES / "codex_mcp_security_agent.py",
+        EXAMPLES / "zed_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -32,6 +32,7 @@ SCRIPTS = [
     EXAMPLES / "windsurf_mcp_security_agent.py",
     EXAMPLES / "cortex_mcp_security_agent.py",
     EXAMPLES / "codex_mcp_security_agent.py",
+    EXAMPLES / "zed_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -346,6 +347,28 @@ class TestHitlGateReachable:
         assert binding["config_path"] == "~/.codex/config.toml"
         assert "[mcp_servers.cloud-ai-security-skills]" in binding["mcp_toml"]
         assert "mcp-server/src/server.py" in binding["mcp_toml"]
+        assert payload["mcp_tools_discovered"]
+
+    def test_zed_mcp_binding_documents_context_servers(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "zed_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["zed_binding"]
+        assert binding["integration"] == "zed_context_servers_json"
+        assert binding["config_path"] == "~/.config/zed/settings.json"
+        servers = binding["context_servers"]["context_servers"]
+        assert "cloud-ai-security-skills" in servers
+        assert servers["cloud-ai-security-skills"]["command"]["args"][0].endswith(
+            "mcp-server/src/server.py"
+        )
         assert payload["mcp_tools_discovered"]
 
     def test_langgraph_reaches_remediation_with_approval(self):

--- a/examples/agents/zed_mcp_security_agent.py
+++ b/examples/agents/zed_mcp_security_agent.py
@@ -1,0 +1,78 @@
+"""Zed — MCP-first security agent example.
+
+Zed loads skills through ``~/.config/zed/settings.json`` (``context_servers``,
+stdio MCP, absolute paths). This reference shows the same harness-profile +
+live ``tools/list`` path as the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/zed_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    REPO_ROOT,
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+
+
+def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block for ``~/.config/zed/settings.json`` — absolute path required."""
+    allowlist = read_allowlist(profile)
+    return {
+        "context_servers": {
+            "cloud-ai-security-skills": {
+                "command": {
+                    "path": mcp_stdio_command()[0],
+                    "args": [str(MCP_SERVER_PATH)],
+                    "env": {
+                        **safe_mcp_env(allowed_skills=allowlist),
+                        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
+                    },
+                },
+            }
+        }
+    }
+
+
+def zed_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "zed_context_servers_json",
+        "config_path": "~/.config/zed/settings.json",
+        "docs": "docs/integrations/zed.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_zed_tools",
+        "context_servers": build_zed_context_servers(profile),
+        "path_note": "Zed does not expand ~ — replace with an absolute clone path before paste",
+        "remediation_chain": "separate_assistant_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="zed-mcp-demo-1")
+    triage["zed_binding"] = zed_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `zed_mcp_security_agent.py` for Zed (`~/.config/zed/settings.json` `context_servers`, absolute MCP path).
- Updates agent README, `AGENT_QUICKSTART`, `HARNESS.md`, and `integrations/zed.md`.
- Includes validate-iac shellcheck install hardening (flaky Microsoft apt repos on ubuntu-latest).
- Smoke + binding tests.

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run ruff format --check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`


Made with [Cursor](https://cursor.com)