### PR TITLE
Add offline emitter for all IDE MCP client configs

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -141,6 +141,7 @@ Reference examples:
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
+- [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of all IDE MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,6 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
+| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | All IDE clients | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 
@@ -40,6 +41,14 @@ python examples/agents/configure_langgraph_harness.py \
   --email sdk-agent@example.com \
   --output-profile artifacts/acme-sdk-cspm.json \
   --output-env artifacts/acme-sdk-cspm.env
+```
+
+Emit all IDE MCP client blocks from that profile (offline JSON bundle):
+
+```bash
+python examples/agents/emit_mcp_client_configs.py \
+  --profile artifacts/acme-sdk-cspm.json \
+  --output artifacts/mcp-client-configs.json
 ```
 
 ## Safety posture — every example enforces the same invariants

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -366,6 +366,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "execute_langgraph_mcp_plan.py",
         EXAMPLES / "sdk_agent_common.py",
         EXAMPLES / "ide_mcp_bindings.py",
+        EXAMPLES / "emit_mcp_client_configs.py",
         EXAMPLES / "anthropic_sdk_security_agent.py",
         EXAMPLES / "openai_sdk_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -1,0 +1,122 @@
+"""Emit IDE MCP client config blocks from a harness profile.
+
+Offline generator for operators wiring multiple IDE clients from one harness
+profile. Does not spawn MCP, call cloud APIs, or run remediation.
+
+Run:
+
+    python examples/agents/emit_mcp_client_configs.py
+    python examples/agents/emit_mcp_client_configs.py --client cursor
+    python examples/agents/emit_mcp_client_configs.py \\
+      --profile examples/agents/harness_profiles/sdk-cspm-agent.json \\
+      --output artifacts/mcp-client-configs.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from ide_mcp_bindings import (
+    build_codex_mcp_toml,
+    build_cortex_mcp_config,
+    build_cursor_mcp_config,
+    build_windsurf_mcp_config,
+    build_zed_context_servers,
+)
+from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
+
+ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "all"]
+CLIENT_NAMES: tuple[ClientName, ...] = ("cursor", "cortex", "windsurf", "codex", "zed", "all")
+
+
+def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
+    if client == "cursor":
+        return {
+            "integration": "cursor_mcp_json",
+            "config_path": ".cursor/mcp.json",
+            "docs": "docs/integrations/cursor.md",
+            "mcp_config": build_cursor_mcp_config(profile),
+        }
+    if client == "cortex":
+        return {
+            "integration": "cortex_mcp_json",
+            "config_path": ".cortex/mcp.json",
+            "docs": "docs/integrations/cortex.md",
+            "mcp_config": build_cortex_mcp_config(profile),
+        }
+    if client == "windsurf":
+        return {
+            "integration": "windsurf_mcp_config_json",
+            "config_path": "~/.codeium/windsurf/mcp_config.json",
+            "docs": "docs/integrations/windsurf.md",
+            "mcp_config": build_windsurf_mcp_config(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+        }
+    if client == "codex":
+        return {
+            "integration": "codex_config_toml",
+            "config_path": "~/.codex/config.toml",
+            "docs": "docs/integrations/codex.md",
+            "mcp_toml": build_codex_mcp_toml(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+        }
+    if client == "zed":
+        return {
+            "integration": "zed_context_servers_json",
+            "config_path": "~/.config/zed/settings.json",
+            "docs": "docs/integrations/zed.md",
+            "context_servers": build_zed_context_servers(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+        }
+    raise ValueError(f"unsupported client: {client}")
+
+
+def emit_client_configs(profile: dict[str, Any], *, client: ClientName = "all") -> dict[str, Any]:
+    selected = CLIENT_NAMES[:-1] if client == "all" else (client,)
+    return {name: _client_payload(name, profile) for name in selected}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        type=Path,
+        default=DEFAULT_PROFILE,
+        help="Harness profile JSON (default: harness_profiles/sdk-cspm-agent.json)",
+    )
+    parser.add_argument(
+        "--client",
+        choices=CLIENT_NAMES,
+        default="all",
+        help="Emit one client block or all five IDE clients",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write JSON (stdout when omitted)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    profile = load_sdk_profile(args.profile)
+    payload = {
+        "schema_version": "mcp-client-config-bundle-v1",
+        "profile_id": profile.get("profile_id"),
+        "clients": emit_client_configs(profile, client=args.client),
+    }
+    rendered = json.dumps(payload, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -435,6 +435,42 @@ class TestIdeMcpBindings:
         assert cortex_args == [ide_mcp_bindings.WORKSPACE_SERVER_ARG]
 
 
+class TestEmitMcpClientConfigs:
+    SCRIPT = EXAMPLES / "emit_mcp_client_configs.py"
+
+    def test_emits_all_clients_offline(self):
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["schema_version"] == "mcp-client-config-bundle-v1"
+        assert set(payload["clients"]) == {"cursor", "cortex", "windsurf", "codex", "zed"}
+        assert "mcp_config" in payload["clients"]["cursor"]
+        assert "mcp_toml" in payload["clients"]["codex"]
+        assert "context_servers" in payload["clients"]["zed"]
+
+    def test_single_client_filter(self):
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT), "--client", "cursor"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert set(payload["clients"]) == {"cursor"}
+
+
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
 


### PR DESCRIPTION
## Summary
- Adds `emit_mcp_client_configs.py` to generate Cursor/Cortex/Windsurf/Codex/Zed MCP blocks from one harness profile.
- Supports `--client` filter and `--output` file write.
- Updates `examples/agents/README.md` and `HARNESS.md` with usage.

Stacks on #590 (merge #588 → #589 → #590 → this).

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`
- [x] `python examples/agents/emit_mcp_client_configs.py --client cursor`


Made with [Cursor](https://cursor.com)