### PR TITLE
Land IDE MCP harness stack and wire generator to emitter

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -96,7 +96,14 @@ Project config details: [`integrations/windsurf.md`](integrations/windsurf.md).
 
 ## Codex · Cortex · Zed
 
-Same shape as the Claude Desktop block above, in each client's MCP config:
+Each client uses a different on-disk config shape — match the integration doc,
+not the Claude Desktop JSON block:
+
+| Client | Config | Shape |
+|---|---|---|
+| Codex | `~/.codex/config.toml` | TOML `[mcp_servers.<name>]` |
+| Cortex | `.cortex/mcp.json` | JSON `mcpServers` + `${workspaceFolder}` |
+| Zed | `~/.config/zed/settings.json` | JSON `context_servers` nested `command` |
 
 - Codex: [`integrations/codex.md`](integrations/codex.md)
 - Cortex: [`integrations/cortex.md`](integrations/cortex.md)

--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -110,6 +110,10 @@ Runnable offline Codex example (harness profile + live `tools/list`):
 
 [`../examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py)
 
+Runnable offline Zed example (harness profile + live `tools/list`):
+
+[`../examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py)
+
 ---
 
 ## Anthropic Agent SDK

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -140,6 +140,7 @@ Reference examples:
 - [`examples/agents/windsurf_mcp_security_agent.py`](../examples/agents/windsurf_mcp_security_agent.py) — Windsurf `mcp_config.json` block
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
+- [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -141,6 +141,7 @@ Reference examples:
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
+- [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of all IDE MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -119,9 +119,9 @@ The demo pauses before ``review``, injects operator ``approval_context`` via
 ## Agent + AI pluggability — MCP first, not LCEL wrappers
 
 Frameworks (LangChain, LangGraph, OpenAI Agents SDK, Anthropic Agent SDK, Cursor,
-Codex) should bind the **repo MCP server** as their tool surface. Skills stay
-behind one audited contract: allowlists, HITL gates, dry-run defaults, and
-HMAC audit chains do not fork per framework.
+Windsurf, Cortex, Codex, Zed) should bind the **repo MCP server** as their tool
+surface. Skills stay behind one audited contract: allowlists, HITL gates,
+dry-run defaults, and HMAC audit chains do not fork per framework.
 
 | Do | Don't |
 |---|---|

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -59,4 +59,4 @@ whitelist explicitly.
 - [`../../mcp-server/README.md`](../../mcp-server/README.md) — server internals, timeout / audit semantics
 - [`../../CLAUDE.md`](../../CLAUDE.md) — agent guardrails required before invoking any skill
 - [`../../docs/HITL_POLICY.md`](../HITL_POLICY.md) — when human approval is required, across all clients
-- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, Codex, LangGraph)
+- [`../../examples/agents/`](../../examples/agents/) — runnable MCP agent examples (Anthropic, OpenAI, LangChain, Cursor, Windsurf, Cortex, Codex, Zed, LangGraph)

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -54,6 +54,12 @@ model cannot call what isn't in its tool registry.
 - Offline reference: [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py)
   emits a `~/.codex/config.toml` fragment from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Same bar as Claude Code: remediation tools stay human-gated, the

