### PR TITLE
Add Continue MCP security agent (10th emitter client)

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -142,6 +142,7 @@ Reference examples:
 - [`examples/agents/codex_mcp_security_agent.py`](../examples/agents/codex_mcp_security_agent.py) — Codex `config.toml` fragment
 - [`examples/agents/zed_mcp_security_agent.py`](../examples/agents/zed_mcp_security_agent.py) — Zed `context_servers` block
 - [`examples/agents/claude_desktop_mcp_security_agent.py`](../examples/agents/claude_desktop_mcp_security_agent.py) — Claude Desktop `claude_desktop_config.json` block
+- [`examples/agents/continue_mcp_security_agent.py`](../examples/agents/continue_mcp_security_agent.py) — Continue `config.yaml` `mcpServers` block
 - [`examples/agents/emit_mcp_client_configs.py`](../examples/agents/emit_mcp_client_configs.py) — offline bundle of IDE + LangChain MCP blocks from one harness profile
 
 Generate a profile with a workflow preset baked in:

--- a/docs/integrations/ide-agents.md
+++ b/docs/integrations/ide-agents.md
@@ -73,6 +73,7 @@ Runnable offline examples and per-client setup guides:
 | Zed | [`zed.md`](zed.md) | [`../../examples/agents/zed_mcp_security_agent.py`](../../examples/agents/zed_mcp_security_agent.py) |
 | LangChain | [`../HARNESS.md`](../HARNESS.md) | [`../../examples/agents/langchain_mcp_security_agent.py`](../../examples/agents/langchain_mcp_security_agent.py) |
 | Claude Desktop | [`claude-desktop.md`](claude-desktop.md) | [`../../examples/agents/claude_desktop_mcp_security_agent.py`](../../examples/agents/claude_desktop_mcp_security_agent.py) |
+| Continue | [`ide-agents.md`](ide-agents.md) | [`../../examples/agents/continue_mcp_security_agent.py`](../../examples/agents/continue_mcp_security_agent.py) |
 
 See also [`../AGENT_QUICKSTART.md`](../AGENT_QUICKSTART.md) and [`README.md`](README.md).
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -16,6 +16,7 @@ allowlist regardless of which SDK is driving the loop.
 | [`codex_mcp_security_agent.py`](codex_mcp_security_agent.py) | Codex | `~/.codex/config.toml` fragment + harness profile; absolute-path MCP stdio |
 | [`zed_mcp_security_agent.py`](zed_mcp_security_agent.py) | Zed | `~/.config/zed/settings.json` `context_servers` block + harness profile; absolute-path MCP stdio |
 | [`claude_desktop_mcp_security_agent.py`](claude_desktop_mcp_security_agent.py) | Claude Desktop | `claude_desktop_config.json` + harness profile; absolute-path MCP stdio |
+| [`continue_mcp_security_agent.py`](continue_mcp_security_agent.py) | Continue | `~/.continue/config.yaml` YAML `mcpServers` list + harness profile; absolute-path MCP stdio |
 | [`emit_mcp_client_configs.py`](emit_mcp_client_configs.py) | IDE + SDK | Offline bundle of IDE, LangChain, Anthropic, and OpenAI MCP blocks from one harness profile |
 | [`langgraph_security_graph.py`](langgraph_security_graph.py) | LangGraph | SOC workflow DAG: ingest → normalize → enrich → correlate → confidence → MITRE/CVSS/EPSS/KEV map → HITL → dry-run remediation → audit/eval writeback |
 | [`langgraph_hitl_interrupt_resume.py`](langgraph_hitl_interrupt_resume.py) | LangGraph | Native `interrupt_before` + checkpointer at the analyst review gate; operator resumes with `approval_context` |

