### PR TITLE
Add MCP client config bundle JSON schema

### DIFF
--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -39,6 +39,7 @@ EXPECTED_SCHEMAS = [
     SCHEMAS / "agent_policy.schema.json",
     SCHEMAS / "checkpoint.schema.json",
     SCHEMAS / "eval_report.schema.json",
+    SCHEMAS / "mcp_client_config_bundle.schema.json",
 ]
 
 REQUIRED_IDE_EXAMPLE_TOKENS = [
@@ -405,6 +406,21 @@ def _check_no_harness_secret_literals() -> DriftCheck:
     )
 
 
+def _check_mcp_client_bundle_schema() -> DriftCheck:
+    from emit_mcp_client_configs import build_mcp_client_bundle
+    from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
+
+    schema = _load_json(SCHEMAS / "mcp_client_config_bundle.schema.json")
+    profile = load_sdk_profile(DEFAULT_PROFILE)
+    bundle = build_mcp_client_bundle(profile)
+    errors = _schema_errors(schema, bundle)
+    return DriftCheck(
+        "mcp_client_bundle_schema",
+        not errors,
+        "default MCP client bundle matches schema" if not errors else errors,
+    )
+
+
 def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
     return [
         _check_schema_documents(),
@@ -415,6 +431,7 @@ def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
         _check_runtime_wrapper(),
         _check_docs_wired(),
         _check_ide_examples_wired(),
+        _check_mcp_client_bundle_schema(),
         _check_no_harness_secret_literals(),
     ]
 

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -31,7 +31,7 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
-from emit_mcp_client_configs import emit_client_configs
+from emit_mcp_client_configs import build_mcp_client_bundle
 from langgraph_security_graph import (
     ALLOWED_SKILLS_READ_ONLY_LIST,
     ALLOWED_SKILLS_REMEDIATION,
@@ -402,11 +402,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     mcp_configs_path = None
     if args.emit_mcp_configs:
-        bundle = {
-            "schema_version": "mcp-client-config-bundle-v1",
-            "profile_id": profile["profile_id"],
-            "clients": emit_client_configs(profile),
-        }
+        bundle = build_mcp_client_bundle(profile)
         args.emit_mcp_configs.parent.mkdir(parents=True, exist_ok=True)
         args.emit_mcp_configs.write_text(
             json.dumps(bundle, indent=2, sort_keys=True) + "\n",

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -96,6 +96,14 @@ def emit_client_configs(profile: dict[str, Any], *, client: ClientName = "all") 
     return {name: _client_payload(name, profile) for name in selected}
 
 
+def build_mcp_client_bundle(profile: dict[str, Any], *, client: ClientName = "all") -> dict[str, Any]:
+    return {
+        "schema_version": "mcp-client-config-bundle-v1",
+        "profile_id": profile.get("profile_id"),
+        "clients": emit_client_configs(profile, client=client),
+    }
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -121,11 +129,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     profile = load_sdk_profile(args.profile)
-    payload = {
-        "schema_version": "mcp-client-config-bundle-v1",
-        "profile_id": profile.get("profile_id"),
-        "clients": emit_client_configs(profile, client=args.client),
-    }
+    payload = build_mcp_client_bundle(profile, client=args.client)
     rendered = json.dumps(payload, indent=2)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/agents/schemas/mcp_client_config_bundle.schema.json
+++ b/examples/agents/schemas/mcp_client_config_bundle.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/mcp_client_config_bundle.schema.json",
+  "title": "MCP client config bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_id",
+    "clients"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "mcp-client-config-bundle-v1"
+    },
+    "profile_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "clients": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "integration",
+          "config_path",
+          "docs"
+        ],
+        "properties": {
+          "integration": {
+            "type": "string",
+            "minLength": 1
+          },
+          "config_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "docs": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mcp_config": {
+            "type": "object"
+          },
+          "mcp_toml": {
+            "type": "string",
+            "minLength": 1
+          },
+          "context_servers": {
+            "type": "object"
+          },
+          "mcp_servers": {
+            "type": "object"
+          },
+          "path_note": {
+            "type": "string"
+          },
+          "anti_pattern": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -482,6 +482,23 @@ class TestEmitMcpClientConfigs:
         payload = json.loads(result.stdout)
         assert set(payload["clients"]) == {"cursor"}
 
+    def test_emit_bundle_matches_schema(self):
+        schema = json.loads(
+            (SCHEMAS / "mcp_client_config_bundle.schema.json").read_text(encoding="utf-8")
+        )
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert _schema_errors(schema, payload) == []
+
 
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
@@ -2566,6 +2583,7 @@ class TestLangGraphHarnessDriftCheck:
         assert "pipeline_diagram_generated" in check_names
         assert "preflight_policy_safe" in check_names
         assert "harness_docs_have_no_secret_literals" in check_names
+        assert "mcp_client_bundle_schema" in check_names
 
 
 class TestOpenAICompatAdapter:


### PR DESCRIPTION
## Summary
- Adds `mcp_client_config_bundle.schema.json` for emitted IDE/LangChain MCP bundles
- Adds `build_mcp_client_bundle()` helper used by emitter and harness generator
- Drift check validates default bundle against schema (10/10 checks)
- Contract test asserts emitter output matches schema

Stacks on #594.

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (119 tests)
- [x] `python examples/agents/check_langgraph_harness_drift.py`


Made with [Cursor](https://cursor.com)