--- a/docs/integrations/cortex.md
+++ b/docs/integrations/cortex.md
@@ -80,6 +80,12 @@ DynamoDB / IAM.
 - Offline reference: [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py)
   emits a portable `.cortex/mcp.json` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Remediation gates apply. The audit record lands in the same log line format

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -70,6 +70,12 @@ remediation):
 - Offline reference: [`../../examples/agents/cursor_mcp_security_agent.py`](../../examples/agents/cursor_mcp_security_agent.py)
   emits a portable `.cursor/mcp.json` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Cursor is just another MCP client — the wrapper's audit trail and human-

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -43,6 +43,37 @@ mcpServers:
       - /absolute/path/to/cloud-ai-security-skills/mcp-server/src/server.py
 ```
 
+## Shape 4 — Zed (`context_servers` map)
+
+Used by Zed assistant (`~/.config/zed/settings.json`):
+
+```json
+{
+  "context_servers": {
+    "cloud-ai-security-skills": {
+      "command": {
+        "path": "python3",
+        "args": ["/absolute/path/to/cloud-ai-security-skills/mcp-server/src/server.py"]
+      }
+    }
+  }
+}
+```
+
+## First-class IDE clients in this repo
+
+Runnable offline examples and per-client setup guides:
+
+| Client | Integration doc | Runnable example |
+|---|---|---|
+| Cursor | [`cursor.md`](cursor.md) | [`../../examples/agents/cursor_mcp_security_agent.py`](../../examples/agents/cursor_mcp_security_agent.py) |
+| Windsurf | [`windsurf.md`](windsurf.md) | [`../../examples/agents/windsurf_mcp_security_agent.py`](../../examples/agents/windsurf_mcp_security_agent.py) |
+| Cortex | [`cortex.md`](cortex.md) | [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py) |
+| Codex | [`codex.md`](codex.md) | [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py) |
+| Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
+
+See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
+
 ## Tool-specific notes
 
 ### Continue (VS Code / JetBrains)

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -54,6 +54,12 @@ connects.
 - Offline reference: [`../../examples/agents/windsurf_mcp_security_agent.py`](../../examples/agents/windsurf_mcp_security_agent.py)
   emits an absolute-path `mcp_config.json` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
+
 ## HITL + audit behavior
 
 Same as every other MCP client: remediation gates stay in place, each call

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -62,6 +62,12 @@ the SARIF converter, and detector skills available but nothing destructive):
 - Offline reference: [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py)
   emits a `context_servers` block from a harness profile.
 
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — Zed `context_servers` shape and generic MCP patterns
+
 ## HITL + audit behavior
 
 Identical to every other MCP client in this repo. The assistant-side agentic

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -59,6 +59,8 @@ the SARIF converter, and detector skills available but nothing destructive):
 - If the assistant can't see the tools, run `:language: zed -> Tasks: Show
   Context Server Logs` to inspect stderr from the wrapper.
 - Zed's `path` field does not expand `~` — use absolute paths.
+- Offline reference: [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py)
+  emits a `context_servers` block from a harness profile.
 
 ## HITL + audit behavior
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -14,6 +14,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
+| [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,6 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
+| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | All IDE clients | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 
@@ -40,6 +41,14 @@ python examples/agents/configure_langgraph_harness.py \
   --email sdk-agent@example.com \
   --output-profile artifacts/acme-sdk-cspm.json \
   --output-env artifacts/acme-sdk-cspm.env
+```
+
+Emit all IDE MCP client blocks from that profile (offline JSON bundle):
+
+```bash
+python examples/agents/emit_mcp_client_configs.py \
+  --profile artifacts/acme-sdk-cspm.json \
+  --output artifacts/mcp-client-configs.json
 ```
 
 ## Safety posture — every example enforces the same invariants

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -348,6 +348,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "windsurf_mcp_security_agent.py",
         EXAMPLES / "cortex_mcp_security_agent.py",
         EXAMPLES / "codex_mcp_security_agent.py",
+        EXAMPLES / "zed_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -365,6 +365,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "run_langgraph_harness.py",
         EXAMPLES / "execute_langgraph_mcp_plan.py",
         EXAMPLES / "sdk_agent_common.py",
+        EXAMPLES / "ide_mcp_bindings.py",
         EXAMPLES / "anthropic_sdk_security_agent.py",
         EXAMPLES / "openai_sdk_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -366,6 +366,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "execute_langgraph_mcp_plan.py",
         EXAMPLES / "sdk_agent_common.py",
         EXAMPLES / "ide_mcp_bindings.py",
+        EXAMPLES / "emit_mcp_client_configs.py",
         EXAMPLES / "anthropic_sdk_security_agent.py",
         EXAMPLES / "openai_sdk_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -41,6 +41,14 @@ EXPECTED_SCHEMAS = [
     SCHEMAS / "eval_report.schema.json",
 ]
 
+REQUIRED_IDE_EXAMPLE_TOKENS = [
+    "cursor_mcp_security_agent.py",
+    "windsurf_mcp_security_agent.py",
+    "cortex_mcp_security_agent.py",
+    "codex_mcp_security_agent.py",
+    "zed_mcp_security_agent.py",
+]
+
 REQUIRED_DOC_TOKENS = [
     "inspect_langgraph_harness.py",
     "run_langgraph_harness.py",
@@ -314,6 +322,22 @@ def _check_runtime_wrapper() -> DriftCheck:
     )
 
 
