### PR TITLE
Polish IDE MCP integration docs and guardrails

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -96,7 +96,14 @@ Project config details: [`integrations/windsurf.md`](integrations/windsurf.md).
 
 ## Codex · Cortex · Zed
 
-Same shape as the Claude Desktop block above, in each client's MCP config:
+Each client uses a different on-disk config shape — match the integration doc,
+not the Claude Desktop JSON block:
+
+| Client | Config | Shape |
+|---|---|---|
+| Codex | `~/.codex/config.toml` | TOML `[mcp_servers.<name>]` |
+| Cortex | `.cortex/mcp.json` | JSON `mcpServers` + `${workspaceFolder}` |
+| Zed | `~/.config/zed/settings.json` | JSON `context_servers` nested `command` |
 
 - Codex: [`integrations/codex.md`](integrations/codex.md)
 - Cortex: [`integrations/cortex.md`](integrations/cortex.md)

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -119,9 +119,9 @@ The demo pauses before ``review``, injects operator ``approval_context`` via
 ## Agent + AI pluggability — MCP first, not LCEL wrappers
 
 Frameworks (LangChain, LangGraph, OpenAI Agents SDK, Anthropic Agent SDK, Cursor,
-Codex) should bind the **repo MCP server** as their tool surface. Skills stay
-behind one audited contract: allowlists, HITL gates, dry-run defaults, and
-HMAC audit chains do not fork per framework.
+Windsurf, Cortex, Codex, Zed) should bind the **repo MCP server** as their tool
+surface. Skills stay behind one audited contract: allowlists, HITL gates,
+dry-run defaults, and HMAC audit chains do not fork per framework.
 
 | Do | Don't |
 |---|---|

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -54,6 +54,12 @@ model cannot call what isn't in its tool registry.
 - Offline reference: [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py)
   emits a `~/.codex/config.toml` fragment from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Same bar as Claude Code: remediation tools stay human-gated, the

