### PR TITLE
Consolidate Anthropic and OpenAI SDK MCP bindings

### DIFF
--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,7 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
-| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + LangChain | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed/LangChain MCP blocks from one harness profile |
+| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + SDK | Offline bundle of IDE, LangChain, Anthropic, and OpenAI MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/anthropic_sdk_security_agent.py
+++ b/examples/agents/anthropic_sdk_security_agent.py
@@ -20,7 +20,9 @@ Run:
 from __future__ import annotations
 
 import json
+from typing import Any
 
+from ide_mcp_bindings import build_anthropic_mcp_config
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
@@ -29,9 +31,21 @@ from sdk_agent_common import (
 )
 
 
+def anthropic_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "anthropic_mcp_json",
+        "config_path": "project .mcp.json or claude_desktop_config.json",
+        "docs": "docs/AGENT_QUICKSTART.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_anthropic_tools",
+        "mcp_config": build_anthropic_mcp_config(profile),
+        "remediation_chain": "separate_agent_session_with_HITL_approval_context",
+    }
+
+
 def main() -> int:
     profile = load_sdk_profile()
     triage = run_cspm_triage(profile, correlation_id="anthropic-demo-1")
+    triage["anthropic_binding"] = anthropic_binding_notes(profile)
     print(json.dumps(triage, indent=2))
 
     approval = human_approval_gate(triage)

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -20,16 +20,28 @@ from pathlib import Path
 from typing import Any, Literal
 
 from ide_mcp_bindings import (
+    build_anthropic_mcp_config,
     build_codex_mcp_toml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
     build_langchain_mcp_servers,
+    build_openai_agents_mcp_server,
     build_windsurf_mcp_config,
     build_zed_context_servers,
 )
 from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
 
-ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "langchain", "all"]
+ClientName = Literal[
+    "cursor",
+    "cortex",
+    "windsurf",
+    "codex",
+    "zed",
+    "langchain",
+    "anthropic",
+    "openai",
+    "all",
+]
 CLIENT_NAMES: tuple[ClientName, ...] = (
     "cursor",
     "cortex",
@@ -37,6 +49,8 @@ CLIENT_NAMES: tuple[ClientName, ...] = (
     "codex",
     "zed",
     "langchain",
+    "anthropic",
+    "openai",
     "all",
 )
 
@@ -88,6 +102,22 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "mcp_servers": build_langchain_mcp_servers(profile),
             "anti_pattern": "do_not_wrap_skill_clis_as_langchain_tools",
         }
