### PR TITLE
Audience uplift Tier 1: doc parity CI + remediation test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - run: python scripts/validate_ocsf_metadata.py
       - run: python scripts/validate_skill_count_consistency.py
       - run: python scripts/validate_doc_counts.py
+      - run: python scripts/validate_doc_parity.py
       - run: python scripts/validate_deny_list_parity.py
       - run: python scripts/validate_captured_provenance.py
       - run: python scripts/add_skill_trust_frontmatter.py --check
@@ -199,7 +200,7 @@ jobs:
             google-cloud-iam google-cloud-resource-manager google-api-python-client
             azure-identity
             clickhouse-connect databricks-sql-connector httpx snowflake-connector-python
-      - run: pytest skills/remediation/iam-departures-aws/tests/ -v -o "testpaths=tests"
+      - run: pytest skills/remediation/ -v -o "testpaths=tests"
 
   test-detection-engineering:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Shipped:
 - Three reference event-driven runners under [`runners/`](runners/)
 
 Not yet:
-- Hosted HTTP/SSE transport for remote MCP deployments
+- **Hosted** remote HTTP/SSE MCP deployments (operator-managed reverse proxy + auth). Opt-in local SSE transport ships today — see [`docs/MCP_TRANSPORT.md`](docs/MCP_TRANSPORT.md) and `mcp-server/src/transports/sse.py`.
 - Tight per-skill input schemas derived from each CLI instead of the current conservative `input` + `args` wrapper
 - Full automatic parity between every possible local entrypoint shape and the MCP wrapper; check `mcp-server/README.md` for current wrapper behavior
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ validate:
 	python scripts/validate_ocsf_metadata.py
 	python scripts/validate_skill_count_consistency.py
 	python scripts/validate_doc_counts.py
+	python scripts/validate_doc_parity.py
 	python scripts/validate_deny_list_parity.py
 	python scripts/validate_captured_provenance.py
 	python scripts/add_skill_trust_frontmatter.py --check

--- a/SECURITY_BAR.md
+++ b/SECURITY_BAR.md
@@ -8,7 +8,7 @@ If you are an AI agent loading a skill, these are the guarantees you can
 rely on. If you are a security team adopting one of these skills, this
 is the row you can take to your auditor.
 
-## The ten principles
+## The eleven principles
 
 | # | Principle | What it means in practice | How we verify it |
 |---|---|---|---|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,7 +190,7 @@ For the detailed contract, see:
 | Layer | Status | Current shape |
 |---|---|---|
 | L0 external sources | external | cloud APIs, raw logs, SaaS identity feeds, lakehouse tables |
-| L1 ingest | shipping | 21 source-specific ingesters plus 4 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
+| L1 ingest | shipping | 22 source-specific ingesters plus 4 read-only source adapters; ingest and detect are fully dual-mode where OCSF-native parity makes sense |
 | L2 discover | shipping | 5 read-only inventory, graph, AI BOM, cloud control evidence, and departure-planning skills |
 | L3 detect | shipping | 71 shipped detectors across cloud, identity, Kubernetes, MCP / agent, warehouse, and SaaS signals (GitHub, Slack, Workspace, Workday, Salesforce, SAP) |
 | L4 evaluate | shipping | 12 benchmark and posture skills across AWS, GCP, Azure, Kubernetes, containers, GPU, AI RMF, and model-serving paths with native and opt-in OCSF 2003 output |

--- a/docs/SKILL_INDEX.md
+++ b/docs/SKILL_INDEX.md
@@ -10,7 +10,8 @@ Each row is a directory under [`skills/`](../skills/). The `SKILL.md` in each
 directory is the single source of truth for what the skill does, what it does
 not do, and what it talks to.
 
-> Counts are auto-validated by `scripts/validate_count_drift.sh`. If a row
+> Counts are auto-validated by `scripts/validate_doc_counts.py` and
+> `scripts/validate_doc_parity.py`. If a row
 > moves, the count check fails CI until this index is regenerated.
 
 ## By environment

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -23,11 +23,11 @@ Remediation parity:
 
 - standalone remediation skills with a single `src/handler.py` entrypoint are
   exposed over MCP
