### PR TITLE
Land MCP bundle schema, SDK bindings, and Claude Desktop agent

### DIFF
--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -40,7 +40,11 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 Restart Claude Desktop (`⌘Q`, reopen).
 
----
+Runnable offline example (harness profile + live `tools/list`):
+
+[`../examples/agents/claude_desktop_mcp_security_agent.py`](../examples/agents/claude_desktop_mcp_security_agent.py)
+
+Full setup: [`integrations/claude-desktop.md`](integrations/claude-desktop.md).
 
 ## Cursor
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -141,7 +141,7 @@ Reference examples:
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
-- [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of all IDE MCP blocks from one harness profile
+- [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of IDE + LangChain MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -141,6 +141,7 @@ Reference examples:
 - [`examples/agents/cortex_mcp_security_agent.py`](../examples/agents/cortex_mcp_security_agent.py) — Cortex `.cortex/mcp.json` block
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
+- [`examples/agents/claude_desktop_mcp_security_agent.py`](../examples/agents/claude_desktop_mcp_security_agent.py) — Claude Desktop `claude_desktop_config.json` block
 - [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of IDE + LangChain MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -75,6 +75,14 @@ skills are not registered as tools.)
   sees at launch. On macOS, Homebrew Python works; if `python3` is only in a
   venv, pass the absolute interpreter path.
 - Config changes need a full app restart, not just a reload.
+- Offline reference: [`../../examples/agents/claude_desktop_mcp_security_agent.py`](../../examples/agents/claude_desktop_mcp_security_agent.py)
+  emits a `claude_desktop_config.json` block from a harness profile.
+
+## See also
+
+- [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) — all runnable MCP agent examples
+- [`README.md`](README.md) — integration index
+- [`ide-agents.md`](ide-agents.md) — generic MCP config shapes
 
 ## HITL behavior
 

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -71,6 +71,7 @@ Runnable offline examples and per-client setup guides:
 | Cortex | [`cortex.md`](cortex.md) | [`../../examples/agents/cortex_mcp_security_agent.py`](../../examples/agents/cortex_mcp_security_agent.py) |
 | Codex | [`codex.md`](codex.md) | [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py) |
 | Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
+| LangChain | [`../HARNESS.md`](../HARNESS.md) | [`../../examples/agents/langchain_mcp_security_agent.py`](../../examples/agents/langchain_mcp_security_agent.py) |
 
 See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
 

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -72,6 +72,7 @@ Runnable offline examples and per-client setup guides:
 | Codex | [`codex.md`](codex.md) | [`../../examples/agents/codex_mcp_security_agent.py`](../../examples/agents/codex_mcp_security_agent.py) |
 | Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
 | LangChain | [`../HARNESS.md`](../HARNESS.md) | [`../../examples/agents/langchain_mcp_security_agent.py`](../../examples/agents/langchain_mcp_security_agent.py) |
+| Claude Desktop | [`claude-desktop.md`](claude-desktop.md) | [`../../examples/agents/claude_desktop_mcp_security_agent.py`](../../examples/agents/claude_desktop_mcp_security_agent.py) |
 
 See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,7 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
-| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + LangChain | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed/LangChain MCP blocks from one harness profile |
+| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + SDK | Offline bundle of IDE, LangChain, Anthropic, and OpenAI MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,7 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
-| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | All IDE clients | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed MCP blocks from one harness profile |
+| [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + LangChain | Offline bundle of Cursor/Cortex/Windsurf/Codex/Zed/LangChain MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -15,6 +15,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`cortex_mcp_security_agent.py`](cortex_mcp_security_agent.py) | Cortex Code CLI | Project-scoped `.cortex/mcp.json` + harness profile; `${workspaceFolder}` MCP stdio |
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
+| [`claude_desktop_mcp_security_agent.py`](claude_desktop_mcp_security_agent.py) | Claude Desktop | `claude_desktop_config.json` + harness profile; absolute-path MCP stdio |
 | [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + SDK | Offline bundle of IDE, LangChain, Anthropic, and OpenAI MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |

--- a/examples/agents/anthropic_sdk_security_agent.py
+++ b/examples/agents/anthropic_sdk_security_agent.py
@@ -20,7 +20,9 @@ Run:
 from __future__ import annotations
 
 import json
+from typing import Any
 
+from ide_mcp_bindings import build_anthropic_mcp_config
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
@@ -29,9 +31,21 @@ from sdk_agent_common import (
 )
 
 
+def anthropic_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "anthropic_mcp_json",
+        "config_path": "project .mcp.json or claude_desktop_config.json",
+        "docs": "docs/AGENT_QUICKSTART.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_anthropic_tools",
+        "mcp_config": build_anthropic_mcp_config(profile),
+        "remediation_chain": "separate_agent_session_with_HITL_approval_context",
+    }
+
+
 def main() -> int:
     profile = load_sdk_profile()
     triage = run_cspm_triage(profile, correlation_id="anthropic-demo-1")
+    triage["anthropic_binding"] = anthropic_binding_notes(profile)
     print(json.dumps(triage, indent=2))
 
     approval = human_approval_gate(triage)

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -39,6 +39,7 @@ EXPECTED_SCHEMAS = [
     SCHEMAS / "agent_policy.schema.json",
     SCHEMAS / "checkpoint.schema.json",
     SCHEMAS / "eval_report.schema.json",
+    SCHEMAS / "mcp_client_config_bundle.schema.json",
 ]
 
 REQUIRED_IDE_EXAMPLE_TOKENS = [
@@ -405,6 +406,21 @@ def _check_no_harness_secret_literals() -> DriftCheck:
     )
 
 
+def _check_mcp_client_bundle_schema() -> DriftCheck:
+    from emit_mcp_client_configs import build_mcp_client_bundle
+    from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
+
+    schema = _load_json(SCHEMAS / "mcp_client_config_bundle.schema.json")
+    profile = load_sdk_profile(DEFAULT_PROFILE)
+    bundle = build_mcp_client_bundle(profile)
+    errors = _schema_errors(schema, bundle)
+    return DriftCheck(
+        "mcp_client_bundle_schema",
+        not errors,
+        "default MCP client bundle matches schema" if not errors else errors,
+    )
+
+
 def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
     return [
         _check_schema_documents(),
@@ -415,6 +431,7 @@ def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
         _check_runtime_wrapper(),
         _check_docs_wired(),
         _check_ide_examples_wired(),
+        _check_mcp_client_bundle_schema(),
         _check_no_harness_secret_literals(),
     ]
 

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -48,6 +48,7 @@ REQUIRED_IDE_EXAMPLE_TOKENS = [
     "cortex_mcp_security_agent.py",
     "codex_mcp_security_agent.py",
     "zed_mcp_security_agent.py",
+    "claude_desktop_mcp_security_agent.py",
 ]
 
 REQUIRED_DOC_TOKENS = [
@@ -376,6 +377,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "cortex_mcp_security_agent.py",
         EXAMPLES / "codex_mcp_security_agent.py",
         EXAMPLES / "zed_mcp_security_agent.py",
+        EXAMPLES / "claude_desktop_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/claude_desktop_mcp_security_agent.py
+++ b/examples/agents/claude_desktop_mcp_security_agent.py
@@ -1,0 +1,54 @@
+"""Claude Desktop — MCP-first security agent example.
+
+Claude Desktop loads skills through ``claude_desktop_config.json`` (stdio MCP,
+absolute paths). This reference shows the same harness-profile + live
+``tools/list`` path as the other SDK examples — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/claude_desktop_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ide_mcp_bindings import build_claude_desktop_mcp_config
+from sdk_agent_common import (
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    run_cspm_triage,
+)
+
+
+def claude_desktop_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "claude_desktop_mcp_json",
+        "config_path": "~/Library/Application Support/Claude/claude_desktop_config.json",
+        "docs": "docs/integrations/claude-desktop.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_claude_desktop_tools",
+        "mcp_config": build_claude_desktop_mcp_config(profile),
+        "path_note": "Claude Desktop does not expand ~ — use an absolute clone path before paste",
+        "remediation_chain": "separate_chat_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="claude-desktop-mcp-demo-1")
+    triage["claude_desktop_binding"] = claude_desktop_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/configure_langgraph_harness.py
+++ b/examples/agents/configure_langgraph_harness.py
@@ -31,7 +31,7 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
-from emit_mcp_client_configs import emit_client_configs
+from emit_mcp_client_configs import build_mcp_client_bundle
 from langgraph_security_graph import (
     ALLOWED_SKILLS_READ_ONLY_LIST,
     ALLOWED_SKILLS_REMEDIATION,
@@ -402,11 +402,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     mcp_configs_path = None
     if args.emit_mcp_configs:
-        bundle = {
-            "schema_version": "mcp-client-config-bundle-v1",
-            "profile_id": profile["profile_id"],
-            "clients": emit_client_configs(profile),
-        }
+        bundle = build_mcp_client_bundle(profile)
         args.emit_mcp_configs.parent.mkdir(parents=True, exist_ok=True)
         args.emit_mcp_configs.write_text(
             json.dumps(bundle, indent=2, sort_keys=True) + "\n",

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -20,16 +20,28 @@ from pathlib import Path
 from typing import Any, Literal
 
 from ide_mcp_bindings import (
+    build_anthropic_mcp_config,
     build_codex_mcp_toml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
     build_langchain_mcp_servers,
+    build_openai_agents_mcp_server,
     build_windsurf_mcp_config,
     build_zed_context_servers,
 )
 from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
 
-ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "langchain", "all"]
+ClientName = Literal[
+    "cursor",
+    "cortex",
+    "windsurf",
+    "codex",
+    "zed",
+    "langchain",
+    "anthropic",
+    "openai",
+    "all",
+]
 CLIENT_NAMES: tuple[ClientName, ...] = (
     "cursor",
     "cortex",
@@ -37,6 +49,8 @@ CLIENT_NAMES: tuple[ClientName, ...] = (
     "codex",
     "zed",
     "langchain",
+    "anthropic",
+    "openai",
     "all",
 )
 
@@ -88,6 +102,22 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "mcp_servers": build_langchain_mcp_servers(profile),
             "anti_pattern": "do_not_wrap_skill_clis_as_langchain_tools",
         }
+    if client == "anthropic":
+        return {
+            "integration": "anthropic_mcp_json",
+            "config_path": "project .mcp.json or claude_desktop_config.json",
+            "docs": "docs/AGENT_QUICKSTART.md",
+            "mcp_config": build_anthropic_mcp_config(profile),
+            "anti_pattern": "do_not_wrap_skill_clis_as_anthropic_tools",
+        }
+    if client == "openai":
+        return {
+            "integration": "openai_agents_mcp_server",
+            "config_path": "openai.agents.McpServer(...)",
+            "docs": "docs/AGENT_QUICKSTART.md",
+            "mcp_server": build_openai_agents_mcp_server(profile),
+            "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -96,7 +126,9 @@ def emit_client_configs(profile: dict[str, Any], *, client: ClientName = "all") 
     return {name: _client_payload(name, profile) for name in selected}
 
 
-def build_mcp_client_bundle(profile: dict[str, Any], *, client: ClientName = "all") -> dict[str, Any]:
+def build_mcp_client_bundle(
+    profile: dict[str, Any], *, client: ClientName = "all"
+) -> dict[str, Any]:
     return {
         "schema_version": "mcp-client-config-bundle-v1",
         "profile_id": profile.get("profile_id"),
@@ -116,7 +148,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all six MCP clients",
+        help="Emit one client block or all eight MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -96,6 +96,14 @@ def emit_client_configs(profile: dict[str, Any], *, client: ClientName = "all") 
     return {name: _client_payload(name, profile) for name in selected}
 
 
+def build_mcp_client_bundle(profile: dict[str, Any], *, client: ClientName = "all") -> dict[str, Any]:
+    return {
+        "schema_version": "mcp-client-config-bundle-v1",
+        "profile_id": profile.get("profile_id"),
+        "clients": emit_client_configs(profile, client=client),
+    }
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -121,11 +129,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     profile = load_sdk_profile(args.profile)
-    payload = {
-        "schema_version": "mcp-client-config-bundle-v1",
-        "profile_id": profile.get("profile_id"),
-        "clients": emit_client_configs(profile, client=args.client),
-    }
+    payload = build_mcp_client_bundle(profile, client=args.client)
     rendered = json.dumps(payload, indent=2)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -23,13 +23,22 @@ from ide_mcp_bindings import (
     build_codex_mcp_toml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
+    build_langchain_mcp_servers,
     build_windsurf_mcp_config,
     build_zed_context_servers,
 )
 from sdk_agent_common import DEFAULT_PROFILE, load_sdk_profile
 
-ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "all"]
-CLIENT_NAMES: tuple[ClientName, ...] = ("cursor", "cortex", "windsurf", "codex", "zed", "all")
+ClientName = Literal["cursor", "cortex", "windsurf", "codex", "zed", "langchain", "all"]
+CLIENT_NAMES: tuple[ClientName, ...] = (
+    "cursor",
+    "cortex",
+    "windsurf",
+    "codex",
+    "zed",
+    "langchain",
+    "all",
+)
 
 
 def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
@@ -71,6 +80,14 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "context_servers": build_zed_context_servers(profile),
             "path_note": "Replace server args with an absolute clone path before paste",
         }
+    if client == "langchain":
+        return {
+            "integration": "langchain_mcp_adapters_stdio",
+            "config_path": "MultiServerMCPClient(mcp_servers=...)",
+            "docs": "docs/HARNESS.md",
+            "mcp_servers": build_langchain_mcp_servers(profile),
+            "anti_pattern": "do_not_wrap_skill_clis_as_langchain_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -91,7 +108,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all five IDE clients",
+        help="Emit one client block or all six MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -21,6 +21,7 @@ from typing import Any, Literal
 
 from ide_mcp_bindings import (
     build_anthropic_mcp_config,
+    build_claude_desktop_mcp_config,
     build_codex_mcp_toml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
@@ -40,6 +41,7 @@ ClientName = Literal[
     "langchain",
     "anthropic",
     "openai",
+    "claude-desktop",
     "all",
 ]
 CLIENT_NAMES: tuple[ClientName, ...] = (
@@ -51,6 +53,7 @@ CLIENT_NAMES: tuple[ClientName, ...] = (
     "langchain",
     "anthropic",
     "openai",
+    "claude-desktop",
     "all",
 )
 
@@ -118,6 +121,15 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "mcp_server": build_openai_agents_mcp_server(profile),
             "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
         }
+    if client == "claude-desktop":
+        return {
+            "integration": "claude_desktop_mcp_json",
+            "config_path": "~/Library/Application Support/Claude/claude_desktop_config.json",
+            "docs": "docs/integrations/claude-desktop.md",
+            "mcp_config": build_claude_desktop_mcp_config(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+            "anti_pattern": "do_not_wrap_skill_clis_as_claude_desktop_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -148,7 +160,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all eight MCP clients",
+        help="Emit one client block or all nine MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -49,6 +49,27 @@ def build_windsurf_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
     return build_mcp_servers_json(profile, server_arg=str(MCP_SERVER_PATH))
 
 
+def build_claude_desktop_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """``claude_desktop_config.json`` — absolute path required."""
+    return build_mcp_servers_json(profile, server_arg=str(MCP_SERVER_PATH))
+
+
+def build_anthropic_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
+    """Anthropic Agent SDK / project MCP — same ``mcpServers`` JSON shape as Claude Desktop."""
+    return build_claude_desktop_mcp_config(profile)
+
+
+def build_openai_agents_mcp_server(profile: dict[str, Any]) -> dict[str, Any]:
+    """Block passed to ``openai.agents.McpServer(...)`` in a live Agents-SDK loop."""
+    command = mcp_stdio_command()
+    return {
+        "name": "cloud-ai-security-skills",
+        "command": command[0],
+        "args": command[1:],
+        "env": mcp_policy_env(profile),
+    }
+
+
 def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
     """``~/.config/zed/settings.json`` ``context_servers`` block."""
     return {

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -1,8 +1,8 @@
-"""Shared MCP client config builders for IDE reference examples.
+"""Shared MCP client config builders for IDE and framework reference examples.
 
-Each IDE agent script stays a thin runnable wrapper; this module centralizes
+Each agent script stays a thin runnable wrapper; this module centralizes
 allowlist → env policy and server path shapes so Cursor/Cortex/Windsurf/Codex/Zed
-stay consistent.
+and LangChain MCP adapters stay consistent.
 """
 
 from __future__ import annotations
@@ -80,3 +80,16 @@ def build_codex_mcp_toml(profile: dict[str, Any]) -> str:
         f"args = [{_toml_string(str(MCP_SERVER_PATH))}]\n"
         f"env = {{ {env_pairs} }}\n"
     )
+
+
+def build_langchain_mcp_servers(profile: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Config block for ``MultiServerMCPClient`` / LangGraph MCP tool nodes."""
+    command = mcp_stdio_command()
+    return {
+        "cloud-ai-security-skills": {
+            "transport": "stdio",
+            "command": command[0],
+            "args": command[1:],
+            "env": mcp_policy_env(profile),
+        }
+    }

--- a/examples/agents/langchain_mcp_security_agent.py
+++ b/examples/agents/langchain_mcp_security_agent.py
@@ -31,29 +31,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_langchain_mcp_servers
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
-
-
-def build_langchain_mcp_servers(profile: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Config block for ``MultiServerMCPClient`` / LangGraph tool nodes."""
-    allowlist = read_allowlist(profile)
-    command = mcp_stdio_command()
-    return {
-        "cloud-ai-security-skills": {
-            "transport": "stdio",
-            "command": command[0],
-            "args": command[1:],
-            "env": safe_mcp_env(allowed_skills=allowlist),
-        }
-    }
 
 
 def langchain_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:

--- a/examples/agents/openai_sdk_security_agent.py
+++ b/examples/agents/openai_sdk_security_agent.py
@@ -26,32 +26,33 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from harness_mcp_transport import safe_mcp_env
+from ide_mcp_bindings import build_openai_agents_mcp_server
 from sdk_agent_common import (
     dry_run_remediation,
     human_approval_gate,
     load_sdk_profile,
-    mcp_stdio_command,
-    read_allowlist,
     run_cspm_triage,
 )
 
 
-def build_mcp_config(profile: dict[str, Any]) -> dict[str, Any]:
-    """Block passed to ``openai.agents.McpServer(...)`` in a live Agents-SDK loop."""
-    allowlist = read_allowlist(profile)
+def openai_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    mcp_server = build_openai_agents_mcp_server(profile)
     return {
-        "name": "cloud-ai-security-skills",
-        "command": mcp_stdio_command()[0],
-        "args": mcp_stdio_command()[1:],
-        "env": safe_mcp_env(allowed_skills=allowlist),
+        "integration": "openai_agents_mcp_server",
+        "config_path": "openai.agents.McpServer(...)",
+        "docs": "docs/AGENT_QUICKSTART.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
+        "mcp_server": mcp_server,
+        "remediation_chain": "separate_agent_session_with_HITL_approval_context",
     }
 
 
 def main() -> int:
     profile = load_sdk_profile()
     triage = run_cspm_triage(profile, correlation_id="openai-demo-1")
-    triage["tool_config"] = build_mcp_config(profile)["name"]
+    binding = openai_binding_notes(profile)
+    triage["openai_binding"] = binding
+    triage["tool_config"] = binding["mcp_server"]["name"]
     print(json.dumps(triage, indent=2))
 
     approval = human_approval_gate(triage)

--- a/examples/agents/schemas/mcp_client_config_bundle.schema.json
+++ b/examples/agents/schemas/mcp_client_config_bundle.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cloud-ai-security-skills.local/examples/agents/schemas/mcp_client_config_bundle.schema.json",
+  "title": "MCP client config bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_id",
+    "clients"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "mcp-client-config-bundle-v1"
+    },
+    "profile_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "clients": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "integration",
+          "config_path",
+          "docs"
+        ],
+        "properties": {
+          "integration": {
+            "type": "string",
+            "minLength": 1
+          },
+          "config_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "docs": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mcp_config": {
+            "type": "object"
+          },
+          "mcp_toml": {
+            "type": "string",
+            "minLength": 1
+          },
+          "context_servers": {
+            "type": "object"
+          },
+          "mcp_servers": {
+            "type": "object"
+          },
+          "path_note": {
+            "type": "string"
+          },
+          "anti_pattern": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/agents/schemas/mcp_client_config_bundle.schema.json
+++ b/examples/agents/schemas/mcp_client_config_bundle.schema.json
@@ -55,6 +55,9 @@
           "mcp_servers": {
             "type": "object"
           },
+          "mcp_server": {
+            "type": "object"
+          },
           "path_note": {
             "type": "string"
           },

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -371,6 +371,40 @@ class TestHitlGateReachable:
         )
         assert payload["mcp_tools_discovered"]
 
+    def test_anthropic_binding_documents_mcp_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["anthropic_binding"]
+        assert binding["integration"] == "anthropic_mcp_json"
+        assert "mcp_config" in binding
+        assert payload["mcp_tools_discovered"]
+
+    def test_openai_binding_documents_mcp_server(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "openai_sdk_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["openai_binding"]
+        assert binding["integration"] == "openai_agents_mcp_server"
+        assert binding["mcp_server"]["name"] == "cloud-ai-security-skills"
+        assert payload["mcp_tools_discovered"]
+
     def test_langgraph_reaches_remediation_with_approval(self):
         env = {
             **os.environ,
@@ -417,11 +451,17 @@ class TestIdeMcpBindings:
         langchain_env = ide_mcp_bindings.build_langchain_mcp_servers(profile)[
             "cloud-ai-security-skills"
         ]["env"]
+        anthropic_env = ide_mcp_bindings.build_anthropic_mcp_config(profile)["mcpServers"][
+            "cloud-ai-security-skills"
+        ]["env"]
+        openai_env = ide_mcp_bindings.build_openai_agents_mcp_server(profile)["env"]
 
         assert cursor_env == expected
         assert windsurf_env == expected
         assert zed_env == expected
         assert langchain_env == expected
+        assert anthropic_env == expected
+        assert openai_env == expected
         assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
         assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
 
@@ -462,11 +502,14 @@ class TestEmitMcpClientConfigs:
             "codex",
             "zed",
             "langchain",
+            "anthropic",
+            "openai",
         }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
         assert "context_servers" in payload["clients"]["zed"]
         assert "mcp_servers" in payload["clients"]["langchain"]
+        assert "mcp_server" in payload["clients"]["openai"]
 
     def test_single_client_filter(self):
         result = subprocess.run(
@@ -2270,6 +2313,8 @@ class TestLangGraphHarnessSetup:
             "codex",
             "zed",
             "langchain",
+            "anthropic",
+            "openai",
         }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -414,10 +414,14 @@ class TestIdeMcpBindings:
         zed_env = ide_mcp_bindings.build_zed_context_servers(profile)["context_servers"][
             "cloud-ai-security-skills"
         ]["command"]["env"]
+        langchain_env = ide_mcp_bindings.build_langchain_mcp_servers(profile)[
+            "cloud-ai-security-skills"
+        ]["env"]
 
         assert cursor_env == expected
         assert windsurf_env == expected
         assert zed_env == expected
+        assert langchain_env == expected
         assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
         assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
 
@@ -451,10 +455,18 @@ class TestEmitMcpClientConfigs:
         assert result.returncode == 0, result.stderr
         payload = json.loads(result.stdout)
         assert payload["schema_version"] == "mcp-client-config-bundle-v1"
-        assert set(payload["clients"]) == {"cursor", "cortex", "windsurf", "codex", "zed"}
+        assert set(payload["clients"]) == {
+            "cursor",
+            "cortex",
+            "windsurf",
+            "codex",
+            "zed",
+            "langchain",
+        }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
         assert "context_servers" in payload["clients"]["zed"]
+        assert "mcp_servers" in payload["clients"]["langchain"]
 
     def test_single_client_filter(self):
         result = subprocess.run(
@@ -2234,7 +2246,14 @@ class TestLangGraphHarnessSetup:
         assert summary["mcp_client_configs"] == str(mcp_path)
         bundle = json.loads(mcp_path.read_text(encoding="utf-8"))
         assert bundle["schema_version"] == "mcp-client-config-bundle-v1"
-        assert set(bundle["clients"]) == {"cursor", "cortex", "windsurf", "codex", "zed"}
+        assert set(bundle["clients"]) == {
+            "cursor",
+            "cortex",
+            "windsurf",
+            "codex",
+            "zed",
+            "langchain",
+        }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):
         result = subprocess.run(

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -482,6 +482,23 @@ class TestEmitMcpClientConfigs:
         payload = json.loads(result.stdout)
         assert set(payload["clients"]) == {"cursor"}
 
+    def test_emit_bundle_matches_schema(self):
+        schema = json.loads(
+            (SCHEMAS / "mcp_client_config_bundle.schema.json").read_text(encoding="utf-8")
+        )
+        result = subprocess.run(
+            [sys.executable, str(self.SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert _schema_errors(schema, payload) == []
+
 
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
@@ -2566,6 +2583,7 @@ class TestLangGraphHarnessDriftCheck:
         assert "pipeline_diagram_generated" in check_names
         assert "preflight_policy_safe" in check_names
         assert "harness_docs_have_no_secret_literals" in check_names
+        assert "mcp_client_bundle_schema" in check_names
 
 
 class TestOpenAICompatAdapter:

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -33,6 +33,7 @@ SCRIPTS = [
     EXAMPLES / "cortex_mcp_security_agent.py",
     EXAMPLES / "codex_mcp_security_agent.py",
     EXAMPLES / "zed_mcp_security_agent.py",
+    EXAMPLES / "claude_desktop_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -371,6 +372,24 @@ class TestHitlGateReachable:
         )
         assert payload["mcp_tools_discovered"]
 
+    def test_claude_desktop_mcp_binding_documents_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "claude_desktop_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["claude_desktop_binding"]
+        assert binding["integration"] == "claude_desktop_mcp_json"
+        assert "claude_desktop_config.json" in binding["config_path"]
+        assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
+        assert payload["mcp_tools_discovered"]
+
     def test_anthropic_binding_documents_mcp_config(self):
         result = subprocess.run(
             [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],
@@ -504,6 +523,7 @@ class TestEmitMcpClientConfigs:
             "langchain",
             "anthropic",
             "openai",
+            "claude-desktop",
         }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
@@ -2315,6 +2335,7 @@ class TestLangGraphHarnessSetup:
             "langchain",
             "anthropic",
             "openai",
+            "claude-desktop",
         }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Adds `mcp_client_config_bundle.schema.json` + drift validation (`mcp_client_bundle_schema` check)
- Consolidates Anthropic/OpenAI SDK MCP bindings into `ide_mcp_bindings.py` with emitter support
- Adds `claude_desktop_mcp_security_agent.py` and docs cross-links
- Wires `build_mcp_client_bundle()` through `configure_langgraph_harness --emit-mcp-configs`

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (123 tests)
- [x] `python examples/agents/check_langgraph_harness_drift.py` (10/10)


Made with [Cursor](https://cursor.com)