+def _check_ide_examples_wired() -> DriftCheck:
+    docs = {
+        str(HARNESS_DOC.relative_to(REPO_ROOT)): HARNESS_DOC.read_text(encoding="utf-8"),
+        str(EXAMPLES_README.relative_to(REPO_ROOT)): EXAMPLES_README.read_text(encoding="utf-8"),
+    }
+    failures: list[str] = []
+    for token in REQUIRED_IDE_EXAMPLE_TOKENS:
+        if not all(token in text for text in docs.values()):
+            failures.append(f"missing IDE example reference: {token}")
+    return DriftCheck(
+        "docs_reference_ide_mcp_examples",
+        not failures,
+        "docs reference all IDE MCP example scripts" if not failures else failures,
+    )
+
+
 def _check_docs_wired() -> DriftCheck:
     docs = {
         str(HARNESS_DOC.relative_to(REPO_ROOT)): HARNESS_DOC.read_text(encoding="utf-8"),
@@ -353,6 +377,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),
         *sorted((REPO_ROOT / "presets").glob("*.json")),
+        *sorted((REPO_ROOT / "docs" / "integrations").glob("*.md")),
     ]
     return [path for path in paths if path.is_file()]
 
@@ -387,6 +412,7 @@ def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
         _check_preflight_policy(),
         _check_runtime_wrapper(),
         _check_docs_wired(),
+        _check_ide_examples_wired(),
         _check_no_harness_secret_literals(),
     ]
 