+    if client == "anthropic":
+        return {
+            "integration": "anthropic_mcp_json",
+            "config_path": "project .mcp.json or claude_desktop_config.json",
+            "docs": "docs/AGENT_QUICKSTART.md",
+            "mcp_config": build_anthropic_mcp_config(profile),
+            "anti_pattern": "do_not_wrap_skill_clis_as_anthropic_tools",
+        }
+    if client == "openai":
+        return {
+            "integration": "openai_agents_mcp_server",
+            "config_path": "openai.agents.McpServer(...)",
+            "docs": "docs/AGENT_QUICKSTART.md",
+            "mcp_server": build_openai_agents_mcp_server(profile),
+            "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -96,7 +126,9 @@ def emit_client_configs(profile: dict[str, Any], *, client: ClientName = "all") 
     return {name: _client_payload(name, profile) for name in selected}
 
 
-def build_mcp_client_bundle(profile: dict[str, Any], *, client: ClientName = "all") -> dict[str, Any]:
+def build_mcp_client_bundle(
+    profile: dict[str, Any], *, client: ClientName = "all"
+) -> dict[str, Any]:
     return {
         "schema_version": "mcp-client-config-bundle-v1",
         "profile_id": profile.get("profile_id"),
@@ -116,7 +148,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all six MCP clients",
+        help="Emit one client block or all eight MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -49,6 +49,27 @@ def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
     return build_mcp_servers_json(profile, server_arg=str(MCP_SERVER_PATH))
 
 
+def build_claude_desktop_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``claude_desktop_config.json`` — absolute path required."""
+    return build_mcp_servers_json(profile, server_arg=str(MCP_SERVER_PATH))
+
+
+def build_anthropic_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """Anthropic Agent SDK / project MCP — same ``mcpServers`` JSON shape as Claude Desktop."""
+    return build_claude_desktop_mcp_config(profile)
+
+
+def build_openai_agents_mcp_server(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block passed to ``openai.agents.McpServer(...)`` in a live Agents-SDK loop."""
+    command = mcp_stdio_command()
+    return {
+        "name": "cloud-ai-security-skills",
+        "command": command[0],
+        "args": command[1:],
+        "env": mcp_policy_env(profile),
+    }
+
+
 def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
     """``~/.config/zed/settings.json`` ``context_servers`` block."""
     return {

--- a/examples/agents/openai_sdk_security_agent.py
+++ b/examples/agents/openai_sdk_security_agent.py
@@ -26,32 +26,33 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_openai_agents_mcp_server
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
 
 
-def build_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block passed to ``openai.agents.McpServer(...)`` in a live Agents-SDK loop."""
-    allowlist = read_allowlist(profile)
+def openai_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    mcp_server = build_openai_agents_mcp_server(profile)
     return {
-        "name": "cloud-ai-security-skills",
-        "command": mcp_stdio_command()[0],
-        "args": mcp_stdio_command()[1:],
-        "env": safe_mcp_env(allowed_skills=allowlist),
+        "integration": "openai_agents_mcp_server",
+        "config_path": "openai.agents.McpServer(...)",
+        "docs": "docs/AGENT_QUICKSTART.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
+        "mcp_server": mcp_server,
+        "remediation_chain": "separate_agent_session_with_HITL_approval_context",
     }
 
 
 def main() -> int:
     profile = load_sdk_profile()
     triage = run_cspm_triage(profile, correlation_id="openai-demo-1")
-    triage["tool_config"] = build_mcp_config(profile)["name"]
+    binding = openai_binding_notes(profile)
+    triage["openai_binding"] = binding
+    triage["tool_config"] = binding["mcp_server"]["name"]
     print(json.dumps(triage, indent=2))
 
     approval = human_approval_gate(triage)

--- a/examples/agents/schemas/mcp_client_config_bundle.schema.json
+++ b/examples/agents/schemas/mcp_client_config_bundle.schema.json
@@ -55,6 +55,9 @@
           "mcp_servers": {
             "type": "object"
           },
+          "mcp_server": {
+            "type": "object"
+          },
           "path_note": {
             "type": "string"
           },

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -371,6 +371,40 @@ class TestHitlGateReachable:
         )
         assert payload["mcp_tools_discovered"]
 
+    def test_anthropic_binding_documents_mcp_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["anthropic_binding"]
+        assert binding["integration"] == "anthropic_mcp_json"
+        assert "mcp_config" in binding
+        assert payload["mcp_tools_discovered"]
+
+    def test_openai_binding_documents_mcp_server(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "openai_sdk_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["openai_binding"]
+        assert binding["integration"] == "openai_agents_mcp_server"
+        assert binding["mcp_server"]["name"] == "cloud-ai-security-skills"
+        assert payload["mcp_tools_discovered"]
+
     def test_langgraph_reaches_remediation_with_approval(self):
         env = {
             **os.environ,
@@ -417,11 +451,17 @@ class TestIdeMcpBindings:
         langchain_env = ide_mcp_bindings.build_langchain_mcp_servers(profile)[
             "cloud-ai-security-skills"
         ]["env"]
+        anthropic_env = ide_mcp_bindings.build_anthropic_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["env"]
+        openai_env = ide_mcp_bindings.build_openai_agents_mcp_server(profile)["env"]
 
         assert cursor_env == expected
         assert windsurf_env == expected
         assert zed_env == expected
         assert langchain_env == expected
+        assert anthropic_env == expected
+        assert openai_env == expected
         assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
         assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
 
@@ -462,11 +502,14 @@ class TestEmitMcpClientConfigs:
             "codex",
             "zed",
             "langchain",
+            "anthropic",
+            "openai",
         }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
         assert "context_servers" in payload["clients"]["zed"]
         assert "mcp_servers" in payload["clients"]["langchain"]
+        assert "mcp_server" in payload["clients"]["openai"]
 
     def test_single_client_filter(self):
         result = subprocess.run(
@@ -2270,6 +2313,8 @@ class TestLangGraphHarnessSetup:
             "codex",
             "zed",
             "langchain",
+            "anthropic",
+            "openai",
         }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Adds `build_anthropic_mcp_config` and `build_openai_agents_mcp_server` to `ide_mcp_bindings.py`
- SDK examples emit `anthropic_binding` / `openai_binding` metadata with MCP blocks
- Emitter `--client all` now includes anthropic + openai (8 clients)
- Schema extended for `mcp_server` object

Stacks on #595 (merge #594 → #595 → this).

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (121 tests)
- [x] `python examples/agents/check_langgraph_harness_drift.py`


Made with [Cursor](https://cursor.com)