--- a/docs/integrations/cortex.md
+++ b/docs/integrations/cortex.md
@@ -80,6 +80,12 @@ DynamoDB / IAM.
 - Offline reference: [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py)
   emits a portable `.cortex/mcp.json` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Remediation gates apply. The audit record lands in the same log line format

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -70,6 +70,12 @@ remediation):
 - Offline reference: [`../../examples/agents/cursor_mcp_security_agent.py`](../../examples/agents/cursor_mcp_security_agent.py)
   emits a portable `.cursor/mcp.json` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Cursor is just another MCP client — the wrapper's audit trail and human-

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -43,6 +43,37 @@ mcpServers:
       - /absolute/path/to/cloud-ai-security-skills/mcp-server/src/server.py
 ```
 
+## Shape 4 — Zed (`context_servers` map)
+
+Used by Zed assistant (`~/.config/zed/settings.json`):
+
+```json
+{
+  "context_servers": {
+    "cloud-ai-security-skills": {
+      "command": {
+        "path": "python3",
+        "args": ["/absolute/path/to/cloud-ai-security-skills/mcp-server/src/server.py"]
+      }
+    }
+  }
+}
+```
+
+## First-class IDE clients in this repo
+
+Runnable offline examples and per-client setup guides:
+
+| Client | Integration doc | Runnable example |
+|---|---|---|
+| Cursor | [`cursor.md`](cursor.md) | [`../../examples/agents/cursor_mcp_security_agent.py`](../../examples/agents/cursor_mcp_security_agent.py) |
+| Windsurf | [`windsurf.md`](windsurf.md) | [`../../examples/agents/windsurf_mcp_security_agent.py`](../../examples/agents/windsurf_mcp_security_agent.py) |
+| Cortex | [`cortex.md`](cortex.md) | [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py) |
+| Codex | [`codex.md`](codex.md) | [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py) |
+| Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
+
+See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
+
 ## Tool-specific notes
 
 ### Continue (VS Code / JetBrains)

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -54,6 +54,12 @@ connects.
 - Offline reference: [`../../examples/agents/windsurf_mcp_security_agent.py`](../../examples/agents/windsurf_mcp_security_agent.py)
   emits an absolute-path `mcp_config.json` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Same as every other MCP client: remediation gates stay in place, each call

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -62,6 +62,12 @@ the SARIF converter, and detector skills available but nothing destructive):
 - Offline reference: [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py)
   emits a `context_servers` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — Zed `context_servers` shape and generic MCP patterns
+
 ## HITL + audit behavior
 
 Identical to every other MCP client in this repo. The assistant-side agentic

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -41,6 +41,14 @@ EXPECTED_SCHEMAS = [
     SCHEMAS / "eval_report.schema.json",
 ]
 
+REQUIRED_IDE_EXAMPLE_TOKENS = [
+    "cursor_mcp_security_agent.py",
+    "windsurf_mcp_security_agent.py",
+    "cortex_mcp_security_agent.py",
+    "codex_mcp_security_agent.py",
+    "zed_mcp_security_agent.py",
+]
+
 REQUIRED_DOC_TOKENS = [
     "inspect_langgraph_harness.py",
     "run_langgraph_harness.py",
@@ -314,6 +322,22 @@ def _check_runtime_wrapper() -> DriftCheck:
     )
 
 
+def _check_ide_examples_wired() -> DriftCheck:
+    docs = {
+        str(HARNESS_DOC.relative_to(REPO_ROOT)): HARNESS_DOC.read_text(encoding="utf-8"),
+        str(EXAMPLES_README.relative_to(REPO_ROOT)): EXAMPLES_README.read_text(encoding="utf-8"),
+    }
+    failures: list[str] = []
+    for token in REQUIRED_IDE_EXAMPLE_TOKENS:
+        if not all(token in text for text in docs.values()):
+            failures.append(f"missing IDE example reference: {token}")
+    return DriftCheck(
+        "docs_reference_ide_mcp_examples",
+        not failures,
+        "docs reference all IDE MCP example scripts" if not failures else failures,
+    )
+
+
 def _check_docs_wired() -> DriftCheck:
     docs = {
         str(HARNESS_DOC.relative_to(REPO_ROOT)): HARNESS_DOC.read_text(encoding="utf-8"),
@@ -353,6 +377,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),
         *sorted((REPO_ROOT / "presets").glob("*.json")),
+        *sorted((REPO_ROOT / "docs" / "integrations").glob("*.md")),
     ]
     return [path for path in paths if path.is_file()]
 
@@ -387,6 +412,7 @@ def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
         _check_preflight_policy(),
         _check_runtime_wrapper(),
         _check_docs_wired(),
+        _check_ide_examples_wired(),
         _check_no_harness_secret_literals(),
     ]
 

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -77,8 +77,8 @@ ROLE_DEFAULTS: dict[HarnessRole, dict[str, Any]] = {
     },
     "sdk-cspm": {
         "description": (
-            "Anthropic, OpenAI, LangChain, and Cursor SDK examples: "
-            "read-only CSPM + detect triage via MCP stdio."
+            "Anthropic, OpenAI, LangChain, and IDE MCP examples (Cursor, Windsurf, "
+            "Cortex, Codex, Zed): read-only CSPM + detect triage via MCP stdio."
         ),
         "roles": "security_engineer",
         "include_remediation": False,

--- a/scripts/check_secret_literals.py
+++ b/scripts/check_secret_literals.py
@@ -51,6 +51,8 @@ TEXT_GLOBS = [
     "examples/agents/harness_profiles/*.json",
     "presets/*.json",
     "docs/AGENT_QUICKSTART.md",
+    "docs/HARNESS.md",
+    "docs/integrations/*.md",
 ]
 
 


### PR DESCRIPTION
## Summary
- Extends harness drift + secret literal scans to `docs/integrations/*.md` and `docs/HARNESS.md`.
- Requires all five IDE MCP example scripts in `HARNESS.md` and `examples/agents/README.md`.
- Fixes stale copy in `configure_langgraph_harness.py`, `HARNESS.md`, and `AGENT_QUICKSTART.md` (Codex/Cortex/Zed config shapes).
- Adds Zed `context_servers` shape + first-class client table to `ide-agents.md`; cross-links in per-client integration docs.

**Stacks on #588** — merge #588 first, then rebase this onto `main`.

## Test plan
- [x] `uv run ruff check examples/agents scripts/check_secret_literals.py`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`
- [x] `python examples/agents/check_langgraph_harness_drift.py`
- [x] `python scripts/check_secret_literals.py`


Made with [Cursor](https://cursor.com)