### PR TITLE
Extract shared IDE MCP binding builders

### DIFF
--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -365,6 +365,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "run_langgraph_harness.py",
         EXAMPLES / "execute_langgraph_mcp_plan.py",
         EXAMPLES / "sdk_agent_common.py",
+        EXAMPLES / "ide_mcp_bindings.py",
         EXAMPLES / "anthropic_sdk_security_agent.py",
         EXAMPLES / "openai_sdk_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",

--- a/examples/agents/codex_mcp_security_agent.py
+++ b/examples/agents/codex_mcp_security_agent.py
@@ -14,40 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_codex_mcp_toml
 from sdk_agent_common import (
-    REPO_ROOT,
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
-
-
-def _toml_string(value: str) -> str:
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
-
-
-def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
-    """Fragment for ``~/.codex/config.toml`` — absolute path required."""
-    allowlist = read_allowlist(profile)
-    env = {
-        **safe_mcp_env(allowed_skills=allowlist),
-        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-    }
-    env_pairs = ", ".join(f"{key} = {_toml_string(value)}" for key, value in sorted(env.items()))
-    command = mcp_stdio_command()[0]
-    return (
-        "[mcp_servers.cloud-ai-security-skills]\n"
-        f"command = {_toml_string(command)}\n"
-        f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
-        f"env = {{ {env_pairs} }}\n"
-    )
 
 
 def codex_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/cortex_mcp_security_agent.py
+++ b/examples/agents/cortex_mcp_security_agent.py
@@ -14,32 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_cortex_mcp_config
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-
-def build_cortex_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``.cortex/mcp.json`` — portable with ``${workspaceFolder}``."""
-    allowlist = read_allowlist(profile)
-    return {
-        "mcpServers": {
-            "cloud-ai-security-skills": {
-                "command": mcp_stdio_command()[0],
-                "args": ["${workspaceFolder}/mcp-server/src/server.py"],
-                "env": {
-                    **safe_mcp_env(allowed_skills=allowlist),
-                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                },
-            }
-        }
-    }
 
 
 def cortex_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/cursor_mcp_security_agent.py
+++ b/examples/agents/cursor_mcp_security_agent.py
@@ -14,32 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_cursor_mcp_config
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-
-def build_cursor_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``.cursor/mcp.json`` — portable with ``${workspaceFolder}``."""
-    allowlist = read_allowlist(profile)
-    return {
-        "mcpServers": {
-            "cloud-ai-security-skills": {
-                "command": mcp_stdio_command()[0],
-                "args": ["${workspaceFolder}/mcp-server/src/server.py"],
-                "env": {
-                    **safe_mcp_env(allowed_skills=allowlist),
-                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                },
-            }
-        }
-    }
 
 
 def cursor_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -1,0 +1,82 @@
+"""Shared MCP client config builders for IDE reference examples.
+
+Each IDE agent script stays a thin runnable wrapper; this module centralizes
+allowlist → env policy and server path shapes so Cursor/Cortex/Windsurf/Codex/Zed
+stay consistent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import REPO_ROOT, mcp_stdio_command, read_allowlist
+
+MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+WORKSPACE_SERVER_ARG = "${workspaceFolder}/mcp-server/src/server.py"
+
+
+def mcp_policy_env(profile: dict[str, Any]) -> dict[str, str]:
+    """Harness allowlist as MCP subprocess env (includes caller-skill enforcement)."""
+    return safe_mcp_env(allowed_skills=read_allowlist(profile))
+
+
+def build_mcp_servers_json(profile: dict[str, Any], *, server_arg: str) -> dict[str, Any]:
+    """JSON ``mcpServers`` block used by Cursor, Cortex, and Windsurf."""
+    return {
+        "mcpServers": {
+            "cloud-ai-security-skills": {
+                "command": mcp_stdio_command()[0],
+                "args": [server_arg],
+                "env": mcp_policy_env(profile),
+            }
+        }
+    }
+
+
+def build_cursor_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``.cursor/mcp.json`` — portable with ``${workspaceFolder}``."""
+    return build_mcp_servers_json(profile, server_arg=WORKSPACE_SERVER_ARG)
+
+
+def build_cortex_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``.cortex/mcp.json`` — portable with ``${workspaceFolder}``."""
+    return build_mcp_servers_json(profile, server_arg=WORKSPACE_SERVER_ARG)
+
+
+def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``~/.codeium/windsurf/mcp_config.json`` — absolute path required."""
+    return build_mcp_servers_json(profile, server_arg=str(MCP_SERVER_PATH))
+
+
+def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
+    """``~/.config/zed/settings.json`` ``context_servers`` block."""
+    return {
+        "context_servers": {
+            "cloud-ai-security-skills": {
+                "command": {
+                    "path": mcp_stdio_command()[0],
+                    "args": [str(MCP_SERVER_PATH)],
+                    "env": mcp_policy_env(profile),
+                },
+            }
+        }
+    }
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
+    """Fragment for ``~/.codex/config.toml`` — absolute path required."""
+    env = mcp_policy_env(profile)
+    env_pairs = ", ".join(f"{key} = {_toml_string(value)}" for key, value in sorted(env.items()))
+    command = mcp_stdio_command()[0]
+    return (
+        "[mcp_servers.cloud-ai-security-skills]\n"
+        f"command = {_toml_string(command)}\n"
+        f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
+        f"env = {{ {env_pairs} }}\n"
+    )

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -389,6 +389,52 @@ class TestHitlGateReachable:
         assert '"dry_run"' in result.stdout
 
 
+class TestIdeMcpBindings:
+    PROFILE = EXAMPLES / "harness_profiles" / "sdk-cspm-agent.json"
+
+    def _bindings_module(self):
+        if str(EXAMPLES) not in sys.path:
+            sys.path.insert(0, str(EXAMPLES))
+        import ide_mcp_bindings
+
+        return ide_mcp_bindings
+
+    def test_all_clients_share_mcp_policy_env(self):
+        ide_mcp_bindings = self._bindings_module()
+
+        profile = json.loads(self.PROFILE.read_text(encoding="utf-8"))
+        expected = ide_mcp_bindings.mcp_policy_env(profile)
+
+        cursor_env = ide_mcp_bindings.build_cursor_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["env"]
+        windsurf_env = ide_mcp_bindings.build_windsurf_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["env"]
+        zed_env = ide_mcp_bindings.build_zed_context_servers(profile)["context_servers"][
+            "cloud-ai-security-skills"
+        ]["command"]["env"]
+
+        assert cursor_env == expected
+        assert windsurf_env == expected
+        assert zed_env == expected
+        assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
+        assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
+
+    def test_workspace_clients_use_workspace_folder_arg(self):
+        ide_mcp_bindings = self._bindings_module()
+
+        profile = json.loads(self.PROFILE.read_text(encoding="utf-8"))
+        cursor_args = ide_mcp_bindings.build_cursor_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["args"]
+        cortex_args = ide_mcp_bindings.build_cortex_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["args"]
+        assert cursor_args == [ide_mcp_bindings.WORKSPACE_SERVER_ARG]
+        assert cortex_args == [ide_mcp_bindings.WORKSPACE_SERVER_ARG]
+
+
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
 

--- a/examples/agents/windsurf_mcp_security_agent.py
+++ b/examples/agents/windsurf_mcp_security_agent.py
@@ -14,35 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_windsurf_mcp_config
 from sdk_agent_common import (
-    REPO_ROOT,
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
-
-
-def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``~/.codeium/windsurf/mcp_config.json`` (absolute path required)."""
-    allowlist = read_allowlist(profile)
-    return {
-        "mcpServers": {
-            "cloud-ai-security-skills": {
-                "command": mcp_stdio_command()[0],
-                "args": [str(MCP_SERVER_PATH)],
-                "env": {
-                    **safe_mcp_env(allowed_skills=allowlist),
-                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                },
-            }
-        }
-    }
 
 
 def windsurf_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/zed_mcp_security_agent.py
+++ b/examples/agents/zed_mcp_security_agent.py
@@ -14,37 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_zed_context_servers
 from sdk_agent_common import (
-    REPO_ROOT,
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
-
-
-def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``~/.config/zed/settings.json`` — absolute path required."""
-    allowlist = read_allowlist(profile)
-    return {
-        "context_servers": {
-            "cloud-ai-security-skills": {
-                "command": {
-                    "path": mcp_stdio_command()[0],
-                    "args": [str(MCP_SERVER_PATH)],
-                    "env": {
-                        **safe_mcp_env(allowed_skills=allowlist),
-                        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                    },
-                },
-            }
-        }
-    }
 
 
 def zed_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Adds `ide_mcp_bindings.py` with shared `mcp_policy_env` and per-client config builders.
- Refactors Cursor, Cortex, Windsurf, Codex, and Zed agent examples to delegate to the shared module.
- Adds unit tests asserting all clients share the same MCP policy env and workspace-folder path shapes.

Stacks on #589 (merge #588 → #589 → this).

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`
- [x] `python examples/agents/check_langgraph_harness_drift.py`


Made with [Cursor](https://cursor.com)