### PR TITLE
Add offline MCP client bundle validator

### DIFF
--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -17,6 +17,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
 | [`claude_desktop_mcp_security_agent.py`](claude_desktop_mcp_security_agent.py) | Claude Desktop | `claude_desktop_config.json` + harness profile; absolute-path MCP stdio |
 | [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + SDK | Offline bundle of IDE, LangChain, Anthropic, and OpenAI MCP blocks from one harness profile |
+| [`validate_mcp_client_configs.py`](validate_mcp_client_configs.py) | Operator | Validate an emitted MCP client bundle against `schemas/mcp_client_config_bundle.schema.json` |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |
 
@@ -51,6 +52,9 @@ Or emit IDE MCP blocks from an existing profile:
 python examples/agents/emit_mcp_client_configs.py \
   --profile artifacts/acme-sdk-cspm.json \
   --output artifacts/mcp-client-configs.json
+
+python examples/agents/validate_mcp_client_configs.py artifacts/mcp-client-configs.json
+python examples/agents/emit_mcp_client_configs.py | python examples/agents/validate_mcp_client_configs.py
 ```
 
 ## Safety posture — every example enforces the same invariants

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from harness_runtime import HarnessRunConfig, run_harness_summary
+from harness_schema import schema_errors
 from langgraph_security_graph import load_harness_profile, pipeline_contract, preview_agent_policy
 from render_langgraph_pipeline_diagram import render_mermaid
 
@@ -58,6 +59,7 @@ REQUIRED_DOC_TOKENS = [
     "eval_langgraph_harness.py --check",
     "render_langgraph_pipeline_diagram.py",
     "check_langgraph_harness_drift.py",
+    "validate_mcp_client_configs.py",
 ]
 
 SECRET_PATTERNS = [
@@ -69,15 +71,6 @@ SECRET_PATTERNS = [
         r"snowflake_password|secret_access_key)\b\s*[:=]\s*[\"'][^\"']{4,}[\"']"
     ),
 ]
-
-JSON_TYPE_MAP = {
-    "array": list,
-    "boolean": bool,
-    "integer": int,
-    "number": (int, float),
-    "object": dict,
-    "string": str,
-}
 
 
 @dataclass(frozen=True)
@@ -92,61 +85,6 @@ class DriftCheck:
             "status": "pass" if self.passed else "fail",
             "details": self.details,
         }
-
-
-def _schema_errors(schema: dict[str, Any], value: Any, path: str = "$") -> list[str]:
-    errors: list[str] = []
-    schema_type = schema.get("type")
-    if schema_type:
-        expected_type = JSON_TYPE_MAP[schema_type]
-        if not isinstance(value, expected_type) or (
-            schema_type in {"integer", "number"} and isinstance(value, bool)
-        ):
-            return [f"{path}: expected {schema_type}"]
-
-    if "const" in schema and value != schema["const"]:
-        errors.append(f"{path}: expected const {schema['const']!r}")
-    if "enum" in schema and value not in schema["enum"]:
-        errors.append(f"{path}: expected one of {schema['enum']!r}")
-    if schema_type == "string":
-        if len(value) < schema.get("minLength", 0):
-            errors.append(f"{path}: shorter than minLength")
-        if pattern := schema.get("pattern"):
-            if not re.match(pattern, value):
-                errors.append(f"{path}: does not match pattern")
-    if schema_type == "integer" and "minimum" in schema and value < schema["minimum"]:
-        errors.append(f"{path}: below minimum")
-
-    if schema_type == "array":
-        if len(value) < schema.get("minItems", 0):
-            errors.append(f"{path}: shorter than minItems")
-        if schema.get("uniqueItems"):
-            stable = [json.dumps(item, sort_keys=True) for item in value]
-            if len(stable) != len(set(stable)):
-                errors.append(f"{path}: duplicate array item")
-        item_schema = schema.get("items")
-        if item_schema:
-            for index, item in enumerate(value):
-                errors.extend(_schema_errors(item_schema, item, f"{path}[{index}]"))
-
-    if schema_type == "object":
-        required = set(schema.get("required", []))
-        for key in sorted(required - set(value)):
-            errors.append(f"{path}: missing required property {key}")
-        properties = schema.get("properties", {})
-        extra = sorted(set(value) - set(properties))
-        additional = schema.get("additionalProperties", True)
-        if additional is False:
-            for key in extra:
-                errors.append(f"{path}: additional property {key}")
-        elif isinstance(additional, dict):
-            for key in extra:
-                errors.extend(_schema_errors(additional, value[key], f"{path}.{key}"))
-        for key, child_schema in properties.items():
-            if key in value:
-                errors.extend(_schema_errors(child_schema, value[key], f"{path}.{key}"))
-
-    return errors
 
 
 def _load_json(path: Path) -> Any:
@@ -176,7 +114,7 @@ def _check_schema_documents() -> DriftCheck:
 def _check_pipeline_contract() -> DriftCheck:
     schema = _load_json(SCHEMAS / "pipeline_contract.schema.json")
     contract = pipeline_contract()
-    errors = _schema_errors(schema, contract)
+    errors = schema_errors(schema, contract)
     node_names = {node["node"] for node in contract.get("nodes", [])}
     for edge in contract.get("edges", []):
         if edge.get("source") not in node_names or edge.get("target") not in node_names:
@@ -217,7 +155,7 @@ def _check_profiles() -> DriftCheck:
     for profile_path in sorted(PROFILES.glob("*.json")):
         profile_names.append(profile_path.name)
         profile = _load_json(profile_path)
-        errors = _schema_errors(schema, profile)
+        errors = schema_errors(schema, profile)
         if errors:
             failures.extend(f"{profile_path.name}: {error}" for error in errors)
             continue
@@ -369,6 +307,8 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "sdk_agent_common.py",
         EXAMPLES / "ide_mcp_bindings.py",
         EXAMPLES / "emit_mcp_client_configs.py",
+        EXAMPLES / "validate_mcp_client_configs.py",
+        EXAMPLES / "harness_schema.py",
         EXAMPLES / "anthropic_sdk_security_agent.py",
         EXAMPLES / "openai_sdk_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",
@@ -415,11 +355,44 @@ def _check_mcp_client_bundle_schema() -> DriftCheck:
     schema = _load_json(SCHEMAS / "mcp_client_config_bundle.schema.json")
     profile = load_sdk_profile(DEFAULT_PROFILE)
     bundle = build_mcp_client_bundle(profile)
-    errors = _schema_errors(schema, bundle)
+    errors = schema_errors(schema, bundle)
     return DriftCheck(
         "mcp_client_bundle_schema",
         not errors,
         "default MCP client bundle matches schema" if not errors else errors,
+    )
+
+
+def _check_mcp_client_bundle_validator_cli() -> DriftCheck:
+    import subprocess
+
+    emit = subprocess.run(
+        [sys.executable, str(EXAMPLES / "emit_mcp_client_configs.py")],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if emit.returncode != 0:
+        return DriftCheck(
+            "mcp_client_bundle_validator_cli",
+            False,
+            emit.stderr.strip() or "emit_mcp_client_configs failed",
+        )
+    validate = subprocess.run(
+        [sys.executable, str(EXAMPLES / "validate_mcp_client_configs.py")],
+        input=emit.stdout,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    return DriftCheck(
+        "mcp_client_bundle_validator_cli",
+        validate.returncode == 0,
+        "emit | validate round-trip passes"
+        if validate.returncode == 0
+        else validate.stderr.strip() or "validate_mcp_client_configs failed",
     )
 
 
@@ -434,6 +407,7 @@ def run_checks(*, update_diagram: bool = False) -> list[DriftCheck]:
         _check_docs_wired(),
         _check_ide_examples_wired(),
         _check_mcp_client_bundle_schema(),
+        _check_mcp_client_bundle_validator_cli(),
         _check_no_harness_secret_literals(),
     ]
 

--- a/examples/agents/harness_schema.py
+++ b/examples/agents/harness_schema.py
@@ -1,0 +1,77 @@
+"""Shared JSON-schema validation helpers for harness artifacts."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+JSON_TYPE_MAP = {
+    "array": list,
+    "boolean": bool,
+    "integer": int,
+    "number": (int, float),
+    "object": dict,
+    "string": str,
+}
+
+
+def schema_errors(schema: dict[str, Any], value: Any, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        type_errors = [schema_errors({**schema, "type": item}, value, path) for item in schema_type]
+        if any(not item for item in type_errors):
+            return []
+        return type_errors[0]
+    if schema_type:
+        expected_type = JSON_TYPE_MAP[schema_type]
+        if not isinstance(value, expected_type) or (
+            schema_type in {"integer", "number"} and isinstance(value, bool)
+        ):
+            return [f"{path}: expected {schema_type}"]
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}")
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']!r}")
+    if schema_type == "string":
+        if len(value) < schema.get("minLength", 0):
+            errors.append(f"{path}: shorter than minLength")
+        if pattern := schema.get("pattern"):
+            if not re.match(pattern, value):
+                errors.append(f"{path}: does not match pattern")
+    if schema_type == "integer" and "minimum" in schema and value < schema["minimum"]:
+        errors.append(f"{path}: below minimum")
+
+    if schema_type == "array":
+        if len(value) < schema.get("minItems", 0):
+            errors.append(f"{path}: shorter than minItems")
+        if schema.get("uniqueItems"):
+            stable = [json.dumps(item, sort_keys=True) for item in value]
+            if len(stable) != len(set(stable)):
+                errors.append(f"{path}: duplicate array item")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(value):
+                errors.extend(schema_errors(item_schema, item, f"{path}[{index}]"))
+
+    if schema_type == "object":
+        required = set(schema.get("required", []))
+        missing = sorted(required - set(value))
+        for key in missing:
+            errors.append(f"{path}: missing required property {key}")
+        properties = schema.get("properties", {})
+        extra = sorted(set(value) - set(properties))
+        additional = schema.get("additionalProperties", True)
+        if additional is False:
+            for key in extra:
+                errors.append(f"{path}: additional property {key}")
+        elif isinstance(additional, dict):
+            for key in extra:
+                errors.extend(schema_errors(additional, value[key], f"{path}.{key}"))
+        for key, child_schema in properties.items():
+            if key in value:
+                errors.extend(schema_errors(child_schema, value[key], f"{path}.{key}"))
+
+    return errors

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -563,6 +563,48 @@ class TestEmitMcpClientConfigs:
         assert _schema_errors(schema, payload) == []
 
 
+class TestValidateMcpClientConfigs:
+    EMIT = EXAMPLES / "emit_mcp_client_configs.py"
+    VALIDATE = EXAMPLES / "validate_mcp_client_configs.py"
+
+    def test_validates_emitted_bundle(self):
+        emit = subprocess.run(
+            [sys.executable, str(self.EMIT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+        assert emit.returncode == 0, emit.stderr
+        validate = subprocess.run(
+            [sys.executable, str(self.VALIDATE)],
+            input=emit.stdout,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+        assert validate.returncode == 0, validate.stderr
+        report = json.loads(validate.stdout)
+        assert report["status"] == "valid"
+        assert report["schema_version"] == "mcp-client-config-bundle-v1"
+
+    def test_rejects_invalid_bundle(self):
+        validate = subprocess.run(
+            [sys.executable, str(self.VALIDATE)],
+            input='{"schema_version":"wrong"}',
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+        assert validate.returncode == 1
+        assert "missing required property" in validate.stderr
+
+
 class TestLangGraphHarnessRuntime:
     """Importable wrapper coverage for embedding the LangGraph harness."""
 
@@ -2650,6 +2692,7 @@ class TestLangGraphHarnessDriftCheck:
         assert "preflight_policy_safe" in check_names
         assert "harness_docs_have_no_secret_literals" in check_names
         assert "mcp_client_bundle_schema" in check_names
+        assert "mcp_client_bundle_validator_cli" in check_names
 
 
 class TestOpenAICompatAdapter:

--- a/examples/agents/validate_mcp_client_configs.py
+++ b/examples/agents/validate_mcp_client_configs.py
@@ -1,0 +1,100 @@
+"""Validate an emitted MCP client config bundle against the repo schema.
+
+Offline operator tool — does not spawn MCP or call cloud APIs.
+
+Run:
+
+    python examples/agents/validate_mcp_client_configs.py artifacts/mcp-client-configs.json
+    python examples/agents/emit_mcp_client_configs.py | python examples/agents/validate_mcp_client_configs.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from harness_schema import schema_errors
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = Path(__file__).resolve().parent / "schemas" / "mcp_client_config_bundle.schema.json"
+
+SECRET_MARKERS = (
+    "ghp_",
+    "github_pat_",
+    "sk-",
+    "AKIA",
+    "-----BEGIN",
+)
+
+
+def _load_bundle(path: Path | None) -> dict[str, Any]:
+    raw = sys.stdin.read() if path is None else path.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("bundle must be a JSON object")
+    return payload
+
+
+def validate_bundle(payload: dict[str, Any], *, schema_path: Path = SCHEMA_PATH) -> list[str]:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return schema_errors(schema, payload)
+
+
+def _secret_literal_errors(payload: dict[str, Any]) -> list[str]:
+    text = json.dumps(payload)
+    findings: list[str] = []
+    for marker in SECRET_MARKERS:
+        if marker in text:
+            findings.append(f"bundle text contains suspicious marker: {marker}")
+    return findings
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "bundle",
+        nargs="?",
+        type=Path,
+        help="Bundle JSON path (stdin when omitted)",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=SCHEMA_PATH,
+        help="Schema path (default: examples/agents/schemas/mcp_client_config_bundle.schema.json)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        bundle = _load_bundle(args.bundle)
+        errors = validate_bundle(bundle, schema_path=args.schema)
+        errors.extend(_secret_literal_errors(bundle))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+    if errors:
+        for error in errors:
+            sys.stderr.write(f"{error}\n")
+        return 1
+    print(
+        json.dumps(
+            {
+                "schema_version": bundle.get("schema_version"),
+                "profile_id": bundle.get("profile_id"),
+                "clients": sorted((bundle.get("clients") or {}).keys()),
+                "status": "valid",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `validate_mcp_client_configs.py` to validate emitted MCP client bundles against `mcp_client_config_bundle.schema.json` (file or stdin).
- Extracts shared `harness_schema.py` helpers and wires drift CI with an `emit | validate` round-trip check (11 drift checks).

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (129 passed)
- [x] `python examples/agents/check_langgraph_harness_drift.py`
- [x] `python examples/agents/emit_mcp_client_configs.py | python examples/agents/validate_mcp_client_configs.py`

**Stacks on:** #598

Made with [Cursor](https://cursor.com)