### PR TITLE
Add Ollama open-model MCP agent with read-only preset

### DIFF
--- a/docs/integrations/ollama.md
+++ b/docs/integrations/ollama.md
@@ -117,6 +117,7 @@ the loop is untrusted.
 
 - [`README.md`](README.md) — full per-client integrations index
 - [`../../CLAUDE.md`](../../CLAUDE.md) — agent guardrails required before invoking any skill
+- [`../../examples/agents/ollama_mcp_security_agent.py`](../../examples/agents/ollama_mcp_security_agent.py) — runnable Ollama / open-model reference
 - [`../../examples/agents/README.md`](../../examples/agents/README.md) — runnable SDK examples
 - [`../HITL_POLICY.md`](../HITL_POLICY.md) — when human approval is required
 - [`../MCP_AUDIT_CONTRACT.md`](../MCP_AUDIT_CONTRACT.md) — audit record schema

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -9,6 +9,7 @@ allowlist regardless of which SDK is driving the loop.
 |---|---|---|
 | [`anthropic_sdk_security_agent.py`](anthropic_sdk_security_agent.py) | Anthropic Python SDK (Managed Agent) | CSPM scan → triage loop with HITL gate on remediation |
 | [`openai_sdk_security_agent.py`](openai_sdk_security_agent.py) | OpenAI Agents SDK | Parallel port of the Anthropic example for portability |
+| [`ollama_mcp_security_agent.py`](ollama_mcp_security_agent.py) | Ollama (OpenAI-compat) | Read-only MCP loop with `preset-open-model-readonly.json`; remediation blocked by design |
 | [`langchain_mcp_security_agent.py`](langchain_mcp_security_agent.py) | LangChain | MCP-first stdio pattern; `langchain-mcp-adapters` config when installed — not LCEL skill wrappers |
 | [`cursor_mcp_security_agent.py`](cursor_mcp_security_agent.py) | Cursor | Project-scoped `.cursor/mcp.json` + harness profile; same MCP audit/HITL contract |
 | [`windsurf_mcp_security_agent.py`](windsurf_mcp_security_agent.py) | Windsurf | `~/.codeium/windsurf/mcp_config.json` + harness profile; absolute-path MCP stdio |

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -311,6 +311,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "harness_schema.py",
         EXAMPLES / "anthropic_sdk_security_agent.py",
         EXAMPLES / "openai_sdk_security_agent.py",
+        EXAMPLES / "ollama_mcp_security_agent.py",
         EXAMPLES / "langchain_mcp_security_agent.py",
         EXAMPLES / "cursor_mcp_security_agent.py",
         EXAMPLES / "windsurf_mcp_security_agent.py",