+- `iam-departures-{aws,gcp,azure-entra}` are also exposed via top-level
+  `src/handler.py` shims (see #411) — one MCP tool per cloud, not one tool for
+  the full multi-Lambda orchestration
 - those tools stay dry-run/re-verify only at the wrapper boundary; the MCP
   wrapper rejects `--apply`
-- multi-handler orchestration workflows such as `iam-departures-*` are still
-  not exposed as one MCP tool because they do not have a single repo-owned
-  top-level entrypoint
 
 Audit behavior:
 

--- a/scripts/validate_doc_parity.py
+++ b/scripts/validate_doc_parity.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Fail CI when secondary docs drift from code-backed facts.
+
+Complements ``validate_doc_counts.py`` (registry count parity) with semantic
+checks: ingest totals in long-form architecture docs, MCP exposure claims,
+security-bar headings, and catalog routing.
+
+Exit codes: 0 on match, 1 on drift.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = REPO_ROOT / "docs" / "framework-coverage.json"
+
+
+def _ingest_count() -> int:
+    reg = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    count = 0
+    for skill in reg["skills"]:
+        if skill.get("layer") != "ingestion":
+            continue
+        name = skill["path"].rsplit("/", 1)[-1]
+        if name.startswith("ingest-"):
+            count += 1
+    return count
+
+
+def _check_ingest_count_in_docs_architecture(expected: int) -> str | None:
+    path = REPO_ROOT / "docs" / "ARCHITECTURE.md"
+    text = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"L1 ingest \| shipping \| (\d+) source-specific ingesters",
+        text,
+    )
+    if not match:
+        return f"{path.relative_to(REPO_ROOT)}: L1 ingest row pattern missing"
+    got = int(match.group(1))
+    if got != expected:
+        return (
+            f"{path.relative_to(REPO_ROOT)}: ingest count drift — doc says {got}, "
+            f"registry says {expected}"
+        )
+    return None
+
+
+def _check_agents_sse_wording() -> str | None:
+    path = REPO_ROOT / "AGENTS.md"
+    text = path.read_text(encoding="utf-8")
+    if "remote HTTP/SSE MCP deployments" not in text:
+        return f"{path.relative_to(REPO_ROOT)}: must document remote-hosted SSE gap"
+    if "Opt-in local SSE" not in text and "mcp-server/src/transports/sse.py" not in text:
+        return (
+            f"{path.relative_to(REPO_ROOT)}: must document opt-in local SSE "
+            "(see docs/MCP_TRANSPORT.md) alongside remote-hosted gap"
+        )
+    return None
+
+
+def _check_security_bar_heading() -> str | None:
+    path = REPO_ROOT / "SECURITY_BAR.md"
+    text = path.read_text(encoding="utf-8")
+    if "## The eleven principles" not in text:
+        return (
+            f"{path.relative_to(REPO_ROOT)}: heading must be "
+            "'## The eleven principles' (table has 11 rows)"
+        )
+    if "## The ten principles" in text:
+        return f"{path.relative_to(REPO_ROOT)}: stale 'ten principles' heading remains"
+    return None
+
+
+def _check_mcp_server_iam_departures_claim() -> str | None:
+    path = REPO_ROOT / "mcp-server" / "README.md"
+    text = path.read_text(encoding="utf-8")
+    if "iam-departures-" not in text and "handler shim" not in text:
+        return (
+            f"{path.relative_to(REPO_ROOT)}: must document iam-departures-* MCP "
+            "exposure via top-level handler shims (#411)"
+        )
+    if re.search(
+        r"iam-departures-\*.*not exposed as one MCP tool",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        return (
+            f"{path.relative_to(REPO_ROOT)}: stale claim that iam-departures-* "
+            "are not MCP-exposed; they ship handler shims"
+        )
+    return None
+
+
+def _check_skills_readme_routes_to_skill_index() -> str | None:
+    path = REPO_ROOT / "skills" / "README.md"
+    text = path.read_text(encoding="utf-8")
+    if "docs/SKILL_INDEX.md" not in text:
+        return f"{path.relative_to(REPO_ROOT)}: must link to docs/SKILL_INDEX.md"
+    if "authoritative" not in text.lower() and "complete catalog" not in text.lower():
+        return (
+            f"{path.relative_to(REPO_ROOT)}: must state SKILL_INDEX is the "
+            "complete / authoritative catalog"
+        )
+    return None
+
+
+def _check_skill_index_validator_reference() -> str | None:
+    path = REPO_ROOT / "docs" / "SKILL_INDEX.md"
+    text = path.read_text(encoding="utf-8")
+    if "validate_doc_counts.py" not in text:
+        return (
+            f"{path.relative_to(REPO_ROOT)}: must reference "
+            "scripts/validate_doc_counts.py (not validate_count_drift.sh)"
+        )
+    if "validate_count_drift.sh" in text:
+        return f"{path.relative_to(REPO_ROOT)}: stale validate_count_drift.sh reference"
+    return None
+
+
+def main() -> int:
+    ingest_count = _ingest_count()
+    checks = [
+        _check_ingest_count_in_docs_architecture(ingest_count),
+        _check_agents_sse_wording(),
+        _check_security_bar_heading(),
+        _check_mcp_server_iam_departures_claim(),
+        _check_skills_readme_routes_to_skill_index(),
+        _check_skill_index_validator_reference(),
+    ]
+    errors = [error for error in checks if error is not None]
+    if errors:
+        print("Doc parity drift detected:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"Doc parity checks passed ({ingest_count} ingest-* skills).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_doc_parity.py
+++ b/scripts/validate_doc_parity.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import re
 import sys
-from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,9 @@
-# Skills Catalog
+# Skills Catalog (curated overview)
+
+> **Complete catalog:** [`docs/SKILL_INDEX.md`](../docs/SKILL_INDEX.md) is the
+> authoritative, CI-gated index of all **131** shipped skills (by environment,
+> purpose, and framework). This file is a curated layer overview — not every
+> detector or evaluation skill is listed here.
 
 Skills are grouped by **layered function**, not by vendor. Start with the problem you are solving, then pick the layer and skill that match it. If you want a guided entry point instead of a catalog, read [`docs/USE_CASES.md`](../docs/USE_CASES.md) first.
 

--- a/tests/integration/test_skill_validation_scripts.py
+++ b/tests/integration/test_skill_validation_scripts.py
@@ -770,6 +770,20 @@ class TestCountDriftScan:
         assert pat.search("The repo ships 49 skills today.") is None
 
 
+class TestDocParityValidator:
+    def test_repo_passes_doc_parity_gate(self):
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / "validate_doc_parity.py")],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=ROOT,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+
+
 class TestSecretLiteralChecker:
     def test_repo_passes_secret_literal_gate(self):
         import subprocess