--- a/examples/agents/check_langgraph_harness_drift.py
+++ b/examples/agents/check_langgraph_harness_drift.py
@@ -49,6 +49,7 @@ REQUIRED_IDE_EXAMPLE_TOKENS = [
     "codex_mcp_security_agent.py",
     "zed_mcp_security_agent.py",
     "claude_desktop_mcp_security_agent.py",
+    "continue_mcp_security_agent.py",
 ]
 
 REQUIRED_DOC_TOKENS = [
@@ -378,6 +379,7 @@ def _harness_secret_scan_paths() -> list[Path]:
         EXAMPLES / "codex_mcp_security_agent.py",
         EXAMPLES / "zed_mcp_security_agent.py",
         EXAMPLES / "claude_desktop_mcp_security_agent.py",
+        EXAMPLES / "continue_mcp_security_agent.py",
         EXAMPLES / "harness_adapters.py",
         EXAMPLES / "harness_mcp_transport.py",
         *sorted(PROFILES.glob("*.json")),

--- a/examples/agents/continue_mcp_security_agent.py
+++ b/examples/agents/continue_mcp_security_agent.py
@@ -1,0 +1,56 @@
+"""Continue — MCP-first security agent example.
+
+Continue loads MCP servers through ``~/.continue/config.yaml`` (YAML list
+shape, absolute paths). This reference shows the harness-profile + live
+``tools/list`` path — no skill CLI wrappers.
+
+Run:
+
+    python examples/agents/continue_mcp_security_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ide_mcp_bindings import build_continue_mcp_servers, build_continue_mcp_yaml
+from sdk_agent_common import (
+    dry_run_remediation,
+    human_approval_gate,
+    load_sdk_profile,
+    run_cspm_triage,
+)
+
+
+def continue_binding_notes(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "integration": "continue_mcp_yaml",
+        "config_path": "~/.continue/config.yaml",
+        "docs": "docs/integrations/ide-agents.md",
+        "anti_pattern": "do_not_wrap_skill_clis_as_continue_tools",
+        "continue_mcp_servers": build_continue_mcp_servers(profile),
+        "mcp_yaml": build_continue_mcp_yaml(profile),
+        "path_note": "Replace server args with an absolute clone path before paste",
+        "reload_note": "Continue: Reload Config from the command palette after edits",
+        "remediation_chain": "separate_session_with_HITL_approval_context",
+    }
+
+
+def main() -> int:
+    profile = load_sdk_profile()
+    triage = run_cspm_triage(profile, correlation_id="continue-mcp-demo-1")
+    triage["continue_binding"] = continue_binding_notes(profile)
+    print(json.dumps(triage, indent=2))
+
+    approval = human_approval_gate(triage)
+    if approval is None:
+        return 0
+
+    remediation = dry_run_remediation(triage["caller_context"], approval)
+    print(json.dumps(remediation, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/emit_mcp_client_configs.py
+++ b/examples/agents/emit_mcp_client_configs.py
@@ -23,6 +23,8 @@ from ide_mcp_bindings import (
     build_anthropic_mcp_config,
     build_claude_desktop_mcp_config,
     build_codex_mcp_toml,
+    build_continue_mcp_servers,
+    build_continue_mcp_yaml,
     build_cortex_mcp_config,
     build_cursor_mcp_config,
     build_langchain_mcp_servers,
@@ -42,6 +44,7 @@ ClientName = Literal[
     "anthropic",
     "openai",
     "claude-desktop",
+    "continue",
     "all",
 ]
 CLIENT_NAMES: tuple[ClientName, ...] = (
@@ -54,6 +57,7 @@ CLIENT_NAMES: tuple[ClientName, ...] = (
     "anthropic",
     "openai",
     "claude-desktop",
+    "continue",
     "all",
 )
 
@@ -130,6 +134,16 @@ def _client_payload(client: str, profile: dict[str, Any]) -> dict[str, Any]:
             "path_note": "Replace server args with an absolute clone path before paste",
             "anti_pattern": "do_not_wrap_skill_clis_as_claude_desktop_tools",
         }
+    if client == "continue":
+        return {
+            "integration": "continue_mcp_yaml",
+            "config_path": "~/.continue/config.yaml",
+            "docs": "docs/integrations/ide-agents.md",
+            "continue_mcp_servers": build_continue_mcp_servers(profile),
+            "mcp_yaml": build_continue_mcp_yaml(profile),
+            "path_note": "Replace server args with an absolute clone path before paste",
+            "anti_pattern": "do_not_wrap_skill_clis_as_continue_tools",
+        }
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -160,7 +174,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--client",
         choices=CLIENT_NAMES,
         default="all",
-        help="Emit one client block or all nine MCP clients",
+        help="Emit one client block or all ten MCP clients",
     )
     parser.add_argument(
         "--output",

--- a/examples/agents/ide_mcp_bindings.py
+++ b/examples/agents/ide_mcp_bindings.py
@@ -7,6 +7,7 @@ and LangChain MCP adapters stay consistent.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from harness_mcp_transport import safe_mcp_env
@@ -114,3 +115,46 @@ def build_langchain_mcp_servers(profile: dict[str, Any]) -> dict[str, dict[str, 
             "env": mcp_policy_env(profile),
         }
     }
+
+
+def _yaml_scalar(value: str) -> str:
+    if not value:
+        return '""'
+    if re.search(r'[:#\n"\'\\]', value):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
+def build_continue_mcp_servers(profile: dict[str, Any]) -> dict[str, Any]:
+    """``~/.continue/config.yaml`` ``mcpServers`` list block — absolute path required."""
+    command = mcp_stdio_command()
+    return {
+        "mcpServers": [
+            {
+                "name": "cloud-ai-security-skills",
+                "command": command[0],
+                "args": [str(MCP_SERVER_PATH)],
+                "env": mcp_policy_env(profile),
+            }
+        ]
+    }
+
+
+def build_continue_mcp_yaml(profile: dict[str, Any]) -> str:
+    """YAML fragment for Continue ``config.yaml``."""
+    server = build_continue_mcp_servers(profile)["mcpServers"][0]
+    lines = [
+        "mcpServers:",
+        f"  - name: {server['name']}",
+        f"    command: {_yaml_scalar(server['command'])}",
+        "    args:",
+    ]
+    for arg in server["args"]:
+        lines.append(f"      - {_yaml_scalar(str(arg))}")
+    env = server.get("env") or {}
+    if env:
+        lines.append("    env:")
+        for key, value in sorted(env.items()):
+            lines.append(f"      {key}: {_yaml_scalar(value)}")
+    return "\n".join(lines) + "\n"

--- a/examples/agents/schemas/mcp_client_config_bundle.schema.json
+++ b/examples/agents/schemas/mcp_client_config_bundle.schema.json
@@ -58,6 +58,13 @@
           "mcp_server": {
             "type": "object"
           },
+          "continue_mcp_servers": {
+            "type": "object"
+          },
+          "mcp_yaml": {
+            "type": "string",
+            "minLength": 1
+          },
           "path_note": {
             "type": "string"
           },

--- a/examples/agents/tests/test_examples.py
+++ b/examples/agents/tests/test_examples.py
@@ -34,6 +34,7 @@ SCRIPTS = [
     EXAMPLES / "codex_mcp_security_agent.py",
     EXAMPLES / "zed_mcp_security_agent.py",
     EXAMPLES / "claude_desktop_mcp_security_agent.py",
+    EXAMPLES / "continue_mcp_security_agent.py",
     EXAMPLES / "langgraph_security_graph.py",
     EXAMPLES / "run_langgraph_harness.py",
 ]
@@ -390,6 +391,27 @@ class TestHitlGateReachable:
         assert "cloud-ai-security-skills" in binding["mcp_config"]["mcpServers"]
         assert payload["mcp_tools_discovered"]
 
+    def test_continue_mcp_binding_documents_yaml_config(self):
+        result = subprocess.run(
+            [sys.executable, str(EXAMPLES / "continue_mcp_security_agent.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=REPO_ROOT,
+            env={**os.environ},
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        binding = payload["continue_binding"]
+        assert binding["integration"] == "continue_mcp_yaml"
+        assert "config.yaml" in binding["config_path"]
+        assert "mcpServers:" in binding["mcp_yaml"]
+        assert binding["continue_mcp_servers"]["mcpServers"][0]["name"] == (
+            "cloud-ai-security-skills"
+        )
+        assert payload["mcp_tools_discovered"]
+
     def test_anthropic_binding_documents_mcp_config(self):
         result = subprocess.run(
             [sys.executable, str(EXAMPLES / "anthropic_sdk_security_agent.py")],
@@ -474,6 +496,9 @@ class TestIdeMcpBindings:
             "cloud-ai-security-skills"
         ]["env"]
         openai_env = ide_mcp_bindings.build_openai_agents_mcp_server(profile)["env"]
+        continue_env = ide_mcp_bindings.build_continue_mcp_servers(profile)["mcpServers"][0][
+            "env"
+        ]
 
         assert cursor_env == expected
         assert windsurf_env == expected
@@ -481,6 +506,7 @@ class TestIdeMcpBindings:
         assert langchain_env == expected
         assert anthropic_env == expected
         assert openai_env == expected
+        assert continue_env == expected
         assert expected["CLOUD_SECURITY_MCP_REQUIRE_CALLER_ALLOWED_SKILLS"] == "true"
         assert "cspm-aws-cis-benchmark" in expected["CLOUD_SECURITY_MCP_ALLOWED_SKILLS"]
 
@@ -524,12 +550,14 @@ class TestEmitMcpClientConfigs:
             "anthropic",
             "openai",
             "claude-desktop",
+            "continue",
         }
         assert "mcp_config" in payload["clients"]["cursor"]
         assert "mcp_toml" in payload["clients"]["codex"]
         assert "context_servers" in payload["clients"]["zed"]
         assert "mcp_servers" in payload["clients"]["langchain"]
         assert "mcp_server" in payload["clients"]["openai"]
+        assert "mcp_yaml" in payload["clients"]["continue"]
 
     def test_single_client_filter(self):
         result = subprocess.run(
@@ -2336,6 +2364,7 @@ class TestLangGraphHarnessSetup:
             "anthropic",
             "openai",
             "claude-desktop",
+            "continue",
         }
 
     def test_setup_generator_rejects_missing_preset(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
Closes #610 — completes the IDE MCP coverage map.

- `continue_mcp_security_agent.py` — runnable offline example with live `tools/list`
- `build_continue_mcp_servers()` + `build_continue_mcp_yaml()` in `ide_mcp_bindings.py`
- Emitter client `continue` (10th client) + bundle schema fields `continue_mcp_servers` / `mcp_yaml`
- Drift, HARNESS.md, `ide-agents.md`, and smoke tests wired

## Test plan
- [x] `uv run pytest examples/agents/tests/test_examples.py -q` (130 passed)
- [x] `python examples/agents/check_langgraph_harness_drift.py` (10/10)
- [x] `uv run ruff check examples/agents --config pyproject.toml`

**Stacks on:** #601
**Epic:** #602

Made with [Cursor](https://cursor.com)