--- a/examples/agents/codex_mcp_security_agent.py
+++ b/examples/agents/codex_mcp_security_agent.py
@@ -14,40 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_codex_mcp_toml
 from sdk_agent_common import (
-    REPO_ROOT,
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
-
-
-def _toml_string(value: str) -> str:
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
-
-
-def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
-    """Fragment for ``~/.codex/config.toml`` — absolute path required."""
-    allowlist = read_allowlist(profile)
-    env = {
-        **safe_mcp_env(allowed_skills=allowlist),
-        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-    }
-    env_pairs = ", ".join(f"{key} = {_toml_string(value)}" for key, value in sorted(env.items()))
-    command = mcp_stdio_command()[0]
-    return (
-        "[mcp_servers.cloud-ai-security-skills]\n"
-        f"command = {_toml_string(command)}\n"
-        f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
-        f"env = {{ {env_pairs} }}\n"
-    )
 
 
 def codex_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -77,8 +77,8 @@ ROLE_DEFAULTS: dict[HarnessRole, dict[str, Any]] = {
     },
     "sdk-cspm": {
         "description": (
-            "Anthropic, OpenAI, LangChain, and Cursor SDK examples: "
-            "read-only CSPM + detect triage via MCP stdio."
+            "Anthropic, OpenAI, LangChain, and IDE MCP examples (Cursor, Windsurf, "
+            "Cortex, Codex, Zed): read-only CSPM + detect triage via MCP stdio."
         ),
         "roles": "security_engineer",
         "include_remediation": False,

--- a/examples/agents/cortex_mcp_security_agent.py
+++ b/examples/agents/cortex_mcp_security_agent.py
@@ -14,32 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_cortex_mcp_config
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-
-def build_cortex_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``.cortex/mcp.json`` — portable with ``${workspaceFolder}``."""
-    allowlist = read_allowlist(profile)
-    return {
-        "mcpServers": {
-            "cloud-ai-security-skills": {
-                "command": mcp_stdio_command()[0],
-                "args": ["${workspaceFolder}/mcp-server/src/server.py"],
-                "env": {
-                    **safe_mcp_env(allowed_skills=allowlist),
-                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                },
-            }
-        }
-    }
 
 
 def cortex_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/cursor_mcp_security_agent.py
+++ b/examples/agents/cursor_mcp_security_agent.py
@@ -14,32 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_cursor_mcp_config
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-
-def build_cursor_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``.cursor/mcp.json`` — portable with ``${workspaceFolder}``."""
-    allowlist = read_allowlist(profile)
-    return {
-        "mcpServers": {
-            "cloud-ai-security-skills": {
-                "command": mcp_stdio_command()[0],
-                "args": ["${workspaceFolder}/mcp-server/src/server.py"],
-                "env": {
-                    **safe_mcp_env(allowed_skills=allowlist),
-                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                },
-            }
-        }
-    }
 
 
 def cursor_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -1,0 +1,122 @@
+"""Emit IDE MCP client config blocks from a harness profile.
+
+Offline generator for operators wiring multiple IDE clients from one harness
+profile. Does not spawn MCP, call cloud APIs, or run remediation.
+
+Run:
+
+    python examples/agents/emit_mcp_client_configs.py
+    python examples/agents/emit_mcp_client_configs.py --client cursor
+    python examples/agents/emit_mcp_client_configs.py \\
+      --profile examples/agents/harness_profiles/sdk-cspm-agent.json \\
+      --output artifacts/mcp-client-configs.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from ide_mcp_bindings import (
+    build_codex_mcp_toml,
+    build_cortex_mcp_config,
+    build_cursor_mcp_config,
+    build_windsurf_mcp_config,
+    build_zed_context_servers,
+)
+from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
+
+ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "all"]
+CLIENT_NAMES: tuple[ClientName, ...] = ("cursor", "cortex", "windsurf", "codex", "zed", "all")
+
+
+def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
+    if client == "cursor":
+        return {
+            "integration": "cursor_mcp_json",
+            "config_path": ".cursor/mcp.json",
+            "docs": "docs/integrations/cursor.md",
+            "mcp_config": build_cursor_mcp_config(profile),
+        }
+    if client == "cortex":
+        return {
+            "integration": "cortex_mcp_json",
+            "config_path": ".cortex/mcp.json",
+            "docs": "docs/integrations/cortex.md",
+            "mcp_config": build_cortex_mcp_config(profile),
+        }
+    if client == "windsurf":
+        return {
+            "integration": "windsurf_mcp_config_json",
+            "config_path": "~/.codeium/windsurf/mcp_config.json",
+            "docs": "docs/integrations/windsurf.md",
+            "mcp_config": build_windsurf_mcp_config(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+        }
+    if client == "codex":
+        return {
+            "integration": "codex_config_toml",
+            "config_path": "~/.codex/config.toml",
+            "docs": "docs/integrations/codex.md",
+            "mcp_toml": build_codex_mcp_toml(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+        }
+    if client == "zed":
+        return {
+            "integration": "zed_context_servers_json",
+            "config_path": "~/.config/zed/settings.json",
+            "docs": "docs/integrations/zed.md",
+            "context_servers": build_zed_context_servers(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+        }
+    raise ValueError(f"unsupported client: {client}")
+
+
+def emit_client_configs(profile: dict[str, Any], *, client: ClientName = "all") -> dict[str, Any]:
+    selected = CLIENT_NAMES[:-1] if client == "all" else (client,)
+    return {name: _client_payload(name, profile) for name in selected}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        type=Path,
+        default=DEFAULT_PROFILE,
+        help="Harness profile JSON (default: harness_profiles/sdk-cspm-agent.json)",
+    )
+    parser.add_argument(
+        "--client",
+        choices=CLIENT_NAMES,
+        default="all",
+        help="Emit one client block or all five IDE clients",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write JSON (stdout when omitted)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    profile = load_sdk_profile(args.profile)
+    payload = {
+        "schema_version": "mcp-client-config-bundle-v1",
+        "profile_id": profile.get("profile_id"),
+        "clients": emit_client_configs(profile, client=args.client),
+    }
+    rendered = json.dumps(payload, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -1,0 +1,82 @@
+"""Shared MCP client config builders for IDE reference examples.
+
+Each IDE agent script stays a thin runnable wrapper; this module centralizes
+allowlist → env policy and server path shapes so Cursor/Cortex/Windsurf/Codex/Zed
+stay consistent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import REPO_ROOT, mcp_stdio_command, read_allowlist
+
+MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+WORKSPACE_SERVER_ARG = "${workspaceFolder}/mcp-server/src/server.py"
+
+
+def mcp_policy_env(profile: dict[str, Any]) -> dict[str, str]:
+    """Harness allowlist as MCP subprocess env (includes caller-skill enforcement)."""
+    return safe_mcp_env(allowed_skills=read_allowlist(profile))
+
+
+def build_mcp_servers_json(profile: dict[str, Any], *, server_arg: str) -> dict[str, Any]:
+    """JSON ``mcpServers`` block used by Cursor, Cortex, and Windsurf."""
+    return {
+        "mcpServers": {
+            "cloud-ai-security-skills": {
+                "command": mcp_stdio_command()[0],
+                "args": [server_arg],
+                "env": mcp_policy_env(profile),
+            }
+        }
+    }
+
+
+def build_cursor_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``.cursor/mcp.json`` — portable with ``${workspaceFolder}``."""
+    return build_mcp_servers_json(profile, server_arg=WORKSPACE_SERVER_ARG)
+
+
+def build_cortex_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``.cortex/mcp.json`` — portable with ``${workspaceFolder}``."""
+    return build_mcp_servers_json(profile, server_arg=WORKSPACE_SERVER_ARG)
+
+
+def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``~/.codeium/windsurf/mcp_config.json`` — absolute path required."""
+    return build_mcp_servers_json(profile, server_arg=str(MCP_SERVER_PATH))
+
+
+def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
+    """``~/.config/zed/settings.json`` ``context_servers`` block."""
+    return {
+        "context_servers": {
+            "cloud-ai-security-skills": {
+                "command": {
+                    "path": mcp_stdio_command()[0],
+                    "args": [str(MCP_SERVER_PATH)],
+                    "env": mcp_policy_env(profile),
+                },
+            }
+        }
+    }
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
+    """Fragment for ``~/.codex/config.toml`` — absolute path required."""
+    env = mcp_policy_env(profile)
+    env_pairs = ", ".join(f"{key} = {_toml_string(value)}" for key, value in sorted(env.items()))
+    command = mcp_stdio_command()[0]
+    return (
+        "[mcp_servers.cloud-ai-security-skills]\n"
+        f"command = {_toml_string(command)}\n"
+        f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
+        f"env = {{ {env_pairs} }}\n"
+    )

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -389,6 +389,52 @@ class TestHitlGateReachable:
         assert '"dry_run"' in result.stdout
 
 
+class TestIdeMcpBindings:
+    PROFILE = EXAMPLES / "harness_profiles" / "sdk-cspm-agent.json"
+
+    def _bindings_module(self):
+        if str(EXAMPLES) not in sys.path:
+            sys.path.insert(0, str(EXAMPLES))
+        import ide_mcp_bindings
+
+        return ide_mcp_bindings
+
+    def test_all_clients_share_mcp_policy_env(self):
+        ide_mcp_bindings = self._bindings_module()
+
+        profile = json.loads(self.PROFILE.read_text(encoding="utf-8"))
+        expected = ide_mcp_bindings.mcp_policy_env(profile)
+
+        cursor_env = ide_mcp_bindings.build_cursor_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["env"]
+        windsurf_env = ide_mcp_bindings.build_windsurf_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["env"]
+        zed_env = ide_mcp_bindings.build_zed_context_servers(profile)["context_servers"][
+            "cloud-ai-security-skills"
+        ]["command"]["env"]
+
+        assert cursor_env == expected
+        assert windsurf_env == expected
+        assert zed_env == expected
+        assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
+        assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
+
+    def test_workspace_clients_use_workspace_folder_arg(self):
+        ide_mcp_bindings = self._bindings_module()
+
+        profile = json.loads(self.PROFILE.read_text(encoding="utf-8"))
+        cursor_args = ide_mcp_bindings.build_cursor_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["args"]
+        cortex_args = ide_mcp_bindings.build_cortex_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["args"]
+        assert cursor_args == [ide_mcp_bindings.WORKSPACE_SERVER_ARG]
+        assert cortex_args == [ide_mcp_bindings.WORKSPACE_SERVER_ARG]
+
+
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
 

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -32,6 +32,7 @@ SCRIPTS = [
     EXAMPLES / "windsurf_mcp_security_agent.py",
     EXAMPLES / "cortex_mcp_security_agent.py",
     EXAMPLES / "codex_mcp_security_agent.py",
+    EXAMPLES / "zed_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -346,6 +347,28 @@ class TestHitlGateReachable:
         assert binding["config_path"] == "~/.codex/config.toml"
         assert "[mcp_servers.cloud-ai-security-skills]" in binding["mcp_toml"]
         assert "mcp-server/src/server.py" in binding["mcp_toml"]
+        assert payload["mcp_tools_discovered"]
+
+    def test_zed_mcp_binding_documents_context_servers(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "zed_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["zed_binding"]
+        assert binding["integration"] == "zed_context_servers_json"
+        assert binding["config_path"] == "~/.config/zed/settings.json"
+        servers = binding["context_servers"]["context_servers"]
+        assert "cloud-ai-security-skills" in servers
+        assert servers["cloud-ai-security-skills"]["command"]["args"][0].endswith(
+            "mcp-server/src/server.py"
+        )
         assert payload["mcp_tools_discovered"]
 
     def test_langgraph_reaches_remediation_with_approval(self):

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -435,6 +435,42 @@ class TestIdeMcpBindings:
         assert cortex_args == [ide_mcp_bindings.WORKSPACE_SERVER_ARG]
 
 
+class TestEmitMcpClientConfigs:
+    SCRIPT = EXAMPLES / "emit_mcp_client_configs.py"
+
+    def test_emits_all_clients_offline(self):
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["schema_version"] == "mcp-client-config-bundle-v1"
+        assert set(payload["clients"]) == {"cursor", "cortex", "windsurf", "codex", "zed"}
+        assert "mcp_config" in payload["clients"]["cursor"]
+        assert "mcp_toml" in payload["clients"]["codex"]
+        assert "context_servers" in payload["clients"]["zed"]
+
+    def test_single_client_filter(self):
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT), "--client", "cursor"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert set(payload["clients"]) == {"cursor"}
+
+
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
 

--- a/examples/agents/windsurf_mcp_security_agent.py
+++ b/examples/agents/windsurf_mcp_security_agent.py
@@ -14,35 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_windsurf_mcp_config
 from sdk_agent_common import (
-    REPO_ROOT,
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
-
-
-def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``~/.codeium/windsurf/mcp_config.json`` (absolute path required)."""
-    allowlist = read_allowlist(profile)
-    return {
-        "mcpServers": {
-            "cloud-ai-security-skills": {
-                "command": mcp_stdio_command()[0],
-                "args": [str(MCP_SERVER_PATH)],
-                "env": {
-                    **safe_mcp_env(allowed_skills=allowlist),
-                    "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                },
-            }
-        }
-    }
 
 
 def windsurf_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/zed_mcp_security_agent.py
+++ b/examples/agents/zed_mcp_security_agent.py
@@ -1,0 +1,78 @@
+"""Zed — MCP-first security agent example.
+
+Zed loads skills through ``~/.config/zed/settings.json`` (``context_servers``,
+stdio MCP, absolute paths). This reference shows the same harness-profile +
+live ``tools/list`` path as the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/zed_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness_mcp_transport import safe_mcp_env
+from sdk_agent_common import (
+    REPO_ROOT,
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    mcp_stdio_command,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
+
+
+def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block for ``~/.config/zed/settings.json`` — absolute path required."""
+    allowlist = read_allowlist(profile)
+    return {
+        "context_servers": {
+            "cloud-ai-security-skills": {
+                "command": {
+                    "path": mcp_stdio_command()[0],
+                    "args": [str(MCP_SERVER_PATH)],
+                    "env": {
+                        **safe_mcp_env(allowed_skills=allowlist),
+                        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
+                    },
+                },
+            }
+        }
+    }
+
+
+def zed_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "zed_context_servers_json",
+        "config_path": "~/.config/zed/settings.json",
+        "docs": "docs/integrations/zed.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_zed_tools",
+        "context_servers": build_zed_context_servers(profile),
+        "path_note": "Zed does not expand ~ — replace with an absolute clone path before paste",
+        "remediation_chain": "separate_assistant_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="zed-mcp-demo-1")
+    triage["zed_binding"] = zed_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/zed_mcp_security_agent.py
+++ b/examples/agents/zed_mcp_security_agent.py
@@ -14,37 +14,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_zed_context_servers
 from sdk_agent_common import (
-    REPO_ROOT,
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-MCP_SERVER_PATH = REPO_ROOT / "mcp-server" / "src" / "server.py"
-
-
-def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block for ``~/.config/zed/settings.json`` — absolute path required."""
-    allowlist = read_allowlist(profile)
-    return {
-        "context_servers": {
-            "cloud-ai-security-skills": {
-                "command": {
-                    "path": mcp_stdio_command()[0],
-                    "args": [str(MCP_SERVER_PATH)],
-                    "env": {
-                        **safe_mcp_env(allowed_skills=allowlist),
-                        "CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS": "true",
-                    },
-                },
-            }
-        }
-    }
 
 
 def zed_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/check_secret_literals.py
+++ b/scripts/check_secret_literals.py
@@ -51,6 +51,8 @@ TEXT_GLOBS = [
     "examples/agents/harness_profiles/*.json",
     "presets/*.json",
     "docs/AGENT_QUICKSTART.md",
+    "docs/HARNESS.md",
+    "docs/integrations/*.md",
 ]
 
 


### PR DESCRIPTION
## Summary
Lands the stacked IDE MCP harness work (#589–#591) onto `main`:
- Integration doc polish + drift/secret scan coverage
- Shared `ide_mcp_bindings.py` (DRY across Cursor/Cortex/Windsurf/Codex/Zed)
- `emit_mcp_client_configs.py` offline bundle emitter
- `configure_langgraph_harness.py --emit-mcp-configs` for one-shot profile + IDE MCP config generation

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (117 tests)
- [x] `python examples/agents/check_langgraph_harness_drift.py`
- [x] `python scripts/check_secret_literals.py`


Made with [Cursor](https://cursor.com)