### PR TITLE
Add LangChain MCP bindings to shared emitter

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -141,7 +141,7 @@ Reference examples:
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
-- [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of all IDE MCP blocks from one harness profile
+- [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of IDE + LangChain MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -71,6 +71,7 @@ Runnable offline examples and per-client setup guides:
 | Cortex | [`cortex.md`](cortex.md) | [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py) |
 | Codex | [`codex.md`](codex.md) | [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py) |
 | Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
+| LangChain | [`../HARNESS.md`](../HARNESS.md) | [`../../examples/agents/langchain_mcp_security_agent.py`](../../examples/agents/langchain_mcp_security_agent.py) |
 
 See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,7 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
-| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | All IDE clients | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed MCP blocks from one harness profile |
+| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + LangChain | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed/LangChain MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -23,13 +23,22 @@ from ide_mcp_bindings import (
     build_codex_mcp_toml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
+    build_langchain_mcp_servers,
     build_windsurf_mcp_config,
     build_zed_context_servers,
 )
 from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
 
-ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "all"]
-CLIENT_NAMES: tuple[ClientName, ...] = ("cursor", "cortex", "windsurf", "codex", "zed", "all")
+ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "langchain", "all"]
+CLIENT_NAMES: tuple[ClientName, ...] = (
+    "cursor",
+    "cortex",
+    "windsurf",
+    "codex",
+    "zed",
+    "langchain",
+    "all",
+)
 
 
 def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
@@ -71,6 +80,14 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "context_servers": build_zed_context_servers(profile),
             "path_note": "Replace server args with an absolute clone path before paste",
         }
+    if client == "langchain":
+        return {
+            "integration": "langchain_mcp_adapters_stdio",
+            "config_path": "MultiServerMCPClient(mcp_servers=...)",
+            "docs": "docs/HARNESS.md",
+            "mcp_servers": build_langchain_mcp_servers(profile),
+            "anti_pattern": "do_not_wrap_skill_clis_as_langchain_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -91,7 +108,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all five IDE clients",
+        help="Emit one client block or all six MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -1,8 +1,8 @@
-"""Shared MCP client config builders for IDE reference examples.
+"""Shared MCP client config builders for IDE and framework reference examples.
 
-Each IDE agent script stays a thin runnable wrapper; this module centralizes
+Each agent script stays a thin runnable wrapper; this module centralizes
 allowlist → env policy and server path shapes so Cursor/Cortex/Windsurf/Codex/Zed
-stay consistent.
+and LangChain MCP adapters stay consistent.
 """
 
 from __future__ import annotations
@@ -80,3 +80,16 @@ def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
         f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
         f"env = {{ {env_pairs} }}\n"
     )
+
+
+def build_langchain_mcp_servers(profile: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Config block for ``MultiServerMCPClient`` / LangGraph MCP tool nodes."""
+    command = mcp_stdio_command()
+    return {
+        "cloud-ai-security-skills": {
+            "transport": "stdio",
+            "command": command[0],
+            "args": command[1:],
+            "env": mcp_policy_env(profile),
+        }
+    }

--- a/examples/agents/langchain_mcp_security_agent.py
+++ b/examples/agents/langchain_mcp_security_agent.py
@@ -31,29 +31,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_langchain_mcp_servers
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-
-def build_langchain_mcp_servers(profile: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Config block for ``MultiServerMCPClient`` / LangGraph tool nodes."""
-    allowlist = read_allowlist(profile)
-    command = mcp_stdio_command()
-    return {
-        "cloud-ai-security-skills": {
-            "transport": "stdio",
-            "command": command[0],
-            "args": command[1:],
-            "env": safe_mcp_env(allowed_skills=allowlist),
-        }
-    }
 
 
 def langchain_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -414,10 +414,14 @@ class TestIdeMcpBindings:
         zed_env = ide_mcp_bindings.build_zed_context_servers(profile)["context_servers"][
             "cloud-ai-security-skills"
         ]["command"]["env"]
+        langchain_env = ide_mcp_bindings.build_langchain_mcp_servers(profile)[
+            "cloud-ai-security-skills"
+        ]["env"]
 
         assert cursor_env == expected
         assert windsurf_env == expected
         assert zed_env == expected
+        assert langchain_env == expected
         assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
         assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
 
@@ -451,10 +455,18 @@ class TestEmitMcpClientConfigs:
         assert result.returncode == 0, result.stderr
         payload = json.loads(result.stdout)
         assert payload["schema_version"] == "mcp-client-config-bundle-v1"
-        assert set(payload["clients"]) == {"cursor", "cortex", "windsurf", "codex", "zed"}
+        assert set(payload["clients"]) == {
+            "cursor",
+            "cortex",
+            "windsurf",
+            "codex",
+            "zed",
+            "langchain",
+        }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
         assert "context_servers" in payload["clients"]["zed"]
+        assert "mcp_servers" in payload["clients"]["langchain"]
 
     def test_single_client_filter(self):
         result = subprocess.run(
@@ -2234,7 +2246,14 @@ class TestLangGraphHarnessSetup:
         assert summary["mcp_client_configs"] == str(mcp_path)
         bundle = json.loads(mcp_path.read_text(encoding="utf-8"))
         assert bundle["schema_version"] == "mcp-client-config-bundle-v1"
-        assert set(bundle["clients"]) == {"cursor", "cortex", "windsurf", "codex", "zed"}
+        assert set(bundle["clients"]) == {
+            "cursor",
+            "cortex",
+            "windsurf",
+            "codex",
+            "zed",
+            "langchain",
+        }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- Adds `build_langchain_mcp_servers` to `ide_mcp_bindings.py`
- Refactors `langchain_mcp_security_agent.py` to use shared bindings
- Includes LangChain in `emit_mcp_client_configs.py --client all`
- Updates docs and consistency tests

## Test plan
- [x] `uv run ruff check examples/agents`
- [x] `uv run pytest examples/agents/tests/test_examples.py -q`


Made with [Cursor](https://cursor.com)