--- a/examples/agents/harness_profiles/sdk-open-model-readonly.json
+++ b/examples/agents/harness_profiles/sdk-open-model-readonly.json
@@ -1,0 +1,105 @@
+{
+  "profile_id": "sdk-open-model-readonly",
+  "description": "Ollama / open-model reference: read-only CSPM + detect triage via MCP stdio with preset-open-model-readonly overlay.",
+  "allowed_skills": [
+    "cspm-aws-cis-benchmark",
+    "cspm-gcp-cis-benchmark",
+    "cspm-azure-cis-benchmark",
+    "detect-lateral-movement",
+    "detect-privilege-escalation-k8s",
+    "ingest-cloudtrail-ocsf",
+    "convert-ocsf-to-sarif"
+  ],
+  "caller_context": {
+    "user_id": "sdk-open-model-readonly",
+    "email": "open-model@example.com",
+    "session_id": "open-model-demo",
+    "roles": "security_engineer",
+    "allowed_skills": [
+      "cspm-aws-cis-benchmark",
+      "detect-lateral-movement",
+      "convert-ocsf-to-sarif"
+    ]
+  },
+  "cloud_identity_hints": {
+    "aws": "AWS_PROFILE=prod-readonly",
+    "gcp": "gcloud auth login",
+    "azure": "az login"
+  },
+  "llm": {
+    "mode": "external_llm_optional",
+    "provider": "ollama-openai-compat",
+    "model": "llama3.3"
+  },
+  "token_budget": {
+    "policy_version": "langgraph-token-budget-v1",
+    "task_class": "triage_summary",
+    "model_tier": "tiny",
+    "max_input_tokens": 1200,
+    "max_output_tokens": 256,
+    "max_total_tokens": 1600,
+    "max_findings_per_call": 5,
+    "max_evidence_chars": 1800,
+    "compression_required": true,
+    "fallback_on_budget_exceeded": true
+  },
+  "model_policy": {
+    "policy_version": "langgraph-model-policy-v1",
+    "task_class": "triage_summary",
+    "selection_strategy": "smallest_sufficient",
+    "default_model_tier": "tiny",
+    "allowed_model_tiers": [
+      "tiny"
+    ],
+    "models": {
+      "tiny": {
+        "provider": "ollama-openai-compat",
+        "model": "llama3.3"
+      },
+      "small": {
+        "provider": "openai",
+        "model": "gpt-4.1-mini"
+      },
+      "large": {
+        "provider": "external-approved",
+        "model": "operator-approved-large-model"
+      }
+    },
+    "fallback": {
+      "provider": "deterministic-local",
+      "model": "policy-bounded-triage-v1"
+    }
+  },
+  "agent_roster": [
+    {
+      "agent_id": "triage-agent",
+      "model_tier": "tiny",
+      "privilege_boundary": "no_tool_writes",
+      "skill_scope": []
+    }
+  ],
+  "approval_policy": {
+    "remediation_requires_approval_context": true,
+    "approval_source": "operator_idp_or_ticketing_system",
+    "min_approvers": 1
+  },
+  "runtime": {
+    "langgraph_runtime_optional": true,
+    "dry_run_default": true,
+    "apply_supported": false,
+    "security_data_source": {
+      "mode": "raw_ingest",
+      "backend": "inline_events",
+      "source_skill": "ingest-cloudtrail-ocsf",
+      "records_format": "raw_vendor",
+      "query": ""
+    },
+    "mcp_execution": {
+      "mode": "operator_stdio",
+      "transport": "mcp_stdio_jsonrpc",
+      "execute_planned_calls": true,
+      "allow_write_calls": false,
+      "max_calls": 4
+    }
+  }
+}

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -70,6 +70,25 @@ def build_openai_agents_mcp_server(profile: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1"
+
+
+def build_ollama_openai_compat_binding(
+    profile: dict[str, Any], *, base_url: str = DEFAULT_OLLAMA_BASE_URL
+) -> dict[str, Any]:
+    """OpenAI-compatible Ollama runtime + the same MCP stdio server block as OpenAI Agents."""
+    return {
+        "integration": "ollama_openai_compat_agents",
+        "docs": "docs/integrations/ollama.md",
+        "ollama_base_url": base_url,
+        "ollama_api_key": "ollama",
+        "preset_recommendation": "presets/preset-open-model-readonly.json",
+        "guardrail_note": "read_only_skills_only_no_remediation_in_allowlist",
+        "anti_pattern": "do_not_wrap_skill_clis_as_openai_tools",
+        "mcp_server": build_openai_agents_mcp_server(profile),
+    }
+
+
 def build_zed_context_servers(profile: dict[str, Any]) -> dict[str, Any]:
     """``~/.config/zed/settings.json`` ``context_servers`` block."""
     return {

--- a/examples/agents/ollama_mcp_security_agent.py
+++ b/examples/agents/ollama_mcp_security_agent.py
@@ -1,0 +1,71 @@
+"""Ollama (OpenAI-compatible) — read-only MCP security agent reference.
+
+Ollama is not an MCP client. Bridge it through the OpenAI Agents SDK (or any
+OpenAI-compatible client) with a **read-only** MCP allowlist. Open models have
+weaker tool-call accuracy — keep the surface small via
+``presets/preset-open-model-readonly.json``.
+
+Prerequisites:
+
+    uv sync --group dev --extra aws
+
+Run:
+
+    CLOUD_SECURITY_HARNESS_PROFILE=examples/agents/harness_profiles/sdk-open-model-readonly.json \
+    CLOUD_SECURITY_MCP_PRESET=presets/preset-open-model-readonly.json \
+      python examples/agents/ollama_mcp_security_agent.py
+
+Remediation is intentionally out of scope for open-model loops. Use a separate
+human-gated workflow if write paths are required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from ide_mcp_bindings import DEFAULT_OLLAMA_BASE_URL, build_ollama_openai_compat_binding
+from sdk_agent_common import (
+    human_approval_gate,
+    load_sdk_profile,
+    read_allowlist,
+    run_cspm_triage,
+)
+
+
+def ollama_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    base_url = os.environ.get("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL)
+    binding = build_ollama_openai_compat_binding(profile, base_url=base_url)
+    binding["openai_client_shape"] = {
+        "base_url": base_url,
+        "api_key": "ollama",
+    }
+    return binding
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    allowlist = read_allowlist(profile)
+    if any(
+        skill.startswith("remediate-") or skill.startswith("iam-departures") for skill in allowlist
+    ):
+        raise SystemExit("open-model profile must not include remediation skills")
+
+    triage = run_cspm_triage(profile, correlation_id="ollama-demo-1")
+    binding = ollama_binding_notes(profile)
+    triage["ollama_binding"] = binding
+    triage["tool_config"] = binding["mcp_server"]["name"]
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    raise SystemExit(
+        "open-model loops must not reach remediation; remove DEMO_APPROVE for this example"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -390,6 +390,32 @@ class TestHitlGateReachable:
         assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
         assert payload["mcp_tools_discovered"]
 
+    def test_ollama_binding_documents_openai_compat_mcp(self):
+        env = {
+            **os.environ,
+            "CLOUD_SECURITY_HARNESS_PROFILE": str(
+                EXAMPLES / "harness_profiles" / "sdk-open-model-readonly.json"
+            ),
+            "CLOUD_SECURITY_MCP_PRESET": "presets/preset-open-model-readonly.json",
+        }
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "ollama_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["ollama_binding"]
+        assert binding["integration"] == "ollama_openai_compat_agents"
+        assert binding["preset_recommendation"] == "presets/preset-open-model-readonly.json"
+        assert binding["mcp_server"]["name"] == "cloud-ai-security-skills"
+        assert "remediate-" not in binding["mcp_server"]["env"]["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
+        assert payload["mcp_tools_discovered"]
+
     def test_anthropic_binding_documents_mcp_config(self):
         result = subprocess.run(
             [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],

--- a/presets/README.md
+++ b/presets/README.md
@@ -33,6 +33,7 @@ broader composition model.
 | [`preset-detection-only.json`](preset-detection-only.json) | feed raw logs through ingest + detect, hand findings to a SIEM | a curated 15-ingest / 32-detect subset plus both view skills (the JSON is authoritative) | none |
 | [`preset-incident-response.json`](preset-incident-response.json) | the workflow at [`../examples/workflows/incident-response-okta-mfa-fatigue.md`](../examples/workflows/incident-response-okta-mfa-fatigue.md) | one detector + one discover + one remediate | one HITL-gated session kill |
 | [`preset-ai-runtime.json`](preset-ai-runtime.json) | runtime guardrails for an AI agent platform — detect prompt injection, tool drift, exfiltration | MCP-proxy ingest, the AI-runtime detectors, MCP tool quarantine | one HITL-gated tool quarantine |
+| [`preset-open-model-readonly.json`](preset-open-model-readonly.json) | Ollama and other open-model agent loops — read-only posture + detect + SARIF | CSPM trio, lateral/priv-esc detect, `ingest-cloudtrail-ocsf`, `convert-ocsf-to-sarif` | none |
 
 ## Loading a preset
 

--- a/presets/preset-open-model-readonly.json
+++ b/presets/preset-open-model-readonly.json
@@ -1,0 +1,13 @@
+{
+  "name": "open-model-readonly",
+  "description": "Read-only posture and detection surface for Ollama and other open-model agent loops. No remediation skills — keep the allowlist small to compensate for weaker tool-call accuracy.",
+  "allowed_skills": [
+    "cspm-aws-cis-benchmark",
+    "cspm-gcp-cis-benchmark",
+    "cspm-azure-cis-benchmark",
+    "detect-lateral-movement",
+    "detect-privilege-escalation-k8s",
+    "ingest-cloudtrail-ocsf",
+    "convert-ocsf-to-sarif"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `ollama_mcp_security_agent.py` — OpenAI-compatible Ollama bridge with read-only MCP triage and remediation blocked by design.
- Ships `presets/preset-open-model-readonly.json` and `harness_profiles/sdk-open-model-readonly.json` for a small, safe tool surface on open models.
- Adds `build_ollama_openai_compat_binding()` in `ide_mcp_bindings.py` and links `docs/integrations/ollama.md`.

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -k ollama -q`
- [x] `python scripts/validate_presets.py` (5 presets)
- [x] `CLOUD_SECURITY_HARNESS_PROFILE=examples/agents/harness_profiles/sdk-open-model-readonly.json CLOUD_SECURITY_MCP_PRESET=presets/preset-open-model-readonly.json python examples/agents/ollama_mcp_security_agent.py`

**Stacks on:** validator PR (feat/mcp-bundle-validator)

Made with [Cursor](https://cursor.com)