### PR TITLE
Add Claude Desktop MCP-first security agent example

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -40,7 +40,11 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 Restart Claude Desktop (`⌘Q`, reopen).
 
----
+Runnable offline example (harness profile + live `tools/list`):
+
+[`../examples/agents/claude_desktop_mcp_security_agent.py`](../examples/agents/claude_desktop_mcp_security_agent.py)
+
+Full setup: [`integrations/claude-desktop.md`](integrations/claude-desktop.md).
 
 ## Cursor
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -141,6 +141,7 @@ Reference examples:
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
+- [`examples/agents/claude_desktop_mcp_security_agent.py`](../examples/agents/claude_desktop_mcp_security_agent.py) — Claude Desktop `claude_desktop_config.json` block
 - [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of IDE + LangChain MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -75,6 +75,14 @@ skills are not registered as tools.)
   sees at launch. On macOS, Homebrew Python works; if `python3` is only in a
   venv, pass the absolute interpreter path.
 - Config changes need a full app restart, not just a reload.
+- Offline reference: [`../../examples/agents/claude_desktop_mcp_security_agent.py`](../../examples/agents/claude_desktop_mcp_security_agent.py)
+  emits a `claude_desktop_config.json` block from a harness profile.
+
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
 
 ## HITL behavior
 

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -72,6 +72,7 @@ Runnable offline examples and per-client setup guides:
 | Codex | [`codex.md`](codex.md) | [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py) |
 | Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
 | LangChain | [`../HARNESS.md`](../HARNESS.md) | [`../../examples/agents/langchain_mcp_security_agent.py`](../../examples/agents/langchain_mcp_security_agent.py) |
+| Claude Desktop | [`claude-desktop.md`](claude-desktop.md) | [`../../examples/agents/claude_desktop_mcp_security_agent.py`](../../examples/agents/claude_desktop_mcp_security_agent.py) |
 
 See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,6 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
+| [`claude_desktop_mcp_security_agent.py`](claude_desktop_mcp_security_agent.py) | Claude Desktop | `claude_desktop_config.json` + harness profile; absolute-path MCP stdio |
 | [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + SDK | Offline bundle of IDE, LangChain, Anthropic, and OpenAI MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -48,6 +48,7 @@ REQUIRED_IDE_EXAMPLE_TOKENS = [
     "cortex_mcp_security_agent.py",
     "codex_mcp_security_agent.py",
     "zed_mcp_security_agent.py",
+    "claude_desktop_mcp_security_agent.py",
 ]
 
 REQUIRED_DOC_TOKENS = [
@@ -376,6 +377,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "cortex_mcp_security_agent.py",
         EXAMPLES / "codex_mcp_security_agent.py",
         EXAMPLES / "zed_mcp_security_agent.py",
+        EXAMPLES / "claude_desktop_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/claude_desktop_mcp_security_agent.py
+++ b/examples/agents/claude_desktop_mcp_security_agent.py
@@ -1,0 +1,54 @@
+"""Claude Desktop — MCP-first security agent example.
+
+Claude Desktop loads skills through ``claude_desktop_config.json`` (stdio MCP,
+absolute paths). This reference shows the same harness-profile + live
+``tools/list`` path as the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/claude_desktop_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ide_mcp_bindings import build_claude_desktop_mcp_config
+from sdk_agent_common import (
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    run_cspm_triage,
+)
+
+
+def claude_desktop_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "claude_desktop_mcp_json",
+        "config_path": "~/Library/Application Support/Claude/claude_desktop_config.json",
+        "docs": "docs/integrations/claude-desktop.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_claude_desktop_tools",
+        "mcp_config": build_claude_desktop_mcp_config(profile),
+        "path_note": "Claude Desktop does not expand ~ — use an absolute clone path before paste",
+        "remediation_chain": "separate_chat_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="claude-desktop-mcp-demo-1")
+    triage["claude_desktop_binding"] = claude_desktop_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -21,6 +21,7 @@ from typing import Any, Literal
 
 from ide_mcp_bindings import (
     build_anthropic_mcp_config,
+    build_claude_desktop_mcp_config,
     build_codex_mcp_toml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
@@ -40,6 +41,7 @@ ClientName = Literal[
     "langchain",
     "anthropic",
     "openai",
+    "claude-desktop",
     "all",
 ]
 CLIENT_NAMES: tuple[ClientName, ...] = (
@@ -51,6 +53,7 @@ CLIENT_NAMES: tuple[ClientName, ...] = (
     "langchain",
     "anthropic",
     "openai",
+    "claude-desktop",
     "all",
 )
 
@@ -118,6 +121,15 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "mcp_server": build_openai_agents_mcp_server(profile),
             "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
         }
+    if client == "claude-desktop":
+        return {
+            "integration": "claude_desktop_mcp_json",
+            "config_path": "~/Library/Application Support/Claude/claude_desktop_config.json",
+            "docs": "docs/integrations/claude-desktop.md",
+            "mcp_config": build_claude_desktop_mcp_config(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+            "anti_pattern": "do_not_wrap_skill_clis_as_claude_desktop_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -148,7 +160,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all eight MCP clients",
+        help="Emit one client block or all nine MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -33,6 +33,7 @@ SCRIPTS = [
     EXAMPLES / "cortex_mcp_security_agent.py",
     EXAMPLES / "codex_mcp_security_agent.py",
     EXAMPLES / "zed_mcp_security_agent.py",
+    EXAMPLES / "claude_desktop_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -371,6 +372,24 @@ class TestHitlGateReachable:
         )
         assert payload["mcp_tools_discovered"]
 
+    def test_claude_desktop_mcp_binding_documents_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "claude_desktop_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["claude_desktop_binding"]
+        assert binding["integration"] == "claude_desktop_mcp_json"
+        assert "claude_desktop_config.json" in binding["config_path"]
+        assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
+        assert payload["mcp_tools_discovered"]
+
     def test_anthropic_binding_documents_mcp_config(self):
         result = subprocess.run(
             [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],
@@ -504,6 +523,7 @@ class TestEmitMcpClientConfigs:
             "langchain",
             "anthropic",
             "openai",
+            "claude-desktop",
         }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
@@ -2315,6 +2335,7 @@ class TestLangGraphHarnessSetup:
             "langchain",
             "anthropic",
             "openai",
+            "claude-desktop",
         }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Adds `claude_desktop_mcp_security_agent.py` using shared `build_claude_desktop_mcp_config`
- Includes `claude-desktop` in `emit_mcp_client_configs.py --client all` (9 clients)
- Updates `AGENT_QUICKSTART`, `HARNESS.md`, `claude-desktop.md`, and drift doc wiring

Stacks on #596 (merge #594 → #595 → #596 → this).

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (123 tests)
- [x] `python examples/agents/check_langgraph_harness_drift.py`


Made with [Cursor](https://cursor.com)