### PR TITLE
Document one-shot IDE MCP config generation

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -121,6 +121,22 @@ Runnable offline Zed example (harness profile + live `tools/list`):
 
 [`../examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py)
 
+Generate all IDE MCP blocks from one harness profile (offline):
+
+[`../examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py)
+
+Or create profile + MCP bundle together:
+
+```bash
+python examples/agents/configure_langgraph_harness.py \
+  --role sdk-cspm \
+  --profile-id acme-sdk-cspm \
+  --email you@example.com \
+  --output-profile artifacts/acme-sdk-cspm.json \
+  --output-env artifacts/acme-sdk-cspm.env \
+  --emit-mcp-configs artifacts/mcp-client-configs.json
+```
+
 ---
 
 ## Anthropic Agent SDK

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -50,6 +50,7 @@ REQUIRED_IDE_EXAMPLE_TOKENS = [
 ]
 
 REQUIRED_DOC_TOKENS = [
+    "emit_mcp_client_configs.py",
     "inspect_langgraph_harness.py",
     "run_langgraph_harness.py",
     "execute_langgraph_mcp_plan.py",


### PR DESCRIPTION
## Summary
- Adds `emit_mcp_client_configs` + `configure_langgraph_harness --emit-mcp-configs` to `AGENT_QUICKSTART.md`
- Drift check requires `emit_mcp_client_configs.py` in harness docs

Stacks on #592.

## Test plan
- [x] `python examples/agents/check_langgraph_harness_drift.py`


Made with [Cursor](https://cursor.com)