### PR DESCRIPTION
## Summary
Closes Tier 1 items **#1**, **#2**, and **#4** from the [Audience 9/10 uplift epic](#602).

- Adds `scripts/validate_doc_parity.py` — CI gate for semantic doc/code drift (ingest count, SSE wording, security-bar heading, MCP iam-departures exposure, skills catalog routing)
- Fixes 5 known drifts: `docs/ARCHITECTURE.md` (22 ingesters), `AGENTS.md` (opt-in SSE vs remote-hosted gap), `SECURITY_BAR.md` (eleven principles), `mcp-server/README.md` (#411 handler shims), `docs/SKILL_INDEX.md` validator reference
- Redirects `skills/README.md` to `docs/SKILL_INDEX.md` as the authoritative catalog
- Expands `test-remediation` CI job to `pytest skills/remediation/` (all 12 bundles)

## Audience impact

| Audience | Before | After (this PR) |
|---|---|---|
| Platform / SRE | 7 | 7.5 |
| Compliance / GRC | 7 | 7 |
| Contributors | 8 | 8.5 |

## Test plan
- [x] `python scripts/validate_doc_parity.py`
- [x] `python scripts/validate_doc_counts.py`
- [x] `pytest tests/integration/test_skill_validation_scripts.py::TestDocParityValidator -q`
- [x] `pytest skills/remediation/ -q`

## Tracking
Epic: #602 | Next: #603, #610